### PR TITLE
Add Icon and detail for 'context.delete' audit entry

### DIFF
--- a/forge/auditLog/formatters.js
+++ b/forge/auditLog/formatters.js
@@ -147,6 +147,14 @@ const formatLogEntry = (auditLogDbRow) => {
                 interval: body?.interval,
                 threshold: body?.threshold
             })
+
+            // if body has the keys:  `key`, `scope`, and `store` AND `store` === 'memory' or 'persistent'
+            // this is a Node-RED context store event
+            if (body?.key && body?.scope && body?.store && (body.store === 'memory' || body.store === 'persistent')) {
+                formatted.body = formatted.body || {}
+                formatted.body.context = { key: body.key, scope: body.scope, store: body.store }
+            }
+
             const roleObj = body?.role && roleObject(body.role)
             if (roleObj) {
                 if (formatted.body?.user) {

--- a/forge/db/controllers/AuditLog.js
+++ b/forge/db/controllers/AuditLog.js
@@ -11,6 +11,11 @@ function addToLog (app, entityType, entityId, event, body) {
     const details = [`event: ${event}`]
     if (entityType) { details.push(`type: ${entityType}`) }
     if (entityId) { details.push(`id: ${entityId}`) }
+    if (event === 'context.delete' && body && typeof body === 'object' && body.key && body.scope && body.store) {
+        details.push(`key: ${body.key}`)
+        details.push(`scope: ${body.scope}`)
+        details.push(`store: ${body.store}`)
+    }
     const msg = details.join(', ')
     if (body && body.error) {
         app.log.error(`AUDIT: ${msg}, ${body.error.message || 'unknown error'}`)

--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -49,7 +49,8 @@ const iconMap = {
         'flows.set',
         'library.set',
         'nodes.install',
-        'nodes.remove'
+        'nodes.remove',
+        'context.delete'
     ],
     template: [
         'application.created',

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -500,6 +500,11 @@
         <label>{{ AuditEvents[entry.event] }}</label>
         <span>Nodes have been removed via the "Manage Palette" option inside Node-RED</span>
     </template>
+    <template v-else-if="entry.event === 'context.delete'">
+        <label>{{ AuditEvents[entry.event] }}</label>
+        <span v-if="entry.body?.context?.scope && entry.body?.context?.store && entry.body?.context?.key">Context key '{{ entry.body.context.scope }}.{{ entry.body.context.key }}' was deleted from context store '{{ entry.body.context.store }}' inside Node-RED.</span>
+        <span v-else>A Context data entry was deleted inside Node-RED. {{ JSON.stringify(entry.body || {}) }} </span>
+    </template>
 
     <template v-else-if="entry.event === 'resource.cpu'">
         <label>Instance High CPU usage</label>

--- a/frontend/src/data/audit-events.json
+++ b/frontend/src/data/audit-events.json
@@ -78,7 +78,8 @@
         "flows.set": "Flow Deployed",
         "library.set": "Saved to Library",
         "nodes.install": "Third-Party Nodes Installed",
-        "nodes.remove": "Third-Party Nodes Removed"
+        "nodes.remove": "Third-Party Nodes Removed",
+        "context.delete": "Context Key Deleted"
     },
     "platform": {
         "platform.license.applied": "License Applied",


### PR DESCRIPTION
## Description

Displays Node-RED icon and event detail in the Audit Log

Before:
![image](https://user-images.githubusercontent.com/44235289/271216324-03a49987-69d1-45a1-a550-42834244442c.png)

After:
![image](https://github.com/FlowFuse/flowfuse/assets/44235289/3d35374b-c89f-4cc4-8900-173d2c160016)


## Related Issue(s)

#2840 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

