### PR TITLE
Add Team Delete route and UI

### DIFF
--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -22,6 +22,15 @@ module.exports = {
                 team.slug = slugify(team.name)
             }
             team.slug = team.slug.toLowerCase();
+        },
+        beforeDestroy: async(team, opts) => {
+            const projectCount = await team.projectCount();
+            if (projectCount > 0) {
+                throw new Error("Cannot delete team that owns projects");
+            }
+        },
+        afterDestroy: async (team, opts) => {
+            // TODO: what needs tidying up after a team is deleted?
         }
     },
     associations: function(M) {
@@ -125,6 +134,9 @@ module.exports = {
                 owners: async function() {
                     // All Team owners
                     return M['TeamMember'].scope('owners').findAll()
+                },
+                projectCount: async function() {
+                    return await M['Project'].count({TeamId: this.id})
                 }
             }
         }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -115,11 +115,11 @@ const ProjectActions = require("./projectActions.js");
             result.team = team.id;
             reply.send(result);
         } else {
-            reply.status(401).send({error: "Current user not in team " + request.body.team})
+            reply.code(401).send({error: "Current user not in team " + request.body.team})
         }
     })
     /**
-     * Delete an project
+     * Delete a project
      * @name /api/v1/project/:id
      * @memberof forge.routes.api.project
      */
@@ -141,7 +141,7 @@ const ProjectActions = require("./projectActions.js");
         } catch(err) {
             console.log("missing", err)
             console.log(err)
-            reply.status(500).send({})
+            reply.code(500).send({})
         }
 
     })

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -140,6 +140,19 @@ module.exports = async function(app) {
     });
 
 
+    app.delete('/:teamId', { preHandler: app.needsPermission("team:delete") }, async (request, reply) => {
+        // At this point we know the requesting user has permission to do this.
+        // But we also need to ensure the team has no projects
+        // That is handled by the beforeDestroy hook on the Team model and the
+        // call to destroy the team will throw an error
+        try {
+            await request.team.destroy();
+            reply.send({ status: "okay"});
+        } catch(err) {
+            reply.code(400).send({error:err.toString()})
+        }
+    })
+
     // app.get('/teams', async (request, reply) => {
     //     const teams = await app.db.models.Team.forUser(request.session.User);
     //     const result = await app.db.views.Team.teamList(teams);

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -24,6 +24,10 @@ const getTeam = (team) => {
     return client.get(url).then(res => res.data);
 }
 
