### PR TITLE
Improve canceled subs handling

### DIFF
--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -102,17 +102,19 @@ module.exports = {
         // Suspend all projects of that team
         const projects = await app.db.models.Project.byTeam(team.hashid)
         await Promise.all(projects.map(async (project) => {
-            app.log.info(`Suspending instance ${project.id} from team ${team.hashid}`)
-            try {
-                app.db.controllers.Project.setInflightState(project, 'suspending')
-                await app.containers.stop(project)
-                app.db.controllers.Project.clearInflightState(project)
-                await app.auditLog.Project.project.suspended(user || 'system', null, project)
-            } catch (err) {
-                app.log.warn(`Failed to suspend instance ${project.id} from team ${team.hashid}: ${err.toString()}`)
-                app.db.controllers.Project.clearInflightState(project)
-                const resp = { code: 'unexpected_error', error: err.toString() }
-                await app.auditLog.Project.project.suspended(null, resp, project)
+            if (project.state !== 'suspended') {
+                app.log.info(`Suspending instance ${project.id} from team ${team.hashid}`)
+                try {
+                    app.db.controllers.Project.setInflightState(project, 'suspending')
+                    await app.containers.stop(project)
+                    app.db.controllers.Project.clearInflightState(project)
+                    await app.auditLog.Project.project.suspended(user || 'system', null, project)
+                } catch (err) {
+                    app.log.warn(`Failed to suspend instance ${project.id} from team ${team.hashid}: ${err.toString()}`)
+                    app.db.controllers.Project.clearInflightState(project)
+                    const resp = { code: 'unexpected_error', error: err.toString() }
+                    await app.auditLog.Project.project.suspended(null, resp, project)
+                }
             }
         }))
         app.log.info(`Suspended all instances for team ${team.hashid}`)

--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -95,5 +95,18 @@ module.exports = {
         }
 
         return false
+    },
+
+    suspendTeam: async function (app, team, user = null) {
+        // Suspend all projects of that team
+        const projects = await app.db.models.Project.byTeam(team.hashid)
+        await Promise.all(projects.map(async (project) => {
+            app.log.info(`Stopping project ${project.id} from team ${team.hashid}`)
+            if (await app.containers.stop(project)) {
+                await app.auditLog.Project.project.suspended(user || 'system', null, project)
+            }
+        }))
+
+        app.log.info(`Suspended all projects for team ${team.hashid}`)
     }
 }

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -388,6 +388,31 @@ module.exports = {
                 },
 
                 /**
+                 * Checks to see if a device can be created in this team.
+                 * At this level, the check looks at any restrictions applied
+                 * by the TeamType object.
+                 * When running with EE, this function is overloaded via
+                 * ee/lib/billing/Team.js to add EE-specific checks as well
+                 * (such as billing and trials)
+                 *
+                 * If the create is not allowed, an error is thrown with code/error
+                 * properties set
+                 */
+                checkDeviceCreateAllowed: async function () {
+                    await this.ensureTeamTypeExists()
+                    const teamDeviceLimit = await this.getDeviceLimit()
+                    if (teamDeviceLimit > -1) {
+                        const currentDeviceCount = await this.deviceCount()
+                        if (currentDeviceCount >= teamDeviceLimit) {
+                            const err = new Error()
+                            err.code = 'device_limit_reached'
+                            err.error = 'Team device limit reached'
+                            throw err
+                        }
+                    }
+                },
+
+                /**
                  * Checks whether the team type can be modified to the requested type.
                  * The team must be within any limits of the target type.
                  */

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -549,7 +549,7 @@ module.exports.init = async function (app) {
                             await app.billing.updateSubscriptionStatus(subscription, stripeSubscription.status, team)
                             await app.db.controllers.Team.suspendTeam(team)
                         } else {
-                            app.log.warn(`Subscription status for team ${team.hashid} does not match stripe "${subscription.status}" vs "${stribeSubscription?.status}". Subscription ${subscription.subscription}.`)
+                            app.log.warn(`Subscription status for team ${team.hashid} does not match stripe "${subscription.status}" vs "${stripeSubscription?.status}". Subscription ${subscription.subscription}.`)
                         }
                     }
                 } catch (err) {

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -541,13 +541,15 @@ module.exports.init = async function (app) {
             if (subscription.subscription) {
                 try {
                     const stripeSubscription = await stripe.subscriptions.retrieve(subscription.subscription)
-                    if (stripeSubscription.status !== subscription.status) {
+                    if (stripeSubscription?.status !== subscription.status) {
                         // We have got out of sync. We primarily care about being
                         // in the canceled state.
                         // Note: a canceled subscription cannot become uncanceled
                         if (stripeSubscription.status === 'canceled') {
                             await app.billing.updateSubscriptionStatus(subscription, stripeSubscription.status, team)
                             await app.db.controllers.Team.suspendTeam(team)
+                        } else {
+                            app.log.warn(`Subscription status for team ${team.hashid} does not match stripe "${subscription.status}" vs "${stribeSubscription?.status}". Subscription ${subscription.subscription}.`)
                         }
                     }
                 } catch (err) {

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -194,13 +194,11 @@ module.exports = async function (app) {
             team = teamMembership.get('Team')
         }
 
-        const teamDeviceLimit = await team.getDeviceLimit()
-        if (teamDeviceLimit > -1) {
-            const currentDeviceCount = await team.deviceCount()
-            if (currentDeviceCount >= teamDeviceLimit) {
-                reply.code(400).send({ code: 'device_limit_reached', error: 'Team device limit reached' })
-                return
-            }
+        try {
+            await team.checkDeviceCreateAllowed()
+        } catch (err) {
+            reply.code(400).send({ code: err.code || 'unexpected_error', error: err.error || err.toString() })
+            return
         }
 
         try {

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -241,6 +241,12 @@
         <span v-if="!error && entry.body?.billingSession" />
         <span v-else-if="!error">Billing data not found in audit entry.</span>
     </template>
+    <template v-else-if="entry.event === 'billing.subscription.updated'">
+        <label>{{ AuditEvents[entry.event] }}</label>
+        <span v-if="!error && entry.body.updates[0]?.key === 'status'">Subscription status updated to '{{ entry.body.updates[0].new }}'</span>
+        <span v-else-if="!error && entry.body.updates">Subscription status updated: '{{ entry.body.updates[0] }}'</span>
+        <span v-else-if="!error">Billing data not found in audit entry.</span>
+    </template>
 
     <!-- Platform License Events -->
     <template v-else-if="entry.event === 'platform.license.applied' || entry.event === 'platform.licence.apply'">

--- a/frontend/src/data/audit-events.json
+++ b/frontend/src/data/audit-events.json
@@ -36,7 +36,8 @@
         "project.duplicated": "Instance Duplicated",
         "billing.session.created": "Billing Session Created",
         "billing.session.completed": "Billing Session Completed",
-        "billing.subscription.deleted": "Billing Subscription Deleted"
+        "billing.subscription.deleted": "Billing Subscription Deleted",
+        "billing.subscription.updated": "Billing Subscription Updated"
     },
     "application": {
         "application.created": "Application Created",

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -50,6 +50,21 @@
                 Something went wrong loading your subscription information, please try again.
             </div>
         </div>
+        <EmptyState v-else-if="subscriptionExpired">
+            <template #img>
+                <img src="../../images/empty-states/team-instances.png">
+            </template>
+            <template #header>Your Team Subscription Has Expired</template>
+            <template #message>
+                <p>
+                    Your subscription has expired. To continue using this team, you will need to
+                    setup billing again.
+                </p>
+            </template>
+            <template #actions>
+                <ff-button data-action="change-team-type" :to="{name: 'TeamChangeType'}">Setup Billing</ff-button>
+            </template>
+        </EmptyState>
         <EmptyState v-else-if="!isUnmanaged">
             <template #img>
                 <img src="../../images/empty-states/team-instances.png">

--- a/test/lib/stripeMock.js
+++ b/test/lib/stripeMock.js
@@ -20,6 +20,9 @@ module.exports = (testSpecificMock = {}) => {
             createBalanceTransaction: sandbox.stub().resolves({ status: 'ok' })
         },
         subscriptions: {
+            _createTestSubscription: (subId, data) => {
+                stripeData[subId] = data
+            },
             create: (subId) => {
                 if (!stripeData[subId]) {
                     stripeData[subId] = { metadata: {}, items: { data: [] } }

--- a/test/unit/forge/db/models/Team_spec.js
+++ b/test/unit/forge/db/models/Team_spec.js
@@ -7,6 +7,7 @@ describe('Team model', function () {
 
     describe('model properties', async function () {
         let pt1, pt2, pt3
+        let d1, d2
         let ATeam
         let smallerTeamType
         let biggerTeamType
@@ -31,9 +32,9 @@ describe('Team model', function () {
             await teamType.save()
             ATeam = await app.db.models.Team.findOne({ where: { name: 'ATeam' } })
 
-            const d1 = await app.db.models.Device.create({ name: 'd1', type: 't1', credentialSecret: '' })
+            d1 = await app.db.models.Device.create({ name: 'd1', type: 't1', credentialSecret: '' })
             await ATeam.addDevice(d1)
-            const d2 = await app.db.models.Device.create({ name: 'd2', type: 't1', credentialSecret: '' })
+            d2 = await app.db.models.Device.create({ name: 'd2', type: 't1', credentialSecret: '' })
             await ATeam.addDevice(d2)
 
             // Create a new teamType with stricter limits
@@ -178,6 +179,16 @@ describe('Team model', function () {
         it('checkTeamTypeUpdateAllowed allows changing type to bigger type', async function () {
             await ATeam.checkTeamTypeUpdateAllowed(biggerTeamType)
         })
+        it('checkDeviceCreateAllowed', async function () {
+            await ATeam.checkDeviceCreateAllowed().should.be.rejected() // Already at the limit
+
+            // Remove a device
+            await d1.destroy()
+
+            // Check we can now create a device
+            await ATeam.checkDeviceCreateAllowed().should.be.resolved()
+        })
+
         it('updateTeamType applies type change', async function () {
             await ATeam.updateTeamType(biggerTeamType)
             const reloadedTeam = await app.db.models.Team.findOne({ where: { name: 'ATeam' } })

--- a/test/unit/forge/ee/lib/billing/Team_spec.js
+++ b/test/unit/forge/ee/lib/billing/Team_spec.js
@@ -1,0 +1,45 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../../setup')
+
+describe('Team model - EE features', function () {
+    // Use standard test data.
+    let app
+    let stripe
+
+    before(async function () {
+        stripe = setup.setupStripe()
+        stripe.subscriptions.create('sub_1234567890') // add existing subscription to mock stripe
+        stripe.subscriptions._createTestSubscription('sub_canceled', { status: 'canceled', metadata: {}, items: { data: [] } })
+        app = await setup({})
+    })
+    after(async function () {
+        await app.close()
+        setup.resetStripe()
+        delete require.cache[require.resolve('stripe')]
+    })
+
+    describe('checkDeviceCreateAllowed', function () {
+        it('allows device create if subscription active', async function () {
+            // Ensure team has active subscription
+            const sub = await app.db.controllers.Subscription.createSubscription(app.team, 'sub_1234567890', 'cust_123')
+            sub.status = app.db.models.Subscription.STATUS.ACTIVE
+            await sub.save()
+            await app.team.checkDeviceCreateAllowed().should.be.resolved()
+        })
+        it('rejects device create if subscription does not exist', async function () {
+            // Remove any existing subscription
+            const sub = await app.team.getSubscription()
+            if (sub) {
+                sub.destroy()
+            }
+            await app.team.checkDeviceCreateAllowed().should.be.rejected()
+        })
+        it('rejects device create if subscription is canceled', async function () {
+            // Ensure team has canceled subscription
+            const sub = await app.db.controllers.Subscription.createSubscription(app.team, 'sub_canceled', 'cust_123')
+            sub.status = app.db.models.Subscription.STATUS.CANCELED
+            await sub.save()
+            await app.team.checkDeviceCreateAllowed().should.be.rejected()
+        })
+    })
+})

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -18,7 +18,7 @@ describe('Billing routes', function () {
 
     async function getLog () {
         const logs = await app.db.models.AuditLog.forEntity()
-        return (await app.db.views.AuditLog.auditLog({ log: logs.log })).log[0]
+        return (await app.db.views.AuditLog.auditLog({ log: logs.log })).log
     }
 
     async function login (username, password) {
@@ -478,7 +478,7 @@ describe('Billing routes', function () {
 
                 const subscription = await app.db.models.Subscription.byCustomerId('cus_1234567890')
                 should(subscription.status).equal(app.db.models.Subscription.STATUS.CANCELED)
-                const log = await getLog()
+                const log = (await getLog())[0]
                 log.event.should.equal('billing.subscription.updated')
                 log.body.updates.should.have.length(1)
                 log.body.updates[0].key.should.equal('status')
@@ -517,7 +517,7 @@ describe('Billing routes', function () {
 
                 const subscription = await app.db.models.Subscription.byCustomerId('cus_1234567890')
                 should(subscription.status).equal(app.db.models.Subscription.STATUS.PAST_DUE)
-                const log = await getLog()
+                const log = (await getLog())[0]
                 log.event.should.equal('billing.subscription.updated')
                 log.body.updates.should.have.length(1)
                 log.body.updates[0].key.should.equal('status')
@@ -711,11 +711,15 @@ describe('Billing routes', function () {
                 projectsStatesAfter.map((project) => project.state).should.match(['suspended', 'suspended', 'suspended'])
 
                 const log = await getLog()
-                log.event.should.equal('billing.subscription.updated')
-                log.body.updates.should.have.length(1)
-                log.body.updates[0].key.should.equal('status')
-                log.body.updates[0].old.should.equal('active')
-                log.body.updates[0].new.should.equal('canceled')
+                // Two projects suspended - check they got logged
+                log[0].event.should.equal('project.suspended')
+                log[1].event.should.equal('project.suspended')
+                // 
+                log[2].event.should.equal('billing.subscription.updated')
+                log[2].body.updates.should.have.length(1)
+                log[2].body.updates[0].key.should.equal('status')
+                log[2].body.updates[0].old.should.equal('active')
+                log[2].body.updates[0].new.should.equal('canceled')
             })
 
             it('Handles cancellation for unknown customers', async () => {

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -67,6 +67,8 @@ describe('Billing routes', function () {
 
         beforeEach(async function () {
             sandbox.stub(app.billing)
+            // Do not stub this one function
+            app.billing.updateSubscriptionStatus.restore()
             sandbox.stub(app.log, 'info')
             sandbox.stub(app.log, 'warn')
             sandbox.stub(app.log, 'error')

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -714,7 +714,7 @@ describe('Billing routes', function () {
                 // Two projects suspended - check they got logged
                 log[0].event.should.equal('project.suspended')
                 log[1].event.should.equal('project.suspended')
-                // 
+                // Third event is the billing.sub.updated event
                 log[2].event.should.equal('billing.subscription.updated')
                 log[2].body.updates.should.have.length(1)
                 log[2].body.updates[0].key.should.equal('status')


### PR DESCRIPTION
## Description

This improves our handling around canceled stripe subscriptions.

We have seen a couple instances where subscription is canceled on stripe, but our local state thinks it is active.

This PR adds a check whenever we come to do billable work to resync our local status with the true stripe status. If we find the status has changed, and that it is now canceled, we suspend all team instances and log it.

It also:
 - adds a proper entry for the `billing.subscription.updated` audit-log event
 - fixes the Team Billing page for when the subscription has expired/canceled - it was previously talking about trials which isn't correct for this state.