### PR TITLE
Add Office365 to email examples

### DIFF
--- a/docs/install/email_providers.md
+++ b/docs/install/email_providers.md
@@ -19,3 +19,19 @@ email:
 ```
 
 Note: Gmail may require an app specific password to be created if you are using 2FA on the account you can set that up [here](https://security.google.com/settings/security/apppasswords)
+
+### Office365
+```yaml
+email:
+  enabled: true
+  debug: false
+  smtp:
+    host: smtp.office365.com,
+    secure: false
+    tls:
+      ciphers: "SSLv3",
+      rejectUnauthorized: false
+    auth:
+      user: [USERNAME]
+      pass: [PASSWORD]
+```


### PR DESCRIPTION
fixes https://github.com/FlowFuse/flowfuse/issues/2933

## Description

<!-- Describe your changes in detail -->
Need an example of Office365 setup

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/issues/2933

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

