### PR TITLE
Extend manual billing options to non-trial teams

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -148,6 +148,10 @@ module.exports = async function (app) {
                     result.billing.trialEndsAt = subscription.trialEndsAt
                     result.billing.trialProjectAllowed = (await team.instanceCount(app.settings.get('user:team:trial-mode:projectType'))) === 0
                 }
+                if (request.session.User.admin) {
+                    result.billing.customer = subscription.customer
+                    result.billing.subscription = subscription.subscription
+                }
             } else {
                 result.billing.active = false
             }

--- a/frontend/src/pages/team/Settings/TeamAdminTools.vue
+++ b/frontend/src/pages/team/Settings/TeamAdminTools.vue
@@ -1,13 +1,29 @@
 <template>
-    <div v-if="features.billing && trialMode" class="space-y-6">
+    <div v-if="features.billing" class="space-y-6">
         <FormHeading class="text-red-700">Admin Only Tools</FormHeading>
 
-        <div v-if="trialMode" class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
+        <div v-if="!isUnmanaged" class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
             <div class="flex-grow">
                 <div class="max-w-sm pr-2">
-                    This team is in trial mode. Setting up manual billing will
-                    allow this team to make full use of the platform without
-                    requiring them to configure their billing details.
+                    <template v-if="trialMode">
+                        <b>This team is in trial mode.</b><br>
+                        Setting up manual billing will allow this team to make
+                        full use of the platform without requiring them to
+                        configure their billing details.
+                    </template>
+                    <template v-else-if="billingSetUp">
+                        <b>This team already has billing setup.</b><br>
+                        Setting up manual billing will cancel their existing
+                        subscription and allow this team to make full use of the
+                        platform without requiring them to configure their billing
+                        details.
+                    </template>
+                    <template v-else>
+                        <b>This team does not have billing setup.</b><br>
+                        Enabling manual billing will allow this team to make full
+                        use of the platform without requiring them to configure
+                        their billing details.
+                    </template>
                 </div>
             </div>
             <div class="min-w-fit flex-shrink-0">
@@ -15,7 +31,7 @@
             </div>
         </div>
     </div>
-    <ConfirmTeamManualBillingDialog v-if="trialMode" ref="confirmTeamManualBillingDialog" @setup-manual-billing="setupManualBilling" />
+    <ConfirmTeamManualBillingDialog ref="confirmTeamManualBillingDialog" @setup-manual-billing="setupManualBilling" />
 </template>
 
 <script>

--- a/frontend/src/pages/team/Settings/TeamAdminTools.vue
+++ b/frontend/src/pages/team/Settings/TeamAdminTools.vue
@@ -1,11 +1,27 @@
 <template>
     <div v-if="features.billing" class="space-y-6">
         <FormHeading class="text-red-700">Admin Only Tools</FormHeading>
+        <table class="table-fixed">
+            <tr>
+                <th class="font-medium font-bold pb-2" colspan="2">Stripe Details</th>
+            </tr>
+            <tr>
+                <td class="font-medium pr-4">Customer ID:</td>
+                <td><div class="py-2">{{ team.billing.customer || 'none' }}</div></td>
+            </tr>
+            <tr>
+                <td class="font-medium pr-4">Subscription ID:</td>
+                <td><div class="py-2">{{ team.billing.subscription || 'none' }}</div></td>
+            </tr>
+        </table>
 
-        <div v-if="!isUnmanaged" class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
+        <div class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
             <div class="flex-grow">
                 <div class="max-w-sm pr-2">
-                    <template v-if="trialMode">
+                    <template v-if="isUnmanaged">
+                        This team is already in unmanaged mode.
+                    </template>
+                    <template v-else-if="trialMode">
                         <b>This team is in trial mode.</b><br>
                         Setting up manual billing will allow this team to make
                         full use of the platform without requiring them to
@@ -27,7 +43,7 @@
                 </div>
             </div>
             <div class="min-w-fit flex-shrink-0">
-                <ff-button kind="danger" data-action="admin-setup-billing" @click="confirmManualBilling()">Setup Manual Billing</ff-button>
+                <ff-button kind="danger" data-action="admin-setup-billing" :disabled="isUnmanaged" @click="confirmManualBilling()">Setup Manual Billing</ff-button>
             </div>
         </div>
     </div>

--- a/frontend/src/pages/team/dialogs/ConfirmTeamManualBillingDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamManualBillingDialog.vue
@@ -6,11 +6,31 @@
                     <p>
                         Are you sure you want to setup manual billing for this team?
                     </p>
