### PR TITLE
Exit trial when billing setup

### DIFF
--- a/forge/ee/db/controllers/Subscription.js
+++ b/forge/ee/db/controllers/Subscription.js
@@ -5,6 +5,10 @@ module.exports = {
         if (existingSub) {
             existingSub.customer = customer
             existingSub.subscription = subscription
+            if (existingSub.status === app.db.models.Subscription.STATUS.TRIAL) {
+                existingSub.trialEndsAt = null
+                existingSub.trialStatus = app.db.models.Subscription.TRIAL_STATUS.ENDED
+            }
             existingSub.status = app.db.models.Subscription.STATUS.ACTIVE
             await existingSub.save()
 

--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -91,8 +91,13 @@ module.exports = {
                     // but the trial has not yet expired.
                     //
                     return !this.trialEndsAt || this.trialEndsAt < Date.now()
-                }
+                },
 
+                async clearTrialState () {
+                    this.trialEndsAt = null
+                    this.trialStatus = TRIAL_STATUS.ENDED
+                    return this.save()
+                }
             },
             static: {
                 STATUS,

--- a/frontend/src/components/banners/TeamTrial.vue
+++ b/frontend/src/components/banners/TeamTrial.vue
@@ -15,10 +15,11 @@
             <span v-if="!team.billing?.trialEnded">
                 You have <span class="font-bold">{{ trialEndsIn }} left</span> of your free trial.
                 <span v-if="team.billing?.active">
+                    <!-- TODO: remove in 1.14 as this will become an unneeded state once existing trials expire -->
                     You trial instances will be added to your billing subscription at the end of your trial.
                 </span>
                 <span v-else>
-                    Click here to setup billing at any time to keep your instances running after the trial the ends.
+                    Click here to upgrade your team and keep your instances running.
                 </span>
             </span>
             <span v-else>

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -53,7 +53,7 @@
                             During the trial you can only create one application instance in the team. To unlock other features you will need to configure your billing details.
                         </template>
                         <template v-else>
-                            During the trial you can make full use of the features available to your team. To keep things running after the trial ends you will need to configure your billing details.
+                            During the trial you can make full use of the features available to your team. To keep things running you will need to configure your billing details.
                         </template>
                     </div>
                     <div v-else>


### PR DESCRIPTION
Part of #2905 

## Description

This modifies the billing flow around trials.

With this change, when a user is in Trial mode and clicks through to setup billing, Stripe will now show the full team plan details, rather than the $0 trial plan. Once they complete billing setup, their team is no longer in trial mode and they are paying for the team as expected.

The net result is we will no longer consider being in Trial mode with Billing setup as a valid state. However it is possible we will have a small number of teams already in that state when this change goes live. So I've left in place the code to handle them - but marked it up as being removable in 1.14 (ie, at least 2 weeks after this change hits production).

Along the way I've tidied up some bits of the language presented to the user, however this is likely to be replaced with the next iteration of #2905 that will allow them to pick a team type before setting up billing.

