### PR TITLE
Fix linux version of install instructions

### DIFF
--- a/docs/device-agent/quickstart.md
+++ b/docs/device-agent/quickstart.md
@@ -23,7 +23,7 @@ Linux:
 ```bash
 mkdir /opt/flowfuse-device
 cd /opt/flowfuse-device
-npm install -g @flowfuse/flowfuse-device-agent
+npm install -g @flowfuse/device-agent
 flowfuse-device-agent -w --ui-user admin --ui-pass password --ui-port 8081
 ```
 


### PR DESCRIPTION
Fixes #3128

## Description

<!-- Describe your changes in detail -->
Typo, 

It shows - `npm install -g @flowfuse/flowfuse-device-agent`
Should be - `npm install -g @flowfuse/device-agent`

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#3128 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

