### PR TITLE
Remove /account/security/sessions placeholder

### DIFF
--- a/frontend/src/pages/account/Security.vue
+++ b/frontend/src/pages/account/Security.vue
@@ -11,7 +11,7 @@
 import SectionSideMenu from '@/components/SectionSideMenu'
 const sideNavigation = [
     { name: "Password", path: "/account/security/password" },
-    { name: "Sessions", path: "/account/security/sessions" }
+    // { name: "Sessions", path: "/account/security/sessions" }
 ]
 
 

--- a/frontend/src/pages/account/routes.js
+++ b/frontend/src/pages/account/routes.js
@@ -2,7 +2,7 @@ import Account from "@/pages/account/index.vue"
 import AccountSettings from "@/pages/account/Settings.vue"
 import AccountSecurity from "@/pages/account/Security.vue"
 import AccountSecurityChangePassword from "@/pages/account/Security/ChangePassword.vue"
-import AccountSecuritySessions from "@/pages/account/Security/Sessions.vue"
+// import AccountSecuritySessions from "@/pages/account/Security/Sessions.vue"
 import AccountTeams from "@/pages/account/Teams/index.vue"
 import AccountTeamTeams from "@/pages/account/Teams/Teams.vue"
 import AccountTeamInvitations from "@/pages/account/Teams/Invitations.vue"
@@ -56,7 +56,7 @@ export default [
             ]},
             { path: 'security', component: AccountSecurity, redirect: '/account/security/password', children: [
                 { path: 'password', component: AccountSecurityChangePassword },
-                { path: 'sessions', component: AccountSecuritySessions }
+                // { path: 'sessions', component: AccountSecuritySessions }
             ]}
         ],
     },


### PR DESCRIPTION
This was a placeholder page were we would list the active login sessions and allow a user to expire them.

This was put in place to test/validate the sidebar navigation structure, but the login session work hasn't been done to populate it with anything.

This PR removes the pane from the view. It will come back as/when we look at #85 
