### PR TITLE
Disable create snapshot button if not assigned to an application or instance

### DIFF
--- a/frontend/src/pages/device/DeveloperMode/index.vue
+++ b/frontend/src/pages/device/DeveloperMode/index.vue
@@ -53,7 +53,7 @@
                             >
                                 Create Snapshot
                             </ff-button>
-                            <span v-if="createSnapshotDisabled" class="ff-description ml-2">A device must first be assigned to an Application, in order to create snapshots.</span>
+                            <span v-if="createSnapshotDisabled" class="ff-description ml-2">A device must first be assigned to an Application or Instance in order to create snapshots.</span>
                         </div>
                     </template>
                 </InfoCardRow>

--- a/frontend/src/pages/device/DeveloperMode/index.vue
+++ b/frontend/src/pages/device/DeveloperMode/index.vue
@@ -117,7 +117,7 @@ export default {
             return this.developerMode && this.device.status === 'running'
         },
         createSnapshotDisabled () {
-            return this.device.ownerType !== 'application'
+            return this.device.ownerType !== 'application' && this.device.ownerType !== 'instance'
         }
     },
     watch: {

--- a/frontend/src/pages/device/DeveloperMode/index.vue
+++ b/frontend/src/pages/device/DeveloperMode/index.vue
@@ -42,16 +42,19 @@
                 </InfoCardRow>
                 <InfoCardRow property="Device Flows:">
                     <template #value>
-                        <ff-button
-                            :disabled="device.ownerType !== 'application'"
-                            kind="secondary"
-                            class="w-28 whitespace-nowrap"
-                            size="small"
-                            data-action="create-snapshot-dialog"
-                            @click="showCreateSnapshotDialog"
-                        >
-                            Create Snapshot
-                        </ff-button>
+                        <div class="flex items-center">
+                            <ff-button
+                                :disabled="createSnapshotDisabled"
+                                kind="secondary"
+                                class="w-28 whitespace-nowrap"
+                                size="small"
+                                data-action="create-snapshot-dialog"
+                                @click="showCreateSnapshotDialog"
+                            >
+                                Create Snapshot
+                            </ff-button>
+                            <span v-if="createSnapshotDisabled" class="ff-description ml-2">A device must first be assigned to an Application, in order to create snapshots.</span>
+                        </div>
                     </template>
                 </InfoCardRow>
             </template>
@@ -112,6 +115,9 @@ export default {
         },
         editorCanBeEnabled: function () {
             return this.developerMode && this.device.status === 'running'
+        },
+        createSnapshotDisabled () {
+            return this.device.ownerType !== 'application'
         }
     },
     watch: {

--- a/frontend/src/pages/device/DeveloperMode/index.vue
+++ b/frontend/src/pages/device/DeveloperMode/index.vue
@@ -43,9 +43,11 @@
                 <InfoCardRow property="Device Flows:">
                     <template #value>
                         <ff-button
+                            :disabled="device.ownerType !== 'application'"
                             kind="secondary"
                             class="w-28 whitespace-nowrap"
                             size="small"
+                            data-action="create-snapshot-dialog"
                             @click="showCreateSnapshotDialog"
                         >
                             Create Snapshot

--- a/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
@@ -45,4 +45,32 @@ describe('FlowForge - Devices - With Billing', () => {
 
         cy.url().should('not.include', '/developer-mode')
     })
+
+    it('has the create snapshot disabled if the snapshot is not assigned to an application', () => {
+        /// Assigned to nothing
+        cy.contains('span', 'team2-unassigned-device').click()
+        cy.get('[data-el="device-devmode-toggle"]').click()
+        cy.get('[data-nav="device-devmode"]').click()
+
+        cy.get('[data-action="create-snapshot-dialog"]').should('be.disabled')
+        cy.get('[data-el="device-devmode-toggle"]').click() // reset
+
+        // Assigned to an instance
+        cy.visit('/team/bteam/devices')
+        cy.contains('span', 'assigned-device-a').click()
+        cy.get('[data-el="device-devmode-toggle"]').click()
+        cy.get('[data-nav="device-devmode"]').click()
+
+        cy.get('[data-action="create-snapshot-dialog"]').should('be.disabled')
+        cy.get('[data-el="device-devmode-toggle"]').click() // reset
+
+        /// Assigned to application
+        cy.visit('/team/bteam/devices')
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-el="device-devmode-toggle"]').click()
+        cy.get('[data-nav="device-devmode"]').click()
+
+        cy.get('[data-action="create-snapshot-dialog"]').should('not.be.disabled')
+        cy.get('[data-el="device-devmode-toggle"]').click() // reset
+    })
 })

--- a/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
@@ -46,7 +46,7 @@ describe('FlowForge - Devices - With Billing', () => {
         cy.url().should('not.include', '/developer-mode')
     })
 
-    it('has the create snapshot disabled if the snapshot is not assigned to an application', () => {
+    it('has the create snapshot disabled if the snapshot is not assigned to an application or instance', () => {
         /// Assigned to nothing
         cy.contains('span', 'team2-unassigned-device').click()
         cy.get('[data-el="device-devmode-toggle"]').click()
@@ -61,7 +61,7 @@ describe('FlowForge - Devices - With Billing', () => {
         cy.get('[data-el="device-devmode-toggle"]').click()
         cy.get('[data-nav="device-devmode"]').click()
 
-        cy.get('[data-action="create-snapshot-dialog"]').should('be.disabled')
+        cy.get('[data-action="create-snapshot-dialog"]').should('not.be.disabled')
         cy.get('[data-el="device-devmode-toggle"]').click() // reset
 
         /// Assigned to application


### PR DESCRIPTION
## Description

Follow up to https://github.com/FlowFuse/flowfuse/pull/3026

![Screenshot 2023-11-17 at 15 06 26](https://github.com/FlowFuse/flowfuse/assets/507155/f669eece-c6c5-44e0-9e2a-fe5ff31df680)

## Related Issue(s)

N/a

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

