### PR TITLE
Fix applying pipeline migrations on non-EE platforms

### DIFF
--- a/forge/db/migrations/20230705-01-add-device-setting-to-stages.js
+++ b/forge/db/migrations/20230705-01-add-device-setting-to-stages.js
@@ -6,6 +6,15 @@ const { DataTypes } = require('sequelize')
 
 module.exports = {
     up: async (context) => {
+        try {
+            await context.describeTable('PipelineStages')
+        } catch (err) {
+            // Missing table means this db was initialised after Pipelines
+            // were introduced and does not have an EE license. So we need to
+            // rerun the Pipeline migrations to ensure the tables exist in the
+            // right state
+            await require('./20230504-01-add-pipelines').up(context)
+        }
         await context.addColumn('PipelineStages', 'deployToDevices', {
             type: DataTypes.BOOLEAN,
             allowNull: false,

--- a/forge/db/migrations/20230919-01-add-action-to-pipeline-stage.js
+++ b/forge/db/migrations/20230919-01-add-action-to-pipeline-stage.js
@@ -11,6 +11,17 @@ module.exports = {
      * @param {QueryInterface} context Sequelize.QueryInterface
      */
     up: async (context) => {
+        try {
+            await context.describeTable('PipelineStages')
+        } catch (err) {
+            // Missing table means this db was initialised after Pipelines
+            // were introduced and does not have an EE license. So we need to
+            // rerun the Pipeline migrations to ensure the tables exist in the
+            // right state
+            await require('./20230504-01-add-pipelines').up(context)
+            await require('./20230705-01-add-device-setting-to-stages').up(context)
+        }
+
         const SNAPSHOT_ACTIONS = {
             CREATE_SNAPSHOT: 'create_snapshot',
             USE_LATEST_SNAPSHOT: 'use_latest_snapshot',


### PR DESCRIPTION
## Description

Full context in this comment: https://github.com/FlowFuse/flowfuse/issues/2803#issuecomment-1786187219

In summary, for any migration that touches an EE table, we need to check whether that table exists and if necessary, create it first - ideally be rerunning the previous migration that should have created it.

This PR fixes it up for the Pipeline migrations. Anyone who installed a clean version of v1.8.0 or later and is running without an EE license, will not have the expected EE DB tables. This causes the migrations to fail that try to touch those missing tables. The PR looks for the missing table, and then reruns the appropriate preceding migration(s) as needed.

There is a wider issue to address in terms of moving forward and how we want to handle this better in the future. I'm still working through the impacts of that.