### PR TITLE
Add standard button and dropdown styles and components

### DIFF
--- a/frontend/src/components/CreateProjectButton.vue
+++ b/frontend/src/components/CreateProjectButton.vue
@@ -1,0 +1,16 @@
+<template>
+<a href="/create" class="forge-button">
+    <PlusSmIcon class="w-5 h-5 my-1 -ml-1 mr-1" /><span>Create Project</span>
+</a>
+</template>
+<script>
+
+import { PlusSmIcon } from '@heroicons/vue/outline'
+
+export default {
+    name: "CreateProjectButton",
+    components: {
+        PlusSmIcon
+    }
+}
+</script>

--- a/frontend/src/components/DropdownMenu.vue
+++ b/frontend/src/components/DropdownMenu.vue
@@ -1,0 +1,49 @@
+<template>
+    <Menu as="div" class="relative inline-block text-left">
+        <div>
+            <MenuButton class="forge-button" :class="buttonClass">
+                <slot></slot>
+                <span class="sr-only">{{ alt }}</span>
+                <ChevronDownIcon class="w-5 h-5 my-1 ml-2 -mr-1 text-violet-200 hover:text-violet-100" aria-hidden="true" />
+            </MenuButton>
+        </div>
+        <transition
+            enter-active-class="transition duration-100 ease-out"
+            enter-from-class="transform scale-95 opacity-0"
+            enter-to-class="transform scale-100 opacity-100"
+            leave-active-class="transition duration-75 ease-in"
+            leave-from-class="transform scale-100 opacity-100"
+            leave-to-class="transform scale-95 opacity-0"
+        >
+        <MenuItems class="z-50 absolute right-0 w-56 mt-2 origin-top-right bg-white divide-y divide-gray-100 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+            <div class="px-1 py-1">
+                <MenuItem v-for="item in options" :key="item.name" v-slot="{ active }">
+                    <template v-if="item.path">
+                        <router-link :to="item" :class="[active ? 'bg-gray-200' : '', 'block px-4 py-2 text-sm text-gray-700']">{{ item.name }}</router-link>
+                    </template>
+                    <template v-else>
+                        <a @click="item.action" :class="[active ? 'bg-gray-200' : '', 'block px-4 py-2 text-sm text-gray-700']">{{ item.name }}</a>
+                    </template>
+
+                </MenuItem>
+            </div>
+        </MenuItems>
+      </transition>
+    </Menu>
+</template>
+<script>
+import { Menu, MenuButton, MenuItems, MenuItem } from '@headlessui/vue'
+import { ChevronDownIcon } from '@heroicons/vue/solid'
+
+export default {
+    name: "DropdownMenu",
+    props: [ 'alt' , 'options', 'buttonClass'],
+    components: {
+        Menu,
+        MenuButton,
+        MenuItems,
+        MenuItem,
+        ChevronDownIcon
+    },
+}
+</script>

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -2,36 +2,22 @@
     <Disclosure as="nav" class="bg-white" v-slot="{ open }">
       <div class="m-w-screen mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between h-16">
-            <div class="flex flex-grow items-center bg-white p-2  text-gray-500">
-              <router-link to="/" class="px-2 py-2 bg-gray-100 text-gray-400 hover:text-gray-600 focus:text-gray-800 rounded-lg flex items-center text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-600 focus:ring-gray-400"><HomeIcon class="h-5 w-5" aria-hidden="true" /></router-link>
+            <div class="hidden md:flex flex-grow items-center bg-white p-2  text-gray-500">
+              <router-link to="/" class="forge-button forge-user-button px-2"><HomeIcon class="h-5 w-5 my-1" aria-hidden="true" /></router-link>
               <ChevronRightIcon v-if="breadcrumbs.length > 0" class="h-5 w-5 mx-2 text-blue-400" aria-hidden="true" />
               <template v-for="(item, itemIdx) in breadcrumbs" :key="item.name">
                   <ChevronRightIcon v-if="itemIdx > 0" class="h-5 w-5 mx-2 text-blue-400" aria-hidden="true" />
                   <router-link :to="item.to || {}">{{ item.label }}</router-link>
               </template>
             </div>
-            <a v-if="$route.name != 'CreateProject'" href="/create" class="pl-2 pr-3 py-1 bg-blue-900 hover:bg-indigo-700 text-white hover:text-gray-200 focus:text-gray-300 rounded-lg flex items-center text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-600 focus:ring-gray-400">
-                <PlusSmIcon class="w-6" /><span>Create Project</span>
-            </a>
+            <CreateProjectButton v-if="$route.name != 'CreateProject'" class="hidden md:flex"/>
           <!-- User Button -->
           <div class="hidden md:block flex-none">
             <div class="ml-4 flex items-center md:ml-6">
