### PR TITLE
Fix: N+1 query for StorageFlows for Instance State End Points

### DIFF
--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -35,7 +35,7 @@ module.exports = {
                         ]
                     })
                 },
-                byTeam: async (teamIdOrHash, { includeInstances = false } = {}) => {
+                byTeam: async (teamIdOrHash, { includeInstances = false, includeInstanceStorageFlow = false } = {}) => {
                     let id = teamIdOrHash
                     if (typeof teamIdOrHash === 'string') {
                         id = M.Team.decodeHashid(teamIdOrHash)
@@ -50,7 +50,7 @@ module.exports = {
                     ]
 
                     if (includeInstances) {
-                        includes.push({
+                        const include = {
                             model: M.Project,
                             as: 'Instances',
                             attributes: ['hashid', 'id', 'name', 'slug', 'links', 'url', 'state'],
@@ -70,7 +70,17 @@ module.exports = {
                                     required: false
                                 }
                             ]
-                        })
+                        }
+
+                        if (includeInstanceStorageFlow) {
+                            // Used for instance status
+                            include.include.push({
+                                model: M.StorageFlow,
+                                attributes: ['id', 'flow', 'updatedAt']
+                            })
+                        }
+
+                        includes.push(include)
                     }
 
                     return this.findAll({

--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -76,7 +76,7 @@ module.exports = {
                             // Used for instance status
                             include.include.push({
                                 model: M.StorageFlow,
-                                attributes: ['id', 'flow', 'updatedAt']
+                                attributes: ['id', 'updatedAt']
                             })
                         }
 

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -325,45 +325,55 @@ module.exports = {
                         }
                     })
                 },
-                byId: async (id) => {
+                byId: async (id, { includeStorageFlows = false } = {}) => {
+                    const include = [
+                        {
+                            model: M.Team,
+                            attributes: ['hashid', 'id', 'name', 'slug', 'links', 'TeamTypeId']
+                        },
+                        {
+                            model: M.Application,
+                            attributes: ['hashid', 'id', 'name', 'links']
+                        },
+                        {
+                            model: M.ProjectType,
+                            attributes: ['hashid', 'id', 'name']
+                        },
+                        {
+                            model: M.ProjectStack,
+                            attributes: ['hashid', 'id', 'name', 'label', 'links', 'properties', 'replacedBy', 'ProjectTypeId']
+                        },
+                        {
+                            model: M.ProjectTemplate,
+                            attributes: ['hashid', 'id', 'name', 'links', 'settings', 'policy']
+                        },
+                        {
+                            model: M.ProjectSettings,
+                            where: {
+                                [Op.or]: [
+                                    { key: KEY_SETTINGS },
+                                    { key: KEY_HOSTNAME },
+                                    { key: KEY_HA }
+                                ]
+                            },
+                            required: false
+                        }
+                    ]
+
+                    // Used for instance status
+                    if (includeStorageFlows) {
+                        include.push({
+                            model: M.StorageFlow,
+                            attributes: ['id', 'flow', 'updatedAt']
+                        })
+                    }
+
                     return this.findOne({
                         where: { id },
-                        include: [
-                            {
-                                model: M.Team,
-                                attributes: ['hashid', 'id', 'name', 'slug', 'links', 'TeamTypeId']
-                            },
-                            {
-                                model: M.Application,
-                                attributes: ['hashid', 'id', 'name', 'links']
-                            },
-                            {
-                                model: M.ProjectType,
-                                attributes: ['hashid', 'id', 'name']
-                            },
-                            {
-                                model: M.ProjectStack,
-                                attributes: ['hashid', 'id', 'name', 'label', 'links', 'properties', 'replacedBy', 'ProjectTypeId']
-                            },
-                            {
-                                model: M.ProjectTemplate,
-                                attributes: ['hashid', 'id', 'name', 'links', 'settings', 'policy']
-                            },
-                            {
-                                model: M.ProjectSettings,
-                                where: {
-                                    [Op.or]: [
-                                        { key: KEY_SETTINGS },
-                                        { key: KEY_HOSTNAME },
-                                        { key: KEY_HA }
-                                    ]
-                                },
-                                required: false
-                            }
-                        ]
+                        include
                     })
                 },
-                byApplication: async (applicationHashId, { includeSettings = false } = {}) => {
+                byApplication: async (applicationHashId, { includeSettings = false, includeStorageFlows = false } = {}) => {
                     const applicationId = M.Application.decodeHashid(applicationHashId)
 
                     const include = [
@@ -398,6 +408,14 @@ module.exports = {
                                 ]
                             },
                             required: false
+                        })
+                    }
+
+                    // Used for instance status
+                    if (includeStorageFlows) {
+                        include.push({
+                            model: M.StorageFlow,
+                            attributes: ['id', 'flow', 'updatedAt']
                         })
                     }
 

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -369,7 +369,7 @@ module.exports = {
                     if (includeStorageFlows) {
                         include.push({
                             model: M.StorageFlow,
-                            attributes: ['id', 'flow', 'updatedAt']
+                            attributes: ['id', 'updatedAt']
                         })
                     }
 
@@ -420,7 +420,7 @@ module.exports = {
                     if (includeStorageFlows) {
                         include.push({
                             model: M.StorageFlow,
-                            attributes: ['id', 'flow', 'updatedAt']
+                            attributes: ['id', 'updatedAt']
                         })
                     }
 

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -266,7 +266,12 @@ module.exports = {
                 },
 
                 async liveState () {
-                    const storageFlow = await M.StorageFlow.byProject(this.id)
+                    let storageFlow = this.StorageFlow
+                    if (storageFlow === undefined) {
+                        app.log.warn(`N+1 warning - Requested live state for instance ${this.id} with no storage flow loaded`)
+                        storageFlow = await M.StorageFlow.byProject(this.id)
+                    }
+
                     const inflightState = Controllers.Project.getInflightState(this)
                     const isDeploying = Controllers.Project.isDeploying(this)
 

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -114,6 +114,7 @@ module.exports = {
         this.belongsTo(M.ProjectStack)
         this.belongsTo(M.ProjectTemplate)
         this.hasMany(M.ProjectSnapshot)
+        this.hasOne(M.StorageFlow)
     },
     hooks: function (M, app) {
         return {

--- a/forge/routes/api/application.js
+++ b/forge/routes/api/application.js
@@ -378,7 +378,8 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
-        const instances = await app.db.models.Project.byApplication(request.application.hashid)
+        // StorageFlows needed for last updated time
+        const instances = await app.db.models.Project.byApplication(request.application.hashid, { includeStorageFlows: true })
         if (instances) {
             const instanceStatuses = await app.db.views.Project.instanceStatusList(instances)
             reply.send({

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -29,7 +29,8 @@ module.exports = async function (app) {
         if (request.params.instanceId !== undefined) {
             if (request.params.instanceId) {
                 try {
-                    request.project = await app.db.models.Project.byId(request.params.instanceId)
+                    // StorageFlow needed for last updates time (live status)
+                    request.project = await app.db.models.Project.byId(request.params.instanceId, { includeStorageFlows: true })
                     if (!request.project) {
                         reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
@@ -88,6 +89,7 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
+        // Storage flow needed for live status
         const projectPromise = app.db.views.Project.project(request.project)
         const projectStatePromise = request.project.liveState()
 

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -317,7 +317,7 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
-        const applications = await app.db.models.Application.byTeam(request.params.teamId, { includeInstances: true })
+        const applications = await app.db.models.Application.byTeam(request.params.teamId, { includeInstances: true, includeInstanceStorageFlow: true })
         if (!applications) {
             return reply.code(404).send({ code: 'not_found', error: 'Not Found' })
         }


### PR DESCRIPTION
## Description

The flowLastUpdatedAt value that's returned from status endpoints for instances is based on the instances StorageFlow.
Previously the `liveStatus` view loaded the StorageFlow, which meant it was happening for each instance we display, not a problem on the instance endpoint, but when loading all instance statuses for an application lead to a slow querytime.

This PR:
 - Updates the view to use `model.StorageFlow`, rather than loading it from the DB, if set
 - Associates StorageFlows with Instances (previously only one way)
 - Includes the StorageFlow when the instance is loaded, if the flag is set

Should reduce a 200ms+ query for some of our larger customers down to <25ms.

## Related Issue(s)

Fixes #2952
Fixes #2954 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

