### PR TITLE
Increase plugin timeout to 20s to avoid failed startups

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -75,7 +75,9 @@ module.exports = async (options = {}) => {
         bodyLimit: 5242880,
         maxParamLength: 500,
         trustProxy: true,
-        logger: loggerConfig
+        logger: loggerConfig,
+        // Increase the default timeout
+        pluginTimeout: 20000
     })
 
     if (runtimeConfig.telemetry.backend?.prometheus?.enabled) {


### PR DESCRIPTION
We are seeing an increase in failed starts in staging where the ee plugin takes longer than 10 seconds to initialise.

This slowness comes when we ask sequelize to synchronise its models with the database. The use of `.sync()` as part of the runtime startup is discouraged by sequelize - for just this reason, as it can be a slow and costly operation.

The right answer is to fully manage the database via migrations. That is how it already works when upgrading from version A to version B. Where we rely on the .sync() function today is when running a clean install with an empty database - in that scenario we don't use migrations to build the initial table structure, we let sequelize do it.

We also have the complication of managing a CE database being upgraded to an EE database.

All of this is to say, there isn't a quick solution here. So, for now, to buy some time, I'm increasing the plugin timeout from 10s to 20s.