### PR TITLE
Flow Blueprints Admin: Fix inactive

### DIFF
--- a/frontend/src/api/flowBlueprints.js
+++ b/frontend/src/api/flowBlueprints.js
@@ -22,13 +22,13 @@ import client from './client.js'
 
 /**
  * Get all flow blueprints from the backend
- * @param {string} state - 'active' (default), 'all' or 'inactive'
+ * @param {string} filter - 'active' (default), 'all' or 'inactive'
  * @param {G} cursor
  * @param {number} limit
  * @returns {Array.<FlowBlueprintSummary>}
  */
-const getFlowBlueprints = async (options = { state: 'active' }, cursor, limit) => {
-    const url = paginateUrl('/api/v1/flow-blueprints', cursor, limit, null, { filter: options.state })
+const getFlowBlueprints = async (options = { filter: 'active' }, cursor, limit) => {
+    const url = paginateUrl('/api/v1/flow-blueprints', cursor, limit, null, { filter: options.filter })
     return client.get(url).then(res => {
         return res.data
     })

--- a/frontend/src/pages/admin/FlowBlueprints/index.vue
+++ b/frontend/src/pages/admin/FlowBlueprints/index.vue
@@ -135,7 +135,7 @@ export default {
         },
         loadItems: async function () {
             this.loading = true
-            const result = await FlowBlueprintsApi.getFlowBlueprints('all', this.nextCursor, 30)
+            const result = await FlowBlueprintsApi.getFlowBlueprints({ filter: 'all' }, this.nextCursor, 30)
             this.nextCursor = result.meta.next_cursor
             result.blueprints.forEach(flowBlueprint => {
                 this.flowBlueprints.set(flowBlueprint.id, flowBlueprint)

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -677,7 +677,7 @@ export default {
                 return []
             }
 
-            const response = await flowBlueprintsApi.getFlowBlueprints({ state: 'active' })
+            const response = await flowBlueprintsApi.getFlowBlueprints()
             const blueprints = response.blueprints
 
             const defaultBlueprint = blueprints.find((blueprint) => blueprint.default) || blueprints[0]


### PR DESCRIPTION
## Description

Fixes inactive blueprints in the admin screen, previously only active ones were listed.

In c528025 this was changed to take an object instead of a string.

## Related Issue(s)

None

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

