### PR TITLE
Guard against refreshing an application page when route is changing

### DIFF
--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -147,46 +147,48 @@ export default {
     methods: {
         async updateApplication () {
             const applicationId = this.$route.params.id
-            try {
-                this.applicationInstances = []
-                const applicationPromise = ApplicationApi.getApplication(applicationId)
-                const instancesPromise = ApplicationApi.getApplicationInstances(applicationId) // To-do needs to be enriched with instance state
-                const devicesPromise = ApplicationApi.getApplicationDevices(applicationId)
+            if (applicationId) {
+                try {
+                    this.applicationInstances = []
+                    const applicationPromise = ApplicationApi.getApplication(applicationId)
+                    const instancesPromise = ApplicationApi.getApplicationInstances(applicationId) // To-do needs to be enriched with instance state
+                    const devicesPromise = ApplicationApi.getApplicationDevices(applicationId)
 
-                this.application = await applicationPromise
-                const deviceData = await devicesPromise
-                this.applicationDevices = deviceData?.devices
-                const applicationInstances = await instancesPromise
+                    this.application = await applicationPromise
+                    const deviceData = await devicesPromise
+                    this.applicationDevices = deviceData?.devices
+                    const applicationInstances = await instancesPromise
 
-                this.applicationInstances = new Map()
-                applicationInstances.forEach(instance => {
-                    this.applicationInstances.set(instance.id, instance)
-                })
+                    this.applicationInstances = new Map()
+                    applicationInstances.forEach(instance => {
+                        this.applicationInstances.set(instance.id, instance)
+                    })
 
-                // Not waited for, as loading status is slightly slower
-                ApplicationApi
-                    .getApplicationInstancesStatuses(applicationId)
-                    .then((instanceStatuses) => {
-                        instanceStatuses.forEach((instanceStatus) => {
-                            this.applicationInstances.set(instanceStatus.id, {
-                                ...this.applicationInstances.get(instanceStatus.id),
-                                ...instanceStatus
+                    // Not waited for, as loading status is slightly slower
+                    ApplicationApi
+                        .getApplicationInstancesStatuses(applicationId)
+                        .then((instanceStatuses) => {
+                            instanceStatuses.forEach((instanceStatus) => {
+                                this.applicationInstances.set(instanceStatus.id, {
+                                    ...this.applicationInstances.get(instanceStatus.id),
+                                    ...instanceStatus
+                                })
                             })
                         })
-                    })
-                    .catch((err) => {
-                        console.error(err)
-                    })
+                        .catch((err) => {
+                            console.error(err)
+                        })
 
-                this.$store.dispatch('account/setTeam', this.application.team.slug)
-            } catch (err) {
-                this.$router.push({
-                    name: 'PageNotFound',
-                    params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
-                    // preserve existing query and hash if any
-                    query: this.$router.currentRoute.value.query,
-                    hash: this.$router.currentRoute.value.hash
-                })
+                    this.$store.dispatch('account/setTeam', this.application.team.slug)
+                } catch (err) {
+                    this.$router.push({
+                        name: 'PageNotFound',
+                        params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
+                        // preserve existing query and hash if any
+                        query: this.$router.currentRoute.value.query,
+                        hash: this.$router.currentRoute.value.hash
+                    })
+                }
             }
         },
 

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -147,6 +147,12 @@ export default {
     methods: {
         async updateApplication () {
             const applicationId = this.$route.params.id
+
+            // See https://github.com/FlowFuse/flowfuse/issues/2929
+            if (!applicationId) {
+                return
+            }
+
             try {
                 this.applicationInstances = []
                 const applicationPromise = ApplicationApi.getApplication(applicationId)

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -147,48 +147,46 @@ export default {
     methods: {
         async updateApplication () {
             const applicationId = this.$route.params.id
-            if (applicationId) {
-                try {
-                    this.applicationInstances = []
-                    const applicationPromise = ApplicationApi.getApplication(applicationId)
-                    const instancesPromise = ApplicationApi.getApplicationInstances(applicationId) // To-do needs to be enriched with instance state
-                    const devicesPromise = ApplicationApi.getApplicationDevices(applicationId)
+            try {
+                this.applicationInstances = []
+                const applicationPromise = ApplicationApi.getApplication(applicationId)
+                const instancesPromise = ApplicationApi.getApplicationInstances(applicationId) // To-do needs to be enriched with instance state
+                const devicesPromise = ApplicationApi.getApplicationDevices(applicationId)
 
-                    this.application = await applicationPromise
-                    const deviceData = await devicesPromise
-                    this.applicationDevices = deviceData?.devices
-                    const applicationInstances = await instancesPromise
+                this.application = await applicationPromise
+                const deviceData = await devicesPromise
+                this.applicationDevices = deviceData?.devices
+                const applicationInstances = await instancesPromise
 
-                    this.applicationInstances = new Map()
-                    applicationInstances.forEach(instance => {
-                        this.applicationInstances.set(instance.id, instance)
-                    })
+                this.applicationInstances = new Map()
+                applicationInstances.forEach(instance => {
+                    this.applicationInstances.set(instance.id, instance)
+                })
 
-                    // Not waited for, as loading status is slightly slower
-                    ApplicationApi
-                        .getApplicationInstancesStatuses(applicationId)
-                        .then((instanceStatuses) => {
-                            instanceStatuses.forEach((instanceStatus) => {
-                                this.applicationInstances.set(instanceStatus.id, {
-                                    ...this.applicationInstances.get(instanceStatus.id),
-                                    ...instanceStatus
-                                })
+                // Not waited for, as loading status is slightly slower
+                ApplicationApi
+                    .getApplicationInstancesStatuses(applicationId)
+                    .then((instanceStatuses) => {
+                        instanceStatuses.forEach((instanceStatus) => {
+                            this.applicationInstances.set(instanceStatus.id, {
+                                ...this.applicationInstances.get(instanceStatus.id),
+                                ...instanceStatus
                             })
                         })
-                        .catch((err) => {
-                            console.error(err)
-                        })
-
-                    this.$store.dispatch('account/setTeam', this.application.team.slug)
-                } catch (err) {
-                    this.$router.push({
-                        name: 'PageNotFound',
-                        params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
-                        // preserve existing query and hash if any
-                        query: this.$router.currentRoute.value.query,
-                        hash: this.$router.currentRoute.value.hash
                     })
-                }
+                    .catch((err) => {
+                        console.error(err)
+                    })
+
+                this.$store.dispatch('account/setTeam', this.application.team.slug)
+            } catch (err) {
+                this.$router.push({
+                    name: 'PageNotFound',
+                    params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
+                    // preserve existing query and hash if any
+                    query: this.$router.currentRoute.value.query,
+                    hash: this.$router.currentRoute.value.hash
+                })
             }
         },
 


### PR DESCRIPTION
Fixes #2929 #2934

## Description

When navigating from an application route, such as `/application/j5KRXxRx8y/instances` to a team route, such as `/team/dev/applications`, a watch on the `id` param of the `/application/...` page is triggered to reload the 'new' application. However as its moving away from the application view, there is no id param - causing it to try loading urls with `undefined` in.

This is a quick fix to only try updating the application if the `id` param is present.

I suspect there's a more vue way of doing this given the component is being unmounted so we shouldn't be watching the param any more.

