### PR TITLE
FIX: wait for all upstream pipelines to complete before package publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ on:
       - 'package.json'
       - '.eslintrc'
       - '.github/workflows/build.yml'
+      - '.github/workflows/publish.yml'
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  wait_for_workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ahmadnassri/action-workflow-run-wait@v1
+
   publish:
+    needs: wait_for_workflows
     if: |
-      ( github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' ) ||
+      github.ref == 'refs/heads/main' ||
       ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@946077578d8a45c3c945f2c390a39fb17460fab9'
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ on:
       - 'UI Tests'
     branches: 
       - main
+      - fix-wait-for-upstream-workflows
     types: 
       - completed
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
       - 'UI Tests'
     branches: 
       - main
-      - fix-wait-for-upstream-workflows
+      - 'fix-wait-for-upstream-workflows'
     types: 
       - completed
 

--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -16,6 +16,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/test-postgresql.yml'
+      - '.github/workflows/publish.yml'
 
 jobs:
   runner-job:

--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -24,6 +24,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '.eslintrc'
+      - '.github/workflows/publish.yml'
 
 jobs:
   cypress-run:


### PR DESCRIPTION
## Description

`workflow_run` github action event will be executed each [time the upstream workflow completes](https://github.com/orgs/community/discussions/16059). In our configuration it might happen, that the publish workflow is executed three times.
This PR fixes this problem by using dedicated gh action.

## Related Issue(s)

[#231](https://github.com/FlowFuse/CloudProject/issues/231)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

