### PR TITLE
DevOps Pipeline: Clearer error messages

### DIFF
--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -168,7 +168,7 @@ export default {
         },
         stageDeployFailed (stage) {
             const nextStage = this.pipeline.stages.find((s) => s.id === stage.NextStageId)
-            this.$emit('stage-deploy-started', stage, nextStage)
+            this.$emit('stage-deploy-failed', stage, nextStage)
         },
         stageDeleted (stageIndex) {
             this.$emit('stage-deleted', stageIndex)

--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -30,6 +30,7 @@
                     :editEnabled="true"
                     @stage-deploy-starting="stageDeployStarting(stage)"
                     @stage-deploy-started="stageDeployStarted(stage)"
+                    @stage-deploy-failed="stageDeployFailed(stage)"
                     @stage-deleted="stageDeleted($index)"
                 />
                 <Transition name="fade">
@@ -87,7 +88,7 @@ export default {
             type: Map
         }
     },
-    emits: ['pipeline-deleted', 'stage-deleted', 'deploy-starting', 'deploy-started', 'stage-deploy-starting', 'stage-deploy-started'],
+    emits: ['pipeline-deleted', 'stage-deleted', 'deploy-starting', 'deploy-started', 'stage-deploy-starting', 'stage-deploy-started', 'stage-deploy-failed'],
     data () {
         const pipeline = this.pipeline
         return {
@@ -162,6 +163,10 @@ export default {
             this.$emit('stage-deploy-starting', stage, nextStage)
         },
         stageDeployStarted (stage) {
+            const nextStage = this.pipeline.stages.find((s) => s.id === stage.NextStageId)
+            this.$emit('stage-deploy-started', stage, nextStage)
+        },
+        stageDeployFailed (stage) {
             const nextStage = this.pipeline.stages.find((s) => s.id === stage.NextStageId)
             this.$emit('stage-deploy-started', stage, nextStage)
         },

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -215,8 +215,13 @@ export default {
                 // sourceSnapshot can be undefined if "create new snapshot" was chosen
                 await PipelineAPI.deployPipelineStage(this.pipeline.id, this.stage.id, sourceSnapshot?.id)
             } catch (error) {
-                Alerts.emit(error.message, 'warning')
-                return
+                this.$emit('stage-deploy-failed')
+
+                if (error.response?.data?.error) {
+                    return Alerts.emit(error.response.data.error, 'warning')
+                }
+
+                return Alerts.emit('Deployment of stage has failed for an unknown reason.', 'warning')
             }
 
             this.$emit('stage-deploy-started')

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -161,7 +161,7 @@ export default {
             type: Boolean
         }
     },
-    emits: ['stage-deleted', 'stage-deploy-starting', 'stage-deploy-started'],
+    emits: ['stage-deleted', 'stage-deploy-starting', 'stage-deploy-started', 'stage-deploy-failed'],
     computed: {
         deploying () {
             return this.stage.isDeploying


### PR DESCRIPTION
## Description

1. Bubbles deploy failed validation errors up to the alerts for the user to see
2. Stops polling if a deploy fails

Example error (manually forced):

![Screenshot 2023-11-23 at 12 38 45](https://github.com/FlowFuse/flowfuse/assets/507155/1292d8c0-8b61-4186-9044-15a7e3acaf78)

## Related Issue(s)

Follow up to #2756

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass - N/a
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

