### PR TITLE
config: Prometheus config is now a map

### DIFF
--- a/docs/admin/telemetry.md
+++ b/docs/admin/telemetry.md
@@ -135,7 +135,8 @@ telemetry:
   backend:
     sentry:
       dsn: <dsn-key>
-    prometheus: true
+    prometheus:
+      enabled: true
 ```
 #### Telemetry During Build
 

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -78,7 +78,7 @@ module.exports = async (options = {}) => {
         logger: loggerConfig
     })
 
-    if (runtimeConfig.telemetry.backend?.prometheus) {
+    if (runtimeConfig.telemetry.backend?.prometheus?.enabled) {
         const metricsPlugin = require('fastify-metrics')
         await server.register(metricsPlugin, { endpoint: '/metrics' })
     }


### PR DESCRIPTION
When working on the helm chart, I noticed that using a plain boolean will make it harder long term to add configuration to prometheus. This is cheap to correct now, expensive to do so later.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

