### PR TITLE
Add description of Agent and FF Cloud to docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,18 +17,25 @@ Node-RED application development and delivery.
 
 ## Device Agent
 
+The [Device Agent](./device-agent/introduction.md) allows you to manage Node-RED instances running on remote Devices. A Device runs a software agent that connects back to FlowFuse in order to receive updates.
+
 - [Install the Device Agent](./device-agent/install.md) - Install the Device Agent on your own hardware to remotely manage your Node-RED instances.
-- [Registering your Device](./device-agent/register.md) - Connect with Device with FlowFuse.
+- [Registering your Device](./device-agent/register.md) - Connecting your Device to the FlowFuse platform.
 - [Deploying flows to your Device](./device-agent/deploy.md) - Learn how to remotely deploy flows to your Device.
 - [Editing flows on your Device](./device-agent/deploy.md) - Setup "Developer Mode" to enable editing of your flows, directly on your Device.
 
 ## FlowFuse Cloud
- - [FlowFuse Cloud](./cloud/) - find out how we've configured FlowFuse for FlowFuse Cloud.
+
+[FlowFuse Cloud](./cloud/introduction.md) is our hosted service allowing users to sign-up and start creating Node-RED instances without having to install and manage their own instance of FlowFuse.
+
  - [Network Connections](./cloud/introduction/#network-connections) - Details what connections can and cannot be established to Node-RED instances running in FlowFuse Cloud.
  - [Single Sign On](./cloud/introduction/#single-sign-on) - FlowFuse supports configuring SAML-based Single Sign-On for particular email domains. Contact us to configure for your team.
  - [Billing](./cloud/billing.md) - find out how we've configured FlowFuse for FlowFuse Cloud.
 
 ## FlowFuse Self-Hosted
+
+You can run the FlowFuse platform for yourself. This guide will help you get setup
+in no time.
 
 - [Installing FlowFuse](./install/introduction.md) - how to install the platform
 - [Upgrade your FlowFuse Instance](./upgrade/README.md)

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -3,4 +3,5 @@ navGroup: FlowFuse Self-Hosted
 navOrder: 3
 navTitle: Administering FlowFuse
 redirect: /docs/admin/introduction
+layout: redirect
 ---

--- a/docs/cloud/README.md
+++ b/docs/cloud/README.md
@@ -3,6 +3,7 @@ navGroup: FlowFuse Cloud
 navOrder: 3
 navTitle: FlowFuse Cloud
 redirect: /docs/cloud/introduction
+layout: redirect
 tags:
   - noDropdown
 ---

--- a/docs/community-support.md
+++ b/docs/community-support.md
@@ -3,4 +3,5 @@ navGroup: Support
 navOrder: 1
 navTitle: Community Support
 redirect: https://community.flowfuse.com/
+layout: redirect
 ---

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -2,4 +2,5 @@
 navGroup: Contributing
 navTitle: Contributing to FlowFuse
 redirect: /docs/contribute/introduction
+layout: redirect
 ---

--- a/docs/device-agent/README.md
+++ b/docs/device-agent/README.md
@@ -2,6 +2,7 @@
 navGroup: Device Agent
 navTitle: Device Agent
 redirect: /docs/device-agent/introduction
+layout: redirect
 navOrder: 1
 tags:
   - noDropdown

--- a/docs/hardware/README.md
+++ b/docs/hardware/README.md
@@ -2,6 +2,7 @@
 navGroup: Device Agent
 navTitle: Hardware Guides
 redirect: /docs/hardware/introduction
+layout: redirect
 navOrder: 2
 tags:
   - noDropdown

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -2,5 +2,6 @@
 navGroup: FlowFuse Self-Hosted
 navTitle: Installing FlowFuse
 redirect: /docs/install/introduction
+layout: redirect
 navOrder: 1
 ---

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -3,4 +3,5 @@ navGroup: FlowFuse User Manuals
 navOrder: 3
 navTitle: Migrating a Node-RED project to FlowFuse
 redirect: /docs/migration/introduction
+layout: redirect
 ---

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -3,4 +3,5 @@ navGroup: FlowFuse User Manuals
 navOrder: 1
 navTitle: Using FlowFuse
 redirect: /docs/user/introduction
+layout: redirect
 ---


### PR DESCRIPTION
## Description

Improve docs index by including a one liner description of the device agent and FF Cloud.

Also fixes a link into the FF Cloud docs because the redirects on `/docs/cloud` -> `/docs/cloud/introduction` isn't working for some reason (which I'll look at separately)