### PR TITLE
Better defaults for Audit Log view

### DIFF
--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -1,36 +1,37 @@
 <template>
     <LockClosedIcon v-if="icon === 'security'" class="ff-icon" />
-    <CogIcon v-if="icon === 'settings'" class="ff-icon" />
-    <ProjectIcon v-if="icon === 'project'" class="ff-icon text-red-700" />
-    <NodeRedIcon v-if="icon === 'nodered'" class="ff-icon text-red-700" />
-    <ClockIcon v-if="icon === 'clock'" class="ff-icon text-purple-700" />
-    <BeakerIcon v-if="icon === 'beaker'" class="ff-icon text-yellow-600" />
-    <DesktopComputerIcon v-if="icon === 'stacks'" class="ff-icon text-red-700" />
-    <ColorSwatchIcon v-if="icon === 'project-types'" class="ff-icon text-red-700" />
-    <ChipIcon v-if="icon === 'device'" class="ff-icon text-blue-700" />
-    <DeviceGroupSolidIcon v-if="icon === 'device-group'" class="ff-icon text-teal-700" />
-    <MailIcon v-if="icon === 'mail'" class="ff-icon text-green-700" />
-    <IdentificationIcon v-if="icon === 'user-profile'" class="ff-icon text-green-700" />
-    <UserIcon v-if="icon === 'user'" class="ff-icon text-green-700" />
-    <UserGroupIcon v-if="icon === 'users'" class="ff-icon text-teal-700" />
-    <CurrencyDollarIcon v-if="icon === 'billing'" class="ff-icon text-yellow-500" />
-    <KeyIcon v-if="icon === 'key'" class="ff-icon text-green-700" />
-    <KeyIcon v-if="icon === 'overage'" class="ff-icon text-red-700" />
-    <LoginIcon v-if="icon === 'login'" class="ff-icon text-blue-700" />
-    <LogoutIcon v-if="icon === 'logout'" class="ff-icon text-gray-600" />
-    <ExclamationCircleIcon v-if="icon === 'error'" class="ff-icon text-red-500" />
-    <TicketIcon v-if="icon === 'token'" class="ff-icon text-blue-500" />
-    <TemplateIcon v-if="icon === 'template'" class="ff-icon text-red-700" />
-    <PipelineIcon v-if="icon === 'pipeline'" class="ff-icon text-indigo-600" />
-    <ExclamationIcon v-if="icon === 'resource'" class="ff-icon text-yellow-500" />
+    <CogIcon v-else-if="icon === 'settings'" class="ff-icon" />
+    <NodeRedIcon v-else-if="icon === 'nodered'" class="ff-icon text-red-700" />
+    <ProjectIcon v-else-if="icon === 'project'" class="ff-icon text-red-700" />
+    <TemplateIcon v-else-if="icon === 'template'" class="ff-icon text-red-700" />
+    <PipelineIcon v-else-if="icon === 'pipeline'" class="ff-icon text-indigo-600" />
+    <ChipIcon v-else-if="icon === 'device'" class="ff-icon text-blue-700" />
+    <BeakerIcon v-else-if="icon === 'beaker'" class="ff-icon text-yellow-600" />
+    <DeviceGroupSolidIcon v-else-if="icon === 'device-group'" class="ff-icon text-teal-700" />
+    <UserIcon v-else-if="icon === 'user'" class="ff-icon text-green-700" />
+    <ClockIcon v-else-if="icon === 'clock'" class="ff-icon text-purple-700" />
+    <LoginIcon v-else-if="icon === 'login'" class="ff-icon text-blue-700" />
+    <LogoutIcon v-else-if="icon === 'logout'" class="ff-icon text-gray-600" />
+    <MailIcon v-else-if="icon === 'mail'" class="ff-icon text-green-700" />
+    <UserGroupIcon v-else-if="icon === 'users'" class="ff-icon text-teal-700" />
+    <DesktopComputerIcon v-else-if="icon === 'stacks'" class="ff-icon text-red-700" />
+    <ColorSwatchIcon v-else-if="icon === 'project-types'" class="ff-icon text-red-700" />
+    <IdentificationIcon v-else-if="icon === 'user-profile'" class="ff-icon text-green-700" />
+    <ExclamationCircleIcon v-else-if="icon === 'error'" class="ff-icon text-red-500" />
+    <TicketIcon v-else-if="icon === 'token'" class="ff-icon text-blue-500" />
+    <ExclamationIcon v-else-if="icon === 'resource'" class="ff-icon text-yellow-500" />
+    <CurrencyDollarIcon v-else-if="icon === 'billing'" class="ff-icon text-yellow-500" />
+    <KeyIcon v-else-if="icon === 'key'" class="ff-icon text-green-700" />
+    <KeyIcon v-else-if="icon === 'overage'" class="ff-icon text-red-700" />
+    <InformationCircleIcon v-else class="ff-icon text-gray-600" />
 </template>
 
 <script>
 
 import {
-    BeakerIcon, ChipIcon, ClockIcon, CogIcon,
-    ColorSwatchIcon, CurrencyDollarIcon, DesktopComputerIcon,
-    ExclamationCircleIcon, ExclamationIcon, IdentificationIcon,
+    BeakerIcon, ChipIcon, ClockIcon, CogIcon, ColorSwatchIcon,
+    CurrencyDollarIcon, DesktopComputerIcon, ExclamationCircleIcon,
+    ExclamationIcon, IdentificationIcon, InformationCircleIcon,
     KeyIcon, LockClosedIcon, LoginIcon, LogoutIcon, MailIcon,
     TemplateIcon, TicketIcon, UserGroupIcon, UserIcon
 } from '@heroicons/vue/outline'
