### PR TITLE
Add better validation of blueprint flows

### DIFF
--- a/forge/ee/db/models/FlowTemplate.js
+++ b/forge/ee/db/models/FlowTemplate.js
@@ -15,6 +15,34 @@ module.exports = {
         category: { type: DataTypes.STRING, defaultValue: '' },
         flows: {
             type: DataTypes.TEXT,
+            validate: {
+                isValidFlow (value) {
+                    if (value) {
+                        let parsedValue
+                        try {
+                            parsedValue = JSON.parse(value)
+                        } catch (err) {
+                            throw new Error('Invalid flow json')
+                        }
+                        if (!parsedValue.flows) {
+                            throw new Error('Flow json missing \'flows\' property')
+                        }
+                        if (!Array.isArray(parsedValue.flows)) {
+                            throw new Error('Flow json \'flows\' property not an Array')
+                        }
+                        // .credentials are optional, but if present, must be an object
+                        // and not appear encrypted
+                        if (parsedValue.credentials) {
+                            if (typeof parsedValue.credentials !== 'object' || Array.isArray(parsedValue.credentials)) {
+                                throw new Error('Flow json \'credentials\' property must be an object')
+                            }
+                            if (parsedValue.credentials.$) {
+                                throw new Error('Flow json \'credentials\' property must not be encrypted - found $ property')
+                            }
+                        }
+                    }
+                }
+            },
             set (value) {
                 this.setDataValue('flows', JSON.stringify(value))
             },

--- a/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
+++ b/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
@@ -298,10 +298,6 @@ describe('Flow Blueprints API', function () {
             resp6.should.have.property('code', 'unexpected_error')
             statusCode6.should.equal(400)
         })
-
-
-
-
     })
 
     describe('Delete Flow Blueprints', function () {

--- a/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
+++ b/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
@@ -56,6 +56,16 @@ describe('Flow Blueprints API', function () {
         return [response.statusCode, response.json()]
     }
 
+    async function updateBlueprint (id, body, token) {
+        const response = await app.inject({
+            method: 'PUT',
+            url: `/api/v1/flow-blueprints/${id}`,
+            body,
+            cookies: { sid: token }
+        })
+        return [response.statusCode, response.json()]
+    }
+
     let objectCount = 0
     const generateName = (prefix = 'object') => `${prefix}-${objectCount++}`
 
@@ -67,7 +77,7 @@ describe('Flow Blueprints API', function () {
                 description: 'a flow',
                 active: true,
                 category: 'starter',
-                flows: {},
+                flows: { flows: [] },
                 modules: {}
             }, TestObjects.tokens.alice)
             statusCode.should.equal(200)
@@ -84,7 +94,7 @@ describe('Flow Blueprints API', function () {
                 description: 'a flow',
                 active: true,
                 category: 'starter',
-                flows: {},
+                flows: { flows: [] },
                 modules: {}
             }, TestObjects.tokens.bob)
             statusCode.should.equal(403)
@@ -208,24 +218,17 @@ describe('Flow Blueprints API', function () {
             const name = generateName('flow blueprint')
             const [statusCode, result] = await createBlueprint({ name }, TestObjects.tokens.alice)
             statusCode.should.equal(200)
-            const templateId = result.id
+            const blueprintId = result.id
+            const [updateStatusCode, template] = await updateBlueprint(blueprintId, {
+                description: 'new desc',
+                active: false,
+                category: 'new cat',
+                flows: { flows: [1, 2, 3] },
+                modules: { a: 1 }
+            }, TestObjects.tokens.alice)
+            updateStatusCode.should.equal(200)
 
-            const response = await app.inject({
-                method: 'PUT',
-                body: {
-                    description: 'new desc',
-                    active: false,
-                    category: 'new cat',
-                    flows: { flows: [1, 2, 3] },
-                    modules: { a: 1 }
-                },
-                url: `/api/v1/flow-blueprints/${templateId}`,
-                cookies: { sid: TestObjects.tokens.alice }
-            })
-            response.statusCode.should.equal(200)
-            const template = response.json()
-
-            template.should.have.property('id', templateId)
+            template.should.have.property('id', blueprintId)
             template.should.have.property('name', name)
             template.should.have.property('description', 'new desc')
             template.should.have.property('active', false)
@@ -236,7 +239,7 @@ describe('Flow Blueprints API', function () {
 
             const fullTemplate = (await app.inject({
                 method: 'GET',
-                url: `/api/v1/flow-blueprints/${templateId}`,
+                url: `/api/v1/flow-blueprints/${blueprintId}`,
                 cookies: { sid: TestObjects.tokens.alice }
             })).json()
 
@@ -248,22 +251,57 @@ describe('Flow Blueprints API', function () {
             const name = generateName('flow blueprint')
             const [statusCode, result] = await createBlueprint({ name }, TestObjects.tokens.alice)
             statusCode.should.equal(200)
-            const templateId = result.id
+            const blueprintId = result.id
 
-            const response = await app.inject({
-                method: 'PUT',
-                body: {
-                    description: 'new desc',
-                    active: false,
-                    category: 'new cat',
-                    flows: { flows: [1, 2, 3] },
-                    modules: { a: 1 }
-                },
-                url: `/api/v1/flow-blueprints/${templateId}`,
-                cookies: { sid: TestObjects.tokens.bob }
-            })
-            response.statusCode.should.equal(403)
+            const [updateStatusCode] = await updateBlueprint(blueprintId, {
+                description: 'new desc',
+                active: false,
+                category: 'new cat',
+                flows: { flows: [1, 2, 3] },
+                modules: { a: 1 }
+            }, TestObjects.tokens.bob)
+            updateStatusCode.should.equal(403)
         })
+
+        it('Invalid flow format is rejected', async function () {
+            const name = generateName('flow blueprint')
+            const [statusCode, result] = await createBlueprint({ name }, TestObjects.tokens.alice)
+            statusCode.should.equal(200)
+            const blueprintId = result.id
+
+            // flows.flows not present
+            const [statusCode1, resp1] = await updateBlueprint(blueprintId, { flows: {} }, TestObjects.tokens.alice)
+            resp1.should.have.property('code', 'unexpected_error')
+            statusCode1.should.equal(400)
+
+            // flows.flows not an array
+            const [statusCode2, resp2] = await updateBlueprint(blueprintId, { flows: { flows: true } }, TestObjects.tokens.alice)
+            statusCode2.should.equal(400)
+            resp2.should.have.property('code', 'unexpected_error')
+
+            // flows.flows not an array
+            const [statusCode3, resp3] = await updateBlueprint(blueprintId, { flows: { flows: {} } }, TestObjects.tokens.alice)
+            statusCode3.should.equal(400)
+            resp3.should.have.property('code', 'unexpected_error')
+
+            // Flows property not an object
+            const [statusCode4] = await updateBlueprint(blueprintId, { flows: 'invalid' }, TestObjects.tokens.alice)
+            statusCode4.should.equal(400)
+
+            // Credentials set to array
+            const [statusCode5, resp5] = await updateBlueprint(blueprintId, { flows: { flows: [], credentials: [] } }, TestObjects.tokens.alice)
+            resp5.should.have.property('code', 'unexpected_error')
+            statusCode5.should.equal(400)
+
+            // Credentials appears to include encrypted values
+            const [statusCode6, resp6] = await updateBlueprint(blueprintId, { flows: { flows: [], credentials: { $: 'foo' } } }, TestObjects.tokens.alice)
+            resp6.should.have.property('code', 'unexpected_error')
+            statusCode6.should.equal(400)
+        })
+
+
+
+
     })
 
     describe('Delete Flow Blueprints', function () {

--- a/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
+++ b/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
@@ -89,6 +89,43 @@ describe('Flow Blueprints API', function () {
             }, TestObjects.tokens.bob)
             statusCode.should.equal(403)
         })
+
+        it('Invalid flow format is rejected', async function () {
+            // flows.flows not present
+            const [statusCode1, resp1] = await createBlueprint({ name: generateName('bp'), flows: {} }, TestObjects.tokens.alice)
+            resp1.should.have.property('code', 'unexpected_error')
+            statusCode1.should.equal(400)
+
+            // flows.flows not an array
+            const [statusCode2, resp2] = await createBlueprint({ name: generateName('bp'), flows: { flows: true } }, TestObjects.tokens.alice)
+            statusCode2.should.equal(400)
+            resp2.should.have.property('code', 'unexpected_error')
+
+            // flows.flows not an array
+            const [statusCode3, resp3] = await createBlueprint({ name: generateName('bp'), flows: { flows: {} } }, TestObjects.tokens.alice)
+            statusCode3.should.equal(400)
+            resp3.should.have.property('code', 'unexpected_error')
+
+            // Flows property not an object
+            const [statusCode4] = await createBlueprint({ name: generateName('bp'), flows: 'invalid' }, TestObjects.tokens.alice)
+            statusCode4.should.equal(400)
+
+            // Credentials set to array
+            const [statusCode5, resp5] = await createBlueprint({ name: generateName('bp'), flows: { flows: [], credentials: [] } }, TestObjects.tokens.alice)
+            resp5.should.have.property('code', 'unexpected_error')
+            statusCode5.should.equal(400)
+
+            // Credentials appears to include encrypted values
+            const [statusCode6, resp6] = await createBlueprint({ name: generateName('bp'), flows: { flows: [], credentials: { $: 'foo' } } }, TestObjects.tokens.alice)
+            resp6.should.have.property('code', 'unexpected_error')
+            statusCode6.should.equal(400)
+        })
+
+        it('Invalid modules format is rejected', async function () {
+            // modules not an object
+            const [statusCode1] = await createBlueprint({ name: generateName('bp'), modules: [] }, TestObjects.tokens.alice)
+            statusCode1.should.equal(400)
+        })
     })
 
     describe('Get Flow Template', function () {


### PR DESCRIPTION
## Description

This adds better validation that a blueprint `flows` property is in the expected format. This ensures we don't inject garbage.

This *could* be reworked as a better fastify schema on the route (and probably should be), but this gets it done.