### PR TITLE
Add telemetry:enabled setting to store user selection

### DIFF
--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -20,6 +20,7 @@ module.exports = async function(app) {
             }
 
             if (request.session.User.admin) {
+                response['telemetry:enabled'] = app.settings.get("telemetry:enabled")
                 response['user:signup'] = app.settings.get("user:signup")
                 response['user:team:auto-create'] = app.settings.get('user:team:auto-create')
                 response.email = app.postoffice.exportSettings(true)

--- a/forge/routes/setup/index.js
+++ b/forge/routes/setup/index.js
@@ -127,4 +127,30 @@ module.exports = async function(app) {
         }
     });
 
+    app.post('/setup/settings', {
+        preValidation: app.csrfProtection,
+        schema: {
+            body: {
+                type: 'object',
+                required: ['telemetry'],
+                properties: {
+                    telemetry: { type: 'boolean' },
+                }
+            }
+        }
+    }, async (request, reply) => {
+        if (app.settings.get("setup:initialised")) {
+            reply.code(404);
+            return
+        }
+        try {
+            await app.settings.set("telemetry:enabled",request.body.telemetry)
+            reply.send({status: "okay"})
+        } catch(err) {
+            console.log(err);
+            let responseMessage = err.toString();
+            reply.code(400).send({error:responseMessage})
+        }
+    });
+
 }

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -8,6 +8,9 @@ module.exports = {
     // Whether the intial setup has been run
     "setup:initialised": false,
 
+    // Is telemetry enabled?
+    "telemetry:enabled": true,
+
     // Can user's signup via the login page
     "user:signup": false,
 

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -32,7 +32,18 @@
                 sent to that email address.</p>
             </template>
         </FormRow>
-
+        <FormHeading>Platform</FormHeading>
+        <FormRow v-model="input['telemetry:enabled']" type="checkbox">
+            Enable collection of anonymous statistics
+            <template #description>
+                <p><b>This release does not collect any information</b></p>
+                <p>A future release will collect anonymous statistics about how
+                FlowForge is used. This allows us to improve how it works and
+                make a better platform.</p>
+                <p>We will clearly communicate when this feature is implemented
+                and exactly what information is being gathered.</p>
+            </template>
+        </FormRow>
         <div>
             <button type="button" :disabled="!saveEnabled" class="forge-button forge-button-small" @click="saveChanges">Save settings</button>
         </div>
@@ -51,7 +62,8 @@ const validSettings = [
     'user:signup',
     'user:team:auto-create',
     'team:create',
-    'team:user:invite:external'
+    'team:user:invite:external',
+    'telemetry:enabled'
 ]
 
 export default {

--- a/frontend/src/pages/setup/Options.vue
+++ b/frontend/src/pages/setup/Options.vue
@@ -43,12 +43,11 @@ export default {
         },
         applyOptions() {
             let opts = { _csrf: SETUP_CSRF_TOKEN, ...this.input }
-            this.$emit('next')
-            // return httpClient.post(`/setup/add-license`, opts).then(res => {
-            //     this.$emit('next')
-            // }).catch(err => {
-            //     this.errors.license = err.response.data.error
-            // });
+            return httpClient.post(`/setup/settings`, opts).then(res => {
+                this.$emit('next')
+            }).catch(err => {
+                console.error(err);
+            });
         }
     },
     components: {


### PR DESCRIPTION
The 'enable telemetry' option in the initial setup was a placeholder and not plumbed up to store the user choice.

Whilst we don't have active telemetry in 0.1.0, we should store the user choice - and also expose it on the main admin settings page so they can change it.