### PR TITLE
fix pipelinestage device action dropdown choices

### DIFF
--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -350,8 +350,8 @@ export default {
                 return
             }
 
-            // If not, set default action
-            this.input.action = this.actionOptions[0].value
+            // If not, reset selection
+            this.input.action = null
         }
     },
     created () {

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -344,13 +344,14 @@ export default {
         }
     },
     watch: {
-        'input.stageType': {
-            handler (_stageType) {
-                // if the stage type is changed, ensure the action is NOT "create_snapshot" when the stage type is "device"
-                if (this.input.stageType === StageType.DEVICE && this.input.action === 'create_snapshot') {
-                    this.input.action = 'use_latest_snapshot' // set default action for device stage
-                }
+        'input.stageType' (newStageType, oldStageType) {
+            // Check if selected action is still available
+            if (this.actionOptions.some((option) => option.value === this.input.action)) {
+                return
             }
+
+            // If not, set default action
+            this.input.action = this.actionOptions[0].value
         }
     },
     created () {

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -345,7 +345,7 @@ export default {
     },
     watch: {
         'input.stageType': {
-            handler (stageType) {
+            handler (_stageType) {
                 // if the stage type is changed, ensure the action is NOT "create_snapshot" when the stage type is "device"
                 if (this.input.stageType === StageType.DEVICE && this.input.action === 'create_snapshot') {
                     this.input.action = 'use_latest_snapshot' // set default action for device stage

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -350,8 +350,8 @@ export default {
                 return
             }
 
-            // If not, reset selection
-            this.input.action = null
+            // If not, reset to the stages original action (if available)
+            this.input.action = this.stage?.action && this.actionOptions.some((option) => option.value === this.stage.action) ? this.stage.action : null
         }
     },
     created () {

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -343,6 +343,16 @@ export default {
             return options
         }
     },
+    watch: {
+        'input.stageType': {
+            handler (stageType) {
+                // if the stage type is changed, ensure the action is NOT "create_snapshot" when the stage type is "device"
+                if (this.input.stageType === StageType.DEVICE && this.input.action === 'create_snapshot') {
+                    this.input.action = 'use_latest_snapshot' // set default action for device stage
+                }
+            }
+        }
+    },
     created () {
         this.StageType = StageType
     },


### PR DESCRIPTION
fixes #3109

## Description

Reset Select Action dropdown if the stage type is "Device" and the "Select Action" is an invalid choice

See a demo in the issue

## Related Issue(s)

#3109 

### Verify

1. Select stage type instance
2. choose item "Create Snapshot" in the "select action" 
3. Select "stage type" "device"
4. See how "select action" still says "Create Snapshot"
   1. This should revert to the top option
