### PR TITLE
Prevent error when device is not found

### DIFF
--- a/forge/auditLog/team.js
+++ b/forge/auditLog/team.js
@@ -61,7 +61,7 @@ module.exports = {
                 },
                 async unassigned (actionedBy, error, team, projectOrApplication, device) {
                     const bodyData = { error, device }
-                    if (device.ownerType === 'application' || projectOrApplication?.constructor?.name === 'Application') {
+                    if (device.isApplicationOwned || projectOrApplication?.constructor?.name === 'Application') {
                         bodyData.application = projectOrApplication
                     } else {
                         bodyData.project = projectOrApplication
@@ -70,7 +70,7 @@ module.exports = {
                 },
                 async assigned (actionedBy, error, team, projectOrApplication, device) {
                     const bodyData = { error, device }
-                    if (device.ownerType === 'application' || projectOrApplication?.constructor?.name === 'Application') {
+                    if (device.isApplicationOwned || projectOrApplication?.constructor?.name === 'Application') {
                         bodyData.application = projectOrApplication
                     } else {
                         bodyData.project = projectOrApplication

--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -109,6 +109,11 @@ class DeviceCommsHandler {
                 }
             } catch (err) {
                 // Not a JSON payload - ignore
+                if (err instanceof SyntaxError) {
+                    return
+                }
+
+                throw err
             }
         }
     }

--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -66,7 +66,6 @@ class DeviceCommsHandler {
         if (status.id && status.status) {
             const deviceId = status.id
             const device = await this.app.db.models.Device.byId(deviceId)
-            const isApplicationOwned = device.ownerType === 'application' && device.Application?.id
             if (!device) {
                 // TODO: log invalid device
                 return
@@ -95,7 +94,7 @@ class DeviceCommsHandler {
                     if (payload.snapshot !== (targetSnapshot?.hashid || null)) {
                         // The Snapshot is incorrect
                         sendUpdateCommand = true
-                    } else if (targetSnapshot && !isApplicationOwned && payload.project !== (targetSnapshot?.ProjectId || null)) {
+                    } else if (targetSnapshot && !device.isApplicationOwned && payload.project !== (targetSnapshot?.ProjectId || null)) {
                         // The project the device is reporting it belongs to does not match the target Snapshot parent project
                         sendUpdateCommand = true
                     }

--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -17,7 +17,7 @@ module.exports = {
             // Check the snapshot is one we recognise
             const snapshotId = app.db.models.ProjectSnapshot.decodeHashid(state.snapshot)
             // hashid.decode returns an array of values, not the raw value.
-            if (snapshotId.length > 0) {
+            if (snapshotId?.length > 0) {
                 // check to see if snapshot still exists
                 if (await app.db.models.ProjectSnapshot.byId(state.snapshot)) {
                     device.set('activeSnapshotId', snapshotId)

--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -93,7 +93,7 @@ module.exports = {
         let snapshotId
         let snapshotName
 
-        if (device.ownerType === 'application') {
+        if (device.isApplicationOwned) {
             snapshotId = device.targetSnapshot ? device.targetSnapshot.hashid : '0' // '0' indicates that the device should start in application mode with starter flows
             snapshotName = device.targetSnapshot ? device.targetSnapshot.name : 'None'
             result.push(makeVar('FF_APPLICATION_ID', device.Application?.hashid || ''))

--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -34,11 +34,10 @@ module.exports = {
     sendDeviceUpdateCommand: async function (app, device) {
         if (app.comms) {
             let snapshotId = device.targetSnapshot?.hashid || null
-            const isApplicationOwned = device.ownerType === 'application' && device.Application?.id
             if (snapshotId) {
                 // device.targetSnapshot is a limited view so we need to load the it from the db
                 // If this device is owned by an instance, check it has an associated instance and that it matches the device's project
-                if (isApplicationOwned === false) {
+                if (!device.isApplicationOwned) {
                     const targetSnapshot = (await app.db.models.ProjectSnapshot.byId(snapshotId))
                     if (!targetSnapshot || !targetSnapshot.ProjectId || targetSnapshot.ProjectId !== device.ProjectId) {
                         snapshotId = null // target snapshot is not associated with this project (possibly orphaned), set it to null
@@ -57,7 +56,7 @@ module.exports = {
             // if the device is assigned to an application but has no snapshot we need to send enough
             // info to start the device in application mode so that it can start node-red and
             // permit the user to generate new flows and submit a snapshot
-            if (isApplicationOwned) {
+            if (device.isApplicationOwned) {
                 delete payload.project // exclude project property to avoid triggering the wrong kind of update on the device
                 if (payload.snapshot === null) {
                     payload.snapshot = '0' // '0' indicates that the application owned device should start with starter flows

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -26,9 +26,15 @@ module.exports = {
         mode: { type: DataTypes.STRING, allowNull: true, defaultValue: 'autonomous' },
         /** @type {'instance'|'application'|null} a virtual column that signifies the parent type e.g. `"instance"`, `"application"` */
         ownerType: {
-            type: DataTypes.VIRTUAL,
+            type: DataTypes.VIRTUAL(DataTypes.ENUM('instance', 'application', null)),
             get () {
                 return this.Project?.id ? 'instance' : (this.Application?.hashid ? 'application' : null)
+            }
+        },
+        isApplicationOwned: {
+            type: DataTypes.VIRTUAL(DataTypes.BOOLEAN),
+            get () {
+                return this.ownerType === 'application'
             }
         }
     },

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -94,7 +94,6 @@ module.exports = async function (app) {
      */
     app.get('/snapshot', async (request, reply) => {
         const device = request.device || null
-        const isApplicationOwned = device?.ownerType === 'application' // && 'EE'?
         if (!request.device.targetSnapshot) {
             let nodeRedVersion = '3.0.2' // default to older Node-RED
             if (SemVer.satisfies(SemVer.coerce(device.agentVersion), '>=1.11.2')) {
@@ -102,7 +101,7 @@ module.exports = async function (app) {
                 nodeRedVersion = 'latest'
             }
             // determine is device is in application mode? if so, return a default snapshot to permit the user to generate flows
-            if (isApplicationOwned) {
+            if (request.device.isApplicationOwned) {
                 const DEFAULT_APP_SNAPSHOT = {
                     id: '0',
                     name: 'Starter Snapshot',

--- a/forge/routes/api/deviceSnapshots.js
+++ b/forge/routes/api/deviceSnapshots.js
@@ -180,7 +180,7 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const device = request.device
-        if (device.ownerType !== 'application') {
+        if (!device.isApplicationOwned) {
             reply.code(400).send({ code: 'invalid_device', error: 'Device is not associated with an application' })
             return
         }

--- a/test/unit/forge/db/controllers/Device_spec.js
+++ b/test/unit/forge/db/controllers/Device_spec.js
@@ -111,6 +111,7 @@ describe('Device controller', function () {
                 name: 'device1',
                 type: 'PI4',
                 ownerType: 'application',
+                isApplicationOwned: true,
                 applicationId: 1,
                 Application: {
                     name: 'application-name',


### PR DESCRIPTION
## Description

Previously the following line was throwing if `device` wasn't defined, but the error was silently being dropped https://github.com/FlowFuse/flowfuse/blob/a8261d8cc5b325e868e7f330d5c39213405aab04/forge/comms/devices.js#L68-L70

Rather than adding a guard, I added a virtual attribute directly to the model, and then I took the opportunity to reactor all the `device.ownerType === 'application'` checks throughout our code (which were slightly inconsistent).

## Related Issue(s)

Fixes https://github.com/FlowFuse/flowfuse/issues/2972

Merge target is: https://github.com/FlowFuse/flowfuse/pull/2973

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

