### PR TITLE
Move to @flowfuse/flowfuse npm package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,11 @@ jobs:
       ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.1.0'
     with:
-      package_name: flowforge
+      package_name: flowfuse
       build_package: true
       publish_package: true
       package_dependencies: |
-        @flowforge/localfs
+        @flowfuse/driver-localfs
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ FlowFuse helps Node-RED developers deliver applications in a more reliable, coll
 * FlowFuse adds team collaboration to Node-RED, allowing multiple developers to work together on a single instance.
 * Many organizations deploy Node-RED instances to remote servers or edge devices. FlowFuse automates this process by creating snapshots on Node-RED instances that can be deployed to multiple remote targets. 
 * FlowFuse simplifies the software development lifecycle of Node-RED applications. You can now set up DevOps delivery pipelines to support development, test and production environments for Node-RED application delivery.
-* FlowFuse is available from [FlowFuse Cloud](https://app.flowforge.com/account/create), a managed cloud service, or a self-hosted solution. 
+* FlowFuse is available from [FlowFuse Cloud](https://app.flowfuse.com/account/create), a managed cloud service, or a self-hosted solution. 
 * FlowFuse offers professional technical support for FlowFuse and Node-RED.
 
 ## Links
 
 - [Home Page](https://flowfuse.com/)
-- [Documentation](https://github.com/flowforge/flowforge/blob/main/docs/README.md)
-- [Contributing](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/flowforge/flowforge/blob/main/CODE_OF_CONDUCT.md)
-- [Security](https://github.com/flowforge/flowforge/blob/main/SECURITY.md)
-- [License](https://github.com/flowforge/flowforge/blob/main/LICENSE)
+- [Documentation](https://flowfuse.com/docs)
+- [Contributing](https://flowfuse.com/docs/contribute/introduction/)
+- [Code of Conduct](https://github.com/FlowFuse/flowfuse/blob/main/CODE_OF_CONDUCT.md)
+- [Security](https://github.com/FlowFuse/flowfuse/blob/main/SECURITY.md)
+- [License](https://github.com/FlowFuse/flowfuse/blob/main/LICENSE)

--- a/forge/app.js
+++ b/forge/app.js
@@ -7,7 +7,7 @@ const semver = require('semver')
 const forge = require('./forge')
 
 /**
-  * The main entry point to the FlowForge application.
+  * The main entry point to the FlowFuse application.
   *
   * This creates the Fastify server, registers our plugins and starts it listen
   * on `process.env.PORT`.
@@ -17,7 +17,7 @@ const forge = require('./forge')
 
 ;(async function () {
     if (!semver.satisfies(process.version, '>=16.0.0')) {
-        console.error(`FlowForge requires at least NodeJS v16, ${process.version} found`)
+        console.error(`FlowFuse requires at least NodeJS v16, ${process.version} found`)
         process.exit(1)
     }
 
@@ -34,9 +34,9 @@ const forge = require('./forge')
         async function exitWhenStopped () {
             if (!stopping) {
                 stopping = true
-                server.log.info('Stopping FlowForge platform')
+                server.log.info('Stopping FlowFuse platform')
                 await server.close()
-                server.log.info('FlowForge platform stopped')
+                server.log.info('FlowFuse platform stopped')
                 process.exit(0)
             }
         }
@@ -59,12 +59,12 @@ const forge = require('./forge')
             if (!server.settings.get('setup:initialised')) {
                 const setupURL = server.config.base_url.replace(/\/$/, '') + '/setup'
                 server.log.info('****************************************************')
-                server.log.info('* To finish setting up FlowForge, open this url:   *')
+                server.log.info('* To finish setting up FlowFuse, open this url:   *')
                 server.log.info(`*   ${setupURL.padEnd(47, ' ')}*`)
                 server.log.info('****************************************************')
             } else {
                 server.log.info('****************************************************')
-                server.log.info('* FlowForge is now running and can be accessed at: *')
+                server.log.info('* FlowFuse is now running and can be accessed at: *')
                 server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
                 server.log.info('****************************************************')
             }

--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -6,7 +6,7 @@ const STATUS = {
     // Any changes to this list *must* be made via migration.
     // See forge/db/migrations/20230130-01-add-subscription-trial-date.js for example
 
-    // A subset of the statuses on Stripe that are important to FlowForge
+    // A subset of the statuses on Stripe that are important to FlowFuse
     // https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses
     ACTIVE: 'active',
     CANCELED: 'canceled',

--- a/forge/ee/index.js
+++ b/forge/ee/index.js
@@ -1,7 +1,7 @@
 const fp = require('fastify-plugin')
 
 /**
- * Loads the FlowForge EE components
+ * Loads the FlowFuse EE components
  */
 module.exports = fp(async function (app, opts, next) {
     // Load ee only if enabled in the license

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -119,7 +119,7 @@ module.exports = async (options = {}) => {
                     return 0.001
                 }
 
-                // Used by nr-launcher and for flowforge-nr-auth
+                // Used by nr-launcher and for nr-auth
                 if (samplingContext?.transactionContext?.name === 'GET POST /account/token') {
                     return 0.01
                 }

--- a/forge/licensing/license-generator.js
+++ b/forge/licensing/license-generator.js
@@ -1,4 +1,4 @@
-// This is a command-line tool used to generate valid FlowForge license files.
+// This is a command-line tool used to generate valid FlowFuse license files.
 
 // A license file is encoded as a JSON Web Token signed using ES256
 // It consists of a well-defined set of claims. These claims identify who
@@ -11,7 +11,7 @@
 // development - they are used by the tests to generate and verify licenses.
 //
 // To generate a production license, you will need to access the Production private key
-// file in the FlowForge 1Password vault
+// file in the FlowFuse 1Password vault
 
 // ref: https://www.scottbrady91.com/OpenSSL/Creating-Elliptical-Curve-Keys-using-OpenSSL
 
@@ -32,7 +32,7 @@ const promptly = require('promptly')
 const { v4: uuidv4 } = require('uuid')
 
 ;(async () => {
-    console.info('FlowForge EE License Generator')
+    console.info('FlowFuse EE License Generator')
     console.info('------------------------------')
     try {
         const devLicense = await promptly.confirm('Is this a development-only license? (Y/n): ', { default: 'y' })

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -421,7 +421,7 @@ module.exports = async function (app) {
             if (newSettings.httpNodeAuth?.type === 'flowforge-user') {
                 const teamType = await request.project.Team.getTeamType()
                 if (teamType.properties.features?.teamHttpSecurity === false) {
-                    reply.code(400).send({ code: 'invalid_request', error: 'FlowForge User Authentication not available for this team type' })
+                    reply.code(400).send({ code: 'invalid_request', error: 'FlowFuse User Authentication not available for this team type' })
                     return
                 }
             }

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -430,7 +430,7 @@ async function init (app, opts, done) {
                 for (let i = 0; i < pendingInvitations.length; i++) {
                     const invite = pendingInvitations[i]
                     // For now we'll auto-accept any invites for this user
-                    // See https://github.com/flowforge/flowforge/issues/275#issuecomment-1040113991
+                    // See https://github.com/FlowFuse/flowfuse/issues/275#issuecomment-1040113991
                     await app.db.controllers.Invitation.acceptInvitation(invite, newUser)
                     // // If we go back to having the user be able to accept invites
                     // // as a secondary step, the following code will convert the external
@@ -529,7 +529,7 @@ async function init (app, opts, done) {
             for (let i = 0; i < pendingInvitations.length; i++) {
                 const invite = pendingInvitations[i]
                 // For now we'll auto-accept any invites for this user
-                // See https://github.com/flowforge/flowforge/issues/275#issuecomment-1040113991
+                // See https://github.com/FlowFuse/flowfuse/issues/275#issuecomment-1040113991
                 await app.db.controllers.Invitation.acceptInvitation(invite, verifiedUser)
                 // // If we go back to having the user be able to accept invites
                 // // as a secondary step, the following code will convert the external

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -157,7 +157,7 @@ module.exports = async function (app) {
             request.session = await app.db.controllers.Session.getOrExpire(request.sid)
             if (request.session) {
                 if (requestObject.client_id === 'ff-plugin') {
-                    // This is the FlowForge Node-RED plugin.
+                    // This is the FlowFuse Node-RED plugin.
                 } else {
                     const authClient = await app.db.controllers.AuthClient.getAuthClient(requestObject.client_id)
                     if (!authClient) {

--- a/forge/routes/setup/index.js
+++ b/forge/routes/setup/index.js
@@ -92,7 +92,7 @@ module.exports = async function (app) {
             await app.settings.set('setup:initialised', true)
 
             app.log.info('****************************************************')
-            app.log.info('* FlowForge setup is complete. You can login at:   *')
+            app.log.info('* FlowFuse setup is complete. You can login at:    *')
             app.log.info(`*   ${app.config.base_url.padEnd(47, ' ')}*`)
             app.log.info('****************************************************')
             reply.send({ status: 'okay' })

--- a/forge/routes/ui/index.js
+++ b/forge/routes/ui/index.js
@@ -94,7 +94,7 @@ module.exports = async function (app) {
             return
         }
         if (app.config.telemetry?.frontend?.plausible) {
-            app.log.warn('Configuration found for Plausible. Please note that support for Plausible will be deprecated after FlowForge 0.9')
+            app.log.warn('Configuration found for Plausible. Please note that support for Plausible will be deprecated after FlowFuse 0.9')
         }
         // check if we need to inject plausible
         if (app.config.telemetry?.frontend) {

--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -81,7 +81,7 @@
                 <template #note>
                     <p>
                         The FlowFuse team also have more planned for Applications, including
-                        <a class="ff-link" href="https://github.com/FlowFuse/flowforge/issues/1734" target="_blank">
+                        <a class="ff-link" href="https://github.com/FlowFuse/flowfuse/issues/1734" target="_blank">
                             shared settings across Instances</a>.
                     </p>
                 </template>

--- a/frontend/src/pages/application/Snapshots.vue
+++ b/frontend/src/pages/application/Snapshots.vue
@@ -5,7 +5,7 @@
                 <template #helptext>
                     <p>Snapshots generate a point-in-time backup of your Node-RED flow, credentials and runtime settings.</p>
                     <p>Snapshots are also required for deploying to devices. In the Deployments page of a Project, you can define your “Target Snapshot”, which will then be deployed to all connected devices.</p>
-                    <p>You can also generate Snapshots directly from any instance of Node-RED using the <a target="_blank" href="https://github.com/FlowFuse/flowforge-nr-tools-plugin">FlowFuse NR Tools Plugin.</a></p>
+                    <p>You can also generate Snapshots directly from any instance of Node-RED using the <a target="_blank" href="https://github.com/FlowFuse/nr-tools-plugin">FlowFuse NR Tools Plugin.</a></p>
                 </template>
             </SectionTopMenu>
         </div>

--- a/frontend/src/pages/device/Snapshots/index.vue
+++ b/frontend/src/pages/device/Snapshots/index.vue
@@ -4,7 +4,7 @@
             <template #helptext>
                 <p>Snapshots generate a point-in-time backup of your Node-RED flow, credentials and runtime settings.</p>
                 <p>Snapshots are also required for deploying to devices. In the Deployments page of a Project, you can define your “Target Snapshot”, which will then be deployed to all connected devices.</p>
-                <p>You can also generate Snapshots directly from any instance of Node-RED using the <a target="_blank" href="https://github.com/FlowFuse/flowforge-nr-tools-plugin">FlowFuse NR Tools Plugin.</a></p>
+                <p>You can also generate Snapshots directly from any instance of Node-RED using the <a target="_blank" href="https://github.com/FlowFuse/nr-tools-plugin">FlowFuse NR Tools Plugin.</a></p>
             </template>
             <template #tools>
                 <div class="space-x-2 flex align-center">

--- a/frontend/src/pages/instance/Snapshots/index.vue
+++ b/frontend/src/pages/instance/Snapshots/index.vue
@@ -4,7 +4,7 @@
             <template #helptext>
                 <p>Snapshots generate a point-in-time backup of your Node-RED flow, credentials and runtime settings.</p>
                 <p>Snapshots are also required for deploying to devices. In the Deployments page of a Project, you can define your “Target Snapshot”, which will then be deployed to all connected devices.</p>
-                <p>You can also generate Snapshots directly from any instance of Node-RED using the <a target="_blank" href="https://github.com/FlowFuse/flowforge-nr-tools-plugin">FlowFuse NR Tools Plugin.</a></p>
+                <p>You can also generate Snapshots directly from any instance of Node-RED using the <a target="_blank" href="https://github.com/FlowFuse/nr-tools-plugin">FlowFuse NR Tools Plugin.</a></p>
             </template>
         </SectionTopMenu>
     </div>

--- a/frontend/src/pages/setup/Options.vue
+++ b/frontend/src/pages/setup/Options.vue
@@ -10,7 +10,7 @@
                 </p>
                 <p>
                     For more information about the data we collect and how it is used,
-                    please see our <a class="forge-link" href="https://github.com/FlowFuse/flowforge/tree/main/docs/admin/telemetry.md" target="_blank">Usage Data Collection Policy</a>
+                    please see our <a class="forge-link" href="https://flowfuse.com/docs/admin/telemetry/" target="_blank">Usage Data Collection Policy</a>
                 </p>
             </template>
         </FormRow>

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -109,7 +109,7 @@
                     <template #note>
                         <p>
                             The FlowFuse team also have more planned for Applications, including
-                            <a class="ff-link" href="https://github.com/FlowFuse/flowforge/issues/1734" target="_blank">
+                            <a class="ff-link" href="https://github.com/FlowFuse/flowfuse/issues/1734" target="_blank">
                                 shared settings across Instances</a>.
                         </p>
                     </template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@flowforge/flowforge",
+    "name": "@flowfuse/flowfuse",
     "version": "1.14.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@flowforge/flowforge",
+            "name": "@flowfuse/flowfuse",
             "version": "1.14.1",
             "license": "SEE LICENSE IN ./LICENSE",
             "dependencies": {
@@ -64,7 +64,8 @@
             },
             "bin": {
                 "ff-install-stack": "scripts/install-stack.js",
-                "flowforge": "forge/app.js"
+                "flowforge": "forge/app.js",
+                "flowfuse": "forge/app.js"
             },
             "devDependencies": {
                 "@babel/core": "^7.22.15",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@flowforge/flowforge",
+    "name": "@flowfuse/flowfuse",
     "version": "1.14.1",
     "description": "An open source low-code development platform",
     "homepage": "https://flowfuse.com",
@@ -16,7 +16,8 @@
     },
     "bin": {
         "ff-install-stack": "./scripts/install-stack.js",
-        "flowforge": "./forge/app.js"
+        "flowforge": "./forge/app.js",
+        "flowfuse": "./forge/app.js"
     },
     "scripts": {
         "start": "node forge/app.js",


### PR DESCRIPTION
## Description

This migrates the package to `@flowfuse/flowfuse`.

Along the way it tidies up yet more FlowForge references and urls.

Before this can merge we need:

 - [x] add new npm token as a secret to this repo
 - [x] do first manual publish to new scope

Once merged and initial version published, the following PRs can be merged:

 - [ ] https://github.com/FlowFuse/helm/pull/244
 - [ ] https://github.com/FlowFuse/docker-compose/pull/113
 - [ ] https://github.com/FlowFuse/installer/pull/94
 - [ ] https://github.com/FlowFuse/admin/pull/257
