### PR TITLE
Fix hostname used for posthog CSP

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -189,10 +189,14 @@ module.exports = async (options = {}) => {
                 }
             }
             if (runtimeConfig.telemetry.frontend?.posthog?.apikey) {
+                let posthogHost = 'app.posthog.com'
+                if (runtimeConfig.telemetry.frontend.posthog.apiurl) {
+                    posthogHost = new URL(runtimeConfig.telemetry.frontend.posthog.apiurl).host
+                }
                 if (contentSecurityPolicy.directives['script-src'] && Array.isArray(contentSecurityPolicy.directives['script-src'])) {
-                    contentSecurityPolicy.directives['script-src'].push(runtimeConfig.telemetry.frontend.posthog.apiurl || 'https://app.posthog.com')
+                    contentSecurityPolicy.directives['script-src'].push(posthogHost)
                 } else {
-                    contentSecurityPolicy.directives['script-src'] = [runtimeConfig.telemetry.frontend.posthog.apiurl || 'https://app.posthog.com']
+                    contentSecurityPolicy.directives['script-src'] = [posthogHost]
                 }
             }
             if (runtimeConfig.support?.enabled && runtimeConfig.support.frontend?.hubspot?.trackingcode) {

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -162,6 +162,8 @@ module.exports = async (options = {}) => {
                         'base-uri': ["'self'"],
                         'default-src': ["'self'"],
                         'script-src': ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+                        'worker-src': ["'self'"],
+                        'connect-src': ["'self'"],
                         'img-src': ["'self'", 'data:', 'www.gravatar.com'],
                         'font-src': ["'self'"],
                         'style-src': ["'self'", 'https:', "'unsafe-inline'"],
@@ -188,7 +190,7 @@ module.exports = async (options = {}) => {
                     contentSecurityPolicy.directives['script-src'] = ['plausible.io']
                 }
             }
-            if (runtimeConfig.telemetry.frontend?.posthog?.apikey) {
+            if (runtimeConfig.telemetry?.frontend?.posthog?.apikey) {
                 let posthogHost = 'app.posthog.com'
                 if (runtimeConfig.telemetry.frontend.posthog.apiurl) {
                     posthogHost = new URL(runtimeConfig.telemetry.frontend.posthog.apiurl).host
@@ -197,6 +199,18 @@ module.exports = async (options = {}) => {
                     contentSecurityPolicy.directives['script-src'].push(posthogHost)
                 } else {
                     contentSecurityPolicy.directives['script-src'] = [posthogHost]
+                }
+                if (contentSecurityPolicy.directives['connect-src'] && Array.isArray(contentSecurityPolicy.directives['connect-src'])) {
+                    contentSecurityPolicy.directives['connect-src'].push(posthogHost)
+                } else {
+                    contentSecurityPolicy.directives['connect-src'] = [posthogHost]
+                }
+            }
+            if (runtimeConfig.telemetry?.sentry) {
+                if (contentSecurityPolicy.directives['connect-src'] && Array.isArray(contentSecurityPolicy.directives['connect-src'])) {
+                    contentSecurityPolicy.directives['connect-src'].push('*.ingest.sentry.io')
+                } else {
+                    contentSecurityPolicy.directives['connect-src'] = ['*.ingest.sentry.io']
                 }
             }
             if (runtimeConfig.support?.enabled && runtimeConfig.support.frontend?.hubspot?.trackingcode) {

--- a/test/unit/forge/configuration/http_security_spec.js
+++ b/test/unit/forge/configuration/http_security_spec.js
@@ -2,7 +2,7 @@ const should = require('should') // eslint-disable-line
 
 const FF_UTIL = require('flowforge-test-utils')
 
-describe.only('Check HTTP Security Headers set', async () => {
+describe('Check HTTP Security Headers set', async () => {
     describe('CSP Headers', async () => {
         let app
 

--- a/test/unit/forge/configuration/http_security_spec.js
+++ b/test/unit/forge/configuration/http_security_spec.js
@@ -197,6 +197,26 @@ describe('Check HTTP Security Headers set', async () => {
             const csp = response.headers['content-security-policy']
             csp.split(';').should.containEql('script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' app.posthog.com js-eu1.hs-analytics.com js-eu1.hs-banner.com js-eu1.hs-scripts.com js-eu1.hscollectedforms.net js-eu1.hubspot.com js-eu1.usemessages.com')
         })
+        it('CSP with sentry.io', async function (){
+            const config = {
+                telemetry: {
+                    sentry: 'foo'
+                },
+                content_security_policy: {
+                    enabled: true
+                }
+            }
+            app = await FF_UTIL.setupApp(config)
+            const response = await app.inject({
+                method: 'GET',
+                url: '/'
+            })
+
+            const headers = response.headers
+            headers.should.have.property('content-security-policy')
+            const csp = response.headers['content-security-policy']
+            csp.split(';').should.containEql('connect-src \'self\' *.ingest.sentry.io')
+        })
     })
 
     describe('HSTS Headers', async () => {

--- a/test/unit/forge/configuration/http_security_spec.js
+++ b/test/unit/forge/configuration/http_security_spec.js
@@ -2,7 +2,7 @@ const should = require('should') // eslint-disable-line
 
 const FF_UTIL = require('flowforge-test-utils')
 
-describe('Check HTTP Security Headers set', async () => {
+describe.only('Check HTTP Security Headers set', async () => {
     describe('CSP Headers', async () => {
         let app
 
@@ -136,7 +136,7 @@ describe('Check HTTP Security Headers set', async () => {
             const headers = response.headers
             headers.should.have.property('content-security-policy')
             const csp = response.headers['content-security-policy']
-            csp.split(';').should.containEql('script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://app.posthog.com')
+            csp.split(';').should.containEql('script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' app.posthog.com')
         })
 
         it('CSP should be enabled with hubspot', async function () {
@@ -195,7 +195,7 @@ describe('Check HTTP Security Headers set', async () => {
             const headers = response.headers
             headers.should.have.property('content-security-policy')
             const csp = response.headers['content-security-policy']
-            csp.split(';').should.containEql('script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://app.posthog.com js-eu1.hs-analytics.com js-eu1.hs-banner.com js-eu1.hs-scripts.com js-eu1.hscollectedforms.net js-eu1.hubspot.com js-eu1.usemessages.com')
+            csp.split(';').should.containEql('script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' app.posthog.com js-eu1.hs-analytics.com js-eu1.hs-banner.com js-eu1.hs-scripts.com js-eu1.hscollectedforms.net js-eu1.hubspot.com js-eu1.usemessages.com')
         })
     })
 

--- a/test/unit/forge/configuration/http_security_spec.js
+++ b/test/unit/forge/configuration/http_security_spec.js
@@ -197,7 +197,7 @@ describe('Check HTTP Security Headers set', async () => {
             const csp = response.headers['content-security-policy']
             csp.split(';').should.containEql('script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' app.posthog.com js-eu1.hs-analytics.com js-eu1.hs-banner.com js-eu1.hs-scripts.com js-eu1.hscollectedforms.net js-eu1.hubspot.com js-eu1.usemessages.com')
         })
-        it('CSP with sentry.io', async function (){
+        it('CSP with sentry.io', async function () {
             const config = {
                 telemetry: {
                     sentry: 'foo'


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
We are getting CSP (soft) failure reports because the wrong hostname is included in the  script-src directive:

```
{
  'csp-report': {
    'document-uri': 'https://forge.flowfuse.dev/instance/c140b5c1-f849-4bf1-afa2-56ff5258606e/devices',
    referrer: '',
    'violated-directive': 'connect-src',
    'effective-directive': 'connect-src',
    'original-policy': "base-uri 'self';default-src 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu.posthog.com;img-src 'self' data: www.gravatar.com;font-src 'self';style-src 'self' https: 'unsafe-inline';report-uri https://csp-report.flowfuse.dev/csp;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none'",
    disposition: 'report',
    'blocked-uri': 'https://eu.posthog.com/e/?compression=gzip-js&ip=1&_=1700683653731&ver=1.92.1',
    'line-number': 2,
    'column-number': 305846,
    'source-file': 'https://forge.flowfuse.dev/app/vendors.js',
    'status-code': 200,
    'script-sample': ''
  }
}
```

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

