### PR TITLE
Fix  Formatting of Copy/Paste of NR Logs

### DIFF
--- a/frontend/src/pages/instance/components/InstanceLogs.vue
+++ b/frontend/src/pages/instance/components/InstanceLogs.vue
@@ -25,9 +25,7 @@
                 </template>
                 <span>{{ item.date }}</span>
                 <span>{{ "  " }}</span>
-                <span>[{{ item.level }}]</span>
-                <span v-if="item.level !=='system'">{{ "   " }}</span>
-                <span v-else>{{ " " }}</span>
+                <span>{{ `[${item.level || ''}]`.padEnd(10, ' ') }}</span>
                 <span class="flex-grow break-all whitespace-pre-wrap inline-flex">{{ item.msg }}</span>
                 <br v-if="itemIdx !== filteredLogEntries.length - 1">
             </span>


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

https://github.com/FlowFuse/flowfuse/assets/110285294/7f39c12b-3734-494d-88e9-c2fa0a594f29

![Screenshot_2023-11-21_22-28-08](https://github.com/FlowFuse/flowfuse/assets/110285294/0329b4df-5880-47ac-ae84-35a8e171b074)


in this change i have use a single span tag to display each item's content. It concatenates the properties like item.date, item.level, item.msg, etc. without creating separate p or div  tag  for each entry. It also includes a br tag to add line breaks between entries, except for the last one. it ensure NR log format will not break and there will be no extra line or space between two rows of log

## Related Issue(s)
Closes #1444 
<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

