### PR TITLE
Flow Blueprints mvp tidy

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -315,7 +315,7 @@ module.exports = {
             ha = null,
             sourceProject = null,
             sourceProjectOptions = {},
-            flowTemplate = null
+            flowBlueprint = null
         } = {}
     ) {
         if (!user) {
@@ -338,8 +338,8 @@ module.exports = {
         // Throws an exception if not allowed
         await team.checkInstanceTypeCreateAllowed(type)
 
-        if (sourceProject && flowTemplate) {
-            throw new ControllerError('invalid_request', 'Source Project and Flow Template cannot both be used')
+        if (sourceProject && flowBlueprint) {
+            throw new ControllerError('invalid_request', 'Source Project and Flow Blueprint cannot both be used')
         }
 
         if (sourceProject) {
@@ -421,8 +421,8 @@ module.exports = {
             }
             await instance.updateSetting(KEY_SETTINGS, newProjectSettings)
             await instance.updateSetting('credentialSecret', app.db.models.Project.generateCredentialSecret())
-            if (flowTemplate) {
-                await app.db.controllers.Project.applyFlowTemplate(instance, flowTemplate)
+            if (flowBlueprint) {
+                await app.db.controllers.Project.applyFlowBlueprint(instance, flowBlueprint)
             }
         }
 
@@ -640,10 +640,10 @@ module.exports = {
      * any existing flows and will merge any modules with those provided by the ProjectTemplate.
      * @param {*} app
      * @param {*} instance
-     * @param {*} flowTemplate
+     * @param {*} flowBlueprint
      */
-    applyFlowTemplate: async function (app, instance, flowTemplate) {
-        const flows = flowTemplate.flows || { flows: [], credentials: {} }
+    applyFlowBlueprint: async function (app, instance, flowBlueprint) {
+        const flows = flowBlueprint.flows || { flows: [], credentials: {} }
         if (flows.flows) {
             await app.db.controllers.StorageFlows.updateOrCreateForProject(instance, JSON.stringify(flows.flows))
         }
@@ -653,7 +653,7 @@ module.exports = {
             await app.db.controllers.StorageCredentials.updateOrCreateForProject(instance, encryptedCreds)
         }
 
-        const modules = flowTemplate.modules || {}
+        const modules = flowBlueprint.modules || {}
         for (const [moduleName, version] of Object.entries(modules)) {
             await app.db.controllers.Project.addProjectModule(instance, moduleName, version)
         }

--- a/forge/ee/db/views/FlowTemplate.js
+++ b/forge/ee/db/views/FlowTemplate.js
@@ -1,6 +1,6 @@
 module.exports = function (app) {
     app.addSchema({
-        $id: 'FlowTemplateSummary',
+        $id: 'FlowBlueprintSummary',
         type: 'object',
         properties: {
             id: { type: 'string' },
@@ -12,44 +12,44 @@ module.exports = function (app) {
             updatedAt: { type: 'string' }
         }
     })
-    function flowTemplateSummary (flowTemplate) {
+    function flowBlueprintSummary (blueprint) {
         return {
-            id: flowTemplate.hashid,
-            active: flowTemplate.active,
-            name: flowTemplate.name,
-            description: flowTemplate.description,
-            category: flowTemplate.category,
-            createdAt: flowTemplate.createdAt,
-            updatedAt: flowTemplate.updatedAt
+            id: blueprint.hashid,
+            active: blueprint.active,
+            name: blueprint.name,
+            description: blueprint.description,
+            category: blueprint.category,
+            createdAt: blueprint.createdAt,
+            updatedAt: blueprint.updatedAt
         }
     }
 
     app.addSchema({
-        $id: 'FlowTemplate',
+        $id: 'FlowBlueprint',
         type: 'object',
-        allOf: [{ $ref: 'FlowTemplateSummary' }],
+        allOf: [{ $ref: 'FlowBlueprintSummary' }],
         properties: {
             flows: { type: 'object', additionalProperties: true },
             modules: { type: 'object', additionalProperties: true }
         }
     })
-    function flowTemplate (flowTemplate) {
-        const result = flowTemplateSummary(flowTemplate)
-        result.flows = flowTemplate.flows
-        result.modules = flowTemplate.modules
+    function flowBlueprint (blueprint) {
+        const result = flowBlueprintSummary(blueprint)
+        result.flows = blueprint.flows
+        result.modules = blueprint.modules
         return result
     }
 
     app.addSchema({
-        $id: 'FlowTemplateSummaryList',
+        $id: 'FlowBlueprintSummaryList',
         type: 'array',
         items: {
-            $ref: 'FlowTemplateSummary'
+            $ref: 'FlowBlueprintSummary'
         }
     })
 
     return {
-        flowTemplate,
-        flowTemplateSummary
+        flowBlueprint,
+        flowBlueprintSummary
     }
 }

--- a/forge/ee/routes/index.js
+++ b/forge/ee/routes/index.js
@@ -13,7 +13,7 @@ module.exports = async function (app) {
     await app.register(require('./pipeline'), { prefix: '/api/v1', logLevel: app.config.logging.http })
     await app.register(require('./deviceEditor'), { prefix: '/api/v1/devices/:deviceId/editor', logLevel: app.config.logging.http })
 
-    await app.register(require('./flowTemplates'), { prefix: '/api/v1/flow-templates', logLevel: app.config.logging.http })
+    await app.register(require('./flowBlueprints'), { prefix: '/api/v1/flow-blueprints', logLevel: app.config.logging.http })
 
     if (app.license.get('tier') === 'enterprise') {
         await app.register(require('./ha'), { prefix: '/api/v1/projects/:projectId/ha', logLevel: app.config.logging.http })

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -128,7 +128,7 @@ module.exports = async function (app) {
                     applicationId: { type: 'string' },
                     projectType: { type: 'string' },
                     stack: { type: 'string' },
-                    flowTemplateId: { type: 'string' },
+                    flowBlueprintId: { type: 'string' },
                     template: { type: 'string' },
                     sourceProject: {
                         type: 'object',
@@ -159,19 +159,19 @@ module.exports = async function (app) {
         const projectStack = await app.db.models.ProjectStack.byId(request.body.stack)
         const projectTemplate = await app.db.models.ProjectTemplate.byId(request.body.template)
 
-        let flowTemplate
-        if (request.body.flowTemplateId) {
-            flowTemplate = await app.db.models.FlowTemplate.byId(request.body.flowTemplateId)
-            if (!flowTemplate) {
-                reply.code(400).send({ code: 'invalid_flow_template', error: 'Flow Template not found' })
+        let flowBlueprint
+        if (request.body.flowBlueprintId) {
+            flowBlueprint = await app.db.models.FlowTemplate.byId(request.body.flowBlueprintId)
+            if (!flowBlueprint) {
+                reply.code(400).send({ code: 'invalid_flow_blueprint', error: 'Flow Blueprint not found' })
                 return
             }
         }
         // Read in any source to copy from
         let sourceProject
         if (request.body.sourceProject?.id) {
-            if (flowTemplate) {
-                reply.code(400).send({ code: 'invalid_request', error: 'Cannot use both sourceProject and flowTemplate' })
+            if (flowBlueprint) {
+                reply.code(400).send({ code: 'invalid_request', error: 'Cannot use both sourceProject and flowBlueprintId' })
                 return
             }
             sourceProject = await app.db.models.Project.byId(request.body.sourceProject.id)
@@ -196,7 +196,7 @@ module.exports = async function (app) {
                     ha: request.body.ha,
                     sourceProject,
                     sourceProjectOptions: request.body.sourceProject?.options,
-                    flowTemplate
+                    flowBlueprint
                 }
             )
         } catch (err) {

--- a/frontend/src/api/flowBlueprints.js
+++ b/frontend/src/api/flowBlueprints.js
@@ -3,16 +3,16 @@ import paginateUrl from '../utils/paginateUrl.js'
 import client from './client.js'
 
 /**
- * Get all flow blueprints (formerly flow templates) from the backend
+ * Get all flow blueprints from the backend
  * @param {string} state - 'active' (default), 'all' or 'inactive'
  * @param {G} cursor
  * @param {number} limit
  * @returns [{ id:number, active:boolean, name:string, description:string, createdAt:string, updatedAt:string }]
  */
 const getFlowBlueprints = async (state = 'active', cursor, limit) => {
-    const url = paginateUrl('/api/v1/flow-templates', cursor, limit, null, { filter: state })
+    const url = paginateUrl('/api/v1/flow-blueprints', cursor, limit, null, { filter: state })
     return client.get(url).then(res => {
-        return res.data.templates
+        return res.data.blueprints
     })
 }
 export default {

--- a/frontend/src/api/instances.js
+++ b/frontend/src/api/instances.js
@@ -17,7 +17,8 @@ const create = async (options) => {
         const props = {
             'created-at': res.data.createdAt,
             'instance-stack': res.data.stack.id,
-            'instance-template': res.data.template.id
+            'instance-template': res.data.template.id,
+            'instance-blueprint': options.flowTemplateId
         }
         product.capture('$ff-instance-created', props, {
             team: res.data.team.id,

--- a/frontend/src/api/instances.js
+++ b/frontend/src/api/instances.js
@@ -9,16 +9,15 @@ import paginateUrl from '../utils/paginateUrl.js'
 import client from './client.js'
 
 const create = async (options) => {
-    // Backend calls these flow templates, UI refers to it as flow blueprints
-    options.flowTemplateId = options.flowBlueprintId
-    delete options.flowBlueprintId
-
+    if (options.flowBlueprintId === '') {
+        delete options.flowBlueprintId
+    }
     return client.post('/api/v1/projects', options).then(res => {
         const props = {
             'created-at': res.data.createdAt,
             'instance-stack': res.data.stack.id,
             'instance-template': res.data.template.id,
-            'instance-blueprint': options.flowTemplateId
+            'instance-blueprint': options.flowBlueprintId
         }
         product.capture('$ff-instance-created', props, {
             team: res.data.team.id,

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -11,7 +11,7 @@
         <!-- Form title -->
         <div class="mb-8 text-sm text-gray-500">
             <template v-if="creatingNew">
-                <template v-if="applicationSelection">
+                <template v-if="!creatingApplication || applicationSelection">
                     Let's get your new Node-RED instance setup in no time.
                 </template>
                 <template v-else-if="!isCopyProject">
@@ -209,7 +209,7 @@
                     <div class="flex flex-wrap gap-1 items-stretch">
                         <label class="w-full block text-sm font-medium text-gray-700 mb-1">Flow Blueprint</label>
                         <label class="text-sm text-gray-400">
-                            We have a collection of pre-built flow templates that you can use as a starting point.
+                            We have a collection of pre-built flow blueprints that you can use as a starting point.
                         </label>
                         <label v-if="errors.flowBlueprint" class="text-sm text-gray-400 mb-1">
                             {{ errors.flowBlueprint }}
@@ -222,8 +222,8 @@
                             <!-- Later this will be grouped by flowBlueprint.category -->
                             <ff-tile-selection-option
                                 value=""
-                                label="Blank"
-                                description="An empty flow"
+                                label="Blank Workspace"
+                                description="An empty workspace to create your flows in"
                             />
 
                             <ff-tile-selection-option

--- a/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
+++ b/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
@@ -3,9 +3,9 @@ const sinon = require('sinon')
 
 const TestModelFactory = require('../../../../../lib/TestModelFactory.js')
 
-const setup = require('../../setup')
+const setup = require('../../setup.js')
 
-describe('Flow Templates API', function () {
+describe('Flow Blueprints API', function () {
     const sandbox = sinon.createSandbox()
 
     const TestObjects = { tokens: {} }
@@ -46,10 +46,10 @@ describe('Flow Templates API', function () {
         sandbox.restore()
     })
 
-    async function createTemplate (body, token) {
+    async function createBlueprint (body, token) {
         const response = await app.inject({
             method: 'POST',
-            url: '/api/v1/flow-templates',
+            url: '/api/v1/flow-blueprints',
             body,
             cookies: { sid: token }
         })
@@ -59,10 +59,10 @@ describe('Flow Templates API', function () {
     let objectCount = 0
     const generateName = (prefix = 'object') => `${prefix}-${objectCount++}`
 
-    describe('Create Flow Templates', function () {
-        it('Admin can create a flow template', async function () {
-            const name = generateName('flow template')
-            const [statusCode, result] = await createTemplate({
+    describe('Create Flow Blueprints', function () {
+        it('Admin can create a flow blueprint', async function () {
+            const name = generateName('flow blueprint')
+            const [statusCode, result] = await createBlueprint({
                 name,
                 description: 'a flow',
                 active: true,
@@ -78,9 +78,9 @@ describe('Flow Templates API', function () {
             result.should.not.have.property('modules')
         })
 
-        it('Non-admin cannot create a flow template', async function () {
-            const [statusCode] = await createTemplate({
-                name: generateName('flow template'),
+        it('Non-admin cannot create a flow blueprint', async function () {
+            const [statusCode] = await createBlueprint({
+                name: generateName('flow blueprint'),
                 description: 'a flow',
                 active: true,
                 category: 'starter',
@@ -92,10 +92,10 @@ describe('Flow Templates API', function () {
     })
 
     describe('Get Flow Template', function () {
-        it('User can get flow template details', async function () {
-            const name = generateName('flow template')
-            const description = generateName('a flow template description')
-            const [statusCode, result] = await createTemplate({
+        it('User can get flow blueprint details', async function () {
+            const name = generateName('flow blueprint')
+            const description = generateName('a flow blueprint description')
+            const [statusCode, result] = await createBlueprint({
                 name,
                 description,
                 active: true,
@@ -107,7 +107,7 @@ describe('Flow Templates API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/flow-templates/${result.id}`,
+                url: `/api/v1/flow-blueprints/${result.id}`,
                 cookies: { sid: TestObjects.tokens.bob }
             })
             response.should.have.property('statusCode', 200)
@@ -122,42 +122,42 @@ describe('Flow Templates API', function () {
         })
     })
 
-    describe('List Flow Templates', function () {
+    describe('List Flow Blueprints', function () {
         before(async function () {
             // Clean up anything created by other tests so we have a known base line
             await app.db.models.FlowTemplate.destroy({ where: {} })
 
             for (let i = 0; i < 10; i++) {
-                await createTemplate({
-                    name: 'flowTemplate-' + i,
-                    // Only mark even-numbered templates as active
+                await createBlueprint({
+                    name: 'flowBlueprint-' + i,
+                    // Only mark even-numbered blueprints as active
                     active: (i % 2) === 0
                 }, TestObjects.tokens.alice)
             }
         })
 
-        it('Lists all active templates by default', async function () {
+        it('Lists all active blueprints by default', async function () {
             const response = await app.inject({
                 method: 'GET',
-                url: '/api/v1/flow-templates',
+                url: '/api/v1/flow-blueprints',
                 cookies: { sid: TestObjects.tokens.bob }
             })
             const result = response.json()
 
             result.should.have.property('count', 5)
-            const incorrectTemplates = result.templates.filter(template => {
-                // Get the number from the name ('flowTemplate-X')
+            const incorrectTemplates = result.blueprints.filter(template => {
+                // Get the number from the name ('flowBlueprint-X')
                 const index = parseInt(template.name.split('-')[1])
-                // Only even-number templates are active - return any that add odd
+                // Only even-number blueprints are active - return any that add odd
                 return (index % 2) !== 0
             })
             incorrectTemplates.should.have.length(0)
         })
 
-        it('Lists all templates when filter set to all', async function () {
+        it('Lists all blueprints when filter set to all', async function () {
             const response = await app.inject({
                 method: 'GET',
-                url: '/api/v1/flow-templates?filter=all',
+                url: '/api/v1/flow-blueprints?filter=all',
                 cookies: { sid: TestObjects.tokens.bob }
             })
             const result = response.json()
@@ -167,9 +167,9 @@ describe('Flow Templates API', function () {
     })
 
     describe('Update Flow Template', function () {
-        it('Admin can update a flow template', async function () {
-            const name = generateName('flow template')
-            const [statusCode, result] = await createTemplate({ name }, TestObjects.tokens.alice)
+        it('Admin can update a flow blueprint', async function () {
+            const name = generateName('flow blueprint')
+            const [statusCode, result] = await createBlueprint({ name }, TestObjects.tokens.alice)
             statusCode.should.equal(200)
             const templateId = result.id
 
@@ -182,7 +182,7 @@ describe('Flow Templates API', function () {
                     flows: { flows: [1, 2, 3] },
                     modules: { a: 1 }
                 },
-                url: `/api/v1/flow-templates/${templateId}`,
+                url: `/api/v1/flow-blueprints/${templateId}`,
                 cookies: { sid: TestObjects.tokens.alice }
             })
             response.statusCode.should.equal(200)
@@ -199,7 +199,7 @@ describe('Flow Templates API', function () {
 
             const fullTemplate = (await app.inject({
                 method: 'GET',
-                url: `/api/v1/flow-templates/${templateId}`,
+                url: `/api/v1/flow-blueprints/${templateId}`,
                 cookies: { sid: TestObjects.tokens.alice }
             })).json()
 
@@ -207,9 +207,9 @@ describe('Flow Templates API', function () {
             fullTemplate.should.have.property('modules')
         })
 
-        it('Non-admin cannot update a flow template', async function () {
-            const name = generateName('flow template')
-            const [statusCode, result] = await createTemplate({ name }, TestObjects.tokens.alice)
+        it('Non-admin cannot update a flow blueprint', async function () {
+            const name = generateName('flow blueprint')
+            const [statusCode, result] = await createBlueprint({ name }, TestObjects.tokens.alice)
             statusCode.should.equal(200)
             const templateId = result.id
 
@@ -222,37 +222,37 @@ describe('Flow Templates API', function () {
                     flows: { flows: [1, 2, 3] },
                     modules: { a: 1 }
                 },
-                url: `/api/v1/flow-templates/${templateId}`,
+                url: `/api/v1/flow-blueprints/${templateId}`,
                 cookies: { sid: TestObjects.tokens.bob }
             })
             response.statusCode.should.equal(403)
         })
     })
 
-    describe('Delete Flow Templates', function () {
-        it('Admin can delete a flow template', async function () {
-            const [statusCode, result] = await createTemplate({
-                name: generateName('flow template')
+    describe('Delete Flow Blueprints', function () {
+        it('Admin can delete a flow blueprint', async function () {
+            const [statusCode, result] = await createBlueprint({
+                name: generateName('flow blueprint')
             }, TestObjects.tokens.alice)
             statusCode.should.equal(200)
 
             const response = await app.inject({
                 method: 'DELETE',
-                url: `/api/v1/flow-templates/${result.id}`,
+                url: `/api/v1/flow-blueprints/${result.id}`,
                 cookies: { sid: TestObjects.tokens.alice }
             })
             response.should.have.property('statusCode', 200)
         })
 
-        it('Non-admin cannot create a flow template', async function () {
-            const [statusCode, result] = await createTemplate({
-                name: generateName('flow template')
+        it('Non-admin cannot create a flow blueprint', async function () {
+            const [statusCode, result] = await createBlueprint({
+                name: generateName('flow blueprint')
             }, TestObjects.tokens.alice)
             statusCode.should.equal(200)
 
             const response = await app.inject({
                 method: 'DELETE',
-                url: `/api/v1/flow-templates/${result.id}`,
+                url: `/api/v1/flow-blueprints/${result.id}`,
                 cookies: { sid: TestObjects.tokens.bob }
             })
             response.should.have.property('statusCode', 403)

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -927,12 +927,12 @@ describe('Project API', function () {
         })
 
         describe('Apply Flow Blueprint', function () {
-            let flowTemplate
+            let flowBlueprint
             before(async function () {
                 const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTk1MjAwLCJleHAiOjc5ODcwNzUxOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjoyLCJkZXYiOnRydWUsImlhdCI6MTY2MjY1MzkyMX0.Tj4fnuDuxi_o5JYltmVi1Xj-BRn0aEjwRPa_fL2MYa9MzSwnvJEd-8bsRM38BQpChjLt-wN-2J21U7oSq2Fp5A'
                 await app.close()
                 await setupApp(license)
-                flowTemplate = await app.db.models.FlowTemplate.create({ name: 'Test Blueprint', description: 'This is a test blueprint\\n - with markdown\\n - formatted *description*', category: 'blueprint', active: true, flows: { flows: [{ id: '0959734f594cf1b7', type: 'tab', label: 'Example Flow', disabled: false, info: '', env: [] }, { id: '99a085239a033276', type: 'inject', z: '0959734f594cf1b7', name: '', props: [{ p: 'payload' }, { p: 'topic', vt: 'str' }], repeat: '', crontab: '', once: false, onceDelay: 0.1, topic: '', payload: '', payloadType: 'date', x: 160, y: 100, wires: [['5fbc411997c05334']] }, { id: '5fbc411997c05334', type: 'debug', z: '0959734f594cf1b7', name: 'debug 1', active: true, tosidebar: true, console: false, tostatus: false, complete: 'false', statusVal: '', statusType: 'auto', x: 410, y: 120, wires: [] }] }, modules: { '@flowforge/node-red-dashboard': '0.6.1' } })
+                flowBlueprint = await app.db.models.FlowTemplate.create({ name: 'Test Blueprint', description: 'This is a test blueprint\\n - with markdown\\n - formatted *description*', category: 'blueprint', active: true, flows: { flows: [{ id: '0959734f594cf1b7', type: 'tab', label: 'Example Flow', disabled: false, info: '', env: [] }, { id: '99a085239a033276', type: 'inject', z: '0959734f594cf1b7', name: '', props: [{ p: 'payload' }, { p: 'topic', vt: 'str' }], repeat: '', crontab: '', once: false, onceDelay: 0.1, topic: '', payload: '', payloadType: 'date', x: 160, y: 100, wires: [['5fbc411997c05334']] }, { id: '5fbc411997c05334', type: 'debug', z: '0959734f594cf1b7', name: 'debug 1', active: true, tosidebar: true, console: false, tostatus: false, complete: 'false', statusVal: '', statusType: 'auto', x: 410, y: 120, wires: [] }] }, modules: { '@flowforge/node-red-dashboard': '0.6.1' } })
             })
             after(async function () {
                 // After this set of tests, close the app and recreate (ie remove the license)
@@ -950,7 +950,7 @@ describe('Project API', function () {
                         projectType: TestObjects.projectType1.hashid,
                         template: TestObjects.template1.hashid,
                         stack: TestObjects.stack1.hashid,
-                        flowTemplateId: flowTemplate.hashid
+                        flowBlueprintId: flowBlueprint.hashid
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -993,16 +993,16 @@ describe('Project API', function () {
                         projectType: TestObjects.projectType1.hashid,
                         template: TestObjects.template1.hashid,
                         stack: TestObjects.stack1.hashid,
-                        flowTemplateId: 'does-not-exist'
+                        flowBlueprintId: 'does-not-exist'
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
                 response.statusCode.should.equal(400)
                 const result = response.json()
-                result.should.have.property('code', 'invalid_flow_template')
+                result.should.have.property('code', 'invalid_flow_blueprint')
             })
 
-            it('Create a project fails with source-project and blueprint', async function () {
+            it('Create a project fails with source-project and flowBlueprintId', async function () {
                 const projectName = generateProjectName()
                 const response = await app.inject({
                     method: 'POST',
@@ -1013,7 +1013,7 @@ describe('Project API', function () {
                         projectType: TestObjects.projectType1.hashid,
                         template: TestObjects.template1.hashid,
                         stack: TestObjects.stack1.hashid,
-                        flowTemplateId: flowTemplate.hashid,
+                        flowBlueprintId: flowBlueprint.hashid,
                         sourceProject: {
                             id: TestObjects.project1.id,
                             options: {


### PR DESCRIPTION
## Description

This applies some final tidy up to the first iteration of Flow Blueprints work - #2828

I've split it into separate commits

 1. Include `instance-blueprint` in the payload sent to posthog when creating an instance
 2. Updates the Blank template wording:
    <img width="307" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/65bf65a5-3fcc-4316-9e08-ccc201fb11bc">
 3. Updates all external apis to use `flow blueprint` terminology rather than flow template.
     - CRUD end-points moved to `/api/v1/flow-blueprints` and scheme updated
     - Property on Instance Create api renamed to `flowBlueprintId`
     - It does *not* modify the model/database table - that felt a step too far for today.

