### PR TITLE
Fix team delete for unmanaged-billing team

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -155,8 +155,6 @@ module.exports = {
                     resolve()
                 }, 250)
             })
-        } else {
-            throw new Error(`${project.id} not found`)
         }
     },
     /**

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -486,8 +486,7 @@ module.exports = async function (app) {
         try {
             if (app.license.active() && app.billing) {
                 const subscription = await request.team.getSubscription()
-                if (subscription && !subscription.isTrial()) {
-                    // const subId = subscription.subscription
+                if (subscription && !subscription.isTrial() && !subscription.isUnmanaged()) {
                     await app.billing.closeSubscription(subscription)
                 }
             }


### PR DESCRIPTION
## Description

The current delete team path attempts to cancel the stripe subscription without taking into account whether the team's billing is unmanaged. This fixes that.

Along the way, a small fix in the stub driver that blocked deleting 'suspended' instances in local testing.