### PR TITLE
Add missing audit logger for pipeline stage deploy

### DIFF
--- a/forge/auditLog/formatters.js
+++ b/forge/auditLog/formatters.js
@@ -7,10 +7,10 @@ const isObject = (obj) => {
 /**
  * Generate a standard format body for the audit log display and database.
  * Any items null or missing must not generate a property in the body
- * @param {{ error?, team?, project?, sourceProject?, targetProject?, device?, sourceDevice?, targetDevice?, user?, stack?, billingSession?, subscription?, license?, updates?, snapshot?, role?, projectType?, info? } == {}} objects objects to include in body
- * @returns {{ error?, team?, project?, sourceProject?, targetProject?, device?, user?, stack?, billingSession?, subscription?, license?, updates?, snapshot?, role?, projectType? info? }
+ * @param {{ error?, team?, project?, sourceProject?, targetProject?, device?, sourceDevice?, targetDevice?, user?, stack?, billingSession?, subscription?, license?, updates?, snapshot?, pipeline?, pipelineStage?, pipelineStageTarget?, role?, projectType?, info?, interval?, threshold? } == {}} objects objects to include in body
+ * @returns {{ error?, team?, project?, sourceProject?, targetProject?, device?, user?, stack?, billingSession?, subscription?, license?, updates?, snapshot?, pipeline?, pipelineStage?, pipelineStageTarget?, role?, projectType? info?, interval?, threshold? }
  */
-const generateBody = ({ error, team, application, project, sourceProject, targetProject, device, sourceDevice, targetDevice, user, stack, billingSession, subscription, license, updates, snapshot, pipeline, pipelineStage, role, projectType, info, interval, threshold } = {}) => {
+const generateBody = ({ error, team, application, project, sourceProject, targetProject, device, sourceDevice, targetDevice, user, stack, billingSession, subscription, license, updates, snapshot, pipeline, pipelineStage, pipelineStageTarget, role, projectType, info, interval, threshold } = {}) => {
     const body = {}
 
     if (isObject(error) || typeof error === 'string') {
@@ -68,6 +68,9 @@ const generateBody = ({ error, team, application, project, sourceProject, target
     }
     if (isObject(pipelineStage)) {
         body.pipelineStage = pipelineStageObject(pipelineStage)
+    }
+    if (isObject(pipelineStageTarget)) {
+        body.pipelineStageTarget = pipelineStageObject(pipelineStageTarget)
     }
     if (isObject(role) || typeof role === 'number') {
         body.role = roleObject(role)
@@ -152,6 +155,7 @@ const formatLogEntry = (auditLogDbRow) => {
                 info: body?.info,
                 pipeline: body?.pipeline,
                 pipelineStage: body?.pipelineStage,
+                pipelineStageTarget: body?.pipelineStageTarget,
                 interval: body?.interval,
                 threshold: body?.threshold
             })

--- a/forge/auditLog/team.js
+++ b/forge/auditLog/team.js
@@ -149,6 +149,9 @@ module.exports = {
                 },
                 async stageAdded (actionedBy, error, team, application, pipeline, pipelineStage) {
                     await log('application.pipeline.stage-added', actionedBy, team?.id, generateBody({ error, team, application, pipeline, pipelineStage }))
+                },
+                async stageDeployed (actionedBy, error, team, application, pipeline, sourcePipelineStage, targetPipelineStage) {
+                    await log('application.pipeline.stage-deployed', actionedBy, team?.id, generateBody({ error, team, application, pipeline, pipelineStage: sourcePipelineStage, pipelineStageTarget: targetPipelineStage }))
                 }
             }
         }

--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -200,6 +200,7 @@ const iconMap = {
         'application.pipeline.updated',
         'application.pipeline.deleted',
         'application.pipeline.stage-added',
+        'application.pipeline.stage-deployed',
         'project.assigned-to-pipeline-stage'
     ],
     resource: [

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -331,6 +331,12 @@
         <span v-if="!error && entry.body?.pipeline && entry.body?.pipelineStage">Pipeline Stage '{{ entry.body.pipelineStage?.name }}' was added to the DevOps Pipeline '{{ entry.body.pipeline?.name }}' {{ entry.body.application ? `in Application '${entry.body.application.name}'` : '' }}</span>
         <span v-else-if="!error">Pipeline data not found in audit entry.</span>
     </template>
+    <template v-else-if="entry.event === 'application.pipeline.stage-deployed'">
+        <label>{{ AuditEvents[entry.event] }}</label>
+        <span v-if="!error && entry.body?.pipeline && entry.body?.pipelineStage && !entry.body?.pipelineStageTarget">Pipeline Stage '{{ entry.body.pipelineStage.name }}' in DevOps Pipeline '{{ entry.body.pipeline.name }}' {{ entry.body.application ? `in Application '${entry.body.application.name}'` : '' }} was deployed</span>
+        <span v-if="!error && entry.body?.pipeline && entry.body?.pipelineStage && entry.body?.pipelineStageTarget">Pipeline Stage '{{ entry.body.pipelineStage.name }}' in DevOps Pipeline '{{ entry.body.pipeline.name }}' {{ entry.body.application ? `in Application '${entry.body.application.name}'` : '' }} was deployed to '{{ entry.body.pipelineStageTarget.name }}'</span>
+        <span v-else-if="!error">Pipeline data not found in audit entry.</span>
+    </template>
 
     <!-- Application Device Events -->
     <template v-else-if="entry.event === 'application.device.assigned'">

--- a/frontend/src/data/audit-events.json
+++ b/frontend/src/data/audit-events.json
@@ -32,6 +32,7 @@
         "application.pipeline.updated": "DevOps Pipeline Updated",
         "application.pipeline.deleted": "DevOps Pipeline Deleted",
         "application.pipeline.stage-added": "Pipeline Stage Added",
+        "application.pipeline.stage-deployed": "Pipeline Stage Deployed",
         "project.created": "Instance Created",
         "project.deleted": "Instance Deleted",
         "project.duplicated": "Instance Duplicated",


### PR DESCRIPTION
## Description

* Adds audit log entry `application.pipeline.stage-deployed`
* Adds UI for this element
* Adds tests for all missing `team-application-*` loggers

### Example:
![image](https://github.com/FlowFuse/flowfuse/assets/44235289/bc58c769-78b7-4521-9235-33684a2edb5e)


## Related Issue(s)

#2989 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

