### PR TITLE
Improve handling of hanging plugin on startup

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -82,7 +82,7 @@ const forge = require('./forge')
                 await server.close()
             }
         } catch (err) {
-            console.log('Error shutting down:', err.toString())
+            console.error('Error shutting down:', err.toString())
         }
     }
 })()

--- a/forge/app.js
+++ b/forge/app.js
@@ -25,9 +25,9 @@ const forge = require('./forge')
     // but risk someone is on older 16.x without it. So for now, just look for
     // this one flag
     const enableRepl = process.argv.includes('--repl')
-
+    let server
     try {
-        const server = await forge()
+        server = await forge()
 
         // Setup shutdown event handling
         let stopping = false
@@ -77,5 +77,12 @@ const forge = require('./forge')
     } catch (err) {
         console.error(err)
         process.exitCode = 1
+        try {
+            if (server) {
+                await server.close()
+            }
+        } catch (err) {
+            console.log('Error shutting down:', err.toString())
+        }
     }
 })()

--- a/forge/auditLog/index.js
+++ b/forge/auditLog/index.js
@@ -19,4 +19,6 @@ module.exports = fp(async function (app, _opts, next) {
     app.decorate('auditLog', loggers)
 
     next()
+}, {
+    name: 'app.auditLog'
 })

--- a/forge/comms/index.js
+++ b/forge/comms/index.js
@@ -57,4 +57,6 @@ module.exports = fp(async function (app, _opts, next) {
         app.log.warn('[comms] Broker not configured - comms unavailable')
     }
     next()
+}, {
+    name: 'app.comms'
 })

--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -136,5 +136,5 @@ module.exports = {
             app.log.info(`Config File: ${config.configFile}`)
         }
         next()
-    })
+    }, { name: 'app.config' })
 }

--- a/forge/containers/index.js
+++ b/forge/containers/index.js
@@ -67,4 +67,4 @@ module.exports = fp(async function (app, _opts, next) {
     }
 
     next()
-})
+}, { name: 'app.containers' })

--- a/forge/db/index.js
+++ b/forge/db/index.js
@@ -90,4 +90,4 @@ module.exports = fp(async function (app, _opts, next) {
     await controllers.init(app)
 
     next()
-})
+}, { name: 'app.db' })

--- a/forge/ee/index.js
+++ b/forge/ee/index.js
@@ -7,11 +7,14 @@ module.exports = fp(async function (app, opts, next) {
     // Load ee only if enabled in the license
     if (app.license.active()) {
         app.log.info('Loading EE Features')
+        app.log.trace(' - EE Database models')
         await require('./db/index.js').init(app)
+        app.log.trace(' - EE Routes')
         await app.register(require('./routes'), { logLevel: app.config.logging.http })
+        app.log.trace(' - EE Libs')
         await app.register(require('./lib'))
+        app.log.trace(' - EE Templates')
         app.postoffice.registerTemplate('LicenseReminder', require('./emailTemplates/LicenseReminder'))
         app.postoffice.registerTemplate('LicenseExpired', require('./emailTemplates/LicenseExpired'))
     }
-    next()
-})
+}, { name: 'app.ee' })

--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -24,4 +24,4 @@ module.exports = fp(async function (app, opts, done) {
     app.config.features.register('customCatalogs', true, true)
 
     done()
-})
+}, { name: 'app.ee.lib' })

--- a/forge/ee/routes/sso/auth.js
+++ b/forge/ee/routes/sso/auth.js
@@ -136,4 +136,4 @@ module.exports = fp(async function (app, opts, done) {
         throw new Error('Invalid SAML response')
     })
     done()
-})
+}, { name: 'app.ee.routes.sso.auth' })

--- a/forge/ee/routes/sso/index.js
+++ b/forge/ee/routes/sso/index.js
@@ -92,4 +92,4 @@ module.exports = fp(async function (app, opts, done) {
     await app.register(require('./auth'))
 
     done()
-})
+}, { name: 'app.ee.routes.sso' })

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -336,8 +336,14 @@ module.exports = async (options = {}) => {
 
         return server
     } catch (err) {
-        console.error(err)
         server.log.error(`Failed to start: ${err.toString()}`)
+        server.log.error(err.stack)
+        try {
+            await server.close()
+        } catch (err2) {
+            server.log.error(`Failed to shutdown: ${err2.toString()}`)
+            server.log.error(err2.stack)
+        }
         throw err
     }
 }

--- a/forge/housekeeper/index.js
+++ b/forge/housekeeper/index.js
@@ -150,4 +150,4 @@ module.exports = fp(async function (app, _opts, next) {
     })
 
     next()
-})
+}, { name: 'app.housekeeper' })

--- a/forge/licensing/index.js
+++ b/forge/licensing/index.js
@@ -177,4 +177,4 @@ module.exports = fp(async function (app, opts, next) {
         }
         await reportUsage()
     }
-})
+}, { name: 'app.licensing' })

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -177,4 +177,4 @@ ${mail.text}
     })
 
     next()
-})
+}, { name: 'app.postoffice' })

--- a/forge/routes/api-docs.js
+++ b/forge/routes/api-docs.js
@@ -157,4 +157,4 @@ module.exports = fp(async function (app, opts, done) {
     })
 
     done()
-})
+}, { name: 'app.routes.api-docs' })

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -37,7 +37,7 @@ const SESSION_COOKIE_OPTIONS = {
  * @typedef {import('../../db/controllers/User')} UserController
  */
 
-module.exports = fp(init)
+module.exports = fp(init, { name: 'app.routes.auth' })
 
 /**
  * Initialize the auth plugin

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -101,4 +101,4 @@ module.exports = fp(async function (app, opts, done) {
     app.decorate('hasPermission', hasPermission)
     app.decorate('needsPermission', needsPermission)
     done()
-})
+}, { name: 'app.routes.auth.permissions' })

--- a/forge/routes/index.js
+++ b/forge/routes/index.js
@@ -29,4 +29,4 @@ module.exports = fp(async function (app, opts, done) {
     await app.register(require('./storage'), { prefix: '/storage', logLevel: app.config.logging.http })
     await app.register(require('./logging'), { prefix: '/logging', logLevel: app.config.logging.http })
     done()
-})
+}, { name: 'app.routes' })

--- a/forge/settings/index.js
+++ b/forge/settings/index.js
@@ -56,4 +56,4 @@ module.exports = fp(async function (app, _opts, next) {
 
     app.decorate('settings', settingsApi)
     next()
-})
+}, { name: 'app.settings' })


### PR DESCRIPTION
## Description

A couple times we have seen staging fail to start due to a hang in the `ee` plugin - although the logs identify it as `index-auto-5` as we haven't named our plugins. The process is left hanging as it didn't exit - on investigation this is because we've already created some timers and network connections (eg broker comms) that keep the process alive.

This PR addresses some of the issues:

 - It ensures all of our component plugins have a name
 - If there is an error during startup, we attempt to shutdown. This ensures any plugins that have created timers/connections will get a chance to clean up.
 - Added some trace statements inside the `ee` plugin to try to identify which part is hanging.