### PR TITLE
Avoid needless settings lookup on instance list endpoint

### DIFF
--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -100,10 +100,13 @@ module.exports = function (app) {
         return result
     }
 
+    // This view is only used by the 'deprecated' /team/:teamId/projects end point.
+    // However it is still used in a few places from the frontend. None of them
+    // require the full details of the instances - so the settings object can be omitted
     async function instancesList (instancesArray) {
         return Promise.all(instancesArray.map(async (instance) => {
-            // Full settings are not
-            const result = await app.db.views.Project.project(instance, { includeSettings: true })
+            // Full settings are not required for the instance summary list
+            const result = await app.db.views.Project.project(instance, { includeSettings: false })
 
             if (!result.url) {
                 delete result.url

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -331,7 +331,11 @@ module.exports = async function (app) {
 
     /**
      * @deprecated Use /:teamId/applications, or /:applicationId/instances
-     * This end-point is still used by the project nodes and nr-tools plugin.
+     * This end-point is still used by:
+     *  - the project nodes and nr-tools plugin.
+     *  - the Team Instances view
+     *  - team/Devices/dialogs/CreateProvisionTokenDialog.vue
+     *  - team/Settings/Devices.vue
      */
     app.get('/:teamId/projects', {
         preHandler: app.needsPermission('team:projects:list')


### PR DESCRIPTION
Fixes #3021 

## Description

When using the (deprecated) `/team/:teamId/projects` endpoint, the view code was triggering an additional db lookup for each instance to find its node-red module list.

For this particular endpoint, the module list is never needed - nor are the rest of the instance settings - so this PR prevents them from been generated in the view. The view being used is *only* used by this route. There is some overlap with the `instanceSummaryList`  view, however it isn't quite a drop-in replacement. I elected to not go down the rabbit hole of resolving that part of it.

I have also documented where this deprecated route is still being used; there isn't an equivalent route for getting a list of a team's instances currently - they are more application oriented. So this route needs to stay for now.