### PR TITLE
Make link a button so it's obvious for change team type

### DIFF
--- a/frontend/src/pages/team/Settings/General.vue
+++ b/frontend/src/pages/team/Settings/General.vue
@@ -13,7 +13,7 @@
             <template #default>Type</template>
             <template #description>
                 <template v-if="editing">
-                    Click <router-link :to="{name: 'TeamChangeType'}">here</router-link> to change the team type
+                    <ff-button kind="secondary" :to="{name: 'TeamChangeType'}">Change Team Type</ff-button>
                 </template>
             </template>
         </FormRow>


### PR DESCRIPTION
fixes #2904

## Description

<!-- Describe your changes in detail -->
The link to change the team type was impossible to find in the team settings (light grey with no highlighting in the sentence)

Changed it to a secondary button so it's clearer what the intention is.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#2904

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

