### PR TITLE
Fix subscription deletion when putting into unmanaged mode

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -546,7 +546,7 @@ module.exports.init = async function (app) {
                             // needed by closeSubscription. This is to ensure when the
                             // stripe callback arrives we don't trigger a suspension of
                             // the team resources.
-                            await stripe.subscriptions.del(subscription.subscription, {
+                            await stripe.subscriptions.del(existingSubscription, {
                                 invoice_now: true,
                                 prorate: true
                             })

--- a/test/unit/forge/ee/lib/billing/index_spec.js
+++ b/test/unit/forge/ee/lib/billing/index_spec.js
@@ -359,6 +359,7 @@ describe('Billing', function () {
 
             // Check we asked stripe to delete/cancel the subscription
             stripe.subscriptions.del.called.should.be.true()
+            stripe.subscriptions.del.lastCall.args[0].should.equal('sub_1234')
         })
     })
 


### PR DESCRIPTION
## Description

A regression was introduced in #3181 that meant when putting teams into unmanaged mode, we'd try to delete a subscription with an id of `''` - not gonna happen.

This fixes that and improves the existing unit test to ensure the delete function is called with the expected subscription id.