-              <Menu as="div" class="ml-3 relative">
-                <div>
-                  <MenuButton class="pl-2 pr-1 py-1 bg-gray-100 text-gray-400 hover:text-gray-600 focus:text-gray-800 rounded-lg flex items-center text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-600 focus:ring-gray-400">
-                    <div class="mr-3">{{user.name}}</div>
-                    <span class="sr-only">Open user menu</span>
-                    <img :src="user.avatar" class="h-6 v-6 rounded-md"/>
-                  </MenuButton>
-                </div>
-                <transition enter-active-class="transition ease-out duration-100" enter-from-class="transform opacity-0 scale-95" enter-to-class="transform opacity-100 scale-100" leave-active-class="transition ease-in duration-75" leave-from-class="transform opacity-100 scale-100" leave-to-class="transform opacity-0 scale-95">
-                  <MenuItems class="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
-                    <MenuItem v-for="item in profile" :key="item.name" v-slot="{ active }">
-                      <router-link :to="item" :class="[active ? 'bg-gray-100' : '', 'block px-4 py-2 text-sm text-gray-700']">{{ item.name }}</router-link>
-                    </MenuItem>
-                  </MenuItems>
-                </transition>
-              </Menu>
+            <DropdownMenu class="ml-8" buttonClass="forge-user-button" alt="Open user menu" :options="profile">
+                <div class="mr-3">{{user.name}}</div>
+                <img :src="user.avatar" class="h-6 v-6 rounded-md"/>
+            </DropdownMenu>
             </div>
           </div>
           <div class="-mr-2 flex md:hidden">
@@ -60,9 +46,11 @@ import { ref } from "vue"
 import { mapState } from 'vuex'
 import router from "@/routes"
 import Logo from "@/components/Logo"
