### PR TITLE
Only use node-red audit events to update local package list

### DIFF
--- a/forge/routes/logging/index.js
+++ b/forge/routes/logging/index.js
@@ -53,7 +53,10 @@ module.exports = async function (app) {
             await app.db.controllers.Project.addProjectModule(request.project, auditEvent.module, auditEvent.version)
         } else if (event === 'nodes.remove' && !error) {
             await app.db.controllers.Project.removeProjectModule(request.project, auditEvent.module)
+        } else if (event === 'modules.install' && !error) {
+            await app.db.controllers.Project.addProjectModule(request.project, auditEvent.module, auditEvent.version || '*')
         }
+
         response.status(200).send()
     })
 }

--- a/forge/routes/storage/index.js
+++ b/forge/routes/storage/index.js
@@ -90,7 +90,6 @@ module.exports = async function (app) {
             })
             await settings.save()
         }
-        await app.db.controllers.Project.mergeProjectModules(request.project, await app.db.controllers.StorageSettings.getProjectModules(request.project))
         response.send(request.body)
     })
 

--- a/test/unit/forge/routes/logging/index_spec.js
+++ b/test/unit/forge/routes/logging/index_spec.js
@@ -93,14 +93,14 @@ describe('Logging API', function () {
             headers: {
                 authorization: `Bearer ${TestObjects.tokens.project1}`
             },
-            payload: { event: 'nodes.install', module: '@flowforge/newmodule', version: '0.4.0', path: '/nodes' }
+            payload: { event: 'nodes.install', module: '@flowfuse/newmodule', version: '0.4.0', path: '/nodes' }
         })
         response.should.have.property('statusCode', 200)
         app.db.controllers.Project.addProjectModule.called.should.be.true()
         const args = app.db.controllers.Project.addProjectModule.lastCall.args
         args.should.have.length(3)
         args[0].should.have.property('id', TestObjects.project1.id)
-        args[1].should.equal('@flowforge/newmodule')
+        args[1].should.equal('@flowfuse/newmodule')
         args[2].should.equal('0.4.0')
     })
 
@@ -112,7 +112,7 @@ describe('Logging API', function () {
             headers: {
                 authorization: `Bearer ${TestObjects.tokens.project1}`
             },
-            payload: { event: 'nodes.install', module: '@flowforge/error', error: 'not_found', version: '0.4.0', path: '/nodes' }
+            payload: { event: 'nodes.install', module: '@flowfuse/error', error: 'not_found', version: '0.4.0', path: '/nodes' }
         })
         response.should.have.property('statusCode', 200)
         app.db.controllers.Project.addProjectModule.called.should.be.false()
@@ -126,13 +126,32 @@ describe('Logging API', function () {
             headers: {
                 authorization: `Bearer ${TestObjects.tokens.project1}`
             },
-            payload: { event: 'nodes.remove', module: '@flowforge/removemodule', version: '0.4.0', path: '/nodes' }
+            payload: { event: 'nodes.remove', module: '@flowfuse/removemodule', version: '0.4.0', path: '/nodes' }
         })
         response.should.have.property('statusCode', 200)
         app.db.controllers.Project.removeProjectModule.called.should.be.true()
         const args = app.db.controllers.Project.removeProjectModule.lastCall.args
         args.should.have.length(2)
         args[0].should.have.property('id', TestObjects.project1.id)
-        args[1].should.equal('@flowforge/removemodule')
+        args[1].should.equal('@flowfuse/removemodule')
+    })
+
+    it('Adds module to instance settings for modules.install event', async function () {
+        const url = `/logging/${TestObjects.project1.id}/audit`
+        const response = await app.inject({
+            method: 'POST',
+            url,
+            headers: {
+                authorization: `Bearer ${TestObjects.tokens.project1}`
+            },
+            payload: { event: 'modules.install', module: '@flowfuse/newmodule', path: '/nodes' }
+        })
+        response.should.have.property('statusCode', 200)
+        app.db.controllers.Project.addProjectModule.called.should.be.true()
+        const args = app.db.controllers.Project.addProjectModule.lastCall.args
+        args.should.have.length(3)
+        args[0].should.have.property('id', TestObjects.project1.id)
+        args[1].should.equal('@flowfuse/newmodule')
+        args[2].should.equal('*')
     })
 })

--- a/test/unit/forge/routes/storage/index_spec.js
+++ b/test/unit/forge/routes/storage/index_spec.js
@@ -204,37 +204,6 @@ describe('Storage API', function () {
             const settings = response.json()
             should(settings).eqls({})
         })
-
-        it('Update Runtime Settings', async function () {
-            const newSettings = JSON.parse('{"nodes":{"node-red":{"name":"node-red","version":"3.0.0","local":false,"user":false},"@flowforge/nr-project-nodes":{"name":"@flowforge/nr-project-nodes","version":"0.1.0","local":false,"user":false},"node-red-node-random":{"name":"node-red-node-random","version":"1.2.3","local":true}}}')
-            const settingsURL = `/storage/${project.id}/settings`
-            await app.inject({
-                method: 'POST',
-                url: settingsURL,
-                payload: newSettings,
-                responseType: 'json',
-                headers: {
-                    authorization: `Bearer ${tokens.token}`
-                }
-            })
-            const response = await app.inject({
-                method: 'GET',
-                url: settingsURL,
-                headers: {
-                    authorization: `Bearer ${tokens.token}`
-                }
-            })
-            const creds = response.json()
-            should(creds).eqls(newSettings)
-            // Reload the project to ensure it is fully populated
-            const localProject = await app.db.models.Project.byId(project.id)
-            const projectSettings = await app.db.controllers.Project.getRuntimeSettings(localProject)
-            projectSettings.should.have.property('palette')
-            projectSettings.palette.should.have.property('modules')
-            projectSettings.palette.modules.should.have.property('node-red-node-random', '~1.2.3')
-            projectSettings.palette.modules.should.not.have.property('node-red')
-            projectSettings.palette.modules.should.not.have.property('@flowforge/nr-project-nodes')
-        })
     })
 
     describe('/sessions', function () {


### PR DESCRIPTION
This fixes how we track what additional modules have been installed in Node-RED.

When this was originally added, it was done in response to Node-RED writing its settings to the database - which includes a list of modules it has loaded.

We then added the ability to do this by listening to the audit events that get sent (`nodes.install` for eg).

We have found a flaw in the logic of the first approach when a module is removed. There is a sequence where Node-RED rewrites its settings *before* it discovers the removed module is gone - causing the module to get added back to the package list.

On review, I've determined we don't need to rely on this mechanism - we can base it entirely on the audit events. So this PR removes this first mechanism.

Whilst there, I've also added support for the `modules.install` event that was added in Node-RED 3.1.1 - this is triggered when the Function node installs a module. This allows us to add those modules to the package list so they get reinstalled as part of the initial dependency install and *not* rely on Node-RED dynamically reinstalling them.