### PR TITLE
Improve session handling on password change

### DIFF
--- a/forge/db/controllers/Session.js
+++ b/forge/db/controllers/Session.js
@@ -37,6 +37,12 @@ module.exports = {
     },
 
     /**
+     * Delete all sessions for a user
+     */
+    deleteAllUserSessions: async function (app, user) {
+        return app.db.models.Session.destroy({ where: { UserId: user.id } })
+    },
+    /**
      * Get a session by its id. If the session has expired, it is deleted
      * and nothing returned.
      */


### PR DESCRIPTION
## Description

When a user changes their password, this ensures we expire any other sessions that user may have, as well as generate a new session id for the current session.

## Related Issue(s)

 - https://github.com/FlowFuse/security/issues/35
 - https://github.com/FlowFuse/security/issues/37

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
