### PR TITLE
Restore leaving developer mode warning dialog

### DIFF
--- a/frontend/src/pages/device/components/DeveloperModeToggle.vue
+++ b/frontend/src/pages/device/components/DeveloperModeToggle.vue
@@ -78,8 +78,8 @@ export default {
                         Any changes made to the device whilst in developer mode will be lost.
                     </p>
                     <p>
-                        To avoid losses, you can cancel this operation use the 'create snapshot'
-                        developer mode option before disabling developer mode.
+                        To avoid losses, you can cancel this operation and create a snapshot
+                        in the developer mode tab.
                     </p>`
                 }
                 const dialogResult = await Dialog.showAsync(msg)

--- a/frontend/src/pages/device/components/DeveloperModeToggle.vue
+++ b/frontend/src/pages/device/components/DeveloperModeToggle.vue
@@ -17,6 +17,7 @@ import { CodeIcon } from '@heroicons/vue/outline'
 import semver from 'semver'
 
 import alerts from '../../../services/alerts.js'
+import Dialog from '../../../services/dialog.js'
 
 export default {
     name: 'DeveloperModeToggle',
@@ -64,9 +65,36 @@ export default {
     methods: {
         async toggleDeveloperMode () {
             this.busy = true
-
+            if (this.developerMode) {
+                const msg = {
+                    header: 'Disable Developer Mode',
+                    kind: 'danger',
+                    confirmLabel: 'Confirm',
+                    html: `<p>
+                        Disabling developer mode will turn off access to the editor and
+                        may redeploy the current target snapshot to the device.
+                    </p>
+                    <p>
+                        Any changes made to the device whilst in developer mode will be lost.
+                    </p>
+                    <p>
+                        To avoid losses, you can cancel this operation use the 'create snapshot'
+                        developer mode option before disabling developer mode.
+                    </p>`
+                }
+                const dialogResult = await Dialog.showAsync(msg)
+                if (dialogResult === 'confirm') {
+                    await this.setDeveloperMode(false)
+                }
+            } else {
+                await this.setDeveloperMode(true)
+            }
+            this.busy = false
+        },
+        async setDeveloperMode (devModeOn) {
+            this.busy = true
             // perform the mode change to the selected mode. @see DevicePage.setDeviceMode
-            this.$emit('mode-change', !this.developerMode ? 'developer' : 'autonomous', (err, _result) => {
+            this.$emit('mode-change', devModeOn ? 'developer' : 'autonomous', (err, _result) => {
                 if (err) {
                     console.warn('Error setting developer mode', err)
                     alerts.emit(err.message, 'warning', 7000)

--- a/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
@@ -18,59 +18,79 @@ describe('FlowForge - Devices - With Billing', () => {
 
     it('provides an option to enable "Developer Mode" when deviceEditor feature is enabled', () => {
         cy.contains('span', 'application-device-a').click()
-        cy.get('[data-el=device-devmode-toggle]').should('exist')
+        cy.get('[data-el="device-devmode-toggle"]').should('exist')
     })
 
     it('has "Developer Mode" tab and status pill when Dev mode is enabled', () => {
         cy.contains('span', 'application-device-a').click()
         cy.get('[data-nav="device-devmode"]').should('not.exist')
         cy.get('[data-el="badge-devmode"]').should('not.exist')
-        cy.get('[data-el=device-devmode-toggle]').click()
+        cy.get('[data-el="device-devmode-toggle"]').click()
         cy.get('[data-nav="device-devmode"]').should('exist')
         cy.get('[data-el="badge-devmode"]').should('exist')
 
         // reset dev mode state
-        cy.get('[data-el=device-devmode-toggle]').click()
+        cy.get('[data-el="device-devmode-toggle"]').click()
+        // verify dialog contains correct text
+        cy.get('[data-el=platform-dialog] > .ff-dialog-box .ff-dialog-content').contains('Any changes made to the device whilst in developer mode will be lost')
+        cy.get('[data-el=platform-dialog] > .ff-dialog-box .ff-dialog-header').contains('Disable Developer Mode')
+        cy.get('[data-el=platform-dialog] > .ff-dialog-box [data-action="dialog-confirm"]').click() // click confirm
     })
 
     it('is redirected away from the Developer Mode tab if leaving that mode, whilst the tab is open', () => {
         cy.contains('span', 'application-device-a').click()
-        cy.get('[data-el=device-devmode-toggle]').click()
+        cy.get('[data-el="device-devmode-toggle"]').click()
         cy.get('[data-nav="device-devmode"]').click()
 
         cy.url().should('include', '/developer-mode')
 
         // reset dev mode state
-        cy.get('[data-el=device-devmode-toggle]').click()
-
+        cy.get('[data-el="device-devmode-toggle"]').click()
+        cy.get('[data-el=platform-dialog] > .ff-dialog-box [data-action="dialog-confirm"]').click() // click confirm
         cy.url().should('not.include', '/developer-mode')
     })
 
     it('has the create snapshot disabled if the snapshot is not assigned to an application or instance', () => {
         /// Assigned to nothing
         cy.contains('span', 'team2-unassigned-device').click()
-        cy.get('[data-el="device-devmode-toggle"]').click()
-        cy.get('[data-nav="device-devmode"]').click()
-
+        cy.get('[data-el="device-devmode-toggle"]').click() // enable
+        cy.get('[data-nav="device-devmode"]').click() // switch to dev mode tab
         cy.get('[data-action="create-snapshot-dialog"]').should('be.disabled')
         cy.get('[data-el="device-devmode-toggle"]').click() // reset
+        cy.get('[data-el=platform-dialog] > .ff-dialog-box [data-action="dialog-confirm"]').click() // click confirm
 
         // Assigned to an instance
         cy.visit('/team/bteam/devices')
         cy.contains('span', 'assigned-device-a').click()
-        cy.get('[data-el="device-devmode-toggle"]').click()
-        cy.get('[data-nav="device-devmode"]').click()
+        cy.get('[data-el="device-devmode-toggle"]').then(($el) => {
+            if ($el.find('.ff-toggle-switch').hasClass('checked')) {
+                // dev mode is enabled - do nothing
+            } else {
+                cy.get('[data-el="device-devmode-toggle"]').click()
+            }
+        }).then(() => {
+            cy.get('[data-nav="device-devmode"]').click()
 
-        cy.get('[data-action="create-snapshot-dialog"]').should('not.be.disabled')
-        cy.get('[data-el="device-devmode-toggle"]').click() // reset
+            cy.get('[data-action="create-snapshot-dialog"]').should('not.be.disabled')
+            cy.get('[data-el="device-devmode-toggle"]').click() // reset
+            cy.get('[data-el=platform-dialog] > .ff-dialog-box [data-action="dialog-confirm"]').click() // click confirm
+        })
 
         /// Assigned to application
         cy.visit('/team/bteam/devices')
         cy.contains('span', 'application-device-a').click()
-        cy.get('[data-el="device-devmode-toggle"]').click()
-        cy.get('[data-nav="device-devmode"]').click()
+        cy.get('[data-el="device-devmode-toggle"]').then(($el) => {
+            if ($el.find('.ff-toggle-switch').hasClass('checked')) {
+                // dev mode is enabled - do nothing
+            } else {
+                cy.get('[data-el="device-devmode-toggle"]').click()
+            }
+        }).then(() => {
+            cy.get('[data-nav="device-devmode"]').click()
 
-        cy.get('[data-action="create-snapshot-dialog"]').should('not.be.disabled')
-        cy.get('[data-el="device-devmode-toggle"]').click() // reset
+            cy.get('[data-action="create-snapshot-dialog"]').should('not.be.disabled')
+            cy.get('[data-el="device-devmode-toggle"]').click() // reset
+            cy.get('[data-el=platform-dialog] > .ff-dialog-box [data-action="dialog-confirm"]').click() // click confirm
+        })
     })
 })


### PR DESCRIPTION
closes #2875

## Description

Show user a warning when exiting developer mode.

* Pressing cancel keeps the device in developer mode
* Pressing confirm proceeds with the mode switch

![chrome_YJMvOzcYCG](https://github.com/FlowFuse/flowfuse/assets/44235289/2fbdbe0c-2603-4f7c-9fb1-9e1b99e94872)

👆 NOTE: GIF text is outdated 👆 
Text now reads:

> Disabling developer mode will turn off access to the editor and
> may redeploy the current target snapshot to the device.
>
> Any changes made to the device whilst in developer mode will be lost.
>
> To avoid losses, you can cancel this operation and create a snapshot
> in the developer mode tab.



dialog text is almost identical to original dialog prior to the toggle button removing it (with a slight tweak)


## Related Issue(s)

 #2875

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

