### PR TITLE
Revert "Bump @vitejs/plugin-vue from 4.5.0 to 4.5.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7543,9 +7543,9 @@
             "dev": true
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.1.tgz",
-            "integrity": "sha512-DaUzYFr+2UGDG7VSSdShKa9sIWYBa1LL8KC0MNOf2H5LjcTPjob0x8LbkqXWmAtbANJCkpiQTj66UVcQkN2s3g==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.0.tgz",
+            "integrity": "sha512-a2WSpP8X8HTEww/U00bU4mX1QpLINNuz/2KMNpLsdu3BzOpak3AGI1CJYBTXcc4SPhaD0eNRUp7IyQK405L5dQ==",
             "dev": true,
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -29080,9 +29080,9 @@
             "dev": true
         },
         "@vitejs/plugin-vue": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.1.tgz",
-            "integrity": "sha512-DaUzYFr+2UGDG7VSSdShKa9sIWYBa1LL8KC0MNOf2H5LjcTPjob0x8LbkqXWmAtbANJCkpiQTj66UVcQkN2s3g==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.0.tgz",
+            "integrity": "sha512-a2WSpP8X8HTEww/U00bU4mX1QpLINNuz/2KMNpLsdu3BzOpak3AGI1CJYBTXcc4SPhaD0eNRUp7IyQK405L5dQ==",
             "dev": true,
             "requires": {}
         },


### PR DESCRIPTION
This appears to have broken our ui tests. Reverting the updated to keep things moving forward.