### PR TITLE
Fix recursion when adding mutating palette catalogue urls

### DIFF
--- a/frontend/src/pages/admin/Template/index.vue
+++ b/frontend/src/pages/admin/Template/index.vue
@@ -125,18 +125,17 @@ export default {
                             changed = changed || pmChanges.changed
                             errors = errors || pmChanges.errors
                         } else if (field === 'palette_catalogue') {
-                            this.editable.changed.settings.palette_catalogue = false
-                            if (this.original.settings.palette_catalogue.length !== this.editable.settings.palette_catalogue.length) {
-                                this.editable.changed.settings.palette_catalogue = true
-                            } else {
+                            let paletteCatalogueHasChanged = this.original.settings.palette_catalogue.length !== this.editable.settings.palette_catalogue.length
+                            if (!paletteCatalogueHasChanged) {
                                 for (const i in this.editable.settings.palette_catalogue) {
                                     if (this.editable.settings.palette_catalogue[i] !== this.original.settings.palette_catalogue[i]) {
-                                        this.editable.changed.settings.palette_catalogue = true
+                                        paletteCatalogueHasChanged = true
                                         break
                                     }
                                 }
                             }
-                            needsRestart = needsRestart || this.editable.changed.settings.palette_catalogue
+                            needsRestart = needsRestart || paletteCatalogueHasChanged
+                            this.editable.changed.settings.palette_catalogue = paletteCatalogueHasChanged
                         } else {
                             this.editable.changed.settings[field] = this.editable.settings[field] !== this.original.settings[field]
                             needsRestart = needsRestart || this.editable.changed.settings[field]

--- a/frontend/src/pages/admin/Template/sections/Catalogues.vue
+++ b/frontend/src/pages/admin/Template/sections/Catalogues.vue
@@ -101,8 +101,7 @@ export default {
             input: {
                 url: '',
                 error: ''
-            },
-            urls: []
+            }
         }
     },
     computed: {
@@ -113,6 +112,9 @@ export default {
             set (localValue) {
                 this.$emit('update:modelValue', localValue)
             }
+        },
+        urls () {
+            return this.editable.settings.palette_catalogue
         },
         projectLauncherCompatible () {
             if (this.editTemplate) {
@@ -143,18 +145,6 @@ export default {
             // whether or not this Template has any third party catalogues enabled
             return this.urls.filter(url => url !== this.defaultCatalogue)
         }
-    },
-    watch: {
-        'editable.settings.palette_catalogue': {
-            deep: true,
-            handler (newValue) {
-                this.urls = newValue
-            }
-        }
-    },
-    mounted () {
-        // deep copy
-        this.urls = JSON.parse(JSON.stringify(this.editable.settings.palette_catalogue))
     },
     methods: {
         addURL () {


### PR DESCRIPTION
## Description

- Only mutate this.editable.changed.settings.palette_catalogue once per handling of the watch 
- Replace object duplication with a computed property - unrelated clean up

This is a quick fix, long term, we should look into removing the change tracking from the editable object.
Mutating an object inside its own watch handler is bad practice and should be avoided to prevent accidental recursion and improve performance.
 
## Related Issue(s)

No issue yet.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass - **We should add test coverage**
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

