### PR TITLE
Navigate to instance settings from stack update button

### DIFF
--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -42,7 +42,7 @@
                         <td class="flex items-center">
                             <div class="py-2 flex-grow">{{ instance.projectType?.name || 'none' }} / {{ instance.stack?.label || instance.stack?.name || 'none' }}</div>
                             <div v-if="instance.stack?.replacedBy">
-                                <ff-button size="small" to="./settings/danger">Update</ff-button>
+                                <ff-button size="small" to="./settings/general">Update</ff-button>
                             </div>
                         </td>
                     </tr>

--- a/frontend/src/pages/instance/Settings/General.vue
+++ b/frontend/src/pages/instance/Settings/General.vue
@@ -15,11 +15,6 @@
 
         <FormRow v-model="input.stackDescription" type="uneditable">
             Stack
-            <template #append>
-                <div v-if="project.stack && project.stack.replacedBy">
-                    <ff-button size="small" to="./danger">Update</ff-button>
-                </div>
-            </template>
         </FormRow>
         <FormRow v-model="input.templateName" type="uneditable">
             Template


### PR DESCRIPTION
Fixes #1898

## Description

The 'update' button on the instance overview page now takes you to `/settings/overview` - not the danger page that was removed a couple releases ago.

On the `/settings/overview` page I've removed the update button as that was also going to the danger page, whereas now the real button is on the same screen. (See the linked issue for what I mean...)

I tried a few variations of replacing the button with some notification that an update was available but nothing quite worked. Rather than spin my wheels on that, I've removed it entirely.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

