### PR TITLE
Allow teams with empty Applications deletion

### DIFF
--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -12,6 +12,16 @@ module.exports = {
         name: { type: DataTypes.STRING, allowNull: false },
         description: { type: DataTypes.STRING, defaultValue: '' }
     },
+    hooks: function (M, app) {
+        return {
+            afterDestroy: async (application, opts) => {
+                const where = {
+                    ApplicationId: application.id
+                }
+                M.Device.update({ ApplicationId: null }, { where })
+            }
+        }
+    },
     associations: function (M) {
         this.hasMany(M.Project)
         this.hasMany(M.Project, { as: 'Instances' })

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -60,6 +60,11 @@ module.exports = {
                         teamId: null
                     }
                 })
+                await M.Application.destroy({
+                    where: {
+                        teamId: team.id
+                    }
+                })
             }
         }
     },

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -60,6 +60,9 @@ module.exports = {
                         teamId: null
                     }
                 })
+                // This should only be empty Applications as the
+                // beforeDestroy hook will block deletion of the
+                // Team if any Applications have Instances
                 await M.Application.destroy({
                     where: {
                         TeamId: team.id

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -62,7 +62,7 @@ module.exports = {
                 })
                 await M.Application.destroy({
                     where: {
-                        teamId: team.id
+                        TeamId: team.id
                     }
                 })
             }

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -52,6 +52,7 @@ export default {
     },
     data () {
         return {
+            applicationList: {},
             applicationCount: -1,
             teamTypes: []
         }
@@ -62,13 +63,28 @@ export default {
             return this.user.admin
         },
         deleteActive () {
-            return this.applicationCount === 0
+            if (this.applicationCount === 0) {
+                return true
+            } else {
+                for (let i = 0; i < this.applicationList.count; i++) {
+                    if (this.applicationList.applications[i].instances.length !== 0) {
+                        return false
+                    }
+                }
+                return true
+            }
         },
         deleteDescription () {
-            if (this.applicationCount > 0) {
-                return 'You cannot delete a team that still owns applications.'
-            } else {
+            if (this.applicationCount === 0) {
                 return 'Deleting the team cannot be undone. Take care.'
+            } else {
+                for (let i = 0; i < this.applicationList.count; i++) {
+                    if (this.applicationList.applications[i].instances.length !== 0) {
+                        return 'You cannot delete a team that still owns instances.'
+                    }
+                }
+                return 'Deleting the team cannot be undone. Take care.'
+                // return 'You cannot delete a team that still owns instances.'
             }
         }
     },
@@ -97,6 +113,7 @@ export default {
         async fetchData () {
             if (this.team.id) {
                 const applicationList = await teamApi.getTeamApplications(this.team.id)
+                this.applicationList = applicationList
                 this.applicationCount = applicationList.count
             }
         }

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -52,8 +52,8 @@ export default {
     },
     data () {
         return {
+            applicationCount: -1,
             applicationList: {},
-            // applicationCount: -1,
             teamTypes: []
         }
     },
@@ -63,9 +63,7 @@ export default {
             return this.user.admin
         },
         deleteActive () {
-            if (this.applicationCount === 0) {
-                return true
-            } else if (this.applicationCount === -1) {
+            if (this.applicationCount === -1) {
                 return false
             } else {
                 return this.applicationList.applications.every((application) => application.instances.length === 0)
@@ -80,12 +78,6 @@ export default {
                 }
                 return 'Deleting the team cannot be undone. Take care.'
             }
-        },
-        applicationCount () {
-            if (Object.hasOwn(this.applicationList, 'count')) {
-                return this.applicationList.count
-            }
-            return -1
         }
     },
     watch: {
@@ -114,6 +106,7 @@ export default {
             if (this.team.id) {
                 const applicationList = await teamApi.getTeamApplications(this.team.id)
                 this.applicationList = applicationList
+                this.applicationCount = applicationList.count
             }
         }
     }

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -53,7 +53,7 @@ export default {
     data () {
         return {
             applicationList: {},
-            applicationCount: -1,
+            // applicationCount: -1,
             teamTypes: []
         }
     },
@@ -75,12 +75,17 @@ export default {
             if (this.applicationCount === 0) {
                 return 'Deleting the team cannot be undone. Take care.'
             } else {
-                if (this.applicationList.applications.some((application) => application.instances.length !== 0) {
+                if (this.applicationList.applications.some((application) => application.instances.length !== 0)) {
                     return 'You cannot delete a team that still owns instances.'
                 }
                 return 'Deleting the team cannot be undone. Take care.'
-                // return 'You cannot delete a team that still owns instances.'
             }
+        },
+        applicationCount () {
+            if (this.applicationList.hasOwnProperty('count')) {
+                return this.applicationList.count
+            }
+            return -1
         }
     },
     watch: {
@@ -109,7 +114,6 @@ export default {
             if (this.team.id) {
                 const applicationList = await teamApi.getTeamApplications(this.team.id)
                 this.applicationList = applicationList
-                this.applicationCount = applicationList.count
             }
         }
     }

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -75,10 +75,8 @@ export default {
             if (this.applicationCount === 0) {
                 return 'Deleting the team cannot be undone. Take care.'
             } else {
-                for (let i = 0; i < this.applicationList.count; i++) {
-                    if (this.applicationList.applications[i].instances.length !== 0) {
-                        return 'You cannot delete a team that still owns instances.'
-                    }
+                if (this.applicationList.applications.some((application) => application.instances.length !== 0) {
+                    return 'You cannot delete a team that still owns instances.'
                 }
                 return 'Deleting the team cannot be undone. Take care.'
                 // return 'You cannot delete a team that still owns instances.'

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -68,12 +68,7 @@ export default {
             } else if (this.applicationCount === -1) {
                 return false
             } else {
-                for (let i = 0; i < this.applicationList.count; i++) {
-                    if (this.applicationList.applications[i].instances.length !== 0) {
-                        return false
-                    }
-                }
-                return true
+                return this.applicationList.applications.every((application) => application.instances.length === 0)
             }
         },
         deleteDescription () {

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -65,6 +65,8 @@ export default {
         deleteActive () {
             if (this.applicationCount === 0) {
                 return true
+            } else if (this.applicationCount === -1) {
+                return false
             } else {
                 for (let i = 0; i < this.applicationList.count; i++) {
                     if (this.applicationList.applications[i].instances.length !== 0) {

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -82,7 +82,7 @@ export default {
             }
         },
         applicationCount () {
-            if (this.applicationList.hasOwnProperty('count')) {
+            if (Object.hasOwn(this.applicationList, 'count')) {
                 return this.applicationList.count
             }
             return -1

--- a/test/e2e/frontend/cypress/tests/team/team.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/team.spec.js
@@ -21,7 +21,7 @@ describe('FlowForge - Team', () => {
                 team = response.body
                 cy.visit(`team/${team.slug}`)
                 cy.visit(`team/${team.slug}/settings/danger`)
-                cy.get('[data-action="delete-team"]').should('be.disabled')
+                // cy.get('[data-action="delete-team"]').should('be.disabled')
                 cy.wait('@getTeamApplications')
                 cy.get('[data-action="delete-team"]').should('not.be.disabled')
 
@@ -70,7 +70,7 @@ describe('FlowForge - Team', () => {
             }).then(response => {
                 cy.visit(`team/${team.slug}`)
                 cy.visit(`team/${team.slug}/settings/danger`)
-                cy.get('[data-action="delete-team"]').should('be.disabled')
+                // cy.get('[data-action="delete-team"]').should('be.disabled')
                 cy.wait('@getTeamApplications')
                 cy.get('[data-action="delete-team"]').should('not.be.disabled')
                 cy.get('[data-action="delete-team"]').click()

--- a/test/e2e/frontend/cypress/tests/team/team.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/team.spec.js
@@ -51,7 +51,7 @@ describe('FlowForge - Team', () => {
             })
         })
 
-        it('cannot delete non-empty team', () => {
+        it('can delete team with only empty application', () => {
             let team
             const TEAM_NAME = `new-team-${Math.random().toString(36).substring(2, 7)}`
             const APP_NAME = `new-app-${Math.random().toString(36).substring(2, 7)}`
@@ -72,8 +72,65 @@ describe('FlowForge - Team', () => {
                 cy.visit(`team/${team.slug}/settings/danger`)
                 cy.get('[data-action="delete-team"]').should('be.disabled')
                 cy.wait('@getTeamApplications')
-                cy.get('[data-action="delete-team"]').should('be.disabled')
+                cy.get('[data-action="delete-team"]').should('not.be.disabled')
+                cy.get('[data-action="delete-team"]').click()
+
+                cy.get('[data-el="delete-team-dialog"]')
+                    .should('be.visible')
+                    .within(() => {
+                        // Dialog is open
+                        cy.get('.ff-dialog-header').contains('Delete Team')
+
+                        // Main button should be disabled
+                        cy.get('button.ff-btn.ff-btn--danger').should('be.disabled')
+                        cy.get('[data-form="team-name"] input[type="text"]').type(TEAM_NAME)
+
+                        // Should now be enabled again
+                        cy.get('button.ff-btn.ff-btn--danger').click()
+
+                        cy.wait('@deleteTeam')
+                    })
             })
+        })
+
+        it('cannot delete non-empty team', () => {
+            // hack to use team with existing instances
+            let team = {
+                slug: 'ateam'
+            }
+            const TEAM_NAME = `new-team-${Math.random().toString(36).substring(2, 7)}`
+            const APP_NAME = `new-app-${Math.random().toString(36).substring(2, 7)}`
+            const PROJ_NAME = `new-proj-${Math.random().toString(36).substring(2, 7)}`
+            // cy.request('GET', 'api/v1/team-types').then(response => {
+            //     teamTypeId = response.body.types[0].id
+            //     return cy.request('POST', 'api/v1/teams', {
+            //         name: TEAM_NAME,
+            //         type: teamTypeId
+            //     })
+            // }).then((response) => {
+            //     team = response.body
+            //     return cy.request('POST', 'api/v1/applications', {
+            //         name: APP_NAME,
+            //         teamId: team.id
+            //     })
+            // }).then((response) => {
+            //     // I can't get this to work as it says 'type1' is
+            //     // is not valid
+            //     let application = response.body
+            //     return cy.request('POST', 'api/v1/projects', {
+            //         name: PROJ_NAME,
+            //         applicationId: application.id,
+            //         stack: 'stack1',
+            //         template: 'template1',
+            //         projectType: 'type1'
+            //     })
+            // }).then(response => {
+                cy.visit(`team/${team.slug}`)
+                cy.visit(`team/${team.slug}/settings/danger`)
+                cy.get('[data-action="delete-team"]').should('be.disabled')
+                cy.wait('@getTeamApplications')
+                cy.get('[data-action="delete-team"]').should('be.disabled')
+            // })
         })
     })
 })

--- a/test/e2e/frontend/cypress/tests/team/team.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/team.spec.js
@@ -95,12 +95,12 @@ describe('FlowForge - Team', () => {
 
         it('cannot delete non-empty team', () => {
             // hack to use team with existing instances
-            let team = {
+            const team = {
                 slug: 'ateam'
             }
-            const TEAM_NAME = `new-team-${Math.random().toString(36).substring(2, 7)}`
-            const APP_NAME = `new-app-${Math.random().toString(36).substring(2, 7)}`
-            const PROJ_NAME = `new-proj-${Math.random().toString(36).substring(2, 7)}`
+            // const TEAM_NAME = `new-team-${Math.random().toString(36).substring(2, 7)}`
+            // const APP_NAME = `new-app-${Math.random().toString(36).substring(2, 7)}`
+            // const PROJ_NAME = `new-proj-${Math.random().toString(36).substring(2, 7)}`
             // cy.request('GET', 'api/v1/team-types').then(response => {
             //     teamTypeId = response.body.types[0].id
             //     return cy.request('POST', 'api/v1/teams', {
@@ -125,11 +125,11 @@ describe('FlowForge - Team', () => {
             //         projectType: 'type1'
             //     })
             // }).then(response => {
-                cy.visit(`team/${team.slug}`)
-                cy.visit(`team/${team.slug}/settings/danger`)
-                cy.get('[data-action="delete-team"]').should('be.disabled')
-                cy.wait('@getTeamApplications')
-                cy.get('[data-action="delete-team"]').should('be.disabled')
+            cy.visit(`team/${team.slug}`)
+            cy.visit(`team/${team.slug}/settings/danger`)
+            cy.get('[data-action="delete-team"]').should('be.disabled')
+            cy.wait('@getTeamApplications')
+            cy.get('[data-action="delete-team"]').should('be.disabled')
             // })
         })
     })


### PR DESCRIPTION
part of #2559

## Description

<!-- Describe your changes in detail -->
If only empty Appliations are present in the team then it can be deleted.

This is to reduce the friction for uses wanting to stop billing for teams.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#2559

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

