### PR TITLE
Revert redirects as it breaks TOC for some reason

### DIFF
--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -2,7 +2,5 @@
 navGroup: FlowFuse Self-Hosted
 navOrder: 3
 navTitle: Administering FlowFuse
-redirect:
-  to: /docs/admin/introduction
-layout: redirect
+redirect: /docs/admin/introduction
 ---

--- a/docs/cloud/README.md
+++ b/docs/cloud/README.md
@@ -2,9 +2,7 @@
 navGroup: FlowFuse Cloud
 navOrder: 3
 navTitle: FlowFuse Cloud
-redirect:
-  to: /docs/cloud/introduction
-layout: redirect
+redirect: /docs/cloud/introduction
 tags:
   - noDropdown
 ---

--- a/docs/community-support.md
+++ b/docs/community-support.md
@@ -2,7 +2,5 @@
 navGroup: Support
 navOrder: 1
 navTitle: Community Support
-redirect: 
-  to: https://community.flowfuse.com/
-layout: redirect
+redirect: https://community.flowfuse.com/
 ---

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -1,7 +1,5 @@
 ---
 navGroup: Contributing
 navTitle: Contributing to FlowFuse
-redirect:
-  to: /docs/contribute/introduction
-layout: redirect
+redirect: /docs/contribute/introduction
 ---

--- a/docs/device-agent/README.md
+++ b/docs/device-agent/README.md
@@ -1,9 +1,7 @@
 ---
 navGroup: Device Agent
 navTitle: Device Agent
-redirect:
-  to: /docs/device-agent/introduction
-layout: redirect
+redirect: /docs/device-agent/introduction
 navOrder: 1
 tags:
   - noDropdown

--- a/docs/hardware/README.md
+++ b/docs/hardware/README.md
@@ -2,7 +2,6 @@
 navGroup: Device Agent
 navTitle: Hardware Guides
 redirect: /docs/hardware/introduction
-layout: redirect
 navOrder: 2
 tags:
   - noDropdown

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,8 +1,6 @@
 ---
 navGroup: FlowFuse Self-Hosted
 navTitle: Installing FlowFuse
-redirect:
-  to: /docs/install/introduction
-layout: redirect
+redirect: /docs/install/introduction
 navOrder: 1
 ---

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -2,7 +2,5 @@
 navGroup: FlowFuse User Manuals
 navOrder: 3
 navTitle: Migrating a Node-RED project to FlowFuse
-redirect:
-  to: /docs/migration/introduction
-layout: redirect
+redirect: /docs/migration/introduction
 ---

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -2,7 +2,5 @@
 navGroup: FlowFuse User Manuals
 navOrder: 1
 navTitle: Using FlowFuse
-redirect:
-  to: /docs/user/introduction
-layout: redirect
+redirect: /docs/user/introduction
 ---


### PR DESCRIPTION
## Description

For some unknown reason (currently) trying to fix the redirects on these pages caused every link in the Table Of Contents in the sidebar of the website to get `[object Object]` as their url.

I am baffled how these things could be related - but can confirm that reverting the change fixes things. Will need to investigate how to achieve these redirects, but reverting now to get the website building again.