### PR TITLE
Ensure device provisioning data shown

### DIFF
--- a/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
@@ -7,7 +7,7 @@
                     configuration. Make a note of it as this is the only
                     time you will see it.
                 </p>
-                <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ configuration }}</pre>
+                <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
             </form>
         </template>
         <template #actions>


### PR DESCRIPTION
fixes #3075

## Description

<!-- Describe your changes in detail -->
When adding a device provisioning token the data is now shown in the dialog (it can be downloaded and copied to clipboard)

## Related Issue(s)

<!-- What issue does this PR relate to? -->
 #3075

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

