### PR TITLE
Validate team id when deleting team invitation

### DIFF
--- a/forge/routes/api/teamInvitations.js
+++ b/forge/routes/api/teamInvitations.js
@@ -217,7 +217,7 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const invitation = await app.db.models.Invitation.byId(request.params.invitationId)
-        if (invitation) {
+        if (invitation && invitation.teamId === request.team.id) {
             const role = invitation.role || Roles.Member
             const invitedUser = app.auditLog.formatters.userObject(invitation.external ? invitation : invitation.invitee)
             await invitation.destroy()


### PR DESCRIPTION
## Description

This ensures that when an invite is deleted, it is done within the context of the owning team.

Fixes https://github.com/FlowFuse/security/issues/42