+import DropdownMenu from "@/components/DropdownMenu"
+import CreateProjectButton from "@/components/CreateProjectButton"
 
 import { Disclosure, DisclosureButton, DisclosurePanel, Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
-import { MenuIcon, XIcon, HomeIcon, ChevronRightIcon, PlusSmIcon } from '@heroicons/vue/outline'
+import { MenuIcon, XIcon, HomeIcon, ChevronRightIcon } from '@heroicons/vue/outline'
 
 const navigation = router.options.routes.filter(r => r.navigationLink)
 export default {
@@ -77,38 +65,17 @@ export default {
       ...mapState('breadcrumbs',['breadcrumbs']),
 
   },
-  // watch: {
-  //     breadcrumbs: 'refreshBreadcrumbs'
-  // },
-  // mounted() {
-  //     this.refreshBreadcrumbs();
-  // },
-  // methods: {
-  //     refreshBreadcrumbs() {
-  //         // const parts = this.$router.currentRoute.value.path.split("/").filter( v => !!v).map(v => {
-  //         //     return {
-  //         //         name: v
-  //         //     }
-  //         // })
-  //
-  //         // this.breadcrumbs = parts
-  //         console.log(this.breadcrumbs);
-  //     }
-  // },
   components: {
       Logo,
+      DropdownMenu,
       Disclosure,
       DisclosureButton,
       DisclosurePanel,
-      Menu,
-      MenuButton,
-      MenuItem,
-      MenuItems,
       MenuIcon,
       XIcon,
       HomeIcon,
       ChevronRightIcon,
-      PlusSmIcon
+      CreateProjectButton
   },
   setup() {
       const open = ref(false)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -13,4 +13,30 @@
         @apply lg:px-8;
         @apply mb-2;
     }
+
+    .forge-button {
+        @apply px-3;
+        @apply py-1;
+        @apply bg-blue-900;
+        @apply hover:bg-indigo-700;
+        @apply text-white;
+        @apply hover:text-gray-200;
+        @apply focus:text-gray-300;
+        @apply rounded-lg;
+        @apply flex;
+        @apply items-center;
+        @apply text-sm;
+        @apply focus:outline-none;
+        @apply focus:ring-2;
+        @apply focus:ring-offset-2;
+        @apply focus:ring-offset-gray-600;
+        @apply focus:ring-gray-400;
+    }
+    .forge-user-button {
+        @apply bg-gray-100;
+        @apply hover:bg-gray-200;
+        @apply text-gray-400;
+        @apply hover:text-gray-600;
+        @apply focus:text-gray-800;
+    }
 }

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -4,7 +4,14 @@
             <router-link to="/account/projects">Projects</router-link>
         </FormHeading>
         <div class="text-sm px-4 sm:px-6 lg:px-8 mt-8">
-            <ProjectsTable :projects="projects" :projectCount="projectCount" />
+            <template v-if="projectCount > 0">
+                <ProjectsTable :projects="projects" :projectCount="projectCount" />
+            </template>
+            <template v-else>
+                <div class="max-w-2xl mx-auto flex justify-center border rounded border-gray-300 overflow-hidden mb-4 p-8">
+                    <CreateProjectButton class="w-auto flex-grow-0"/>
+                </div>
+            </template>
         </div>
     </div>
     <div class="forge-block">
@@ -25,6 +32,7 @@ import teamApi from '@/api/team'
 import TeamsTable from '@/components/tables/TeamsTable'
 import ProjectsTable from '@/components/tables/ProjectsTable'
 import FormHeading from '@/components/FormHeading'
+import CreateProjectButton from "@/components/CreateProjectButton"
 
 import Breadcrumbs from '@/mixins/Breadcrumbs';
 
@@ -58,7 +66,8 @@ export default {
     components: {
         ProjectsTable,
         TeamsTable,
-        FormHeading
+        FormHeading,
+        CreateProjectButton
     }
 }
 </script>

--- a/frontend/src/pages/project/Debug.vue
+++ b/frontend/src/pages/project/Debug.vue
@@ -1,0 +1,17 @@
+<template>
+    <pre class="overflow-x-scroll">{{ project }}</pre>
+</template>
+
+<script>
+
+import Breadcrumbs from '@/mixins/Breadcrumbs';
+
+export default {
+    name: 'ProjectDebug',
+    mixins: [Breadcrumbs],
+    props:[ "project" ],
+    created() {
+        this.replaceLastBreadcrumb({ label:"Debug" })
+    }
+}
+</script>

--- a/frontend/src/pages/project/create.vue
+++ b/frontend/src/pages/project/create.vue
@@ -16,7 +16,7 @@
 
                 <!-- <FormRow v-model="input.description" id="description">Description</FormRow> -->
 
-                <button type="button" @click="createProject" class="py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-900 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-700">
+                <button type="button" @click="createProject" class="forge-button">
                     Create project
                 </button>
             </form>

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -1,10 +1,14 @@
 <template>
     <div class="forge-block">
         <div class="flex items-center mb-8">
-            <div class="mr-3"><img :src="project.avatar" class="h-14 v-14 rounded-md"/></div>
-            <div class="flex flex-col">
-                <div class="text-xl font-bold">{{ project.name }}</div>
+            <div class="text-xl font-bold">{{ project.name }}</div>
+            <div class="ml-8 flex-grow flex items-center">
+                <a :href="project.url" target="_blank" class="forge-button">
+                    <ExternalLinkIcon class="w-5 h-5 my-1 mr-1" /><span class="ml-1">Open Editor</span>
+                </a>
+                <button type="button" title="Copy url" class="forge-button forge-user-button px-2 h-8 py-0 ml-1"><span class="sr-only">Copy url</span><ClipboardCopyIcon class="w-4 h-4" /></button>
             </div>
+            <DropdownMenu class="ml-8" alt="Open options menu" :options="options">Options</DropdownMenu>
         </div>
         <ul class="flex border-b border-gray-700 mb-10 text-gray-500">
             <template v-for="(item, itemIdx) in navigation" :key="project.name">
@@ -23,7 +27,9 @@
 <script>
 import projectApi from '@/api/project'
 import FormHeading from '@/components/FormHeading'
-import Breadcrumbs from '@/mixins/Breadcrumbs';
+import Breadcrumbs from '@/mixins/Breadcrumbs'
+import DropdownMenu from '@/components/DropdownMenu'
+import { ExternalLinkIcon, ClipboardCopyIcon } from '@heroicons/vue/outline'
 
 export default {
     name: 'Project',
@@ -34,8 +40,20 @@ export default {
             navigation: []
         }
     },
+    computed: {
+        options: function() {
+            return [
+                {name: "Start", action: function() { console.log("start")}},
+                {name: "Restart", action: function() { console.log("start")}},
+                {name: "Stop"}
+            ]
+        }
+    },
     components: {
         FormHeading,
+        ExternalLinkIcon,
+        ClipboardCopyIcon,
+        DropdownMenu
     },
     async created() {
         this.setBreadcrumbs([
@@ -57,6 +75,7 @@ export default {
         this.navigation = [
             { name: "Overview", path: `/projects/${parts[2]}/overview` },
             { name: "Settings", path: `/projects/${parts[2]}/settings` },
+            { name: "Debug", path: `/projects/${parts[2]}/debug` },
         ]
     }
 }

--- a/frontend/src/routes/index.js
+++ b/frontend/src/routes/index.js
@@ -14,6 +14,7 @@ import OrgTeams from "@/pages/org/Teams.vue"
 import Project from "@/pages/project/index.vue"
 import ProjectOverview from "@/pages/project/Overview.vue"
 import ProjectSettings from "@/pages/project/Settings.vue"
+import ProjectDebug from "@/pages/project/Debug.vue"
 import CreateProject from "@/pages/project/create.vue"
 
 
@@ -56,7 +57,8 @@ const routes = [
         component: Project,
         children: [
             { path: 'overview', component: ProjectOverview },
-            { path: 'settings', component: ProjectSettings }
+            { path: 'settings', component: ProjectSettings },
+            { path: 'debug', component: ProjectDebug }
         ],
     },
     {


### PR DESCRIPTION
Adds some standard css classes for buttons in the UI.

Also adds a DropdownMenu component that can be easily reused where needed.

The project page now has a link to open the editor in a new tab - assuming the `url` property is correct.

Also has a dropdown menu for start/stop/restart type actions - all of which are just placeholders and don't do anything yet.