### PR TITLE
Ensure editor sessions are revoked when logging out of the platform

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -266,5 +266,6 @@ module.exports = {
             nodered: '3.0.2',
             ...this._app.config.driver.options?.default_stack
         }
-    }
+    },
+    revokeUserToken: async (project, token) => { }
 }

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -203,6 +203,9 @@ module.exports = {
     },
     revokeUserToken: async (project, token) => { // logout:nodered(step-2)
         if (this._driver.revokeUserToken) {
+            if (project.state === 'suspended') {
+                return
+            }
             await this._driver.revokeUserToken(project, token) // logout:nodered(step-3)
         }
     },

--- a/forge/db/controllers/StorageSession.js
+++ b/forge/db/controllers/StorageSession.js
@@ -1,0 +1,36 @@
+module.exports = {
+    async removeUserFromSessions (app, user) {
+        const sessions = await app.db.models.StorageSession.byUsername(user.username)
+        for (let sessionIndex = 0; sessionIndex < sessions.length; sessionIndex++) {
+            const session = sessions[sessionIndex]
+            const instanceId = session.ProjectId
+            const sessionInfo = JSON.parse(session.sessions)
+            let modified = false
+            const userSessions = Object.values(sessionInfo).filter(session => {
+                if (session.user === user.username) {
+                    delete sessionInfo[session.accessToken]
+                    modified = true
+                    return true
+                }
+                return false
+            })
+            if (modified) {
+                // Save back the session table without this user's sessions included
+                // This ensures any suspended instances have their session table updated
+                session.sessions = JSON.stringify(sessionInfo)
+                await session.save()
+            }
+            if (userSessions.length > 0) {
+                const instance = await app.db.models.Project.byId(instanceId)
+                for (let i = 0; i < userSessions.length; i++) {
+                    const token = userSessions[i].accessToken
+                    try {
+                        await app.containers.revokeUserToken(instance, token) // logout:nodered(step-2)
+                    } catch (error) {
+                        app.log.warn(`Failed to revoke token for Instance ${instanceId}: ${error.toString()}`) // log error but continue to delete session
+                    }
+                }
+            }
+        }
+    }
+}

--- a/forge/db/controllers/index.js
+++ b/forge/db/controllers/index.js
@@ -27,7 +27,8 @@ const modelTypes = [
     'BrokerClient',
     'StorageCredentials',
     'StorageFlows',
-    'StorageSettings'
+    'StorageSettings',
+    'StorageSession'
 ]
 
 async function init (app) {

--- a/forge/db/models/StorageSession.js
+++ b/forge/db/models/StorageSession.js
@@ -22,20 +22,14 @@ module.exports = {
                     })
                 },
                 byUsername: async (username) => {
-                    const allStorageSessions = await this.findAll({
+                    return this.findAll({
                         where: {
                             sessions: {
                                 [Op.like]: '%"' + username + '"%'
                             }
                         },
-                        attributes: ['sessions', 'ProjectId']
+                        attributes: ['id', 'sessions', 'ProjectId']
                     })
-                    return allStorageSessions.map(m => {
-                        const session = m.sessions ? JSON.parse(m.sessions) : {}
-                        const sessions = Object.values(session) || []
-                        const usersSessions = sessions.filter(e => e.user === username && e.client === 'node-red-editor')
-                        return { ProjectId: m.ProjectId, sessions: usersSessions }
-                    }).filter(m => m.sessions.length > 0 && M.ProjectId)
                 }
             }
         }

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -308,20 +308,7 @@ async function init (app, opts, done) {
             if (userInfo.id != null) {
                 const user = await app.db.models.User.byId(userInfo.id)
                 userInfo = app.auditLog.formatters.userObject(user)
-                const sessions = await app.db.models.StorageSession.byUsername(user.username)
-                for (let index = 0; index < sessions.length; index++) {
-                    const session = sessions[index]
-                    const ProjectId = session.ProjectId
-                    const project = await app.db.models.Project.byId(ProjectId)
-                    for (let index = 0; index < session.sessions.length; index++) {
-                        const token = session.sessions[index].accessToken
-                        try {
-                            await app.containers.revokeUserToken(project, token) // logout:nodered(step-2)
-                        } catch (error) {
-                            app.log.warn(`Failed to revoke token for Project ${ProjectId}: ${error.toString()}`) // log error but continue to delete session
-                        }
-                    }
-                }
+                await app.db.controllers.User.logout(user)
             }
             await app.db.controllers.Session.deleteSession(request.sid)
         }

