### PR TITLE
Avoid unnecessary retrieval of full snapshot contents where possible

### DIFF
--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -90,7 +90,7 @@ class DeviceCommsHandler {
                 if (Object.hasOwn(payload, 'snapshot')) {
                     // load the full snapshot (as specified by the device) from the db so we can check the snapshots
                     // `ProjectId` is "something" (not orphaned) and matches the device's project
-                    const targetSnapshot = (await this.app.db.models.ProjectSnapshot.byId(payload.snapshot))
+                    const targetSnapshot = (await this.app.db.models.ProjectSnapshot.byId(payload.snapshot, { includeFlows: false, includeSettings: false }))
                     if (payload.snapshot !== (targetSnapshot?.hashid || null)) {
                         // The Snapshot is incorrect
                         sendUpdateCommand = true

--- a/forge/db/models/ProjectSnapshot.js
+++ b/forge/db/models/ProjectSnapshot.js
@@ -71,11 +71,10 @@ module.exports = {
                             exclude: toExclude
                         }
                     }
-                    const r = await self.findOne({
+                    return self.findOne({
                         where: { id },
                         attributes
                     })
-                    return r
                 },
                 forProject: async (projectId, pagination = {}) => {
                     const limit = parseInt(pagination.limit) || 1000

--- a/forge/db/models/ProjectSnapshot.js
+++ b/forge/db/models/ProjectSnapshot.js
@@ -51,15 +51,31 @@ module.exports = {
         const self = this
         return {
             static: {
-                byId: async function (id) {
-                    // This returns the full snapshot - including settings and flows
-                    // This should _only_ be used when getting all of that information
+                byId: async function (id, { includeFlows = true, includeSettings = true } = {}) {
+                    // By default, this returns the full snapshot - including settings and flows
+                    // This should _only_ be used when getting all of that information.
+                    // Otherwise use the options to disable retrieving flows/settings
                     if (typeof id === 'string') {
                         id = M.ProjectSnapshot.decodeHashid(id)
                     }
-                    return self.findOne({
-                        where: { id }
+                    const toExclude = []
+                    if (!includeFlows) {
+                        toExclude.push('flows')
+                    }
+                    if (!includeSettings) {
+                        toExclude.push('settings')
+                    }
+                    let attributes = null
+                    if (toExclude.length > 0) {
+                        attributes = {
+                            exclude: toExclude
+                        }
+                    }
+                    const r = await self.findOne({
+                        where: { id },
+                        attributes
                     })
+                    return r
                 },
                 forProject: async (projectId, pagination = {}) => {
                     const limit = parseInt(pagination.limit) || 1000

--- a/forge/db/views/AccessToken.js
+++ b/forge/db/views/AccessToken.js
@@ -44,7 +44,7 @@ module.exports = function (app) {
                 targetSnapshot: null
             }
             if (project && deviceSettings?.targetSnapshot) {
-                const snapshot = await app.db.models.ProjectSnapshot.byId(deviceSettings.targetSnapshot)
+                const snapshot = await app.db.models.ProjectSnapshot.byId(deviceSettings.targetSnapshot, { includeFlows: false, includeSettings: false })
                 tokenSummary.targetSnapshot = snapshot?.name
             }
         }

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -431,7 +431,7 @@ module.exports = async function (app) {
             // ### Modify device properties ###
             if (request.body.targetSnapshot !== undefined && request.body.targetSnapshot !== device.targetSnapshotId) {
                 // get snapshot from db
-                const targetSnapshot = await app.db.models.ProjectSnapshot.byId(request.body.targetSnapshot)
+                const targetSnapshot = await app.db.models.ProjectSnapshot.byId(request.body.targetSnapshot, { includeFlows: false, includeSettings: false })
                 if (!targetSnapshot) {
                     reply.code(400).send({ code: 'invalid_snapshot', error: 'invalid snapshot' })
                     return

--- a/forge/routes/api/deviceSnapshots.js
+++ b/forge/routes/api/deviceSnapshots.js
@@ -16,6 +16,9 @@ module.exports = async function (app) {
         if (request.params.snapshotId !== undefined) {
             if (request.params.snapshotId) {
                 try {
+                    // TODO: I don't think `request.snapshot.flows` is ever accessed by
+                    // any of the routes. If that is confirmed, we should add `{ includeFlows: false }`
+                    // to the following call to avoid unncessary work
                     request.snapshot = await app.db.models.ProjectSnapshot.byId(request.params.snapshotId)
                     if (!request.snapshot) {
                         reply.code(404).send({ code: 'not_found', error: 'Not Found' })

--- a/forge/routes/api/projectDevices.js
+++ b/forge/routes/api/projectDevices.js
@@ -119,7 +119,7 @@ module.exports = async function (app) {
             // For now, only care about that - when we add other device settings, this
             // will need to be rewritten
 
-            const targetSnapshot = await app.db.models.ProjectSnapshot.byId(request.body.targetSnapshot)
+            const targetSnapshot = await app.db.models.ProjectSnapshot.byId(request.body.targetSnapshot, { includeFlows: false, includeSettings: false })
 
             if (!targetSnapshot) {
                 reply.code(400).send({ code: 'invalid_snapshot', error: 'Invalid snapshot' })

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -16,6 +16,9 @@ module.exports = async function (app) {
         if (request.params.snapshotId !== undefined) {
             if (request.params.snapshotId) {
                 try {
+                    // TODO: Only the export snapshot route requires the snapshot to have flows attached.
+                    // We could single that out (as an uncommon path) and otherwise add { includeFlows: false }
+                    // here to avoid loading the full flow object.
                     request.snapshot = await app.db.models.ProjectSnapshot.byId(request.params.snapshotId)
                     if (!request.snapshot) {
                         reply.code(404).send({ code: 'not_found', error: 'Not Found' })


### PR DESCRIPTION
Fixes #2980 

## Description

Whenever a device checks in, we validate the snapshot it reports is still one it is allowed to be using. This only requires checking the owner of the snapshot - it doesn't require the full contents of the snapshot.

Given how often devices check-in, we want to be mindful of not doing any more work than is needed.

This PR updates the `ProjectSnapshot.byId` function to accept options to turn off retrieval of the flows and settings objects.

It then updates any callers to that function that don't require the full object.

I did spot a couple places where the full object is retrieved in a preHandler - but the flows are only needed for one of the routes. I have documented that in the code - but didn't want to overdo the refactoring at this point.