@@ -227,10 +228,22 @@ export default {
         }
     },
     setup (props) {
-        for (const [icon, events] of Object.entries(iconMap)) {
-            if (events.includes(props.event)) {
-                return {
-                    icon
+        // convert the iconMap into an object where the key is the event and the value is the icon
+        const flatIconMap = Object.entries(iconMap).flatMap(([icon, events]) => events.map(event => [event, icon]))
+        const icon = flatIconMap.find(([event]) => event === props.event)
+
+        if (icon) {
+            return { icon: icon[1] }
+        }
+        // if we get here, we don't have an icon for this event. Lets
+        // at least attempt to show something relevant by looking at
+        // the first two parts of the event
+        const eventParts = props.event.split('.')
+        if (eventParts.length > 1) {
+            const first2Parts = eventParts.slice(0, 2).join('.')
+            for (const [event, icon] of flatIconMap) {
+                if (event.startsWith(first2Parts)) {
+                    return { icon }
                 }
             }
         }
@@ -261,7 +274,8 @@ export default {
         CurrencyDollarIcon,
         ExclamationCircleIcon,
         ExclamationIcon,
-        TicketIcon
+        TicketIcon,
+        InformationCircleIcon
     }
 }
 </script>

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -555,8 +555,8 @@
 
     <!-- Catch All -->
     <template v-else>
-        <label>{{ AuditEvents[entry.event] }}: {{ entry.event }}</label>
-        <span>We have no details available for this event type</span>
+        <label>{{ computeLabelForUnknown(entry) }}</label>
+        <span>We have no details available for event type{{ entry?.event ? ` '${entry.event}'` : '' }}</span>
     </template>
 
     <template v-if="error">
@@ -604,6 +604,23 @@ export default {
         ChevronRightIcon,
         ChevronDownIcon,
         AuditEntryUpdates
+    },
+    methods: {
+        computeLabelForUnknown (entry) {
+            if (!entry?.event) return 'Unknown'
+            const known = !!this.AuditEvents[entry.event]
+            if (known) {
+                return this.AuditEvents[entry.event]
+            }
+            let labelText = entry.event
+            // now replace any dashes, dots, underscores or colons with spaces
+            labelText = labelText.replace(/[-._:]/g, ' ')
+            // now capitalise the first letter of each word
+            labelText = labelText.replace(/\b\w/g, l => l.toUpperCase())
+            // replace camel case with spaces
+            labelText = labelText.replace(/([a-z])([A-Z])/g, '$1 $2')
+            return labelText
+        }
     }
 }
 </script>


### PR DESCRIPTION
closes #3125

## Description

Improve the situation where audit log entries do not have a matching icon or string.

NOTE: This is not meant to be a substitute for making the necessary updates when adding new audit log entries BUT it will be a catch all and will handle cases out of our control (like new or unhandled Node-RED events)
As discussed in the task:
> Forgetting for the moment, all new audit entries should have the UI when they are submitted, do we want to consider presenting new Audit entries a little friendlier?

More background: https://github.com/FlowFuse/flowfuse/issues/2302#issuecomment-1825756477



### Platform Log

#### Before
![image](https://github.com/FlowFuse/flowfuse/assets/44235289/f5872d2d-3e12-48b9-be41-89def3f56852)

#### After

![image](https://github.com/FlowFuse/flowfuse/assets/44235289/2617f960-a371-4f80-99a8-73e6ee1c2d69)



### Team Log

#### Before

![image](https://github.com/FlowFuse/flowfuse/assets/44235289/3939b506-9125-4e5e-a437-0a7a02fe4f2f)

#### After

![image](https://github.com/FlowFuse/flowfuse/assets/44235289/e2e06646-6739-4530-a174-3a44c44eb7f1)



### Application Log

#### Before

![image](https://github.com/FlowFuse/flowfuse/assets/44235289/4ea5e575-69d2-47f9-acb3-ed8b3e5c604c)


#### After

![image](https://github.com/FlowFuse/flowfuse/assets/44235289/92b6598f-be62-4c9f-b9f8-1489d29e1cdf)




### Instance/Project Log

#### Before

![image](https://github.com/FlowFuse/flowfuse/assets/44235289/27ef37e1-0bae-4a59-815a-9704c5ca82b2)


#### After

![image](https://github.com/FlowFuse/flowfuse/assets/44235289/3ffe9ba9-a287-4c6d-97bb-17e8e33a3ade)


## Related Issue(s)

#3125

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

