### PR TITLE
docs: Render docs of running instance under /docs

### DIFF
--- a/forge/routes/docs/index.js
+++ b/forge/routes/docs/index.js
@@ -1,0 +1,45 @@
+var MarkdownIt = require('markdown-it'), md = new MarkdownIt();
+const path = require('path')
+const { stat } = require('fs')
+const { readFile } = require('fs/promises')
+
+const docsBasePath = path.normalize(path.join(__dirname, "..", "..", "..", "docs"))
+const indexFile = "README.md"
+
+// User requests are unsafe and need to be validated so there's no path
+// traversal or related issues.
+function safeDocRequestPath(unsafeSuffix) {
+	  var safeSuffix = path.normalize(unsafeSuffix).replace(/^(\.\.(\/|\\|$))+/, '');
+
+	  // after the call to normalize() there should be no more path traversal
+	  return path.join(docsBasePath, safeSuffix);
+}
+
+/**
+ * Render documentation from this repository locally. So users always have a
+ * rendered version at hand.
+ *
+ * - /docs
+ *
+ * @namespace docs
+ * @memberof ???
+ */
+module.exports = async function (app) {
+	app.get('/*', async (request, response) => {
+		const cleanPath = safeDocRequestPath(request.params["*"])
+
+		// Assume rendering of the index is requested
+		let mdFile = mdFile = "${cleanPath}.md"
+		let mdFile = path.join(cleanPath, indexFile)
+		await stat(mdFile, (err, statResult) => {
+			if (!err) {
+			}
+		})
+
+		const data = await readFile(mdFile, { encoding: 'utf8' });
+
+		response
+			.type('text/html')
+			.send(md.render(data))
+	})
+}

--- a/forge/routes/index.js
+++ b/forge/routes/index.js
@@ -18,5 +18,7 @@ module.exports = fp(async function (app, opts, done) {
     await app.register(require('./setup'), { logLevel: app.config.logging.http })
     await app.register(require('./storage'), { prefix: '/storage', logLevel: app.config.logging.http })
     await app.register(require('./logging'), { prefix: '/logging', logLevel: app.config.logging.http })
+    await app.register(require('./docs'), { prefix: '/docs', logLevel: app.config.logging.http })
+    await app.register
     done()
 })

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "jsonwebtoken": "^8.5.1",
         "lottie-web-vue": "^2.0.6",
         "lru-cache": "^7.14.0",
+        "markdown-it": "^13.0.1",
         "marked": "^4.1.1",
         "moment": "^2.29.4",
         "mqtt": "^4.3.7",


### PR DESCRIPTION
While the repository always comes with docs, these aren't rendered. If FlowForge is either outdated or in an environment without internet access it's hard to read what's contained. With this change it's rendered under /docs as if it were `flowforge.com/docs`.