-                    <p>
-                        This will bring the trial to an end and allow the team to make
-                        full use of the platform without requiring them to configure
-                        their billing details.
-                    </p>
+                    <template v-if="trialMode">
+                        <p><b>This team is in trial mode.</b></p>
+                        <p>
+                            Setting up manual billing will allow this team to make
+                            full use of the platform without requiring them to
+                            configure their billing details.
+                        </p>
+                    </template>
+                    <template v-else-if="billingSetUp">
+                        <p><b>This team already has billing setup.</b></p>
+                        <p>
+                            Setting up manual billing will cancel their existing
+                            subscription and allow this team to make full use of the
+                            platform without requiring them to configure their billing
+                            details.
+                        </p>
+                    </template>
+                    <template v-else>
+                        <p><b>This team does not have billing setup.</b></p>
+                        <p>
+                            Enabling manual billing will allow this team to make full
+                            use of the platform without requiring them to configure
+                            their billing details.
+                        </p>
+                    </template>
                 </div>
 
                 <FormRow id="teamType" v-model="input.teamType" data-form="team-type" :options="teamTypes">Select the team type to apply:</FormRow>
@@ -54,6 +74,23 @@ export default {
             },
             team: null,
             teamTypes: []
+        }
+    },
+    computed: {
+        billingSetUp () {
+            return this.team.billing?.active
+        },
+        subscriptionExpired () {
+            return this.team.billing?.canceled
+        },
+        isUnmanaged () {
+            return this.team.billing?.unmanaged
+        },
+        trialMode () {
+            return this.team.billing?.trial
+        },
+        trialHasEnded () {
+            return this.team.billing?.trialEnded
         }
     },
     methods: {

--- a/test/lib/stripeMock.js
+++ b/test/lib/stripeMock.js
@@ -62,7 +62,8 @@ module.exports = (testSpecificMock = {}) => {
                         data: items
                     }
                 }
-            })
+            }),
+            del: sandbox.stub()
         },
         subscriptionItems: {
             update: sandbox.stub().callsFake(async function (itemId, update) {

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -1492,7 +1492,7 @@ describe('Billing routes', function () {
                     }
                 })
             })
-            it('Admin can put team into unmanaged subscription mode', async function () {
+            it('Admin can put team into unmanaged subscription mode - trial team', async function () {
                 // Create trial team
                 const trialTeam = await app.factory.createTeam({ name: generateName('unmanagedSubTeam') })
                 await trialTeam.addUser(TestObjects.alice, { through: { role: Roles.Owner } })
@@ -1514,6 +1514,35 @@ describe('Billing routes', function () {
 
                 // Check the team subscription is flagged as unmanaged
                 const sub = await trialTeam.getSubscription()
+                sub.isActive().should.be.false()
+                sub.isUnmanaged().should.be.true()
+                sub.isCanceled().should.be.false()
+                sub.isPastDue().should.be.false()
+                sub.isTrial().should.be.false()
+                sub.isTrialEnded().should.be.true()
+            })
+            it('Admin can put team into unmanaged subscription mode - regular team', async function () {
+                // Create team
+                const team = await app.factory.createTeam({ name: generateName('unmanagedSubTeam') })
+                await team.addUser(TestObjects.alice, { through: { role: Roles.Owner } })
+                await app.factory.createSubscription(team)
+
+                const response = await app.inject({
+                    method: 'POST',
+                    url: `/ee/billing/teams/${team.hashid}/manual`,
+                    payload: {
+                        teamTypeId: unmanagedSubTargetTeamType.hashid
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(200)
+
+                // Check the team type has been updated to the target type
+                await team.reload()
+                team.TeamTypeId.should.equal(unmanagedSubTargetTeamType.id)
+
+                // Check the team subscription is flagged as unmanaged
+                const sub = await team.getSubscription()
                 sub.isActive().should.be.false()
                 sub.isUnmanaged().should.be.true()
                 sub.isCanceled().should.be.false()
@@ -1547,26 +1576,6 @@ describe('Billing routes', function () {
                     cookies: { sid: TestObjects.tokens.bob }
                 })
                 response.statusCode.should.equal(403)
-            })
-            it('Cannot make non-trial team unmanaged', async function () {
-                // Create team
-                const nonTrialTeam = await app.factory.createTeam({ name: generateName('unmanagedSubTeam') })
-                await nonTrialTeam.addUser(TestObjects.alice, { through: { role: Roles.Owner } })
-                // Create active subscription
-                await app.factory.createSubscription(nonTrialTeam)
-
-                // Attempt to make unmanaged
-                const response = await app.inject({
-                    method: 'POST',
-                    url: `/ee/billing/teams/${nonTrialTeam.hashid}/manual`,
-                    payload: {
-                        teamTypeId: unmanagedSubTargetTeamType.hashid
-                    },
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
-                response.statusCode.should.equal(500)
-                const result = response.json()
-                result.should.have.property('code', 'invalid_request')
             })
         })
     })


### PR DESCRIPTION
## Description

This extends the work done in #3138 so it can be applied to regular teams.

The original PR only considered the user journey of a customer who signs up, is in trial mode and wants to setup an annual billing agreement.

This PR allows us to convert a customer who has already setup monthly billing into annual billing.

In this new scenario, we will cancel their existing subscription as part of setting up the unmanaged mode of billing.

To help with the overall workflow, I've added details of the team's stripe customer/subscription ids to the admin-only tools section. This will make it much easier to correlate without having to do user/email lookups.