### PR TITLE
fix delete conformation dialogs

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -655,15 +655,28 @@ export default {
                 Dialog.show({
                     header: 'Delete Device',
                     kind: 'danger',
-                    text: 'Are you sure you want to delete this device? Once deleted, there is no going back.',
+                    html: `<p>Are you sure you want to delete this device? Once deleted, there is no going back</p>
+                       <code class="flex w-max h-4 items-center">${device.name}</code>
+                       <br>
+                       <label>Name</label>
+                       <div class="ff-input ff-text-input !w-96">
+                         <input  id="enteredDeviceName" placeholder="Enter your device name to continue" autocomplete="off">
+                       </div>
+                    `,
                     confirmLabel: 'Delete'
                 }, async () => {
-                    try {
-                        await deviceApi.deleteDevice(device.id)
-                        Alerts.emit('Successfully deleted the device', 'confirmation')
-                        this.deleteLocalCopyOfDevice(device)
-                    } catch (err) {
-                        Alerts.emit('Failed to delete device: ' + err.toString(), 'warning', 7500)
+                    const enteredDeviceName = document.getElementById('enteredDeviceName').value
+
+                    if (enteredDeviceName === device.name) {
+                        try {
+                            await deviceApi.deleteDevice(device.id)
+                            Alerts.emit('Successfully deleted the device', 'confirmation')
+                            this.deleteLocalCopyOfDevice(device)
+                        } catch (err) {
+                            Alerts.emit('Failed to delete device: ' + err.toString(), 'warning', 7500)
+                        }
+                    } else {
+                        Alerts.emit('Entered device name is incorrect. deletion aborted.", "warning')
                     }
                 })
             } else if (action === 'updateCredentials') {

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -203,18 +203,29 @@ export default {
             dialog.show({
                 header: 'Delete Account',
                 kind: 'danger',
-                html: `<p>Are you sure you want to delete your account?</p>
-                       <p>This action cannot be undone.</p>`,
+                html: `<p>Are you sure you want to delete your account? Once deleted, there is no going back.</p>
+                       <code class="flex w-max h-4 items-center">${this.user.username}</code>
+                       <br>
+                       <label class="font-bold">Username</label>
+                       <div class="ff-input ff-text-input !w-96">
+                         <input id="enteredUsername" placeholder="Enter your username to continue" autocomplete="off">
+                       </div>
+                    `,
                 confirmLabel: 'Delete'
             }, async () => {
-                try {
-                    await userApi.deleteUser()
-                    // this.$store.dispatch('account/logout')
-                    this.$store.dispatch('account/checkState')
-                    this.$router.push({ name: 'login' })
-                } catch (error) {
-                    const msg = error.response?.data?.error || 'Error deleting account'
-                    alerts.emit(msg, 'warning')
+                const enteredUsername = document.getElementById('enteredUsername').value
+
+                if (enteredUsername === this.user.username) {
+                    try {
+                        await userApi.deleteUser()
+                        this.$store.dispatch('account/checkState')
+                        this.$router.push({ name: 'login' })
+                    } catch (error) {
+                        const msg = error.response?.data?.error || 'Error deleting account'
+                        alerts.emit(msg, 'warning')
+                    }
+                } else {
+                    alerts.emit('Entered username is incorrect. Deletion aborted.", "warning')
                 }
             })
         }

--- a/frontend/src/pages/application/Settings/dialogs/ConfirmApplicationDeleteDialog.vue
+++ b/frontend/src/pages/application/Settings/dialogs/ConfirmApplicationDeleteDialog.vue
@@ -14,11 +14,9 @@
                     <p>
                         Are you sure you want to delete this application? Once deleted, there is no going back.
                     </p>
-                    <p class="flex">
-                        Enter the application name <code>{{ application?.name }}</code> to continue.
-                    </p>
+                    <code class="flex w-max h-4 items-center">{{ application?.name }}</code>
                 </div>
-                <FormRow id="projectName" v-model="input.projectName" data-form="application-name">Name</FormRow>
+                <FormRow id="projectName" v-model="input.projectName" data-form="application-name" placeholder="Enter the application name to continue">Name</FormRow>
             </form>
         </template>
     </ff-dialog>

--- a/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
+++ b/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
@@ -6,12 +6,9 @@
                     <p>
                         Are you sure you want to delete this device? Once deleted, there is no going back.
                     </p>
-                    <p>
-                        Enter the device name to continue.
-                        <code class="block">{{ device?.name }}</code>
-                    </p>
+                    <code class="flex w-max h-4 items-center">{{ device?.name }}</code>
                 </div>
-                <FormRow v-model="input.deviceName" id="deviceName">Name</FormRow>
+                <FormRow v-model="input.deviceName" id="deviceName" placeholder="Enter device name to continue">Name</FormRow>
             </form>
         </template>
     </ff-dialog>

--- a/frontend/src/pages/instance/Settings/dialogs/ConfirmInstanceDeleteDialog.vue
+++ b/frontend/src/pages/instance/Settings/dialogs/ConfirmInstanceDeleteDialog.vue
@@ -14,11 +14,9 @@
                     <p>
                         Are you sure you want to delete this instance and the application that contains it? Once deleted, there is no going back.
                     </p>
-                    <p class="flex">
-                        Enter the instance name <code>{{ instance?.name }}</code> to continue.
-                    </p>
+                    <code class="flex w-max h-4 items-center">{{ instance?.name }}</code>
                 </div>
-                <FormRow v-model="input.instanceName" data-form="instance-name">Name</FormRow>
+                <FormRow v-model="input.instanceName" data-form="instance-name" placeholder="Enter the instance name to continue">Name</FormRow>
             </form>
         </template>
     </ff-dialog>

--- a/frontend/src/pages/team/Settings/Devices.vue
+++ b/frontend/src/pages/team/Settings/Devices.vue
@@ -205,18 +205,31 @@ export default {
                 Dialog.show({
                     header: 'Delete Provisioning Token',
                     kind: 'danger',
-                    text: 'Are you sure you want to delete this provisioning token? Once deleted, it can no longer be used to provision new devices to the team.',
+                    html: `<p>Are you sure you want to delete this provisioning token? Once deleted, there is no going back.</p>
+                       <code class="flex w-max h-4 items-center">${token.name}</code>
+                       <br>
+                       <label class="font-bold">Name</label>
+                       <div class="ff-input ff-text-input !w-96">
+                         <input id="enteredTokenName" placeholder="Enter your token name to continue" autocomplete="off">
+                       </div>
+                    `,
                     confirmLabel: 'Delete'
                 }, async () => {
-                    this.deletingItem = true
-                    try {
-                        await teamApi.deleteTeamDeviceProvisioningToken(this.team.id, token.id)
-                        Alerts.emit('Successfully deleted the token', 'confirmation')
-                        this.tokens.delete(token.id)
-                    } catch (err) {
-                        Alerts.emit('Failed to delete token: ' + err.toString(), 'warning', 7500)
-                    } finally {
-                        this.deletingItem = false
+                    const enteredTokenName = document.getElementById('enteredTokenName').value
+
+                    if (enteredTokenName === token.name) {
+                        this.deletingItem = true
+                        try {
+                            await teamApi.deleteTeamDeviceProvisioningToken(this.team.id, token.id)
+                            Alerts.emit('Successfully deleted the token', 'confirmation')
+                            this.tokens.delete(token.id)
+                        } catch (err) {
+                            Alerts.emit('Failed to delete token: ' + err.toString(), 'warning', 7500)
+                        } finally {
+                            this.deletingItem = false
+                        }
+                    } else {
+                        Alerts.emit('Entered token name is incorrect. Deletion aborted.", "warning')
                     }
                 })
             } else if (action === 'updateCredentials') {

--- a/test/e2e/frontend/cypress/tests/devices.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices.spec.js
@@ -57,13 +57,18 @@ describe('FlowForge - Team Devices', () => {
             cy.get('[data-el="devices-browser"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').contains('Delete Device').click()
 
             cy.get('.ff-dialog-box').should('be.visible')
-            cy.get('.ff-dialog-header').contains('Delete Device')
 
-            // Click "Delete"
-            cy.get('.ff-dialog-box button.ff-btn.ff-btn--danger').contains('Delete').click()
+            cy.get('code').then(($deviceName) => {
+                const deviceNameText = $deviceName.text().trim()
 
-            cy.wait('@deleteDevice')
+                cy.get('.ff-dialog-header').contains('Delete Device')
 
+                cy.get('#enteredDeviceName').type(deviceNameText)
+                // Click "Delete"
+                cy.get('.ff-dialog-box button.ff-btn.ff-btn--danger').contains('Delete').click()
+
+                cy.wait('@deleteDevice')
+            })
             cy.get('main').contains('Connect your First Device')
         })
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

https://github.com/FlowFuse/flowfuse/assets/110285294/6791f2d3-6876-4836-acaf-b41c28603822

In this change, I removed the text 'Enter the instance name, etc.,' and replaced it with a placeholder. Additionally, I moved the code block to the next line. Moreover, I added a confirmation feature for deleting provisioning tokens, devices, and accounts. This ensures users confirm these actions before execution. I also disabled autocomplete for those input elements.
## Related Issue(s)

<!-- What issue does this PR relate to? -->
Closes #2674 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

