### PR TITLE
Add /api/v1/teams end point and associated Admin View

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -103,6 +103,7 @@ module.exports = {
         extensions: ["*", ".js", ".vue", ".json"],
         alias: {
             "vue": "vue/dist/vue.esm-bundler.js",
+            "@core": getPath("forge"),
             "@": getPath("frontend/src")
         }
     },

--- a/forge/db/views/Team.js
+++ b/forge/db/views/Team.js
@@ -9,7 +9,8 @@ module.exports = {
                 name: d.Team.name,
                 role: d.role,
                 avatar: d.Team.avatar,
-                projects: d.projectCount
+                projectCount: d.projectCount,
+                memberCount: d.memberCount
             }
         });
     },

--- a/forge/routes/api/index.js
+++ b/forge/routes/api/index.js
@@ -8,6 +8,7 @@
 const User = require("./user.js");
 const Users = require("./users.js");
 const Team = require("./team.js");
+const Teams = require("./teams.js");
 const Project = require("./project.js");
 const Admin = require("./admin.js");
 const Settings = require("./settings.js");

--- a/forge/routes/api/teams.js
+++ b/forge/routes/api/teams.js
@@ -1,0 +1,26 @@
+/**
+ * Teams api routes
+ *
+ * - /api/v1/teams
+ *
+ * @namespace teams
+ * @memberof forge.routes.api
+ */
+module.exports = async function(app) {
+
+    // Lets assume all apis that access bulk teams are admin only.
+    app.addHook('preHandler',app.verifyAdmin);
+
+    /**
+     * Get a list of all known users
+     * @name /api/v1/teams
+     * @static
+     * @memberof forge.routes.api.teams
+     */
+    app.get('/', async (request, reply) => {
+        const paginationOptions = app.getPaginationOptions(request)
+        const teams = await app.db.models.Team.getAll(paginationOptions);
+        teams.teams = users.users.map(u => app.db.views.User.userProfile(u))
+        reply.send(teams);
+    })
+}

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -3,11 +3,13 @@ import slugify from '@/utils/slugify';
 import daysSince from '@/utils/daysSince';
 import elapsedTime from '@/utils/elapsedTime';
 import paginateUrl from '@/utils/paginateUrl';
+import { RoleNames } from '@core/lib/roles'
 
 const getTeams = () => {
     return client.get('/api/v1/user/teams').then(res => {
         res.data.teams = res.data.teams.map(r => {
             r.link = { name: 'Team', params: { id: slugify(r.name) }}
+            r.roleName = RoleNames[r.role]
             return r;
         })
         return res.data;

--- a/frontend/src/api/teams.js
+++ b/frontend/src/api/teams.js
@@ -1,0 +1,20 @@
+import client from './client';
+import slugify from '@/utils/slugify';
+import paginateUrl from '@/utils/paginateUrl';
+
+const getTeams = async (cursor, limit) => {
+    const url = paginateUrl('/api/v1/teams',cursor,limit);
+    return client.get(url).then(res => {
+        res.data.teams = res.data.teams.map(r => {
+            r.link = { name: 'Team', params: { id: slugify(r.name) }}
+            return r;
+        })
+        return res.data;
+    });
+
+
+}
+
+export default {
+    getTeams
+}

--- a/frontend/src/pages/account/components/TeamsTable.vue
+++ b/frontend/src/pages/account/components/TeamsTable.vue
@@ -15,8 +15,9 @@ export default {
         return {
             columns: [
                 {name: 'Name',  class:['flex-grow'], component: { is: markRaw(TeamCell) }, link:true},
-                {name: 'Projects', class:['w-32','text-center'],property: 'projects'},
-                {name: 'Role',     class:['w-40'],property: 'role'}
+                {name: 'Projects', class:['w-32','text-center'],property: 'projectCount'},
+                {name: 'Members', class:['w-32','text-center'],property: 'memberCount'},
+                {name: 'Role',     class:['w-40'],property: 'roleName'}
             ]
         }
     },

--- a/frontend/src/pages/admin/Teams.vue
+++ b/frontend/src/pages/admin/Teams.vue
@@ -1,27 +1,62 @@
 <template>
     <form class="space-y-6">
         <FormHeading>Teams</FormHeading>
-        <i>Not implemented yet</i>
+        <ItemTable :items="teams" :columns="columns" />
+        <div v-if="nextCursor">
+            <a v-if="!loading" @click.stop="loadItems" class="forge-button-inline">Load more...</a>
+        </div>
     </form>
 </template>
 
 <script>
+import teamsApi from '@/api/teams'
+
+import ItemTable from '@/components/tables/ItemTable'
 import FormRow from '@/components/FormRow'
 import FormHeading from '@/components/FormHeading'
 import Breadcrumbs from '@/mixins/Breadcrumbs';
 
+import TeamCell from '@/components/tables/cells/TeamCell'
+import { markRaw } from "vue"
+
+
 export default {
     name: 'AdminTeams',
     mixins: [ Breadcrumbs ],
-    created() {
+    data() {
+        return {
+            teams: [],
+            loading: false,
+            nextCursor: null,
+            columns: [
+                {name: "Team", class: ['flex-grow'], component: { is: markRaw(TeamCell) }, link: true},
+                {name: 'Members', class:['w-32','text-center'],property: 'memberCount'},
+                {name: 'Projects', class:['w-32','text-center'],property: 'projectCount'},
+            ]
+        }
+    },
+    async created() {
         this.setBreadcrumbs([
             {label:"Admin", to:{name:"Admin"}},
             {label:"Teams"}
         ]);
+        await this.loadItems()
+    },
+    methods: {
+        loadItems: async function() {
+            this.loading = true;
+            const result = await teamsApi.getTeams(this.nextCursor,30)
+            this.nextCursor = result.meta.next_cursor;
+            result.teams.forEach(v => {
+                this.teams.push(v);
+            })
+            this.loading = false;
+        },
     },
     components: {
         FormRow,
-        FormHeading
+        FormHeading,
+        ItemTable
     }
 }
 </script>


### PR DESCRIPTION
Fixes #161 

 - adds `/api/v1/teams` as an admin-only endpoint for retrieving list of teams (with pagination implemented)
 - adds `admin/teams` view in the UI that lists them
