### PR TITLE
Add click-outside directive to team switcher to ensure it closes

### DIFF
--- a/frontend/src/components/SideTeamSelection.vue
+++ b/frontend/src/components/SideTeamSelection.vue
@@ -7,8 +7,8 @@
                 <h5>{{ team.name }}</h5>
             </div>
         </div>
-        <SwitchHorizontalIcon :class="{'active': teamSelectionOpen }" @click="toggleList()"/>
-        <ul :class="{'active': teamSelectionOpen }">
+        <SwitchHorizontalIcon :class="{'active': teamSelectionOpen }" @click="toggleList()" />
+        <ul v-if="teamSelectionOpen" :class="{'active': teamSelectionOpen }" v-click-outside="close" >
             <li class="ff-nav-item"><label>Team Selection</label></li>
             <nav-item v-for="t in teams" :key="t.id" :label="t.name" :avatar="t?.avatar" @click="selectTeam(t);toggleList()"></nav-item>
             <nav-item label="Create Team" :icon="plusIcon" @click="createTeam"></nav-item>
@@ -57,6 +57,9 @@ export default {
                 name: 'CreateTeam'
             })
             this.toggleList()
+        },
+        close () {
+            this.teamSelectionOpen = false
         }
     }
 }


### PR DESCRIPTION
This adds the new `click-outside` directive to the team switcher to ensure it closes if you click away from it.