### PR TITLE
Chore: Reduce sentry reporting rate

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -85,12 +85,13 @@ module.exports = async (options = {}) => {
     }
 
     if (runtimeConfig.telemetry.backend?.sentry?.dsn) {
+        const environment = process.env.SENTRY_ENV ?? (process.env.NODE_ENV ?? 'unknown')
         server.register(require('@immobiliarelabs/fastify-sentry'), {
             dsn: runtimeConfig.telemetry.backend.sentry.dsn,
-            environment: process.env.SENTRY_ENV ?? (process.env.NODE_ENV ?? 'unknown'),
+            environment,
             release: `flowfuse@${runtimeConfig.version}`,
-            tracesSampleRate: 0.1,
-            profilesSampleRate: 0.1,
+            tracesSampleRate: environment === 'production' ? 0.05 : 0.1,
+            profilesSampleRate: environment === 'production' ? 0.05 : 0.1,
             integrations: [
                 new ProfilingIntegration()
             ],

--- a/frontend/src/services/error-tracking.js
+++ b/frontend/src/services/error-tracking.js
@@ -27,7 +27,7 @@ export const setupSentry = (app, router) => {
         environment: window.sentryConfig.environment,
 
         // Performance Monitoring
-        tracesSampleRate: window.sentryConfig.production ? 1.0 : 0.1,
+        tracesSampleRate: window.sentryConfig.production ? 0.5 : 1.0,
 
         // Which URLs distributed tracing should be enabled
         tracePropagationTargets: [/^https:\/\/forge.flowforge.dev\/api/, /^https:\/\/app.flowforge.com\//],

--- a/frontend/src/services/error-tracking.js
+++ b/frontend/src/services/error-tracking.js
@@ -33,8 +33,8 @@ export const setupSentry = (app, router) => {
         tracePropagationTargets: [/^https:\/\/forge.flowforge.dev\/api/, /^https:\/\/app.flowforge.com\//],
 
         // Session Replay
-        replaysSessionSampleRate: window.sentryConfig.production ? 0.1 : 0.5,
-        replaysOnErrorSampleRate: 1.0,
+        replaysSessionSampleRate: window.sentryConfig.production ? 0.05 : 0.25,
+        replaysOnErrorSampleRate: 0.5,
 
         // Skip localhost reporting
         beforeSend: (event) => {


### PR DESCRIPTION
## Description

We've hit our reporting limit in Sentry for both replays and performance units.

As a first step, this PR configures Sentry to report less, but we still need to look into why it's reporting quite so many units in the first place.

I've confirmed the config being passed to the setnry API localy is: 

```javascript
{
  dsn: '[REMOVED]',
  environment: 'development',
  release: 'flowfuse@1.13.1-git',
  tracesSampleRate: 0.1, // clearly set to 10%
  profilesSampleRate: 0.1, // clearly set to 10%
  integrations: [
    ProfilingIntegration {
      name: 'ProfilingIntegration',
      getCurrentHub: undefined
    }
  ]
}
```

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