--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -86,7 +86,8 @@ const iconMap = {
     ],
     logout: [
         'account.logout',
-        'auth.logout' // node-red event
+        'auth.logout', // node-red event
+        'auth.login.revoke' // node-red event
     ],
     security: [
         'account.verify.auto-create-team',

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -149,7 +149,7 @@
         <span v-if="!error && entry.trigger?.name">User '{{ entry.trigger.name }}' has logged in.</span>
         <span v-else-if="!error">User data not found in audit entry.</span>
     </template>
-    <template v-else-if="entry.event === 'account.logout' || entry.event === 'auth.logout'">
+    <template v-else-if="entry.event === 'account.logout' || entry.event === 'auth.logout' || entry.event === 'auth.login.revoke'">
         <label>{{ AuditEvents[entry.event] }}</label>
         <span v-if="!error && entry.trigger?.name">User '{{ entry.trigger.name }}' has logged out.</span>
         <span v-else-if="!error">User data not found in audit entry.</span>

--- a/frontend/src/data/audit-events.json
+++ b/frontend/src/data/audit-events.json
@@ -73,6 +73,7 @@
         "project.snapshot.deviceTarget": "Device Target Set",
         "auth.login": "User Logged In",
         "auth.logout": "User Logged Out",
+        "auth.login.revoke": "User Logged Out",
         "crashed": "Node-RED has crashed",
         "stopped": "Node-RED has stopped",
         "settings.update": "Node-RED Settings Updated",

--- a/test/unit/forge/db/controllers/StorageSession_spec.js
+++ b/test/unit/forge/db/controllers/StorageSession_spec.js
@@ -1,0 +1,73 @@
+const should = require('should') // eslint-disable-line
+const sinon = require('sinon')
+const setup = require('../setup')
+
+const FF_UTIL = require('flowforge-test-utils')
+const stubDriver = FF_UTIL.require('forge/containers/stub/index.js')
+
+describe('Storage Session controller', function () {
+    // Use standard test data.
+    let app
+    before(async function () {
+        app = await setup()
+        sinon.stub(stubDriver, 'revokeUserToken').resolves()
+    })
+
+    after(async function () {
+        await app.close()
+        stubDriver.revokeUserToken.restore()
+    })
+
+    describe('removeUserFromSessions', function () {
+        it('removes user from any existing storage session', async function () {
+            const p1 = await app.db.models.Project.create({ name: 'testProject-01', type: '', url: '' })
+            const p2 = await app.db.models.Project.create({ name: 'testProject-02', type: '', url: '' })
+            const p3 = await app.db.models.Project.create({ name: 'testProject-03', type: '', url: '' })
+            p3.state = 'suspended'
+            await p3.save()
+
+            // p1 - two active sessions for alice, one for bob
+            // p2 - no sessions for alice
+            // p3 - one session for alice, one for bob - suspended
+            const s1 = await app.db.models.StorageSession.create({
+                sessions: '{"token1":{"user":"alice","client":"node-red-editor","scope":["*"],"accessToken":"token1","expires":1676376174919},"token2":{"user":"alice","client":"node-red-editor","scope":["*"],"accessToken":"token2","expires":1676376174919},"token3":{"user":"bob","client":"node-red-editor","scope":["*"],"accessToken":"token3","expires":1676376174919}}',
+                ProjectId: p1.id
+            })
+            const s2 = await app.db.models.StorageSession.create({
+                sessions: '{"token4":{"user":"bob","client":"node-red-editor","scope":["*"],"accessToken":"token3","expires":1676376174919}}',
+                ProjectId: p2.id
+            })
+            const s3 = await app.db.models.StorageSession.create({
+                sessions: '{"token5":{"user":"alice","client":"node-red-editor","scope":["*"],"accessToken":"token5","expires":1676376174919}}',
+                ProjectId: p3.id
+            })
+
+            stubDriver.revokeUserToken.callCount.should.equal(0)
+            await app.db.controllers.StorageSession.removeUserFromSessions(app.TestObjects.userAlice)
+
+            // Should have asked the container driver to revoke 2 sessions (both p1 alice sessions)
+            stubDriver.revokeUserToken.callCount.should.equal(2)
+
+            stubDriver.revokeUserToken.firstCall.args[0].should.have.property('id', p1.id)
+            stubDriver.revokeUserToken.firstCall.args[1].should.equal('token1')
+            stubDriver.revokeUserToken.secondCall.args[0].should.have.property('id', p1.id)
+            stubDriver.revokeUserToken.secondCall.args[1].should.equal('token2')
+
+            await Promise.all([
+                s1.reload(),
+                s2.reload(),
+                s3.reload()
+            ])
+
+            const s1Sessions = JSON.parse(s1.sessions)
+            const s2Sessions = JSON.parse(s2.sessions)
+            const s3Sessions = JSON.parse(s3.sessions)
+
+            s1Sessions.should.not.have.property('token1')
+            s1Sessions.should.not.have.property('token2')
+            s1Sessions.should.have.property('token3')
+            s2Sessions.should.have.property('token4')
+            s3Sessions.should.not.have.property('token5')
+        })
+    })
+})

--- a/test/unit/forge/db/controllers/StorageSession_spec.js
+++ b/test/unit/forge/db/controllers/StorageSession_spec.js
@@ -1,5 +1,6 @@
 const should = require('should') // eslint-disable-line
 const sinon = require('sinon')
+
 const setup = require('../setup')
 
 const FF_UTIL = require('flowforge-test-utils')


### PR DESCRIPTION
## Description

This fixes the handling of logging out of Node-RED sessions when a user logs out of the platform.

It reduces code duplication by moving it into a new controller for the StorageSession object.

Adds unit test for the logic.

Adds audit-log details in the frontend for the event.