### PR TITLE
Update references to flowfuse

### DIFF
--- a/docs/hardware/raspbian.md
+++ b/docs/hardware/raspbian.md
@@ -30,22 +30,22 @@ You can run the device agent as a service, which means it can run in the backgro
 
 If you want Node-RED to run when the device is turned on, or re-booted, you can enable the service to autostart by running the command:
 
-```sudo systemctl enable flowforge-device-agent.service```
+```sudo systemctl enable flowfuse-device-agent.service```
 
 To disable the service, run the command:
 
-```sudo systemctl disable flowforge-device-agent.service```
+```sudo systemctl disable flowfuse-device-agent.service```
 
 ### Controlling the service
 
 You can start the service with the command:
 
-```sudo systemctl start flowforge-device-agent```
+```sudo systemctl start flowfuse-device-agent```
 
 You can check the current status with the command:
 
-```sudo systemctl status flowforge-device-agent```
+```sudo systemctl status flowfuse-device-agent```
 
 You can stop your with the command:
 
-```sudo systemctl stop flowforge-device-agent```
+```sudo systemctl stop flowfuse-device-agent```


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Instructions still say flowforge, when they have been updated to flowfuse in the device agent install script

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

