### PR TITLE
Tidy up delete dialogs

### DIFF
--- a/frontend/src/pages/application/Settings/dialogs/ConfirmApplicationDeleteDialog.vue
+++ b/frontend/src/pages/application/Settings/dialogs/ConfirmApplicationDeleteDialog.vue
@@ -4,21 +4,22 @@
         :disable-primary="!formValid"
         confirm-label="Delete"
         data-el="delete-application-dialog"
-        header="Delete Application"
+        :header="'Delete Application: \'' + application?.name + '\''"
         kind="danger"
         @confirm="confirm()"
     >
         <template #default>
-            <form class="space-y-6" @submit.prevent>
-                <div class="mt-2 space-y-2">
-                    <p>
-                        Are you sure you want to delete this application? Once deleted, there is no going back.
-                    </p>
-                    <p class="flex">
-                        Enter the application name <code>{{ application?.name }}</code> to continue.
-                    </p>
-                </div>
-                <FormRow id="projectName" v-model="input.projectName" data-form="application-name">Name</FormRow>
+            <form class="space-y-4" @submit.prevent>
+                <p>
+                    Are you sure you want to delete this application? Once deleted, there is no going back.
+                </p>
+                <p>
+                    Name: <span class="font-bold">{{ application?.name }}</span>
+                </p>
+                <p>
+                    Please type in the application name to confirm.
+                </p>
+                <FormRow id="projectName" v-model="input.projectName" :placeholder="'Application Name'" data-form="application-name" />
             </form>
         </template>
     </ff-dialog>

--- a/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
+++ b/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
@@ -1,17 +1,17 @@
 <template>
-    <ff-dialog ref="dialog" header="Delete Device" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="!formValid">
+    <ff-dialog ref="dialog" :header="'Delete Device: \'' + device?.name + '\''" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="!formValid">
         <template #default>
-            <form class="space-y-6" @submit.prevent>
-                <div class="mt-2 space-y-2">
-                    <p>
-                        Are you sure you want to delete this device? Once deleted, there is no going back.
-                    </p>
-                    <p>
-                        Enter the device name to continue.
-                        <code class="block">{{ device?.name }}</code>
-                    </p>
-                </div>
-                <FormRow v-model="input.deviceName" id="deviceName">Name</FormRow>
+            <form class="space-y-4" @submit.prevent>
+                <p>
+                    Are you sure you want to delete this device? Once deleted, there is no going back.
+                </p>
+                <p>
+                    Name: <span class="font-bold">{{ device?.name }}</span>
+                </p>
+                <p>
+                    Please type in the device name to confirm.
+                </p>
+                <FormRow v-model="input.deviceName" :placeholder="'Device Name'" id="deviceName" />
             </form>
         </template>
     </ff-dialog>

--- a/frontend/src/pages/instance/Settings/dialogs/ConfirmInstanceDeleteDialog.vue
+++ b/frontend/src/pages/instance/Settings/dialogs/ConfirmInstanceDeleteDialog.vue
@@ -3,22 +3,23 @@
         ref="dialog"
         confirm-label="Delete"
         data-el="delete-instance-dialog"
-        header="Delete Instance"
+        :header="'Delete Instance: \'' + instance?.name + '\''"
         kind="danger"
         :disable-primary="!formValid"
         @confirm="confirm()"
     >
         <template #default>
-            <form class="space-y-6" @submit.prevent>
-                <div class="mt-2 space-y-2">
-                    <p>
-                        Are you sure you want to delete this instance and the application that contains it? Once deleted, there is no going back.
-                    </p>
-                    <p class="flex">
-                        Enter the instance name <code>{{ instance?.name }}</code> to continue.
-                    </p>
-                </div>
-                <FormRow v-model="input.instanceName" data-form="instance-name">Name</FormRow>
+            <form class="space-y-4" @submit.prevent>
+                <p>
+                    Are you sure you want to delete this instance? Once deleted, there is no going back.
+                </p>
+                <p>
+                    Name: <span class="font-bold">{{ instance?.name }}</span>
+                </p>
+                <p>
+                    Please type in the instance name to confirm.
+                </p>
+                <FormRow v-model="input.instanceName" :placeholder="'Instance Name'" data-form="instance-name" />
             </form>
         </template>
     </ff-dialog>

--- a/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
@@ -1,16 +1,17 @@
 <template>
-    <ff-dialog ref="dialog" data-el="delete-team-dialog" header="Delete Team" kind="danger" confirm-label="Delete" :disable-primary="!formValid" @confirm="confirm()">
+    <ff-dialog ref="dialog" data-el="delete-team-dialog" :header="'Delete Team: \'' + team?.name + '\''" kind="danger" confirm-label="Delete" :disable-primary="!formValid" @confirm="confirm()">
         <template #default>
             <form v-if="team" class="space-y-6" @submit.prevent>
-                <div class="space-y-6">
-                    <p>
-                        Are you sure you want to delete this team? Once deleted, there is no going back.
-                    </p>
-                    <p>
-                        Enter the team name <code class="block">{{ team.name }}</code> to continue.
-                    </p>
-                </div>
-                <FormRow id="projectName" v-model="input.teamName" data-form="team-name">Name</FormRow>
+                <p>
+                    Are you sure you want to delete this team? Once deleted, there is no going back.
+                </p>
+                <p>
+                    Name: <span class="font-bold">{{ team?.name }}</span>
+                </p>
+                <p>
+                    Please type in the team name to confirm.
+                </p>
+                <FormRow id="projectName" v-model="input.teamName" :placeholder="'Team Name'" data-form="team-name" />
             </form>
         </template>
     </ff-dialog>


### PR DESCRIPTION
Fixes #2674 

This tidies up the delete dialogs that prompt the user to enter a thing's name to confirm to ensure they are consistent in appearance.

<img width="611" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/b74571d1-7a11-4eef-bd43-7036af95eb72">
