### PR TITLE
Fix: Deploying of device to instance

### DIFF
--- a/forge/db/models/ProjectSnapshot.js
+++ b/forge/db/models/ProjectSnapshot.js
@@ -175,6 +175,16 @@ module.exports = {
                         snapshots: rows
                     }
                 }
+            },
+            instance: {
+                getCredentialSecret: async function () {
+                    // default to project in the absence of ownerType
+                    if (this.ownerType === 'instance' || !this.ownerType) {
+                        return await (await this.getProject()).getCredentialSecret()
+                    } else {
+                        return (await this.getDevice()).credentialSecret
+                    }
+                }
             }
         }
     }

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -204,7 +204,7 @@ module.exports = {
                 const targetSnapshot = await copySnapshot(app, sourceSnapshot, targetInstance, {
                     importSnapshot: true, // target instance should import the snapshot
                     setAsTarget: setAsTargetForDevices,
-                    decryptAndReEncryptCredentialsSecret: await sourceInstance.getCredentialSecret(),
+                    decryptAndReEncryptCredentialsSecret: await sourceSnapshot.getCredentialSecret(),
                     targetSnapshotProperties: {
                         name: generateDeploySnapshotName(sourceSnapshot),
                         description: generateDeploySnapshotDescription(sourceStage, targetStage, pipeline, sourceSnapshot)

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -225,7 +225,7 @@ module.exports = {
                 await app.auditLog.Project.project.imported(user.id, null, targetInstance, sourceInstance, sourceDevice) // technically this isn't a project event
                 await app.auditLog.Project.project.snapshot.imported(user.id, err, targetInstance, sourceInstance, sourceDevice, null)
 
-                throw PipelineControllerError('unexpected_error', `Error during deploy: ${err.toString()}`, 500, { cause: err })
+                throw new PipelineControllerError('unexpected_error', `Error during deploy: ${err.toString()}`, 500, { cause: err })
             }
         })()
     },
@@ -255,7 +255,7 @@ module.exports = {
             const updatedDevice = await app.db.models.Device.byId(targetDevice.id) // fully reload with associations
             await app.db.controllers.Device.sendDeviceUpdateCommand(updatedDevice)
         } catch (err) {
-            throw PipelineControllerError('unexpected_error', `Error during deploy: ${err.toString()}`, 500, { cause: err })
+            throw new PipelineControllerError('unexpected_error', `Error during deploy: ${err.toString()}`, 500, { cause: err })
         }
     }
 }

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -188,7 +188,10 @@ module.exports = {
      * @param {Object} targetStage - The target stage
      * @returns {Promise<Function>} - Resolves with the deploy is complete
      */
-    deploySnapshotToInstance: function (app, { pipeline, sourceStage, sourceSnapshot, targetInstance, sourceInstance, sourceDevice, user, targetStage }) {
+    deploySnapshotToInstance: function (app, sourceSnapshot, targetInstance, deployToDevices, deployMeta = { pipeline: undefined, sourceStage: undefined, sourceInstance: undefined, sourceDevice: undefined, targetStage: undefined, user: undefined }) {
+        // Only used for reporting and logging, should not be used for any logic
+        const { pipeline, sourceStage, sourceInstance, sourceDevice, targetStage, user } = deployMeta
+
         const restartTargetInstance = targetInstance?.state === 'running'
 
         app.db.controllers.Project.setInflightState(targetInstance, 'importing')
@@ -197,7 +200,7 @@ module.exports = {
         // Complete heavy work async
         return (async function () {
             try {
-                const setAsTargetForDevices = targetStage.deployToDevices ?? false
+                const setAsTargetForDevices = deployToDevices ?? false
                 const targetSnapshot = await copySnapshot(app, sourceSnapshot, targetInstance, {
                     importSnapshot: true, // target instance should import the snapshot
                     setAsTarget: setAsTargetForDevices,

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -548,15 +548,16 @@ module.exports = async function (app) {
 
             if (targetInstance) {
                 const deployPromise = app.db.controllers.Pipeline.deploySnapshotToInstance(
+                    sourceSnapshot,
+                    targetInstance,
+                    targetStage.deployToDevices ?? false,
                     {
                         pipeline: request.pipeline,
                         sourceStage,
-                        sourceSnapshot,
-                        targetInstance,
                         sourceInstance,
                         sourceDevice,
-                        user,
-                        targetStage
+                        targetStage,
+                        user
                     }
                 )
 

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -139,18 +139,11 @@ module.exports = async function (app) {
                     ...snapshot.settings,
                     ...snapshot.flows
                 }
-                const getSecret = async () => {
-                    // default to project in the absence of ownerType
-                    if (snapshot.ownerType === 'instance' || !snapshot.ownerType) {
-                        return await (await snapshot.getProject()).getCredentialSecret()
-                    } else {
-                        return (await snapshot.getDevice()).credentialSecret
-                    }
-                }
+
                 if (result.credentials) {
                     // Need to re-encrypt these credentials from the source secret
                     // to the target Device secret
-                    const secret = await getSecret()
+                    const secret = await snapshot.getCredentialSecret()
                     const deviceSecret = request.device.credentialSecret
                     result.credentials = app.db.controllers.Project.exportCredentials(result.credentials, secret, deviceSecret)
                 }


### PR DESCRIPTION
## Description

Right now, deploys from a device to an instance are failing as it's always assumed there is a source instance which can be used to decrypt the credentials. 

This changes `deploySnapshotToInstance` to always read the credentials from the snapshot, not the instance directly.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/pull/3024

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass - To be added in a follow up for time purposes
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

