### PR TITLE
Allow admin to disable MFA for a user

### DIFF
--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -112,6 +112,10 @@ module.exports = {
                 if (request.body.email_verified !== undefined) {
                     user.email_verified = request.body.email_verified
                 }
+                if (app.config.features.enabled('mfa') && request.body.mfa_enabled === false) {
+                    user.mfa_enabled = false
+                    await app.db.models.MFAToken.deleteTokenForUser(user)
+                }
 
                 if (request.body.admin !== undefined) {
                     user.admin = request.body.admin

--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -118,7 +118,8 @@ module.exports = async function (app) {
                     admin: { type: 'boolean' },
                     password_expired: { type: 'boolean' },
                     suspended: { type: 'boolean' },
-                    defaultTeam: { type: 'string' }
+                    defaultTeam: { type: 'string' },
+                    mfa_enabled: { type: 'boolean' }
                 }
             },
             response: {

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -80,7 +80,7 @@ export default {
     computed: {
         ...mapState('account', ['settings', 'pending', 'loginError', 'redirectUrlAfterLogin']),
         tokenInvalid () {
-            return this.mfaRequired && this.input.token.length !== 6
+            return this.mfaRequired && !/^\d{6}$/.test(this.input.token)
         }
     },
     watch: {

--- a/frontend/src/pages/account/Security/MultiFactorAuth.vue
+++ b/frontend/src/pages/account/Security/MultiFactorAuth.vue
@@ -13,8 +13,8 @@
                 </div>
             </div>
             <div class="min-w-fit flex-shrink-0">
-                <ff-button v-if="!user.mfa_enabled" data-action="enable-mfa" kind="secondary" @click="setupMFA()">Enable two-factor authentication</ff-button>
-                <ff-button v-else data-action="disable-mfa" kind="secondary" @click="disableMFA()">Disable two-factor authentication</ff-button>
+                <ff-button v-if="!user.mfa_enabled" data-action="enable-mfa" kind="primary" @click="setupMFA()">Enable two-factor authentication</ff-button>
+                <ff-button v-else data-action="disable-mfa" kind="danger" @click="disableMFA()">Disable two-factor authentication</ff-button>
             </div>
         </div>
     </form>

--- a/frontend/src/pages/account/Security/dialogs/MFASetupDialog.vue
+++ b/frontend/src/pages/account/Security/dialogs/MFASetupDialog.vue
@@ -1,23 +1,41 @@
 <template>
     <ff-dialog ref="dialog" data-el="mfa-setup" header="Setup two-factor authentication">
         <template #default>
-            <template v-if="step === 0">
-                <div class="text-center">
-                    <img v-if="!!qrcode" :src="qrcode">
-                </div>
-            </template>
-            <template v-if="step === 1">
-                <FormRow v-model="verifyToken" data-form="verify-token" maxlength="6">
-                    Enter a code from your Authenticator app to ensure its working
-                </FormRow>
-            </template>
-            <template v-if="step === 2">
-                Two-factor authentication is now enabled.
-            </template>
-            <template v-if="step === 3">
-                Failed to verify the autentication code. You will need to restart
-                the setup to try again.
-            </template>
+            <div class="space-y-4">
+                <template v-if="step === 0">
+                    <p>
+                        To get started, scan the following QR code into your Authenticator app, then click next to continue.
+                    </p>
+                    <div class="text-center mt-4">
+                        <img v-if="!!qrcode" :src="qrcode" class="m-auto border rounded">
+                    </div>
+                </template>
+                <template v-if="step === 1">
+                    <p>
+                        Enter a code from your Authenticator app to check everything is working.
+                    </p>
+                    <div class="w-32">
+                        <ff-text-input
+                            ref="verify-token"
+                            v-model="verifyToken"
+                            :maxlength="6"
+                            data-form="verify-token"
+                            class=""
+                        />
+                    </div>
+                </template>
+                <template v-if="step === 2">
+                    <p>
+                        Two-factor authentication is now enabled.
+                    </p>
+                    <p>
+                        You will need to provide a code from your Authenticator app each time you login from now on.
+                    </p>
+                </template>
+                <template v-if="step === 3">
+                    Failed to verify the code. You will need to restart the setup to try again.
+                </template>
+            </div>
         </template>
         <template #actions>
             <ff-button v-if="step < 2" data-action="mfa-setup-cancel" kind="secondary" @click="cancel()">Cancel</ff-button>
@@ -29,15 +47,10 @@
 </template>
 
 <script>
-
 import userApi from '../../../../api/user.js'
-import FormRow from '../../../../components/FormRow.vue'
 
 export default {
     name: 'MFASetupDialog',
-    components: {
-        FormRow
-    },
     emits: ['user-updated'],
     setup () {
         return {
@@ -66,7 +79,7 @@ export default {
     computed: {
         canContinue () {
             return this.step === 0 ||
-                (this.step === 1 && this.verifyToken.length === 6)
+                (this.step === 1 && /^\d{6}$/.test(this.verifyToken))
         }
     },
     methods: {
@@ -85,6 +98,8 @@ export default {
         async next () {
             if (this.step === 0) {
                 this.step = 1
+                await this.$nextTick()
+                this.$refs['verify-token'].focus()
             } else if (this.step === 1) {
                 try {
                     await userApi.verifyMFA(this.verifyToken)

--- a/frontend/src/pages/admin/Users/General.vue
+++ b/frontend/src/pages/admin/Users/General.vue
@@ -56,8 +56,10 @@ export default {
             nextCursor: null,
             columns: [
                 { label: 'User', class: ['flex-grow'], key: 'name', component: { is: markRaw(UserCell) }, sortable: true },
-                { label: 'Password Expired', class: ['w-56', 'text-center'], key: 'password_expired', sortable: true },
-                { label: 'Email Verified', class: ['w-56', 'text-center'], key: 'email_verified', sortable: true },
+                { label: 'Password Expired', class: ['w-32', 'text-center'], key: 'password_expired', sortable: true },
+                { label: 'Email Verified', class: ['w-32', 'text-center'], key: 'email_verified', sortable: true },
+                { label: 'SSO', class: ['w-32', 'text-center'], key: 'sso_enabled', sortable: true },
+                { label: 'MFA', class: ['w-32', 'text-center'], key: 'mfa_enabled', sortable: true },
                 { label: 'Admin', class: ['w-32', 'text-center'], key: 'admin', sortable: true },
                 { label: 'Suspended', class: ['w-32', 'text-center'], key: 'suspended', sortable: true }
             ]

--- a/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
+++ b/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
@@ -44,6 +44,22 @@
                     </template>
                 </FormRow>
                 <FormHeading class="text-red-700">Danger Zone</FormHeading>
+                <FormRow v-if="features.mfa" :error="errors.disableMFA" wrapperClass="block">
+                    <template #input>
+                        <div class="flex justify-between items-center">
+                            <ff-button :disabled="mfaLocked" :kind="mfaLocked?'secondary':'danger'" @click="disableMFA">
+                                <template v-if="user.mfa_enabled">Disable MFA</template>
+                                <template v-else>MFA not enabled</template>
+                            </ff-button>
+                            <ff-button v-if="mfaLocked && user.mfa_enabled" kind="danger" size="small" @click="unlockMFA()">
+                                Unlock
+                                <template #icon>
+                                    <LockClosedIcon />
+                                </template>
+                            </ff-button>
+                        </div>
+                    </template>
+                </FormRow>
                 <FormRow :error="errors.expirePassword" wrapperClass="block">
                     <template #input>
                         <div class="flex justify-between items-center">
@@ -76,7 +92,9 @@
 </template>
 
 <script>
+
 import { LockClosedIcon } from '@heroicons/vue/outline'
+import { mapState } from 'vuex'
 
 import usersApi from '../../../../api/users.js'
 import FormHeading from '../../../../components/FormHeading.vue'
@@ -108,6 +126,7 @@ export default {
                 this.expirePassLocked = true
                 this.user_suspendedLocked = true
                 this.input.user_suspended = user.suspended
+                this.mfaLocked = true
                 this.errors = {}
             }
         }
@@ -121,10 +140,12 @@ export default {
             email_verifiedLocked: false,
             deleteLocked: true,
             expirePassLocked: true,
-            user_suspendedLocked: true
+            user_suspendedLocked: true,
+            mfaLocked: true
         }
     },
     computed: {
+        ...mapState('account', ['features']),
         disableSave () {
             const { isChanged, isValid } = this.getChanges()
             return !isValid || !isChanged
@@ -161,6 +182,9 @@ export default {
         },
         unlockSuspended () {
             this.user_suspendedLocked = false
+        },
+        unlockMFA () {
+            this.mfaLocked = false
         },
         getChanges () {
             const changes = {}
@@ -249,6 +273,15 @@ export default {
                     this.$emit('user-updated', response)
                 }).catch(err => {
                     this.errors.expirePassword = err.response.data.error
+                })
+        },
+        disableMFA () {
+            usersApi.updateUser(this.user.id, { mfa_enabled: false })
+                .then((response) => {
+                    this.$refs.dialog.close()
+                    this.$emit('user-updated', response)
+                }).catch(err => {
+                    this.errors.disableMFA = err.response.data.error
                 })
         }
     }

--- a/test/unit/forge/ee/routes/mfa/index_spec.js
+++ b/test/unit/forge/ee/routes/mfa/index_spec.js
@@ -1,0 +1,80 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../../setup')
+
+describe('Users API - MFA', async function () {
+    let app
+    const TestObjects = {}
+
+    before(async function () {
+        const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTA4ODAwLCJleHAiOjc5ODY5ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo1LCJ0ZWFtcyI6NTAsInByb2plY3RzIjo1MCwiZGV2aWNlcyI6NTAsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNTQ4NjAyfQ.vvSw6pm-NP5e0NUL7yMOG-w0AgB8H3NRGGN7b5Dw_iW5DiIBbVQ4HVLEi3dyy9fk7WgKnloiCCkIFJvN79fK_g'
+        app = await setup({ license })
+        TestObjects.mfaUser = await app.factory.createUser({
+            admin: true,
+            username: 'mfaUser',
+            name: 'MFA User',
+            email: 'mfa@example.com',
+            password: 'mmPassword',
+            mfa_enabled: 'true'
+        })
+        await app.db.models.MFAToken.createTokenForUser(TestObjects.mfaUser)
+
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+    })
+    after(async function () {
+        return app.close()
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    describe('Update user settings', async function () {
+        describe('Disable MFA on user', async function () {
+            it('can disable mfa for a user', async function () {
+                // Alice can clear mfaUser mfa status
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/users/${TestObjects.mfaUser.hashid}`,
+                    payload: {
+                        mfa_enabled: false
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('mfa_enabled', false)
+
+                const token = await app.db.models.MFAToken.forUser(TestObjects.mfaUser)
+                should.not.exist(token)
+            })
+
+            it('cannot enable mfa for a user', async function () {
+                // Alice cannot enable mfa on themselves via this api
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/users/${TestObjects.alice.hashid}`,
+                    payload: {
+                        mfa_enabled: true
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('mfa_enabled', false)
+
+                const token = await app.db.models.MFAToken.forUser(TestObjects.alice)
+                should.not.exist(token)
+            })
+        })
+    })
+})


### PR DESCRIPTION
## Description

Allows an admin user to disable MFA on a users account.

In absence of providing users recovery codes, this will be one path for a user to get back into their account via a support request.