### PR TITLE
Add canonical link to current base_url

### DIFF
--- a/forge/routes/ui/index.js
+++ b/forge/routes/ui/index.js
@@ -69,6 +69,10 @@ module.exports = async function (app) {
                 injection += `<script>window.sentryConfig = { dsn: "${telemetry.frontend.sentry.dsn}", production_mode: ${telemetry.frontend.sentry.production_mode ?? true}, version: "flowfuse@${config.version}", environment: "${process.env.SENTRY_ENV ?? (process.env.NODE_ENV ?? 'unknown')}" }</script>`
             }
 
+            if (config.base_url) {
+                injection += `<link rel="canonical" href="${config.base_url}" />`
+            }
+
             // inject into index.html
             cachedIndex = data.replace(/<script>\/\*inject-ff-scripts\*\/<\/script>/g, injection)
         }


### PR DESCRIPTION
fixes https://github.com/FlowFuse/flowfuse/issues/3034

## Description

<!-- Describe your changes in detail -->
Add a canonical link to app.flowfuse.com to it updates SOE links to app.flowforge.com

It only gets applied if frontend telemetry is enabled which is fine for FF Cloud.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/issues/3034

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

