### PR TITLE
Allow stack properties to have descriptions

### DIFF
--- a/frontend/src/pages/admin/Stacks/dialogs/AdminStackEditDialog.vue
+++ b/frontend/src/pages/admin/Stacks/dialogs/AdminStackEditDialog.vue
@@ -9,7 +9,10 @@
                 <FormRow v-model="input.name" :error="errors.name" :disabled="editDisabled">Name</FormRow>
                 <FormRow v-model="input.active" type="checkbox">Active</FormRow>
                 <template v-for="(prop) in stackProperties" :key="prop.name">
-                    <FormRow v-model="input.properties[prop.name]" :error="errors[prop.name]" :disabled="editDisabled">{{prop.label}}</FormRow>
+                    <FormRow v-model="input.properties[prop.name]" :error="errors[prop.name]" :disabled="editDisabled">
+                        {{prop.label}}
+                        <template v-if="prop.description" #description>{{prop.description}}</template>
+                    </FormRow>
                 </template>
             </form>
         </template>
@@ -104,6 +107,7 @@ export default {
                 return {
                     name: key,
                     label: value.label,
+                    description: value.description,
                     invalidMessage: value.invalidMessage || 'Invalid',
                     validator: new RegExp(value.validate)
                 }


### PR DESCRIPTION
To improve the usability of creating stacks, the driver-defined stack properties can now include a `description` field that is presented in the Create Stack dialog:

<img width="359" alt="image" src="https://user-images.githubusercontent.com/51083/167823195-27f31509-e127-4c32-ae7b-e4751c72a0e3.png">

A separate PR is incoming to add descriptions to the localfs stack.