### PR TITLE
Blueprint UI Follow ups

### DIFF
--- a/frontend/src/pages/instance/Blueprints/BlueprintSelection.vue
+++ b/frontend/src/pages/instance/Blueprints/BlueprintSelection.vue
@@ -37,20 +37,13 @@ export default {
     },
     computed: {
         blueprintsGrouped () {
-            const grouped = (this.blueprints || this.localBlueprints).reduce((acc, blueprint) => {
+            return (this.blueprints || this.localBlueprints).sort((a, b) => {
+                return a.order - b.order
+            }).reduce((acc, blueprint) => {
                 const category = blueprint.category || 'Other';
                 (acc[category] = acc[category] || []).push(blueprint)
                 return acc
             }, {})
-
-            // sort each group
-            Object.keys(grouped).forEach(key => {
-                grouped[key].sort((a, b) => {
-                    return a.order - b.order
-                })
-            })
-
-            return grouped
         }
     },
     mounted () {

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -72,7 +72,7 @@
         </FormRow>
 
         <div v-if="!creatingApplication || input.createInstance" :class="creatingApplication ? 'ml-6' : ''" class="space-y-6">
-            <template v-if="creatingNew && showFlowBlueprintSelection && !input.flowBlueprintId">
+            <template v-if="blueprintSelectionVisible">
                 <!-- Blueprints Selection First -->
                 <BlueprintSelection :blueprints="blueprints" @selected="selectBlueprint" />
             </template>
@@ -232,7 +232,7 @@
             </template>
         </div>
         <!-- Submit -->
-        <div class="flex flex-wrap gap-1 items-center">
+        <div v-if="!blueprintSelectionVisible" class="flex flex-wrap gap-1 items-center">
             <ff-button
                 v-if="!creatingNew"
                 class="ff-btn--secondary"
@@ -468,6 +468,9 @@ export default {
         },
         selectedBlueprint () {
             return this.blueprints.find((blueprint) => blueprint.id === this.input.flowBlueprintId)
+        },
+        blueprintSelectionVisible () {
+            return this.creatingNew && this.showFlowBlueprintSelection && !this.input.flowBlueprintId
         }
     },
     watch: {


### PR DESCRIPTION
## Description

- Orders the blueprint _categories_ based on the order of blueprints
- Hides the submit button if displaying the blueprint list
- 
![Screenshot 2023-12-19 at 17 27 09](https://github.com/FlowFuse/flowfuse/assets/507155/9c32b827-1e63-4312-8102-7fab2196250f)

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/2948

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

