### PR TITLE
Add 'ci/' to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ frontend/public/
 forge/containers/localfs_root/
 forge/licensing/dev-private-key_enc.pem
 test/
+ci/


### PR DESCRIPTION
## Description

Add a `ci` directory, which contains files related to the Continues Integration process, to `.npmignore`.

## Related Issue(s)

#3224 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

