### PR TITLE
Allow a trial team to be put into unmanaged mode to bypass billing

### DIFF
--- a/forge/db/migrations/20231128-01-EE-add-unmanaged-sub-state.js.js
+++ b/forge/db/migrations/20231128-01-EE-add-unmanaged-sub-state.js.js
@@ -1,0 +1,19 @@
+/**
+ * Add unmanaged as valid state for a Subscription
+ */
+
+module.exports = {
+    up: async (queryInterface) => {
+        const tableExists = await queryInterface.tableExists('Subscriptions')
+        if (!tableExists) {
+            return queryInterface.sequelize.log('Skipping Subscription migration as table does not exist')
+        }
+
+        if (queryInterface.sequelize.options.dialog === 'postgres') {
+            // Postgres enums need to be explicitly updated
+            queryInterface.sequelize.query("ALTER TYPE \"enum_Subscriptions_status\" ADD VALUE 'unmanaged';")
+        }
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -12,7 +12,10 @@ const STATUS = {
     CANCELED: 'canceled',
     PAST_DUE: 'past_due',
     // Local only status, not from Stripe
-    TRIAL: 'trial'
+    TRIAL: 'trial',
+    // Local only - means this team's subscription on stripeon strip is not
+    // managed by the platform
+    UNMANAGED: 'unmanaged'
 }
 
 Object.freeze(STATUS)
@@ -67,6 +70,7 @@ module.exports = {
             instance: {
                 // States:
                 //  isActive : Billing details setup
+                //  isUnmanaged : The subscription on stripe is manually managed - no further setup required
                 //  isTrial  : In trial mode, no billing details setup, trial might have ended (isTrialEnded)
                 //  isActive && !isTrialEnded : Started as a trial, added billing, still in trial period
                 //  isActive && isTrialEnded  : Started as trial, added billing, trial ended
@@ -74,6 +78,9 @@ module.exports = {
                 // Should this subscription be treated as active/usable
                 isActive () {
                     return this.status === STATUS.ACTIVE || this.status === STATUS.PAST_DUE
+                },
+                isUnmanaged () {
+                    return this.status === STATUS.UNMANAGED
                 },
                 isCanceled () {
                     return this.status === STATUS.CANCELED

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -1,5 +1,3 @@
-const { Op } = require('sequelize')
-
 module.exports.init = async function (app) {
     // Set the billing feature flag
     app.config.features.register('billing', true, true)
@@ -104,7 +102,7 @@ module.exports.init = async function (app) {
                     }
                 }
             }
-            const instanceCounts = await team.instanceCountByType({ state: { [Op.notIn]: ['suspended', 'deleting'] } })
+            const instanceCounts = await team.getBillableInstanceCountByType()
             const instanceTypes = await app.db.models.ProjectType.findAll()
             for (const instanceType of instanceTypes) {
                 // Get the stripe ids to use for this instance type in this team type
@@ -224,8 +222,13 @@ module.exports.init = async function (app) {
          * @param {Team} team
          */
         updateTeamInstanceCount: async (team) => {
-            const counts = await team.instanceCountByType({ state: { [Op.notIn]: ['suspended', 'deleting'] } })
+            const counts = await team.getBillableInstanceCountByType()
             const subscription = await team.getSubscription()
+            if (subscription && subscription.isUnmanaged()) {
+                // Unmanaged subscription means the platform is not responsible
+                // for managing the stripe configuration
+                return
+            }
             if (subscription && subscription.isActive()) {
                 const prorationBehavior = await team.getBillingProrationBehavior()
                 const stripeSubscription = await stripe.subscriptions.retrieve(subscription.subscription)
@@ -328,6 +331,11 @@ module.exports.init = async function (app) {
                 return
             }
             const subscription = await team.getSubscription()
+            if (subscription && subscription.isUnmanaged()) {
+                // Unmanaged subscription means the platform is not responsible
+                // for managing the stripe configuration
+                return
+            }
             if (subscription && subscription.isActive()) {
                 const deviceCount = await team.deviceCount()
                 const deviceFreeAllocation = await team.getDeviceFreeAllowance()
@@ -442,8 +450,13 @@ module.exports.init = async function (app) {
          */
         updateTeamType: async (team, targetTeamType) => {
             const subscription = await team.getSubscription()
-            // The team must have billing setup with an active subscription before
+            // The team must have billing setup with an active or unmanaged subscription before
             // it can change its type
+            if (subscription && subscription.isUnmanaged()) {
+                // Unmanaged subscription means the platform is not responsible
+                // for managing the stripe configuration
+                return
+            }
             if (subscription && subscription.isActive()) {
                 if (subscription.isTrial()) {
                     // This block can be removed in 1.14 as it is a condition

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -139,6 +139,7 @@ module.exports = async function (app) {
             const subscription = await team.getSubscription()
             if (subscription) {
                 result.billing.active = subscription.isActive()
+                result.billing.unmanaged = subscription.isUnmanaged()
                 result.billing.canceled = subscription.isCanceled()
                 result.billing.pastDue = subscription.isPastDue()
                 if (subscription.isTrial()) {

--- a/frontend/src/api/billing.js
+++ b/frontend/src/api/billing.js
@@ -23,8 +23,17 @@ const createSubscription = async (teamId, teamTypeId = undefined) => {
     })
 }
 
+const setupManualBilling = async (teamId, teamTypeId) => {
+    return client.post('/ee/billing/teams/' + teamId + '/manual', {
+        teamTypeId
+    }).then(res => {
+        return res.data
+    })
+}
+
 export default {
     toCustomerPortal,
     getSubscriptionInfo,
-    createSubscription
+    createSubscription,
+    setupManualBilling
 }

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -39,6 +39,7 @@ const getTeam = (team) => {
         if ('billing' in res.data) {
             props['billing-active'] = res.data.billing.active
             props['billing-canceled'] = res.data.billing.canceled
+            props['billing-unmanaged'] = res.data.billing.unmanaged
 
             if ('trial' in res.data.billing) {
                 props['billing-trial'] = res.data.billing.trial

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -504,7 +504,7 @@ export default {
         this.flowBlueprints = (await flowBlueprintsPromise).blueprints
 
         this.activeProjectTypeCount = projectTypes.length
-        if (this.billingEnabled) {
+        if (this.billingEnabled && !this.team.billing?.unmanaged) {
             try {
                 this.subscription = await billingApi.getSubscriptionInfo(this.team.id)
             } catch (err) {
@@ -557,7 +557,6 @@ export default {
                         pt.currency = ''
                         pt.cost = 0
                     }
-
                     if (this.team.billing?.trial) {
                         if (this.team.type.properties?.trial?.instanceType) {
                             const isTrialProjectType = pt.id === this.team.type.properties?.trial?.instanceType
@@ -606,11 +605,12 @@ export default {
         }
 
         // Team must not have billing set up
-        if (this.team.billing?.active ?? true) {
+        if ((this.team.billing?.active || this.team.billing?.unmanaged) ?? true) {
             return
         }
 
         // Redirect to billing if:
+        //   - subscription is not unmanaged
         //   - team has cancelled their subscription
         //   - team is not a trial team, or:
         //   - team is a trial team and:

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -50,7 +50,7 @@
                 Something went wrong loading your subscription information, please try again.
             </div>
         </div>
-        <EmptyState v-else>
+        <EmptyState v-else-if="!isUnmanaged">
             <template #img>
                 <img src="../../images/empty-states/team-instances.png">
             </template>
@@ -72,6 +72,20 @@
             </template>
             <template #actions>
                 <ff-button data-action="change-team-type" :to="{name: 'TeamChangeType'}">Setup Billing</ff-button>
+            </template>
+        </EmptyState>
+        <EmptyState v-else>
+            <template #img>
+                <img src="../../images/empty-states/team-instances.png">
+            </template>
+            <template #header>Team Billing</template>
+            <template #message>
+                <p>
+                    Your team billing cannot currently be managed from the dashboard.
+                </p>
+                <p>
+                    Please contact <a href="https://flowfuse.com/support/" class="underline" target="_blank">Support</a> for help.
+                </p>
             </template>
         </EmptyState>
     </ff-page>
@@ -172,6 +186,9 @@ export default {
         subscriptionExpired () {
             return this.team.billing?.canceled
         },
+        isUnmanaged () {
+            return this.team.billing?.unmanaged
+        },
         trialMode () {
             return this.team.billing?.trial
         },
@@ -198,14 +215,12 @@ export default {
     },
     watch: { },
     async mounted () {
-        if (!this.billingSetUp) {
+        if (!this.billingSetUp && !this.isUnmanaged) {
             return
         }
-
         if (!this.hasPermission('team:edit')) {
             return this.$router.push({ path: `/team/${this.team.slug}/overview` })
         }
-
         this.loading = true
         try {
             const billingSubscription = await billingApi.getSubscriptionInfo(this.team.id)

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -21,10 +21,13 @@
                 <ConfirmTeamDeleteDialog ref="confirmTeamDeleteDialog" @delete-team="deleteTeam" />
             </div>
         </div>
+        <TeamAdminTools v-if="isAdmin" :team="team" />
     </div>
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import teamApi from '../../../api/team.js'
 import teamTypesApi from '../../../api/teamTypes.js'
 
@@ -32,11 +35,14 @@ import FormHeading from '../../../components/FormHeading.vue'
 
 import ConfirmTeamDeleteDialog from '../dialogs/ConfirmTeamDeleteDialog.vue'
 
+import TeamAdminTools from './TeamAdminTools.vue'
+
 export default {
     name: 'TeamSettingsDanger',
     components: {
         FormHeading,
-        ConfirmTeamDeleteDialog
+        ConfirmTeamDeleteDialog,
+        TeamAdminTools
     },
     props: {
         team: {
@@ -51,6 +57,10 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['user']),
+        isAdmin: function () {
+            return this.user.admin
+        },
         deleteActive () {
             return this.applicationCount === 0
         },

--- a/frontend/src/pages/team/Settings/TeamAdminTools.vue
+++ b/frontend/src/pages/team/Settings/TeamAdminTools.vue
@@ -1,0 +1,78 @@
+<template>
+    <div v-if="features.billing" class="space-y-6">
+        <FormHeading class="text-red-700">Admin Only Tools</FormHeading>
+
+        <div v-if="trialMode" class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
+            <div class="flex-grow">
+                <div class="max-w-sm pr-2">
+                    This team is in trial mode. Setting up manual billing will
+                    allow this team to make full use of the platform without
+                    requiring them to configure their billing details.
+                </div>
+            </div>
+            <div class="min-w-fit flex-shrink-0">
+                <ff-button kind="danger" data-action="admin-setup-billing" @click="confirmManualBilling()">Setup Manual Billing</ff-button>
+            </div>
+        </div>
+    </div>
+    <ConfirmTeamManualBillingDialog ref="confirmTeamManualBillingDialog" @setup-manual-billing="setupManualBilling" />
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+import billingApi from '../../../api/billing.js'
+
+import FormHeading from '../../../components/FormHeading.vue'
+
+import ConfirmTeamManualBillingDialog from '../dialogs/ConfirmTeamManualBillingDialog.vue'
+
+export default {
+    name: 'TeamAdminTools',
+    components: {
+        FormHeading,
+        ConfirmTeamManualBillingDialog
+    },
+    props: {
+        team: {
+            type: Object,
+            required: true
+        }
+    },
+    data () {
+        return {
+        }
+    },
+    computed: {
+        ...mapState('account', ['features']),
+        billingSetUp () {
+            return this.team.billing?.active
+        },
+        subscriptionExpired () {
+            return this.team.billing?.canceled
+        },
+        isUnmanaged () {
+            return this.team.billing?.unmanaged
+        },
+        trialMode () {
+            return this.team.billing?.trial
+        },
+        trialHasEnded () {
+            return this.team.billing?.trialEnded
+        }
+    },
+    methods: {
+        confirmManualBilling () {
+            this.$refs.confirmTeamManualBillingDialog.show(this.team)
+        },
+        async setupManualBilling (teamTypeId) {
+            billingApi.setupManualBilling(this.team.id, teamTypeId).then(async () => {
+                await this.$store.dispatch('account/refreshTeams')
+                await this.$store.dispatch('account/refreshTeam')
+            }).catch(err => {
+                console.warn(err)
+            })
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -23,6 +23,14 @@
                         Select your team type
                     </template>
                 </FormHeading>
+                <div v-if="isUnmanaged" class="space-y-2">
+                    <p>
+                        Your team type cannot currently be managed from the dashboard.
+                    </p>
+                    <p>
+                        Please contact <a href="https://flowfuse.com/support/" class="underline" target="_blank">Support</a> for help.
+                    </p>
+                </div>
                 <!-- TeamType Type -->
                 <div class="flex flex-wrap gap-1 items-stretch">
                     <ff-tile-selection v-model="input.teamTypeId" data-form="team-type">
@@ -32,6 +40,7 @@
                             :price="billingEnabled ? teamType.billingPrice : ''"
                             :price-interval="billingEnabled ? teamType.billingInterval : ''"
                             :value="teamType.id"
+                            :disabled="isUnmanaged"
                         />
                     </ff-tile-selection>
                 </div>
@@ -97,7 +106,7 @@ export default {
     computed: {
         ...mapState('account', ['user', 'team', 'features']),
         formValid () {
-            return this.input.teamTypeId && (!this.isTypeChange || this.input.teamTypeId !== this.team.type.id)
+            return !this.isUnmanaged && this.input.teamTypeId && (!this.isTypeChange || this.input.teamTypeId !== this.team.type.id)
         },
         billingEnabled () {
             return this.features.billing
@@ -113,6 +122,9 @@ export default {
         },
         isTypeChange () {
             return !this.billingEnabled || this.billingSetup
+        },
+        isUnmanaged () {
+            return this.team.billing?.unmanaged
         }
     },
     watch: {

--- a/frontend/src/pages/team/dialogs/ConfirmTeamManualBillingDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamManualBillingDialog.vue
@@ -1,0 +1,65 @@
+<template>
+    <ff-dialog ref="dialog" data-el="delete-team-dialog" header="Setup Manual Billing" kind="danger" confirm-label="Setup manual billing" @confirm="confirm()">
+        <template #default>
+            <form v-if="team" class="space-y-6" @submit.prevent>
+                <div class="space-y-6">
+                    <p>
+                        Are you sure you want to setup manual billing for this team?
+                    </p>
+                    <p>
+                        This will bring the trial to an end and allow the team to make
+                        full use of the platform without requiring them to configure
+                        their billing details.
+                    </p>
+                </div>
+
+                <FormRow id="teamType" v-model="input.teamType" data-form="team-type" :options="teamTypes">Select the team type to apply:</FormRow>
+            </form>
+        </template>
+    </ff-dialog>
+</template>
+
+<script>
+import teamTypesApi from '../../../api/teamTypes.js'
+
+import FormRow from '../../../components/FormRow.vue'
+
+export default {
+    name: 'ConfirmTeamManualBillingDialog',
+    components: {
+        FormRow
+    },
+    emits: ['setup-manual-billing'],
+    setup () {
+        return {
+            show (team) {
+                this.team = team
+                this.input.teamType = this.team.type.id
+                this.$refs.dialog.show()
+                teamTypesApi.getTeamTypes().then(response => {
+                    this.teamTypes = response.types.reduce((types, type) => {
+                        if (type.active) {
+                            types.push(type)
+                        }
+                        return types
+                    }, [])
+                }).catch(err => { console.warn(err) })
+            }
+        }
+    },
+    data () {
+        return {
+            input: {
+                teamType: null
+            },
+            team: null,
+            teamTypes: []
+        }
+    },
+    methods: {
+        confirm () {
+            this.$emit('setup-manual-billing', this.input.teamType)
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -105,6 +105,7 @@ export default {
         checkBilling: async function () {
             // Team Billing
             if (this.features.billing &&
+                (!this.team.billing?.unmanaged) &&
                 (!this.team.billing?.trial || this.team.billing?.trialEnded) &&
                 !this.team.billing?.active
             ) {


### PR DESCRIPTION
## Description

This PR allows a trial team to be put into 'unmanaged' mode. Once in this mode, the team no longer interacts directly with Stripe - on the assumption that all billing is being handled manually.

Once in 'unmanaged' mode, a team type cannot be changed, but it is free to create instances/devices as needed.

For this iteration, the Billing page notifies the user they cannot manage their subscription and should contact FF Support for help. The Change Team Type page does similar.

Under the covers, this adds a new state to the Subscription object - `unmanaged` (inc migration for postgres enum).

The API end point for putting a Trial Team into this mode is only accessible by Admin users.

The Team Settings - Danger page has an Admin Only Tools section (only shown when viewing as Admin user on a Trial Team):

<img width="811" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/6029acfd-dff0-4d8b-87df-ada4bfc039bf">

The Setup manual billing button opens a dialog to confirm - and select the desired TeamType

<img width="645" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/5cd78a67-bb2a-4c94-8002-3fe1007764d8">






