### PR TITLE
Rename default dev db name

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -9,7 +9,7 @@ DB_TYPE=sqlite
 
 # If you want to use an in-memory database that wipes on each restart
 # comment the following property out
-DB_SQLITE_STORAGE=.forge.db
+DB_SQLITE_STORAGE=forge.db
 
 
 # Root domain for instances


### PR DESCRIPTION
Gets rid of the . prefix as it was a pain to have the db file hidden.

I've started using a utility for examining the sqlite DB to help debug things. The app refuses to load the db with the `.` at the start of its filename.

There's little benefit at this point to having that in the name, so suggest we rename it.