### PR TITLE
Remove Add To Existing Team option in create user view

### DIFF
--- a/frontend/src/pages/admin/Users/createUser.vue
+++ b/frontend/src/pages/admin/Users/createUser.vue
@@ -13,7 +13,7 @@
                 <FormRow id="createDefaultTeam" v-model="input.createDefaultTeam" type="checkbox">Create personal team
                     <template v-slot:description>A user needs to be in a team to create projects</template>
                 </FormRow>
-                <FormRow v-model="input.addToTeam">Add to existing team</FormRow>
+                <!-- <FormRow v-model="input.addToTeam">Add to existing team</FormRow> -->
                 <button type="button" :disabled="!formValid" @click="createUser" class="forge-button">
                     Create user
                 </button>


### PR DESCRIPTION
The Admin Create User form has the checkbox to create a personal team for the user.

It also had an input where you could enter an existing team to add them to - but the input had not been implemented and did nothing.

This PR hides the input for the time being.