### PR TITLE
Remove redundant reply.send calls in api routes

### DIFF
--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -62,6 +62,5 @@ module.exports = async function(app) {
             count: result.length,
             invitations:result
         })
-        reply.send(result)
     })
 }

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -81,7 +81,6 @@ module.exports = async function(app) {
                 count: result.length,
                 projects:result
             })
-            reply.send(result)
         } else {
             reply.code(404).type('text/html').send('Not Found')
         }
@@ -190,6 +189,7 @@ module.exports = async function(app) {
             reply.send({
                 role: request.teamMembership.role
             })
+            return
         }
         reply.code(404).type('text/html').send('Not Found')
     })

--- a/forge/routes/api/teamInvitations.js
+++ b/forge/routes/api/teamInvitations.js
@@ -21,7 +21,6 @@ module.exports = async function(app) {
             count: result.length,
             invitations:result
         })
-        reply.send(result)
     })
 
     /**

--- a/forge/routes/api/teamMembers.js
+++ b/forge/routes/api/teamMembers.js
@@ -43,7 +43,6 @@ module.exports = async function(app) {
             count: result.length,
             members:result
         })
-        reply.send(result)
     })
 
     /**

--- a/forge/routes/api/userInvitations.js
+++ b/forge/routes/api/userInvitations.js
@@ -19,7 +19,6 @@ module.exports = async function(app) {
             count: result.length,
             invitations:result
         })
-        reply.send(result)
     })
 
     /**


### PR DESCRIPTION
Fixes #150

Looks like some redundant calls to reply.send crept in after some routes were copied around.

Have reviewed all routes and can't see any other instances.