### PR TITLE
Update container loading for new module scopes

### DIFF
--- a/forge/containers/index.js
+++ b/forge/containers/index.js
@@ -35,12 +35,16 @@ const fp = require('fastify-plugin')
 
 const wrapper = require('./wrapper.js')
 
+const DRIVER_MODULES = {
+    stub: './stub/index.js',
+    localfs: '@flowfuse/driver-localfs',
+    docker: '@flowforge/docker',
+    kubernetes: '@flowforge/kubernetes'
+}
+
 module.exports = fp(async function (app, _opts, next) {
     const containerDialect = app.config.driver.type
-    const containerModule = containerDialect === 'stub'
-        ? './stub/index.js'
-        : `@flowforge/${containerDialect}`
-
+    const containerModule = DRIVER_MODULES[containerDialect]
     try {
         const driver = require(containerModule)
         await wrapper.init(app, driver, {
@@ -58,7 +62,7 @@ module.exports = fp(async function (app, _opts, next) {
             await wrapper.shutdown()
         })
     } catch (err) {
-        app.log.error('Failed to load the container driver')
+        app.log.error(`Failed to load the container driver: ${containerDialect}`)
         throw err
     }
 

--- a/forge/containers/index.js
+++ b/forge/containers/index.js
@@ -39,7 +39,7 @@ const DRIVER_MODULES = {
     stub: './stub/index.js',
     localfs: '@flowfuse/driver-localfs',
     docker: '@flowfuse/driver-docker',
-    kubernetes: '@flowforge/kubernetes'
+    kubernetes: '@flowfuse/driver-kubernetes'
 }
 
 module.exports = fp(async function (app, _opts, next) {

--- a/forge/containers/index.js
+++ b/forge/containers/index.js
@@ -38,7 +38,7 @@ const wrapper = require('./wrapper.js')
 const DRIVER_MODULES = {
     stub: './stub/index.js',
     localfs: '@flowfuse/driver-localfs',
-    docker: '@flowforge/docker',
+    docker: '@flowfuse/driver-docker',
     kubernetes: '@flowforge/kubernetes'
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@fastify/swagger": "^8.10.1",
                 "@fastify/swagger-ui": "^1.9.0",
                 "@fastify/websocket": "^8.1.0",
-                "@flowforge/localfs": "^1.14.0",
+                "@flowfuse/driver-localfs": "^1.14.0",
                 "@headlessui/vue": "1.7.16",
                 "@heroicons/vue": "1.0.6",
                 "@immobiliarelabs/fastify-sentry": "^7.1.1",
@@ -4783,10 +4783,10 @@
                 "ws": "^8.0.0"
             }
         },
-        "node_modules/@flowforge/localfs": {
+        "node_modules/@flowfuse/driver-localfs": {
             "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/@flowforge/localfs/-/localfs-1.14.0.tgz",
-            "integrity": "sha512-HEz1Q6x/fDsin5yovOPNL64YNzL367HddmGU6YMEprIsivm1cFNaKZdyoFtcVpx9iJQxGt0KHDQ6Wc5PtJ/hWQ==",
+            "resolved": "https://registry.npmjs.org/@flowfuse/driver-localfs/-/driver-localfs-1.14.0.tgz",
+            "integrity": "sha512-M+qPy0AGtchjsBrLZs3MXgdWcHBFt2UzlJ37w7BXXacymw2zFYH7DwQ5bWGibxdD/ouiby7vbTvfcnrMY7APBA==",
             "dependencies": {
                 "@flowfuse/nr-launcher": "^1.14.0",
                 "got": "^11.8.5",
@@ -26797,10 +26797,10 @@
                 "ws": "^8.0.0"
             }
         },
-        "@flowforge/localfs": {
+        "@flowfuse/driver-localfs": {
             "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/@flowforge/localfs/-/localfs-1.14.0.tgz",
-            "integrity": "sha512-HEz1Q6x/fDsin5yovOPNL64YNzL367HddmGU6YMEprIsivm1cFNaKZdyoFtcVpx9iJQxGt0KHDQ6Wc5PtJ/hWQ==",
+            "resolved": "https://registry.npmjs.org/@flowfuse/driver-localfs/-/driver-localfs-1.14.0.tgz",
+            "integrity": "sha512-M+qPy0AGtchjsBrLZs3MXgdWcHBFt2UzlJ37w7BXXacymw2zFYH7DwQ5bWGibxdD/ouiby7vbTvfcnrMY7APBA==",
             "requires": {
                 "@flowfuse/nr-launcher": "^1.14.0",
                 "got": "^11.8.5",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@fastify/swagger": "^8.10.1",
         "@fastify/swagger-ui": "^1.9.0",
         "@fastify/websocket": "^8.1.0",
-        "@flowforge/localfs": "^1.14.0",
+        "@flowfuse/driver-localfs": "^1.14.0",
         "@headlessui/vue": "1.7.16",
         "@heroicons/vue": "1.0.6",
         "@immobiliarelabs/fastify-sentry": "^7.1.1",


### PR DESCRIPTION
## Description

This updates the core to pick up the new `@flowfuse` scoped localfs module.

It updates the container loading mechanism to map the config value to the module name more explicitly rather than rely on string concatenation. This also allows us to incrementally migrate the drivers.

Before merge:
 - [x] Publish initial version of `@flowfuse/driver-localfs` to npm
 - [x] Update `package-lock.json` in this PR
 - [x] https://github.com/FlowFuse/driver-docker/pull/77
 - [x] Publish initial version of `@flowfuse/driver-docker` to npm
 - [x] https://github.com/FlowFuse/driver-k8s/pull/126
 - [x] https://github.com/FlowFuse/helm/pull/235
 - [x] Publish initial version of `@flowfuse/driver-kubernetes` to npm