### PR TITLE
Add offline state handling

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,13 @@
 <template>
     <div class="min-h-screen flex flex-col bg-gray-300 ">
-        <template v-if="pending">
+        <template v-if="offline">
+            <main class="flex-grow flex flex-col">
+                <div class="w-full max-w-screen-2xl mx-auto my-2 sm:my-8 flex-grow flex flex-col">
+                    <Offline />
+                </div>
+            </main>
+        </template>
+        <template v-else-if="pending">
             <main class="flex-grow flex flex-col">
                 <div class="w-full max-w-screen-2xl mx-auto my-2 sm:my-8 flex-grow flex flex-col">
                     <Loading />
@@ -38,12 +45,13 @@ import PageFooter from "@/components/PageFooter.vue"
 import PageHeader from "@/components/PageHeader.vue"
 import Login from "@/pages/Login.vue"
 import Loading from '@/components/Loading';
+import Offline from '@/components/Offline';
 import PasswordExpired from "@/pages/PasswordExpired.vue"
 
 export default {
     name: 'App',
     computed: {
-        ...mapState('account',['pending','user','team']),
+        ...mapState('account',['pending','user','team','offline']),
         loginRequired() {
             return this.$route.meta.requiresLogin !== false
         }
@@ -53,7 +61,8 @@ export default {
         PageHeader,
         Login,
         PasswordExpired,
-        Loading
+        Loading,
+        Offline
     },
     mounted() {
         this.$store.dispatch('account/checkState');

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -16,7 +16,10 @@ client.interceptors.response.use(function (response) {
         // 401 when !pending && !loginInflight means the session has expired
         store.dispatch("account/logout")
         return Promise.reject(error);
-    };
+    } else if (!error.response) {
+        // network error
+        store.dispatch("account/setOffline", true)
+    }
     return Promise.reject(error);
 });
 

--- a/frontend/src/components/Offline.vue
+++ b/frontend/src/components/Offline.vue
@@ -1,0 +1,19 @@
+<template>
+    <div class="flex-grow flex flex-col items-center justify-center mx-auto h-92 text-gray-400">
+        <div class="text-center">
+            <div class="text-9xl">Oh Dear</div>
+            <div class="text-2xl">We tried phoning the server, but no-one answered.</div>
+            <div class="text-2xl mt-4"><button class="forge-button" @click="reload">Try again</button></div>
+        </div>
+    </div>
+</template>
+<script>
+export default {
+    name: "Offline",
+    methods: {
+        reload() {
+            this.$store.dispatch('account/checkState');
+        }
+    }
+}
+</script>

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -5,6 +5,7 @@ import router from "@/routes"
 
 // initial state
 const state = () => ({
+    // Runtime settings
     settings: null,
     // We do not know if there is a valid session yet
     pending: true,
@@ -23,7 +24,10 @@ const state = () => ({
     // An error during login
     loginError: null,
     //
-    pendingTeamChange: false
+    pendingTeamChange: false,
+    // As an SPA, if we get a network error we should present
+    // a suitable 'offline' message.
+    offline: null,
 })
 
 // getters
@@ -51,6 +55,9 @@ const getters = {
     },
     pendingTeamChange(state) {
         return state.pendingTeamChange
+    },
+    offline(state) {
+        return state.offline
     }
 }
 
@@ -103,6 +110,9 @@ const mutations = {
     },
     clearPendingTeamChange(state) {
         state.pendingTeamChange = false;
+    },
+    setOffline(state,value) {
+        state.offline = value
     }
 }
 
@@ -112,6 +122,8 @@ const actions = {
         try {
             const settings = await settingsApi.getSettings();
             state.commit('setSettings', settings);
+
+            state.commit('setOffline', false);
 
             const user = await userApi.getUser();
             state.commit('login', user)
@@ -258,6 +270,9 @@ const actions = {
     async refreshSettings(state) {
         const settings = await settingsApi.getSettings();
         state.commit('setSettings', settings);
+    },
+    setOffline(state,value) {
+        state.commit('setOffline',value)
     }
 }
 


### PR DESCRIPTION
As the front-end is a single-page app, the browser doesn't generally reload the whole page between views - it is all done via api calls under the covers.

This means if the server is unavailable those api calls fail in the background and the user gets no feedback.

This PR adds centralised error handling so that if an API call gets a network error (ie server offline), it displays a suitable message.

The 'try again' message will trigger a check in the background to see if the server is responding again and will return the user to the page they were on.

![image](https://user-images.githubusercontent.com/51083/149560172-57762e4b-720f-44bf-b71e-4cf01e9aeb6b.png)
