### PR TITLE
Pin fastify to 4.23.0 due to HEAD bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "bcrypt": "^5.1.0",
                 "cronosjs": "^1.7.1",
                 "dotenv": "^16.3.1",
-                "fastify": "^4.18.0",
+                "fastify": "4.23.2",
                 "fastify-metrics": "^10.3.2",
                 "fastify-plugin": "^4.5.0",
                 "handlebars": "^4.7.7",
@@ -11338,9 +11338,9 @@
             }
         },
         "node_modules/find-my-way": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.6.2.tgz",
-            "integrity": "sha512-0OjHn1b1nCX3eVbm9ByeEHiscPYiHLfhei1wOUU9qffQkk98wE0Lo8VrVYfSGMgnSnDh86DxedduAnBf4nwUEw==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.7.0.tgz",
+            "integrity": "sha512-+SrHpvQ52Q6W9f3wJoJBbAQULJuNEEQwBvlvYwACDhBTLOTMiQ0HYWh4+vC3OivGP2ENcTI1oKlFA2OepJNjhQ==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-querystring": "^1.0.0",
@@ -30458,9 +30458,9 @@
             }
         },
         "find-my-way": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.6.2.tgz",
-            "integrity": "sha512-0OjHn1b1nCX3eVbm9ByeEHiscPYiHLfhei1wOUU9qffQkk98wE0Lo8VrVYfSGMgnSnDh86DxedduAnBf4nwUEw==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.7.0.tgz",
+            "integrity": "sha512-+SrHpvQ52Q6W9f3wJoJBbAQULJuNEEQwBvlvYwACDhBTLOTMiQ0HYWh4+vC3OivGP2ENcTI1oKlFA2OepJNjhQ==",
             "requires": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-querystring": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "bcrypt": "^5.1.0",
         "cronosjs": "^1.7.1",
         "dotenv": "^16.3.1",
-        "fastify": "^4.18.0",
+        "fastify": "4.23.2",
         "fastify-metrics": "^10.3.2",
         "fastify-plugin": "^4.5.0",
         "handlebars": "^4.7.7",


### PR DESCRIPTION
## Description

Fastify 4.24.0 has introduced a regression (due to https://github.com/fastify/fastify/pull/5078 I think) that causes the forge app to fail to start with the error:

```
Failed to start: Error: Method 'HEAD' already declared for route '/api/v1/devices/:/editor/proxy/*' with constraints '{}'
```

This reverts the module to the last working version - and pins it for now. We can unpin once the issue is confirmed and fix released.

I'll be raising an issue against fastify tomorrow - just need to produce a clear reproduction for them - will link back here for reference.