### PR TITLE
Ensure feature unavailable has a message

### DIFF
--- a/frontend/src/pages/team/Library.vue
+++ b/frontend/src/pages/team/Library.vue
@@ -39,7 +39,7 @@
             </ff-data-table>
             <ff-code-previewer v-else ref="code-preview" :snippet="contents" />
         </div>
-        <EmptyState v-else :featureUnavailable="!featureEnabledForPlatform" :featureUnavailableToTeam="!featureEnabledForTeam">
+        <EmptyState v-else :featureUnavailable="!featureEnabledForPlatform" :featureUnavailableToTeam="!featureEnabledForTeam" :featureUnavailableMessage="'This feature is not available'">
             <template #img>
                 <img src="../../images/empty-states/team-library.png">
             </template>


### PR DESCRIPTION
closes #3219 

## Description

### before
![image](https://github.com/FlowFuse/flowfuse/assets/44235289/61a76cb5-38cf-4568-833e-e79d39148681)

### After (no licence)
![image](https://github.com/FlowFuse/flowfuse/assets/44235289/46eec199-2f52-41d6-be04-54afea9b8122)


### After (not set for team tier)
![image](https://github.com/FlowFuse/flowfuse/assets/44235289/39593fa4-33a6-48b9-8e99-58e0d326f8e8)



## Related Issue(s)
 #3219 

