### PR TITLE
Remove not null constraint on ProjectSnapshot.ProjectId column

### DIFF
--- a/forge/db/migrations/20231005-01-update-projectSnapshot-constraint.js
+++ b/forge/db/migrations/20231005-01-update-projectSnapshot-constraint.js
@@ -7,19 +7,21 @@ module.exports = {
     up: async (context) => {
         const dialect = context.sequelize.options.dialect
         if (dialect === 'sqlite') {
-            // Disable foreign_keys so that when sequelize does its sqlite-specific
-            // copy/drop workaround for renaming columns, we don't cause cascade
-            // delete on any other tables
-            await context.sequelize.query('PRAGMA foreign_keys = 0;')
-        }
-
-        await context.changeColumn('ProjectSnapshots', 'ProjectId', {
-            type: DataTypes.UUID,
-            allowNull: true
-        })
-
-        if (dialect === 'sqlite') {
-            await context.sequelize.query('PRAGMA foreign_keys = 1;')
+            // We have to do this the hard way due to limitations of sqlite and
+            // changing table constraints. The changeColumn approach causes all
+            // table constraints to be lost. We can keep them on the one column
+            // we're modifying, but it also strips them for the others.
+            await context.sequelize.query('pragma writable_schema=1;')
+            const sql = "update SQLITE_MASTER set sql = replace(sql, '`ProjectId` UUID NOT NULL', '`ProjectId` UUID') where name = 'ProjectSnapshots' and type = 'table';"
+            context.sequelize.query(sql)
+            await context.sequelize.query('pragma writable_schema=0;')
+        } else {
+            // Postgres allows us to modify a constraint without breaking all
+            // the other properties
+            await context.changeColumn('ProjectSnapshots', 'ProjectId', {
+                type: DataTypes.UUID,
+                allowNull: true
+            })
         }
     },
     down: async (context) => {

--- a/forge/db/migrations/20231005-01-update-projectSnapshot-constraint.js
+++ b/forge/db/migrations/20231005-01-update-projectSnapshot-constraint.js
@@ -9,7 +9,7 @@ module.exports = {
         if (dialect === 'sqlite') {
             // Disable foreign_keys so that when sequelize does its sqlite-specific
             // copy/drop workaround for renaming columns, we don't cause cascade
-            // delete on the Teams table
+            // delete on any other tables
             await context.sequelize.query('PRAGMA foreign_keys = 0;')
         }
 

--- a/forge/db/migrations/20231005-01-update-projectSnapshot-constraint.js
+++ b/forge/db/migrations/20231005-01-update-projectSnapshot-constraint.js
@@ -1,0 +1,27 @@
+/**
+ * Remove not null on ProjectSnapshots.ProjectId
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        const dialect = context.sequelize.options.dialect
+        if (dialect === 'sqlite') {
+            // Disable foreign_keys so that when sequelize does its sqlite-specific
+            // copy/drop workaround for renaming columns, we don't cause cascade
+            // delete on the Teams table
+            await context.sequelize.query('PRAGMA foreign_keys = 0;')
+        }
+
+        await context.changeColumn('ProjectSnapshots', 'ProjectId', {
+            type: DataTypes.UUID,
+            allowNull: true
+        })
+
+        if (dialect === 'sqlite') {
+            await context.sequelize.query('PRAGMA foreign_keys = 1;')
+        }
+    },
+    down: async (context) => {
+    }
+}


### PR DESCRIPTION
## Description

The `ProjectSnapshot.ProjectId` column has got a `not null` constraint applied. This is preventing Device/Application snapshots from being created in *some* environments.

This constraint is not set in all environments.

 - Local sqlite, clean db - no constraint
 - Local sqlite, existing db that has run through migrations - constaint applied
 - Staging Postgres - no constraint
 - Production Postgres - constraint


I have tested this migration against:

 - sqlite with the constraint already present
 - sqlite without the constraint
 - postgres with the constraint
 - postgres without the constraint