+const deleteTeam = async (teamId) => {
+    return await client.delete(`/api/v1/teams/${teamId}`)
+}
+
 const getTeamProjects = async (teamId) => {
     let res = await client.get(`/api/v1/teams/${teamId}/projects`);
     let promises = [];
@@ -105,6 +109,7 @@ const updateTeam = async(teamId, options) => {
 export default {
     create,
     getTeam,
+    deleteTeam,
     updateTeam,
     getTeams,
     getTeamProjects,

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -4,7 +4,8 @@
         <div class="flex">
             <div class="max-w-sm pr-2">{{deleteDescription}}</div>
             <div class="pl-2">
-                <button type="button" :disabled="!deleteActive" class="forge-button-danger" @click="showConfigDeleteDialog" >Delete Team</button>
+                <button type="button" :disabled="!deleteActive" class="forge-button-danger" @click="showConfirmDeleteDialog" >Delete Team</button>
+                <ConfirmTeamDeleteDialog @deleteTeam="deleteTeam" ref="confirmTeamDeleteDialog"/>
             </div>
         </div>
     </form>
@@ -15,6 +16,7 @@ import teamApi from '@/api/team'
 
 import FormRow from '@/components/FormRow'
 import FormHeading from '@/components/FormHeading'
+import ConfirmTeamDeleteDialog from '../dialogs/ConfirmTeamDeleteDialog'
 
 export default {
     name: 'TeamSettingsDanger',
@@ -28,7 +30,7 @@ export default {
     computed: {
         deleteActive() {
             if (this.projectCount > 0) {
-                this.deleteDescription = "You cannot delete a team that still owns projects. You must either transfer them to other teams or delete the projects."
+                this.deleteDescription = "You cannot delete a team that still owns projects." //" You must either transfer them to other teams or delete the projects."
                 return false
             } else if (this.projectCount === 0){
                 this.deleteDescription = "Deleting the team cannot be undone. Take care.";
@@ -43,6 +45,16 @@ export default {
         this.fetchData()
     },
     methods: {
+        showConfirmDeleteDialog() {
+            this.$refs.confirmTeamDeleteDialog.show(this.team);
+        },
+        deleteTeam() {
+            teamApi.deleteTeam(this.team.id).then(() => {
+                this.$store.dispatch('account/checkState',"/");
+            }).catch(err => {
+                console.warn(err);
+            })
+        },
         async fetchData () {
             if (this.team.id) {
                 const data = await teamApi.getTeamProjects(this.team.id);
@@ -52,7 +64,8 @@ export default {
     },
     components: {
         FormRow,
-        FormHeading
+        FormHeading,
+        ConfirmTeamDeleteDialog
     }
 }
 </script>

--- a/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
@@ -1,0 +1,101 @@
+<template>
+  <TransitionRoot appear :show="isOpen" as="template">
+    <Dialog as="div" @close="close">
+      <div class="fixed inset-0 z-10 overflow-y-auto">
+        <div class="min-h-screen px-4 text-center">
+          <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
+          <span class="inline-block h-screen align-middle" aria-hidden="true">
+            &#8203;
+          </span>
+          <TransitionChild
+            as="template"
+            enter="duration-300 ease-out"
+            enter-from="opacity-0 scale-95"
+            enter-to="opacity-100 scale-100"
+            leave="duration-200 ease-in"
+            leave-from="opacity-100 scale-100"
+            leave-to="opacity-0 scale-95"
+          >
+            <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
+              <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Delete team</DialogTitle>
+                <form class="space-y-6">
+                  <div class="mt-2 space-y-2">
+                      <p class="text-sm text-gray-500">
+                          Are you sure you want to delete this team? Once deleted, there is no going back.
+                      </p>
+                      <p class="text-sm text-gray-500">
+                          Enter the team name '<code>{{team.name}}</code>' to continue.
+                      </p>
+                  </div>
+                  <FormRow v-model="input.teamName" id="projectName">Name</FormRow>
+                  <div class="mt-4 flex flex-row justify-end">
+                      <button type="button" class="forge-button-secondary ml-4" @click="close">Cancel</button>
+                      <button type="button" :disabled="!formValid" class="forge-button-danger ml-4" @click="confirm">Delete</button>
+                  </div>
+              </form>
+          </div>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+
+<script>
+import { ref } from 'vue'
+import {
+    TransitionRoot,
+    TransitionChild,
+    Dialog,
+    DialogOverlay,
+    DialogTitle,
+} from '@headlessui/vue'
+
+import FormRow from '@/components/FormRow'
+
+export default {
+    name: 'ConfirmProjectDeleteDialog',
+
+    components: {
+        TransitionRoot,
+        TransitionChild,
+        Dialog,
+        DialogOverlay,
+        DialogTitle,
+        FormRow
+    },
+    data() {
+        return {
+            input: {
+                teamName: ""
+            },
+            formValid: false,
+            team: null
+        }
+    },
+    watch: {
+        'input.teamName': function() {
+            this.formValid = this.team.name === this.input.teamName
+        }
+    },
+    methods: {
+        confirm() {
+            this.$emit('deleteTeam')
+            this.isOpen = false
+        }
+    },
+    setup() {
+        const isOpen = ref(false)
+        return {
+            isOpen,
+            close() {
+                isOpen.value = false
+            },
+            show(team) {
+                this.team = team;
+                isOpen.value = true
+            },
+        }
+    },
+}
+</script>


### PR DESCRIPTION
Fixes #154

 - Adds `DELETE /api/v1/teams/:teamId` route handler
 - Connects 'Delete Team' button in UI to confirmation dialog

A Team can only be delete if it doesn't own any projects. We previously had text in the UI saying projects should be transferred to another team before deleting. As we don't have project transfer yet, I've removed that part of the text.