### PR TITLE
Adds tooltip clarification to the "Editor Access" button for a Device

### DIFF
--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -38,7 +38,7 @@
                                 <ExternalLinkIcon />
                             </span>
                         </a>
-                        <button v-else data-action="open-editor" class="ff-btn ff-btn--secondary" disabled>
+                        <button v-else v-ff-tooltip:left="device.mode === 'developer' ? 'Please enable \'Editor Access\' in the \'Developer Mode\' tab' : '\'Developer Mode\' must be enabled'" data-action="open-editor" class="ff-btn ff-btn--secondary" disabled>
                             Editor Disabled
                             <span class="ff-btn--icon ff-btn--icon-right">
                                 <ExternalLinkIcon />


### PR DESCRIPTION
## Description

As per title, added to offer clarification the steps a user needs to take in order to Enable Editor Access.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)

Just adding a tooltip, no need for additional tests