### PR TITLE
Update platform audit-log to provide correct set of event types to filter with

### DIFF
--- a/frontend/src/pages/admin/AuditLog.vue
+++ b/frontend/src/pages/admin/AuditLog.vue
@@ -1,5 +1,5 @@
 <template>
-    <AuditLogBrowser ref="AuditLog" :users="users" :logEntries="logEntries" logType="project" @load-entries="loadEntries">
+    <AuditLogBrowser ref="AuditLog" :users="users" :logEntries="logEntries" logType="platform" @load-entries="loadEntries">
         <template #title>
             <SectionTopMenu hero="Platform Audit Log" info="Recorded events that have taken place at the Platform level." />
         </template>


### PR DESCRIPTION
The list of available event types in the Platform-wide Activity log has the wrong set of types.

This updates the view to offer the platform event types.