### PR TITLE
Unpin fastify

### DIFF
--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -192,6 +192,9 @@ module.exports = async function (app) {
     app.route({
         method: 'GET', // only GET is permitted for WS
         url: '/proxy/*',
+        // By default, fastify adds a HEAD route for each GET route. Given
+        // we want our own HEAD route handler, we tell fastify not to do it here.
+        exposeHeadRoute: false,
         // Set 'allowAnonymous' as we don't want to return the standard API
         // response object. Instead, we will use the preHandler to detect
         // there's no session user and redirect to the device overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "bcrypt": "^5.1.0",
                 "cronosjs": "^1.7.1",
                 "dotenv": "^16.3.1",
-                "fastify": "4.23.2",
+                "fastify": "^4.24.0",
                 "fastify-metrics": "^10.3.2",
                 "fastify-plugin": "^4.5.0",
                 "handlebars": "^4.7.7",
@@ -11146,9 +11146,9 @@
             }
         },
         "node_modules/fastify": {
-            "version": "4.23.2",
-            "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.23.2.tgz",
-            "integrity": "sha512-WFSxsHES115svC7NrerNqZwwM0UOxbC/P6toT9LRHgAAFvG7o2AN5W+H4ihCtOGuYXjZf4z+2jXC89rVEoPWOA==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.24.0.tgz",
+            "integrity": "sha512-6Uu2cCAV1UgexPnWKchgRt77lng9ivNmyFhPMcgUbJ4VaVBE1l6aYluiYZiVsgOBFpHrmdj7FD6n1aHswln4yQ==",
             "dependencies": {
                 "@fastify/ajv-compiler": "^3.5.0",
                 "@fastify/error": "^3.2.0",
@@ -11157,7 +11157,7 @@
                 "avvio": "^8.2.1",
                 "fast-content-type-parse": "^1.0.0",
                 "fast-json-stringify": "^5.7.0",
-                "find-my-way": "^7.6.0",
+                "find-my-way": "^7.7.0",
                 "light-my-request": "^5.9.1",
                 "pino": "^8.12.0",
                 "process-warning": "^2.2.0",
@@ -30306,9 +30306,9 @@
             "dev": true
         },
         "fastify": {
-            "version": "4.23.2",
-            "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.23.2.tgz",
-            "integrity": "sha512-WFSxsHES115svC7NrerNqZwwM0UOxbC/P6toT9LRHgAAFvG7o2AN5W+H4ihCtOGuYXjZf4z+2jXC89rVEoPWOA==",
+            "version": "4.24.0",
+            "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.24.0.tgz",
+            "integrity": "sha512-6Uu2cCAV1UgexPnWKchgRt77lng9ivNmyFhPMcgUbJ4VaVBE1l6aYluiYZiVsgOBFpHrmdj7FD6n1aHswln4yQ==",
             "requires": {
                 "@fastify/ajv-compiler": "^3.5.0",
                 "@fastify/error": "^3.2.0",
@@ -30317,7 +30317,7 @@
                 "avvio": "^8.2.1",
                 "fast-content-type-parse": "^1.0.0",
                 "fast-json-stringify": "^5.7.0",
-                "find-my-way": "^7.6.0",
+                "find-my-way": "^7.7.0",
                 "light-my-request": "^5.9.1",
                 "pino": "^8.12.0",
                 "process-warning": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "bcrypt": "^5.1.0",
         "cronosjs": "^1.7.1",
         "dotenv": "^16.3.1",
-        "fastify": "4.23.2",
+        "fastify": "^4.24.0",
         "fastify-metrics": "^10.3.2",
         "fastify-plugin": "^4.5.0",
         "handlebars": "^4.7.7",


### PR DESCRIPTION
## Description

Follow-up to #2931 , this updates our route handler to avoid the issue with fastify 4.24.0.

In summary, by default, whenever you register a GET route, fastify will add a default HEAD route to match. If you don't want it to do that, you either set `exposeHeadRoute: false` or you register the HEAD route first.

In this instance, I've gone for the more explicit fix - setting the `exposeHeadRoute` property.

They have identified a bug where you should be able to register a HEAD route even if it matches one of these default HEAD routes - but we don't need to wait for that fix by using the setting above.
