### PR TITLE
Add loading indicator to Pipelines.vue

### DIFF
--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -37,8 +37,11 @@
             </ff-button>
         </template>
     </SectionTopMenu>
-
-    <div v-if="pipelines?.length > 0" class="pt-4 space-y-6" data-el="pipelines-list">
+    <ff-loading
+        v-if="loading"
+        message="Loading Pipelines..."
+    />
+    <div v-else-if="pipelines?.length > 0" class="pt-4 space-y-6" data-el="pipelines-list">
         <PipelineRow
             v-for="pipeline in pipelines"
             :key="pipeline.id"
@@ -125,6 +128,7 @@ export default {
     },
     data () {
         return {
+            loading: false,
             pipelines: [],
             instanceStatusMap: new Map(),
             deviceStatusMap: new Map(),
@@ -240,6 +244,8 @@ export default {
             }
         },
         async loadPipelines () {
+            this.loading = true
+
             // getPipelines doesn't include full instance status information, kick this off async
             // Not needed for devices as device status is returned as part of pipelines API
             this.loadInstanceStatus()
@@ -248,9 +254,11 @@ export default {
                 .then((pipelines) => {
                     this.pipelines = pipelines
                     this.loadDeviceGroupStatus(this.pipelines)
+                    this.loading = false
                 })
                 .catch((err) => {
                     console.error(err)
+                    this.loading = false
                 })
         },
         async loadInstanceStatus () {


### PR DESCRIPTION
fixes #3253

## Description

Shows loading instead of empty state

#### Without pipelines

![no-pipelines](https://github.com/FlowFuse/flowfuse/assets/44235289/93345bed-aadf-4815-98a8-fcc12b723779)


#### With pipelines

![with-pipelines](https://github.com/FlowFuse/flowfuse/assets/44235289/12fc6fbd-0ec4-4f79-acd8-8e43eb1e3526)


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

