### PR TITLE
Add app device access verification to ACL manager

### DIFF
--- a/forge/comms/authRoutes.js
+++ b/forge/comms/authRoutes.js
@@ -52,6 +52,8 @@ module.exports = async function (app) {
         }
     }, async (request, response) => {
         const allowed = await app.comms.aclManager.verify(request.body.username, request.body.topic, request.body.acc)
+        // ↓ Useful for debugging ↓
+        // console.warn(`${allowed ? 'ALLOWED' : 'FORBIDDEN'}! ACL check: '${request.body.topic}' for user ${request.body.username} (${request.body.acc === 2 ? 'PUB' : 'SUB'})`)
         if (allowed) {
             response.status(200).send()
         } else {

--- a/forge/ee/lib/projectComms/index.js
+++ b/forge/ee/lib/projectComms/index.js
@@ -62,41 +62,59 @@ module.exports.init = function (app) {
             'sub',
             { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/out\/[^/]+($|\/.*$)/, verify: 'checkDeviceIsAssigned' }
         )
-        // Receive messages sent to this project
+        // Receive messages sent to this device
         // - ff/v1/<team>/p/<project>/in/+/#
         app.comms.aclManager.addACL(
             'device',
             'sub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/in\/[^/]+($|\/.*$)$/, verify: 'checkDeviceAssignedToProject' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/in\/[^/]+($|\/.*$)$/, verify: 'checkDeviceCanAccessProject' }
         )
-        // Receive link-call response messages sent to this project
+        // Receive link-call response messages sent to this device (instance owned)
         // - ff/v1/<team>/p/<project>/res/+/#
         app.comms.aclManager.addACL(
             'device',
             'sub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/res\/[^/]+($|\/.*$)$/, verify: 'checkDeviceAssignedToProject' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]{11,})\/res\/[^/]+($|\/.*$)$/, verify: 'checkDeviceCanAccessProject' }
+        )
+        // Receive link-call response messages sent to this device (app owned)
+        // - ff/v1/<team>/p/<appid>/res/+/#
+        app.comms.aclManager.addACL(
+            'device',
+            'sub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]{10})\/res\/[^/]+($|\/.*$)$/, verify: 'checkDeviceAssignedToApplication' }
         )
 
-        // Send message to other project
-        // - ff/v1/<team>/p/+/in/+/#
+        // Send message to specific project
+        // A device ID is exactly 10 chars long, so any topic with an ID longer than that
+        // is a project instance topic
+        // At this time, we don't support sending messages direct to an app owned device
+        // - ff/v1/<team>/p/<project>/in/+/#
         app.comms.aclManager.addACL(
             'device',
             'pub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/in\/[^/]+($|\/.*$)/, verify: 'checkDeviceCanAccessProject' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]{11,})\/in\/[^/]+($|\/.*$)/, verify: 'checkDeviceCanAccessProject' }
         )
-        // Send broadcast messages
+        // Send broadcast messages (from instance owned devices in the team)
         // - ff/v1/<team>/p/<project>/out/+/#
         app.comms.aclManager.addACL(
             'device',
             'pub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/out\/[^/]+($|\/.*$)/, verify: 'checkDeviceAssignedToProject' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]{11,})\/out\/[^/]+($|\/.*$)/, verify: 'checkDeviceCanAccessProject' }
         )
-        // Send link-call response messages to other project
+        // Send broadcast messages (from app owned devices in the team)
+        // - ff/v1/<team>/p/<device>/out/+/#
+        app.comms.aclManager.addACL(
+            'device',
+            'pub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]{10})\/out\/[^/]+($|\/.*$)/, verify: 'checkDeviceAssignedToApplication' }
+        )
+        // Send link-call response messages back to source instance
+        // app owned devices not supported at this time
         // - ff/v1/<team>/p/+/res/+/#
         app.comms.aclManager.addACL(
             'device',
             'pub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/res\/[^/]+($|\/.*$)/, verify: 'checkDeviceCanAccessProject' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]{11,})\/res\/[^/]+($|\/.*$)/, verify: 'checkDeviceCanAccessProject' }
         )
     }
 }


### PR DESCRIPTION
part of #3018

## Description

This pull request adds device access verification to the ACL manager, allowing for devices assigned to an application to use the nr-project-nodes 

The changes include new functions for checking device access to projects and applications, as well as updates to existing functions for verifying device access to topics.
## Related Issue(s)

### TODO: 
- Explore possible tests
- Update docs
- (Next iteration) support device/instance --> to device direct messaging


#3018


## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

