### PR TITLE
DevOps Pipelines: Deploy active device snapshot

### DIFF
--- a/forge/db/migrations/20231123-01-add-action-active-snapshot.js
+++ b/forge/db/migrations/20231123-01-add-action-active-snapshot.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-unused-vars */
+/**
+ * Add use_active_snapshot as valid action for a PiplineStage
+ */
+
+const { DataTypes, QueryInterface } = require('sequelize')
+
+module.exports = {
+    /**
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (queryInterface) => {
+        if (queryInterface.sequelize.options.dialog === 'postgres') {
+            // Postgres enums need to be explicitly updated
+            queryInterface.sequelize.query("ALTER TYPE \"enum_PipelineStages_action\" ADD VALUE 'use_active_snapshot';")
+        }
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/migrations/20231123-01-add-action-active-snapshot.js
+++ b/forge/db/migrations/20231123-01-add-action-active-snapshot.js
@@ -10,6 +10,11 @@ module.exports = {
      * @param {QueryInterface} context Sequelize.QueryInterface
      */
     up: async (queryInterface) => {
+        const tableExists = await queryInterface.tableExists('PipelineStages')
+        if (!tableExists) {
+            return queryInterface.sequelize.log('Skipping PipelineStages migration as table does not exist')
+        }
+
         if (queryInterface.sequelize.options.dialog === 'postgres') {
             // Postgres enums need to be explicitly updated
             queryInterface.sequelize.query("ALTER TYPE \"enum_PipelineStages_action\" ADD VALUE 'use_active_snapshot';")

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -105,7 +105,10 @@ module.exports = {
         return { sourceInstance, targetInstance, sourceDevice, targetDevice, targetStage }
     },
 
-    getOrCreateSnapshotForSourceInstance: async function (app, { pipeline, sourceStage, sourceInstance, sourceSnapshotId, user, targetStage }) {
+    getOrCreateSnapshotForSourceInstance: async function (app, sourceStage, sourceInstance, sourceSnapshotId, deployMeta = { pipeline: null, user: null, targetStage: null }) {
+        // Only used for reporting and logging, should not be used for any logic
+        const { pipeline, targetStage, user } = deployMeta
+
         if (sourceStage.action === app.db.models.PipelineStage.SNAPSHOT_ACTIONS.USE_LATEST_SNAPSHOT) {
             const sourceSnapshot = await sourceInstance.getLatestSnapshot()
             if (!sourceSnapshot) {
@@ -142,7 +145,7 @@ module.exports = {
         throw new PipelineControllerError('invalid_action', `Unsupported pipeline deploy action: ${sourceStage.action}`, 400)
     },
 
-    getOrCreateSnapshotForSourceDevice: async function (app, { pipeline, sourceStage, sourceDevice, sourceSnapshotId }) {
+    getOrCreateSnapshotForSourceDevice: async function (app, sourceStage, sourceDevice, sourceSnapshotId) {
         if (sourceStage.action === app.db.models.PipelineStage.SNAPSHOT_ACTIONS.USE_LATEST_SNAPSHOT) {
             const sourceSnapshot = await sourceDevice.getLatestSnapshot()
             if (!sourceSnapshot) {
@@ -152,7 +155,7 @@ module.exports = {
         }
 
         if (sourceStage.action === app.db.models.PipelineStage.SNAPSHOT_ACTIONS.CREATE_SNAPSHOT) {
-            throw new PipelineControllerError('invalid_source_action', 'When using a device as a source, create snapshot is not yet supported', 400)
+            throw new PipelineControllerError('invalid_source_action', 'When using a device as a source, create snapshot is not supported', 400)
         }
 
         if (sourceStage.action === app.db.models.PipelineStage.SNAPSHOT_ACTIONS.PROMPT) {
@@ -238,7 +241,10 @@ module.exports = {
      * @param {Object} user - The user performing the deploy
      * @returns {Promise<Function>} - Resolves with the deploy is complete
      */
-    deploySnapshotToDevice: async function (app, { sourceSnapshot, targetDevice, user }) {
+    deploySnapshotToDevice: async function (app, sourceSnapshot, targetDevice, deployMeta = { user: null }) {
+        // Only used for reporting and logging, should not be used for any logic
+        const { user } = deployMeta
+
         try {
             // store original value for later audit log
             const originalSnapshotId = targetDevice.targetSnapshotId

--- a/forge/ee/db/models/PipelineStage.js
+++ b/forge/ee/db/models/PipelineStage.js
@@ -5,6 +5,7 @@ const {
 const SNAPSHOT_ACTIONS = {
     // Any changes to this list *must* be made via migration.
     CREATE_SNAPSHOT: 'create_snapshot',
+    USE_ACTIVE_SNAPSHOT: 'use_active_snapshot',
     USE_LATEST_SNAPSHOT: 'use_latest_snapshot',
     PROMPT: 'prompt'
 }

--- a/forge/ee/db/models/PipelineStage.js
+++ b/forge/ee/db/models/PipelineStage.js
@@ -26,7 +26,39 @@ module.exports = {
         action: {
             type: DataTypes.ENUM(Object.values(SNAPSHOT_ACTIONS)),
             defaultValue: SNAPSHOT_ACTIONS.CREATE_SNAPSHOT,
-            allowNull: false
+            allowNull: false,
+            validate: {
+                isIn: [Object.values(SNAPSHOT_ACTIONS)],
+                async validActionForStageType () {
+                    const devicesPromise = this.getDevices()
+                    const instancesPromise = this.getInstances()
+
+                    const devices = await devicesPromise
+                    const instances = await instancesPromise
+
+                    if (devices.length > 0) {
+                        const validActionsForDevices = [
+                            SNAPSHOT_ACTIONS.USE_ACTIVE_SNAPSHOT,
+                            SNAPSHOT_ACTIONS.USE_LATEST_SNAPSHOT,
+                            SNAPSHOT_ACTIONS.PROMPT
+                        ]
+
+                        if (!validActionsForDevices.includes(this.action)) {
+                            throw new Error(`Device stages only support the following actions: ${validActionsForDevices.join(', ')}.`)
+                        }
+                    } else if (instances.length > 0) {
+                        const validActionsForInstances = [
+                            SNAPSHOT_ACTIONS.CREATE_SNAPSHOT,
+                            SNAPSHOT_ACTIONS.USE_LATEST_SNAPSHOT,
+                            SNAPSHOT_ACTIONS.PROMPT
+                        ]
+
+                        if (!validActionsForInstances.includes(this.action)) {
+                            throw new Error(`Instance stages only support the following actions: ${validActionsForInstances.join(', ')}.`)
+                        }
+                    }
+                }
+            }
         },
 
         // relations

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -526,22 +526,21 @@ module.exports = async function (app) {
             let sourceSnapshot
             if (sourceInstance) {
                 sourceSnapshot = await app.db.controllers.Pipeline.getOrCreateSnapshotForSourceInstance(
+                    sourceStage,
+                    sourceInstance,
+                    request.body?.sourceSnapshotId,
                     {
                         pipeline: request.pipeline,
-                        sourceStage,
-                        sourceInstance,
-                        sourceSnapshotId: request.body?.sourceSnapshotId,
                         user,
                         targetStage
                     }
                 )
             } else if (sourceDevice) {
-                sourceSnapshot = await app.db.controllers.Pipeline.getOrCreateSnapshotForSourceDevice({
-                    pipeline: request.pipeline,
+                sourceSnapshot = await app.db.controllers.Pipeline.getOrCreateSnapshotForSourceDevice(
                     sourceStage,
                     sourceDevice,
-                    sourceSnapshotId: request.body?.sourceSnapshotId
-                })
+                    request.body?.sourceSnapshotId
+                )
             } else {
                 throw new Error('No source device or instance found.')
             }
@@ -566,11 +565,13 @@ module.exports = async function (app) {
 
                 await deployPromise
             } else if (targetDevice) {
-                const deployPromise = app.db.controllers.Pipeline.deploySnapshotToDevice({
+                const deployPromise = app.db.controllers.Pipeline.deploySnapshotToDevice(
                     sourceSnapshot,
                     targetDevice,
-                    user
-                })
+                    {
+                        user
+
+                    })
 
                 reply.code(200).send({ status: 'importing' })
                 repliedEarly = true

--- a/frontend/src/api/pipeline.js
+++ b/frontend/src/api/pipeline.js
@@ -10,6 +10,7 @@ export const StageType = Object.freeze({
 
 export const StageAction = Object.freeze({
     CREATE_SNAPSHOT: 'create_snapshot',
+    USE_ACTIVE_SNAPSHOT: 'use_active_snapshot',
     USE_LATEST_SNAPSHOT: 'use_latest_snapshot',
     PROMPT: 'prompt'
 })

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -82,13 +82,16 @@
             <div v-if="playEnabled" class="ff-pipeline-stage-row">
                 <label>Deploy Action:</label>
                 <span>
-                    <template v-if="stage.action === 'create_snapshot'">
+                    <template v-if="stage.action === StageAction.CREATE_SNAPSHOT">
                         Create new snapshot
                     </template>
-                    <template v-else-if="stage.action === 'use_latest_snapshot'">
+                    <template v-else-if="stage.action === StageAction.USE_ACTIVE_SNAPSHOT">
+                        Use currently active device snapshot
+                    </template>
+                    <template v-else-if="stage.action== StageAction.USE_LATEST_SNAPSHOT">
                         Use latest {{ stage.stageType === StageType.INSTANCE ? 'instance' : 'device' }} snapshot
                     </template>
-                    <template v-else-if="stage.action==='prompt'">
+                    <template v-else-if="stage.action== StageAction.PROMPT">
                         Prompt to select snapshot
                     </template>
                 </span>
@@ -110,7 +113,7 @@
 <script>
 import { PencilAltIcon, PlayIcon, PlusCircleIcon, TrashIcon } from '@heroicons/vue/outline'
 
-import PipelineAPI, { StageType } from '../../api/pipeline.js'
+import PipelineAPI, { StageAction, StageType } from '../../api/pipeline.js'
 
 import InstanceStatusBadge from '../../pages/instance/components/InstanceStatusBadge.vue'
 
@@ -165,7 +168,9 @@ export default {
         }
     },
     created () {
+        // Expose enums to template
         this.StageType = StageType
+        this.StageAction = StageAction
     },
     methods: {
         runStage: async function () {

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -86,7 +86,7 @@
                         Create new snapshot
                     </template>
                     <template v-else-if="stage.action === StageAction.USE_ACTIVE_SNAPSHOT">
-                        Use currently active device snapshot
+                        Use active snapshot
                     </template>
                     <template v-else-if="stage.action== StageAction.USE_LATEST_SNAPSHOT">
                         Use latest {{ stage.stageType === StageType.INSTANCE ? 'instance' : 'device' }} snapshot

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -129,6 +129,9 @@
                             When a device Pipeline stage type is triggered an Device Snapshot is deployed to the next stage. You can configure how this stage picks what snapshot to deploy.
                         </p>
                         <p>
+                            Use Active Snapshot: Will use the snapshot currently active on the device. The deploy will fail is there is no active snapshot.
+                        </p>
+                        <p>
                             Use Latest Device Snapshot: Uses the most recent existing snapshot of the device. The deploy will fail if no snapshot exists.
                         </p>
                         <p>
@@ -188,7 +191,7 @@
 <script>
 import { InformationCircleIcon } from '@heroicons/vue/outline'
 
-import { StageType } from '../../../api/pipeline.js'
+import { StageAction, StageType } from '../../../api/pipeline.js'
 
 import FormRow from '../../../components/FormRow.vue'
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
@@ -332,12 +335,14 @@ export default {
             const type = this.input.stageType === StageType.DEVICE ? 'device' : 'instance'
 
             const options = [
-                { value: 'use_latest_snapshot', label: `Use latest ${type} snapshot` },
-                { value: 'prompt', label: `Prompt to select ${type} snapshot` }
+                { value: StageAction.USE_LATEST_SNAPSHOT, label: `Use latest ${type} snapshot` },
+                { value: StageAction.PROMPT, label: `Prompt to select ${type} snapshot` }
             ]
 
             if (this.input.stageType === StageType.INSTANCE) {
-                options.unshift({ value: 'create_snapshot', label: `Create new ${type} snapshot` })
+                options.unshift({ value: StageAction.CREATE_SNAPSHOT, label: 'Create new instance snapshot' })
+            } else if (this.input.stageType === StageType.DEVICE) {
+                options.unshift({ value: StageAction.USE_ACTIVE_SNAPSHOT, label: 'Use active device snapshot' })
             }
 
             return options

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -115,13 +115,13 @@
                             When a instance Pipeline stage type is triggered an Instance Snapshot is deployed to the next stage. You can configure how this stage picks what snapshot to deploy.
                         </p>
                         <p>
-                            Create New Snapshot: Creates a new snapshot using the current flows and settings.
+                            <b>Create New Snapshot:</b> Creates a new snapshot using the current flows and settings.
                         </p>
                         <p>
-                            Use Latest Instance Snapshot: Uses the most recent existing snapshot of the instance. The deploy will fail if no snapshot exists.
+                            <b>Use Latest Instance Snapshot:</b> Uses the most recent existing snapshot of the instance. The deploy will fail if no snapshot exists.
                         </p>
                         <p>
-                            Prompt to Select Snapshot: Will ask at deploy time, which snapshot from the source stage should be copied to the next stage.
+                            <b>Prompt to Select Snapshot:</b> Will ask at deploy time, which snapshot from the source stage should be copied to the next stage.
                         </p>
                     </div>
                     <div v-else-if="input.stageType === StageType.DEVICE">
@@ -129,13 +129,13 @@
                             When a device Pipeline stage type is triggered an Device Snapshot is deployed to the next stage. You can configure how this stage picks what snapshot to deploy.
                         </p>
                         <p>
-                            Use Active Snapshot: Will use the snapshot currently active on the device. The deploy will fail is there is no active snapshot.
+                            <b>Use Active Snapshot:</b> Will use the snapshot currently active on the device. The deploy will fail is there is no active snapshot.
                         </p>
                         <p>
-                            Use Latest Device Snapshot: Uses the most recent existing snapshot of the device. The deploy will fail if no snapshot exists.
+                            <b>Use Latest Device Snapshot:</b> Uses the most recent snapshot created from the device. The deploy will fail if no snapshot exists.
                         </p>
                         <p>
-                            Prompt to Select Snapshot: Will ask at deploy time, which snapshot from the source stage should be copied to the next stage.
+                            <b>Prompt to Select Snapshot:</b> Will ask at deploy time, which snapshot from the source stage should be copied to the next stage.
                         </p>
                     </div>
                 </div>
@@ -342,7 +342,7 @@ export default {
             if (this.input.stageType === StageType.INSTANCE) {
                 options.unshift({ value: StageAction.CREATE_SNAPSHOT, label: 'Create new instance snapshot' })
             } else if (this.input.stageType === StageType.DEVICE) {
-                options.unshift({ value: StageAction.USE_ACTIVE_SNAPSHOT, label: 'Use active device snapshot' })
+                options.unshift({ value: StageAction.USE_ACTIVE_SNAPSHOT, label: 'Use active snapshot' })
             }
 
             return options


### PR DESCRIPTION
## Description

**Do not merge**: This is likely to be part of a follow up release.

Adds support to DevOps pipelines for a device to deploy its currently active snapshot (which might not be from this device) to the next stage in the pipeline. Rather than requiring the user to manually create a snapshot for the device.

This is much clearer to the user, and likely to be the most frequently used, given a device must be in developer mode to create a snapshot which can then deploy.

![Screenshot 2023-11-23 at 11 26 29](https://github.com/FlowFuse/flowfuse/assets/507155/f156cd4f-b759-4884-bb05-42bce4dd50ae)
![Screenshot 2023-11-23 at 11 26 21](https://github.com/FlowFuse/flowfuse/assets/507155/789bf46c-cd1c-4c8a-a81f-612fdb7f6bea)

Feature white-boarded with @robmarcer, @joepavitt and @Steve-Mcl during a validation call this morning where Rob accidentally deployed the wrong snapshot from a device.

## Related Issue(s)

Fixes #3113 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

