### PR TITLE
Update built-in module list to include newly scoped packages

### DIFF
--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -1,3 +1,4 @@
+const { BUILT_IN_MODULES } = require('../../lib/builtInModules')
 const { templateFields, defaultTemplateValues, defaultTemplatePolicy } = require('../../lib/templates')
 const { hash } = require('../utils')
 
@@ -89,9 +90,6 @@ module.exports = {
             // ensure names and version are valid
             // NOTE: `validateModuleName` and `validateModuleVersion` have frontend counterparts
             // in `/frontend/src/pages/admin/Template/sections/PaletteModules.vue` and should be kept in sync
-            const BUILT_IN_MODULES = [
-                '@flowforge/nr-project-nodes'
-            ]
             const validateModuleName = (name) => !BUILT_IN_MODULES.includes(name) && /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name)
             const validateModuleVersion = (version) => /^\*$|x|(?:[\^~]?(0|[1-9]\d*)\.(x$|0|[1-9]\d*)(?:\.(x$|0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?)$/.test(version)
             const moduleMap = {}

--- a/forge/db/controllers/StorageSettings.js
+++ b/forge/db/controllers/StorageSettings.js
@@ -1,11 +1,4 @@
-// These are the modules we preinstall that Node-RED will report back in its
-// runtime settings.
-// Pre 1.0, for docker/k8s, they might have been included in the main package.json
-// which means they are flagged as local - but they shouldn't be. We need to explicitly
-// filter them out.
-const BUILT_IN_MODULES = [
-    '@flowforge/nr-project-nodes'
-]
+const { BUILT_IN_MODULES } = require('../../lib/builtInModules')
 
 module.exports = {
     getProjectModules: async function (app, project) {

--- a/forge/lib/builtInModules.js
+++ b/forge/lib/builtInModules.js
@@ -1,0 +1,12 @@
+// These are the modules we preinstall that Node-RED will report back in its
+// runtime settings.
+
+const BUILT_IN_MODULES = [
+    '@flowforge/nr-project-nodes',
+    '@flowfuse/nr-project-nodes',
+    '@flowforge/nr-file-nodes',
+    '@flowfuse/nr-file-nodes'
+]
+module.exports = {
+    BUILT_IN_MODULES
+}

--- a/frontend/src/pages/admin/Template/sections/PaletteModules.vue
+++ b/frontend/src/pages/admin/Template/sections/PaletteModules.vue
@@ -150,6 +150,8 @@
 
 import { CheckIcon, LockClosedIcon, PencilIcon, PlusSmIcon, TrashIcon, XIcon } from '@heroicons/vue/outline'
 
+import { BUILT_IN_MODULES } from '../../../../../../forge/lib/builtInModules.js'
+
 import FormHeading from '../../../../components/FormHeading.vue'
 import FormRow from '../../../../components/FormRow.vue'
 import ChangeIndicator from '../components/ChangeIndicator.vue'
@@ -272,9 +274,6 @@ export default {
     },
     methods: {
         validateModuleName (name) {
-            const BUILT_IN_MODULES = [
-                '@flowforge/nr-project-nodes'
-            ]
             return /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name) && !BUILT_IN_MODULES.includes(name)
         },
         validateModuleVersion (version) {


### PR DESCRIPTION
This updates the list of built-in modules we need to filter from the view.

As this list appeared in three different places, I've pulled them into one place that can be reused.