### PR TITLE
Restrict custom catalogs and npmrc to licensed team types

### DIFF
--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -18,5 +18,8 @@ module.exports = fp(async function (app, opts, done) {
     // Set the DevOps Pipelines
     app.config.features.register('devops-pipelines', true, true)
 
+    // Set the Custom Catalogs Flag
+    app.config.features.register('customCatalogs', true, true)
+
     done()
 })

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -76,6 +76,8 @@
                     <FormRow v-model="input.properties.features.projectComms" type="checkbox">Project Nodes</FormRow>
                     <FormRow v-model="input.properties.features.ha" type="checkbox">High Availability</FormRow>
                     <FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
+                    <FormRow v-model="input.properties.features.customCatalogs" type="checkbox">Custom NPM Catalogs</FormRow>
+                    <div />
                     <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
                     <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow>
                 </div>
@@ -157,6 +159,9 @@ export default {
                     }
                     if (this.input.properties.features.teamHttpSecurity === undefined) {
                         this.input.properties.features.teamHttpSecurity = true
+                    }
+                    if (this.input.properties.features.customCatalogs === undefined) {
+                        this.input.properties.features.customCatalogs = true
                     }
                     if (this.input.properties.billing.proration === undefined) {
                         this.input.properties.billing.proration = 'always_invoice'

--- a/frontend/src/pages/admin/Template/Palette.vue
+++ b/frontend/src/pages/admin/Template/Palette.vue
@@ -1,8 +1,8 @@
 <template>
     <form class="space-y-6">
         <TemplateSectionPalette v-model="editableTemplate" :editTemplate="true" />
-        <TemplateSectionCatalogue v-model="editableTemplate" :editTemplate="true" :project="project" />
-        <TemplateSectionNPM v-model="editableTemplate" :editTemplate="true" :project="project" />
+        <TemplateSectionCatalogue v-if="catalogFeatureAvailable" v-model="editableTemplate" :editTemplate="true" :project="project" />
+        <TemplateSectionNPM v-if="catalogFeatureAvailable" v-model="editableTemplate" :editTemplate="true" :project="project" />
         <TemplateSectionPaletteModules
             v-model="editableTemplate" :editTemplate="true" :readOnly="false" :project="project"
             header="Default Modules"
@@ -11,6 +11,8 @@
 </template>
 
 <script>
+
+import { mapState } from 'vuex'
 
 import permissionsMixin from '../../../mixins/Permissions.js'
 
@@ -42,6 +44,10 @@ export default {
     },
     emits: ['update:modelValue'],
     computed: {
+        ...mapState('account', ['features']),
+        catalogFeatureAvailable () {
+            return !!this.features.customCatalogs
+        },
         editableTemplate: {
             get () { return this.modelValue },
             set (localValue) { this.$emit('update:modelValue', localValue) }

--- a/frontend/src/pages/instance/Settings/Palette.vue
+++ b/frontend/src/pages/instance/Settings/Palette.vue
@@ -1,8 +1,8 @@
 <template>
     <form class="space-y-6">
         <TemplateSettingsPalette v-model="editable" :editTemplate="false" />
-        <TemplateSectionCatalogue v-model="editable" :editTemplate="false" :readOnly="!catalogueEditable" :project="project" />
-        <TemplateSectionNPM v-model="editable" :editTemplate="false" :readOnly="!npmEditable" :project="project" />
+        <TemplateSectionCatalogue v-if="catalogFeatureEnabledForTeam" v-model="editable" :editTemplate="false" :readOnly="!catalogueEditable" :project="project" />
+        <TemplateSectionNPM v-if="catalogFeatureEnabledForTeam" v-model="editable" :editTemplate="false" :readOnly="!npmEditable" :project="project" />
         <TemplatePaletteModulesEditor v-model="editable" :editTemplate="false" :readOnly="!paletteEditable" :project="project" />
         <div class="space-x-4 whitespace-nowrap">
             <ff-button size="small" :disabled="!unsavedChanges && !modulesChanged" @click="saveSettings()">Save settings</ff-button>
@@ -72,7 +72,14 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership']),
+        ...mapState('account', ['team', 'teamMembership', 'features']),
+        catalogFeatureEnabledForTeam () {
+            if (!this.features.customCatalogs) {
+                return false
+            }
+            const flag = this.team.type.properties.features?.customCatalogs
+            return flag === undefined || flag
+        },
         paletteEditable () {
             return this.editable?.settings.palette_allowInstall
         },


### PR DESCRIPTION
Fixes #2950

## Description

This PR moves the custom catalog and npmrc settings to be behind a licensed feature flag.

Furthermore, it is added as a TeamType feature flag so only select teams types within a licensed instance will have access to the feature.

---

This is currently UI only. Getting that side raised whilst I add some backend handling for this to match along with tests.