### PR TITLE
Add contributing/support files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to FlowForge
+
+Before raising an issue or pull-request, please take a moment to read through
+this guide to help ensure everything is done properly.
+
+We welcome contributions of all kinds, including bug fixes, documentation
+improvements and new features.
+
+However if you would like to contribute a new feature or other significant item,
+please raise an issue first. That gives us a chance to discuss the idea, make
+sure it fits with the goals of the project and that we don't waste your or our time.
+
+## Bug Reports
+
+Please ensure you use the Bug Report template when raising the issue - and provide
+as much information as you can.
+
+The perfect bug report is one that provides clear and concise steps to reproduce
+the issue and information on what versions of node and FlowForge you are using.
+
+---
+
+<a id="developers-certificate-of-origin"></a>
+
+## Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+- (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
+
+- (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
+- (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+- (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,5 @@
+# Getting Support
+
+FlowForge provides community-based support for the Open Source code base.
+
+Please raise an issue with details of your question.


### PR DESCRIPTION
Once we make repos public, we should move the standard files to the `flowforge/.github` repo where they then get applied to all repositories in the org.

https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file