### PR TITLE
Ignore subscription events if we don't know the subscription

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -87,7 +87,7 @@ module.exports = async (options = {}) => {
     if (runtimeConfig.telemetry.backend?.sentry?.dsn) {
         server.register(require('@immobiliarelabs/fastify-sentry'), {
             dsn: runtimeConfig.telemetry.backend.sentry.dsn,
-            environment: process.env.SENTRY_ENV ?? process.env.NODE_ENV,
+            environment: process.env.SENTRY_ENV ?? (process.env.NODE_ENV ?? 'unknown'),
             release: `flowfuse@${runtimeConfig.version}`,
             tracesSampleRate: 0.1,
             profilesSampleRate: 0.1,


### PR DESCRIPTION
Fixes #2962 

## Description

If a customer has multiple subscriptions in Stripe (because some have been manually created), then any operation on those subscriptions was being mishandled as on operation on the platform-owned subscription.

This PR fixes that by validating the local subscription ID against the id in the stripe event.