### PR TITLE
Update StatusBadge styling for "Crashed"

### DIFF
--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -5,7 +5,7 @@
         class="forge-badge"
         :class="['forge-status-' + status, pendingChange ? 'opacity-40' : '']"
     >
-        <ExclamationCircleIcon v-if="status === 'error'" class="w-4 h-4" />
+        <ExclamationCircleIcon v-if="status === 'error' || status === 'crashed'" class="w-4 h-4" />
         <ExclamationIcon v-if="status === 'suspended'" class="w-4 h-4" />
         <PlayIcon v-if="status === 'running'" class="w-4 h-4" />
         <StopIcon v-if="status === 'stopping' || status === 'suspending'" class="w-4 h-4" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -142,8 +142,9 @@
         @apply inline-flex;
         @apply items-center;
     }
-    .forge-status-error {
-        @apply bg-red-200;
+    .forge-status-error,
+    .forge-status-crashed {
+        @apply bg-red-100;
         @apply border-red-400;
         @apply text-red-600;
     }


### PR DESCRIPTION
## Description

Noticed that the "crashed" status badge was styled black/white, which doesn't draw (warranted) attention. This change make it use the same red styling as "error" in order to flag attention to the user.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)