### PR TITLE
Show admin create-team button when logging in first time

### DIFF
--- a/frontend/src/pages/account/NoTeamsUser.vue
+++ b/frontend/src/pages/account/NoTeamsUser.vue
@@ -9,9 +9,9 @@
             </div>
             <form class="px-4 sm:px-6 lg:px-8 mt-8 space-y-4 text-center">
                 <p class="text-gray-700 text-lg mt-10 ">You need to be in a team to create projects.</p>
-                <p v-if="invitationCount === 0 && !settings['team:create']" class="text-gray-700 text-lg mt-10 ">Ask an Admin or Team Owner to add you to a team.</p>
+                <p v-if="invitationCount === 0 && !user.admin && !settings['team:create']" class="text-gray-700 text-lg mt-10 ">Ask an Admin or Team Owner to add you to a team.</p>
                 <div class="grid grid-cols-1 gap-4"  :class="invitationCount > 0?'sm:grid-cols-2':'max-w-xs mx-auto'">
-                    <router-link v-if="settings['team:create']" to="/team/create" class="forge-button-secondary p-4 sm:h-36 inline-flex sm:flex-col items-center sm:justify-center gap-4">
+                    <router-link v-if="user.admin || settings['team:create']" to="/team/create" class="forge-button-secondary p-4 sm:h-36 inline-flex sm:flex-col items-center sm:justify-center gap-4">
                         <UserGroupIcon class="w-10" />
                         Create a new team
                     </router-link>
@@ -40,7 +40,7 @@ export default {
         InboxInIcon
     },
     computed: {
-        ...mapState('account',['settings']),
+        ...mapState('account',['settings','user']),
     },
     data() {
         return {

--- a/frontend/src/pages/help/routes.js
+++ b/frontend/src/pages/help/routes.js
@@ -2,6 +2,7 @@ import { SupportIcon } from '@heroicons/vue/outline'
 
 export default [
     {
+        path: "/help",
         link: "https://github.com/flowforge/flowforge/tree/main/docs",
         external: true,
         profileLink: true,


### PR DESCRIPTION
As `user:team:auto-create` and `team:create` now both default to false, when the initial admin user logs in for the first time they are told to ask an admin to create a team for them. This is a dead-end as we don't have the tools for admins to create teams yet.

This PR fixes that so that an admin user is always presented the 'create team' button if they login and don't have a team.