### PR TITLE
Fix up case in inline SQL

### DIFF
--- a/forge/db/index.js
+++ b/forge/db/index.js
@@ -29,11 +29,40 @@ module.exports = fp(async function(app, _opts, next) {
         if (process.env.DB_SQLITE_STORAGE) {
             dbOptions.storage =  process.env.DB_SQLITE_STORAGE
         }
+    } else if (dbOptions.dialect === 'mariadb') {
+        if (process.env.DB_MARIADB_HOST) {
+            dbOptions.host = process.env.DB_MARIADB_HOST || "mariadb"
+        }
+         if (process.env.DB_MARIADB_PORT) {
+            dbOptions.host = process.env.DB_MARIADB_PORT || 3306
+        }
+        if (process.env.DB_MARIADB_USER) {
+            dbOptions.username = process.env.DB_MARIADB_USER
+        }
+        if (process.env.DB_MARIADB_PASSWORD) {
+            dbOptions.password = process.env.DB_MARIADB_PASSWORD
+        }
+        dbOptions.database = "flowforge"
+    } else if (dbOptions.dialect === 'postgres') {
+        if (process.env.DB_POSTGRES_HOST) {
+            dbOptions.host = process.env.DB_POSTGRES_HOST || "postgres"
+        }
+         if (process.env.DB_POSTGRES_PORT) {
+            dbOptions.host = process.env.DB_POSTGRES_PORT || 5432
+        }
+        if (process.env.DB_POSTGRES_USER) {
+            dbOptions.username = process.env.DB_POSTGRES_USER
+        }
+        if (process.env.DB_POSTGRES_PASSWORD) {
+            dbOptions.password = process.env.DB_POSTGRES_PASSWORD
+        }
+        dbOptions.database = "flowforge"
     }
 
     if (process.env.DB_LOGGING !== 'true') {
         dbOptions.logging = false;
     }
+
     const sequelize = new Sequelize(dbOptions)
 
     // const R = async function(f) { console.log(JSON.stringify(await f," ",4)); }

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -65,18 +65,18 @@ module.exports = {
                                 [
                                     literal(`(
                                         SELECT COUNT(*)
-                                        FROM Projects AS project
+                                        FROM "Projects" AS "project"
                                         WHERE
-                                        project.TeamId = team.id
+                                        "project"."TeamId" = "Team"."id"
                                     )`),
                                     'projectCount'
                                 ],
                                 [
                                     literal(`(
                                         SELECT COUNT(*)
-                                        FROM TeamMembers AS members
+                                        FROM "TeamMembers" AS "members"
                                         WHERE
-                                        members.TeamId = team.id
+                                        "members"."TeamId" = "Team"."id"
                                     )`),
                                     'memberCount'
                                 ]
@@ -98,18 +98,18 @@ module.exports = {
                                 [
                                     literal(`(
                                         SELECT COUNT(*)
-                                        FROM Projects AS project
+                                        FROM "Projects" AS "project"
                                         WHERE
-                                        project.TeamId = teamMember.TeamId
+                                        "project"."TeamId" = "TeamMember"."TeamId"
                                     )`),
                                     'projectCount'
                                 ],
                                 [
                                     literal(`(
                                         SELECT COUNT(*)
-                                        FROM TeamMembers AS members
+                                        FROM "TeamMembers" AS "members"
                                         WHERE
-                                        members.TeamId = team.id
+                                        "members"."TeamId" = "Team"."id"
                                     )`),
                                     'memberCount'
                                 ]


### PR DESCRIPTION
SQLite appears to be very lenient with SQL syntaxt but both mariadb and postgress are case sensitive and need table names wrapping in quotes.