### PR TITLE
Add tunnel recreation unit test

### DIFF
--- a/test/unit/forge/ee/routes/deviceEditor/index_spec.js
+++ b/test/unit/forge/ee/routes/deviceEditor/index_spec.js
@@ -115,6 +115,22 @@ describe('Device Editor API', function () {
             result.should.have.property('code')
         })
 
+        it('Recreates the tunnel upon enablement when the tunnel is open but connected state is `false', async function () {
+            // first enable the tunnel
+            const result = await setDeviceEditorStatus(app.device.hashid, TestObjects.tokens.alice, true)
+            result.should.have.property('enabled', true)
+            result.should.have.property('connected', false)
+            // now watch for `tunnelManager.closeTunnel` then `tunnelManager.newTunnel` being called
+            const closeTunnelSpy = sinon.spy(app.comms.devices.tunnelManager, 'closeTunnel')
+            const newTunnelSpy = sinon.spy(app.comms.devices.tunnelManager, 'newTunnel')
+            // now enable the tunnel again
+            const result2 = await setDeviceEditorStatus(app.device.hashid, TestObjects.tokens.alice, true)
+            result2.should.have.property('enabled', true)
+            // check that the tunnel was closed and re-created
+            closeTunnelSpy.calledWith(app.device.hashid).should.equal(true)
+            newTunnelSpy.calledWith(app.device.hashid).should.equal(true)
+        })
+
         it('enable editor mode', async function () {
             const result = await setDeviceEditorStatus(app.device.hashid, TestObjects.tokens.alice, true)
             result.should.have.property('enabled', true)


### PR DESCRIPTION
closes #3094

## Description

Unit test to ensure tunnel improvements work as expected

In short, if the tunnel is determined to be open, but disconnected, the one-click operation now recreates the tunnel automatically. This test ensures that.

Previously, the user had to manually disable and re-enable the tunnel.

## Related Issue(s)

#3094 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

