### PR TITLE
metrics: Expose `/metrics` with Prometheus data

### DIFF
--- a/docs/admin/telemetry.md
+++ b/docs/admin/telemetry.md
@@ -135,6 +135,7 @@ telemetry:
   backend:
     sentry:
       dsn: <dsn-key>
+    prometheus: true
 ```
 #### Telemetry During Build
 

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -78,8 +78,8 @@ module.exports = async (options = {}) => {
         logger: loggerConfig
     })
 
-  	const metricsPlugin = require('fastify-metrics');
-    await server.register(metricsPlugin, { endpoint: '/metrics' });
+    const metricsPlugin = require('fastify-metrics')
+    await server.register(metricsPlugin, { endpoint: '/metrics' })
 
     if (runtimeConfig.telemetry.backend?.sentry?.dsn) {
         server.register(require('@immobiliarelabs/fastify-sentry'), {

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -78,8 +78,10 @@ module.exports = async (options = {}) => {
         logger: loggerConfig
     })
 
-    const metricsPlugin = require('fastify-metrics')
-    await server.register(metricsPlugin, { endpoint: '/metrics' })
+    if (runtimeConfig.telemetry.backend?.prometheus) {
+        const metricsPlugin = require('fastify-metrics')
+        await server.register(metricsPlugin, { endpoint: '/metrics' })
+    }
 
     if (runtimeConfig.telemetry.backend?.sentry?.dsn) {
         server.register(require('@immobiliarelabs/fastify-sentry'), {

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -78,6 +78,9 @@ module.exports = async (options = {}) => {
         logger: loggerConfig
     })
 
+  	const metricsPlugin = require('fastify-metrics');
+    await server.register(metricsPlugin, { endpoint: '/metrics' });
+
     if (runtimeConfig.telemetry.backend?.sentry?.dsn) {
         server.register(require('@immobiliarelabs/fastify-sentry'), {
             dsn: runtimeConfig.telemetry.backend.sentry.dsn,

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
                 "cronosjs": "^1.7.1",
                 "dotenv": "^16.3.1",
                 "fastify": "^4.18.0",
+                "fastify-metrics": "^10.3.2",
                 "fastify-plugin": "^4.5.0",
                 "handlebars": "^4.7.7",
                 "hashids": "^2.3.0",
@@ -7025,6 +7026,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/bintrees": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+            "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
+        },
         "node_modules/bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -10405,6 +10411,18 @@
                 "secure-json-parse": "^2.5.0",
                 "semver": "^7.5.0",
                 "toad-cache": "^3.2.0"
+            }
+        },
+        "node_modules/fastify-metrics": {
+            "version": "10.3.2",
+            "resolved": "https://registry.npmjs.org/fastify-metrics/-/fastify-metrics-10.3.2.tgz",
+            "integrity": "sha512-02SEIGH02zfguqRMho0LB8L7YVAj5cIgWM0iqZslIErqaUWc1iHVAOC+YXYG3S2DZU6VHdFaMyuxjEOCQHAETA==",
+            "dependencies": {
+                "fastify-plugin": "^4.3.0",
+                "prom-client": "^14.2.0"
+            },
+            "peerDependencies": {
+                "fastify": ">=4"
             }
         },
         "node_modules/fastify-plugin": {
@@ -17165,6 +17183,17 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/prom-client": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+            "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+            "dependencies": {
+                "tdigest": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/promise-inflight": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -19707,6 +19736,14 @@
             "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/tdigest": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+            "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+            "dependencies": {
+                "bintrees": "1.0.2"
             }
         },
         "node_modules/terser": {
@@ -26473,6 +26510,11 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
         },
+        "bintrees": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+            "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
+        },
         "bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -29000,6 +29042,15 @@
                 "secure-json-parse": "^2.5.0",
                 "semver": "^7.5.0",
                 "toad-cache": "^3.2.0"
+            }
+        },
+        "fastify-metrics": {
+            "version": "10.3.2",
+            "resolved": "https://registry.npmjs.org/fastify-metrics/-/fastify-metrics-10.3.2.tgz",
+            "integrity": "sha512-02SEIGH02zfguqRMho0LB8L7YVAj5cIgWM0iqZslIErqaUWc1iHVAOC+YXYG3S2DZU6VHdFaMyuxjEOCQHAETA==",
+            "requires": {
+                "fastify-plugin": "^4.3.0",
+                "prom-client": "^14.2.0"
             }
         },
         "fastify-plugin": {
@@ -33839,6 +33890,14 @@
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
         },
+        "prom-client": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+            "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+            "requires": {
+                "tdigest": "^0.1.1"
+            }
+        },
         "promise-inflight": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -35799,6 +35858,14 @@
                     "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
                     "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
                 }
+            }
+        },
+        "tdigest": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+            "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+            "requires": {
+                "bintrees": "1.0.2"
             }
         },
         "terser": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "cronosjs": "^1.7.1",
         "dotenv": "^16.3.1",
         "fastify": "^4.18.0",
+        "fastify-metrics": "^10.3.2",
         "fastify-plugin": "^4.5.0",
         "handlebars": "^4.7.7",
         "hashids": "^2.3.0",


### PR DESCRIPTION
To get requests per seconds data for FlowFuse a new package is added that leverages fastify to get data for the Node.JS runtime and request data.

For example (not exhaustive):
1. Request per endpoint with timing
2. GC timings
3. Memory utilization

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

