### PR TITLE
Ensure password reset tokens cannot be reused

### DIFF
--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -82,6 +82,9 @@ module.exports = async function (app) {
             if (sessionInfo) {
                 reply.setCookie('sid', sessionInfo.session.sid, sessionInfo.cookieOptions)
             }
+            // Clear any password reset tokens
+            await app.db.controllers.AccessToken.deleteAllUserPasswordResetTokens(request.session.User)
+
             reply.send({ status: 'okay' })
         } catch (err) {
             const resp = { code: 'password_change_failed', error: 'password change failed' }

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -785,6 +785,9 @@ async function init (app, opts, done) {
                 userInfo = user
                 try {
                     await app.db.controllers.User.resetPassword(user, request.body.password)
+                    // Clear any existing sessions to force a re-login
+                    await app.db.controllers.Session.deleteAllUserSessions(user)
+                    await app.db.controllers.AccessToken.deleteAllUserPasswordResetTokens(user)
                     success = true
                 } catch (err) {
                 }


### PR DESCRIPTION
## Description

This tidies up some handling around password reset tokens.

 - It ensures a user can only have one active password reset token at any one time
 - It ensures all existing user sessions are cleared when a password is reset
 - It ensures all password reset tokens are removed when a user changes their password

Fixes
 - https://github.com/FlowFuse/security/issues/38