### PR TITLE
Enable the built-in fastify logger

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -23,7 +23,16 @@ const postoffice = require('./postoffice');
   */
 
 (async function() {
-    const server = fastify({maxParamLength: 500 })
+    const server = fastify({
+        maxParamLength: 500,
+        logger: {
+            level: 'info',
+            prettyPrint: {
+                translateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss.l'Z'",
+                ignore: 'pid,hostname'
+            }
+        }
+    })
 
     server.addHook('onError', async (request, reply, error) => {
         // Useful for debugging when a route goes wrong
@@ -54,7 +63,7 @@ const postoffice = require('./postoffice');
     // License
     await server.register(license);
     // Routes : the HTTP routes
-    await server.register(routes)
+    await server.register(routes, { logLevel: 'warn' })
     // Post Office : handles email
     server.register(postoffice);
     // Containers:
@@ -68,7 +77,6 @@ const postoffice = require('./postoffice');
             console.error(err)
             process.exit(1)
         }
-        console.log(`Server listening on ${address}`)
     })
 
 })()


### PR DESCRIPTION
Closes #10

The Fastify framework has the [pino](https://www.npmjs.com/package/pino) logger integrated. This PR enables it with the following configuration:

 - Applies `pino-pretty` to get human-readable logs. We will likely want to take advantage of the other pino transports in the future that will send logs to a number of different services.
 - As it logs all http requests by default, that can make the log very noisy. For now, I've set the log level for all HTTP routes to 'warn'.

All internal components should be updated to use `app.log.info("hello world")` rather than `console.log`. See https://github.com/pinojs/pino/blob/HEAD/docs/api.md#logging-method-parameters for API.
