### PR TITLE
DOCS: Encourage users to click through to "first run" after initial setup

### DIFF
--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -152,7 +152,7 @@ Or to run as a service:
 
 Once FlowForge is started, you will be ready to perform the first run setup.
 
-Please, follow [this guide](../first-run.md) to continue.
+Follow [this guide](../first-run.md) to continue.
 
 ## Setting up Mosquitto (optional)
 


### PR DESCRIPTION
closes #1401

## Description

Remove the link to the newly created FlowForge instance leaving only the link to "First Run Setup" (where the user will find the link to the newly created FlowForge instance) 

This reduces the "sources of truth" and encourages the user to follow the guide.

## Related Issue(s)

#1401

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

