### PR TITLE
Chore: Throw for unhandled exceptions in tests

### DIFF
--- a/test/unit/forge/routes/setup.js
+++ b/test/unit/forge/routes/setup.js
@@ -2,6 +2,11 @@ const TestModelFactory = require('../../../lib/TestModelFactory')
 
 const FF_UTIL = require('flowforge-test-utils')
 
+process.on('unhandledRejection', (error) => {
+    // Tests should fail if an unhandledRejection occurs
+    throw error
+})
+
 module.exports = async function (config = {}) {
     const forge = await FF_UTIL.setupApp(config)
     await forge.db.models.PlatformSettings.upsert({ key: 'setup:initialised', value: true })


### PR DESCRIPTION
## Description

I discovered that have unhandled promise rejections being thrown in production meaning that some error states are being silently dropped without our knowledge.

Adding this guard to our tests should stop them slipping through the net while we work on more long term fixes.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/2972

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

