### PR TITLE
Prevent snapshots of devices without applications / instances

### DIFF
--- a/forge/db/controllers/ProjectSnapshot.js
+++ b/forge/db/controllers/ProjectSnapshot.js
@@ -76,12 +76,12 @@ module.exports = {
             ProjectId: project.id,
             UserId: user.id
         }
-        if (deviceConfig.flows) {
+        if (deviceConfig?.flows) {
             const projectSecret = await project.getCredentialSecret()
             snapshotOptions.flows.flows = deviceConfig.flows
             snapshotOptions.flows.credentials = app.db.controllers.Project.exportCredentials(deviceConfig.credentials || {}, device.credentialSecret, projectSecret)
         }
-        if (deviceConfig.package?.modules) {
+        if (deviceConfig?.package?.modules) {
             snapshotOptions.settings.modules = deviceConfig.package.modules
         }
         const snapshot = await app.db.models.ProjectSnapshot.create(snapshotOptions)

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -689,6 +689,15 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
+        if (request.device.isApplicationOwned) {
+            reply.code(400).send({ code: 'invalid_device', error: 'Device is not associated with a instance, application owned devices must use the application device snapshot endpoint' })
+            return
+        }
+        if (!request.device.Project) {
+            reply.code(400).send({ code: 'invalid_device', error: 'Device must be associated with a instance to create a snapshot' })
+            return
+        }
+
         const snapshotOptions = {
             name: request.body.name,
             description: request.body.description,

--- a/frontend/src/pages/device/Snapshots/index.vue
+++ b/frontend/src/pages/device/Snapshots/index.vue
@@ -45,7 +45,7 @@
                     </p>
                 </template>
                 <template v-if="hasPermission('device:snapshot:create')" #actions>
-                    <ff-button kind="primary" :disabled="!developerMode || busyMakingSnapshot || !features.deviceEditor" data-action="create-snapshot" @click="showCreateSnapshotDialog">
+                    <ff-button kind="primary" :disabled="!developerMode || busyMakingSnapshot || !features.deviceEditor || device.ownerType !== 'application'" data-action="create-snapshot" @click="showCreateSnapshotDialog">
                         <template #icon-left><PlusSmIcon /></template>Create Snapshot
                     </ff-button>
                 </template>


### PR DESCRIPTION
- Red test coverage of creating snapshots of instance devices
- Guard against application owned devices
- Disable the create snapshot button if device does not have an application

## Description

Previously the create snapshot dialog was still available on the Device > Snapshots page if a device was not assigned to an application or instance.

This PR adds API level guards for creating instance snapshots of devices that are assigned to an application or not assigned to an instance and adds a simple UI guard for it too. The developer mode tab is not affected as that is only visible when the device is assigned to a project.

<img width="1305" alt="Screenshot 2023-10-30 at 13 15 18" src="https://github.com/FlowFuse/flowfuse/assets/507155/d79e86eb-2825-4f3e-be8d-10c1eaa4ab6f">

Fixes https://github.com/FlowFuse/flowfuse/issues/2927

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/2927

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

