### PR TITLE
Fix: Loading project snapshot for every device status update

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -19,7 +19,7 @@ module.exports = {
             // hashid.decode returns an array of values, not the raw value.
             if (snapshotId?.length > 0 && snapshotId !== device.activeSnapshotId) {
                 // Check to see if snapshot exists
-                if (await app.db.models.ProjectSnapshot.byId(state.snapshot)) {
+                if (await app.db.models.ProjectSnapshot.count({ where: { id: snapshotId }, limit: 1 }) > 0) {
                     device.set('activeSnapshotId', snapshotId[0])
                 }
             }

--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -14,16 +14,17 @@ module.exports = {
                 device.set('activeSnapshotId', null)
             }
         } else {
-            // Check the snapshot is one we recognise
+            // Update the activeSnapshotId if valid and not already set
             const snapshotId = app.db.models.ProjectSnapshot.decodeHashid(state.snapshot)
             // hashid.decode returns an array of values, not the raw value.
-            if (snapshotId?.length > 0) {
-                // check to see if snapshot still exists
+            if (snapshotId?.length > 0 && snapshotId !== device.activeSnapshotId) {
+                // Check to see if snapshot exists
                 if (await app.db.models.ProjectSnapshot.byId(state.snapshot)) {
-                    device.set('activeSnapshotId', snapshotId)
+                    device.set('activeSnapshotId', snapshotId[0])
                 }
             }
         }
+
         await device.save()
     },
     /**

--- a/test/lib/TestModelFactory.js
+++ b/test/lib/TestModelFactory.js
@@ -184,6 +184,7 @@ module.exports = class TestModelFactory {
             ...deviceDetails
         })
         await team.addDevice(device)
+        await device.setTeam(team)
         if (project) {
             await device.setProject(project)
         } else if (application) {

--- a/test/unit/forge/comms/devices_spec.js
+++ b/test/unit/forge/comms/devices_spec.js
@@ -43,6 +43,11 @@ describe('DeviceCommsHandler', function () {
             name: 'device1'
         }, TestObjects.ATeam)
 
+        TestObjects.applicationDevice = await app.factory.createDevice({
+            name: 'device2',
+            ownerType: 'application'
+        }, TestObjects.ATeam)
+
         TestObjects.tokens = {}
         await login('alice', 'aaPassword')
     }
@@ -252,6 +257,34 @@ describe('DeviceCommsHandler', function () {
             msg.should.have.property('payload')
             const payload = JSON.parse(msg.payload)
             payload.should.have.property('command', 'update')
+        })
+
+        it('updates the active snapshot ID if it is found in the database', async function () {
+            TestObjects.device.Team = await TestObjects.device.getTeam() // .Team is not loaded in the tests
+
+            const knownSnapshot = await app.db.models.ProjectSnapshot.create({
+                name: 'Test Snapshot',
+                description: 'Test Description',
+                flows: {},
+                ApplicationId: TestObjects.device.ApplicationId,
+                DeviceId: TestObjects.applicationDevice.id,
+                UserId: TestObjects.alice.id
+            })
+
+            client.emit('status/device', {
+                id: TestObjects.applicationDevice.hashid,
+                status: JSON.stringify({
+                    state: 'online',
+                    snapshot: knownSnapshot.hashid
+                })
+            })
+
+            // Task happens async
+            await sleep(100)
+
+            await TestObjects.applicationDevice.reload()
+
+            TestObjects.applicationDevice.activeSnapshotId.should.equal(knownSnapshot.id)
         })
     })
 })


### PR DESCRIPTION
## Description

Previously every device status update resulted in pulling a full project snapshot object from the database.

This PR changes that to:
 - Only load the snapshot if the snapshot ID has changed
 - Use count rather then loading the full object for the times it has changed

Includes green/green test coverage too confirm no change in behaviour.

## Related Issue(s)

Fixes #2980

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

