### PR TITLE
Allow team membership to be managed by SAML Group assertion

### DIFF
--- a/docs/admin/sso/README.md
+++ b/docs/admin/sso/README.md
@@ -106,8 +106,10 @@ The following configuration options should then be set:
      - `Apply to selected teams` - this will restrict what teams can be managed to the provided list. This
        is suitable for shared-tenancy platforms with multiple SSO configurations for different groups of users,
        such as FlowFuse Cloud.
-       In this mode, users who sign-in via this SSO configuration can *only* be members of the configured teams - 
-       they will be removed from any team not in this list.
+       When this option is selected, an additional option is available - `Allow users to be in other teams`. This
+       will allow users who sign-in via this SSO configuration to be members of teams not in the list above.
+       Their membership of those teams will not be managed by the SSO groups.
+       If that option is disabled, then the user will be removed from any teams not in the list above.
 
 ### SAML Groups configuration
 

--- a/docs/admin/sso/README.md
+++ b/docs/admin/sso/README.md
@@ -87,23 +87,65 @@ The general points are:
 Once you have setup both sides of the configuration you can enable it for use
 by ticking the `active` checkbox and clicking `Update configuration`.
 
+## Managing Team Membership with SAML Groups
+
+Some SAML providers allow user group information to be shared as part of the sign-in process.
+When properly configured, this can be used to manage what FlowFuse teams a user has access to.
+
+To enable this option, select the `Manage roles using group assertions` in the SSO configuration.
+
+The following configuration options should then be set:
+
+ - `Group Assertion Name` - this is used to identify the group membership information in the response
+   sent by the Identity Provider. It defaults to `ff-roles` but can be customised if the Identify Provider
+   requires it.
+ - `Team Scope` - this determines what teams can be managed using this configuration. There are two options:
+     - `Apply to all teams` - this will allow the SAML groups to manage all teams on the platform. This is
+       suitable for a self-hosted installation of FlowFuse with a single SSO configuration for all users on
+       the platform.
+     - `Apply to selected teams` - this will restrict what teams can be managed to the provided list. This
+       is suitable for shared-tenancy platforms with multiple SSO configurations for different groups of users,
+       such as FlowFuse Cloud.
+       In this mode, users who sign-in via this SSO configuration can *only* be members of the configured teams - 
+       they will be removed from any team not in this list.
+
+### SAML Groups configuration
+
+A user's team membership is managed by what groups they are in. When the user logs in, the SAML provider
+must be configured to provide a list of groups they are a member of as a SAML assertion.
+
+The group name is used to identify a team, using its slug property, and the user's role in the team.
+The name must take the form `ff-<team>-<role>`. For example, the group `ff-development-owner` will
+container the owners of the team `development`.
+
+The valid roles for a user in a team are:
+ - `owner`
+ - `member`
+ - `viewer`
+ - `dashboard`
+
+*Note*: this uses the team slug property to identify the team. This has been chosen to simplify managing
+the groups in the SAML Provider - rather than using the team's id. However, a team's slug can be changed
+by a team owner. Doing so will break the link between the group and the team membership - so should only
+be done with care.
 
 ## Providers
 
 The following is a non-exhaustive list of the providers that are known to work
 with FlowFuse SAML SSO.
 
- - [Azure AD](#azure-ad)
+ - [Microsoft Entra](#microsoft-entra)
  - [Google Workspace](#google-workspace)
  - [OneLogin](#onelogin)
+ - [Okta](#okta)
 
-### Azure AD
+### Microsoft Entra
 
-Microsoft provide a guide for creating a custom SAML Application [here](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/add-application-portal).
+Microsoft provide a guide for creating a custom SAML Application [here](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/add-application-portal).
 
-The following table maps the Azure terminology to the FlowFuse settings.
+The following table maps the Entra terminology to the FlowFuse settings.
 
-FlowFuse Setting | Azure Setting
+FlowFuse Setting | Entra Setting
 ----|----
 `ACS URL` | `Reply URL (Assertion Consumer Service URL)`
 `Identity Provider Single Sign-On URL` | `App Federation Metadata Url`
@@ -111,6 +153,15 @@ FlowFuse Setting | Azure Setting
 `X.509 Certificate Public Key` | `Certificate (Base64)`
 
 Within the `SAML Signing Certificate` configuration, the `Signing Option` must be set to `Sign SAML response and assertion`.
+
+#### Group Membership Configuration
+
+By default, when enabled, Entra will share group assertions under the name `http://schemas.microsoft.com/ws/2008/06/identity/claims/groups` and provides the groups as a list of object ids.
+
+Either the `Group Assertion Name` should be set to this name, or Entra configured to use a custom
+assertion name that matches the FlowFuse SSO Configuration value.
+
+Entra must also be configured to return group names rather than object ids.
 
 ### Google Workspace
 
@@ -139,3 +190,35 @@ FlowFuse Setting | OneLogin Setting
 `Identity Provider Single Sign-On URL` | `SAML 2.0 Endpoint (HTTP)`
 `Identity Provider Issuer ID / URL` | `Issuer URL`
 `X.509 Certificate Public Key` | `X.509 Certificate`
+
+### Okta
+
+Within your Okta Admin dashboard, browse the App Integration catalog and add a new
+instance of the `SAML Service Provider` integration.
+
+
+On the Sign-On Options section, ensure SAML 2.0 is selected. Below that section
+you will see a notice saying:
+
+> SAML 2.0 in not configured until you complete the setup instructions.
+
+Click the 'View setup instructions' button to open the page in a new window.
+
+Follow the instructions on that - copying the `Identity Provider Issuer`,
+`Identity Provider HTTP POST URL` and `Identity Provider Certificate` values
+into the FlowFuse SSO configuration.
+
+Back on the Okta SAML Application configuration page, under the `Advanced Sign-on Settings`
+section enter the `Assertion Consumer Service URL` and `Service Provider Entity Id`
+from the FlowFuse SSO configuration.
+
+Under `Credential Details` section, change the Application username format to `Email`.
+
+#### Group Membership Configuration
+
+To configure Okta to return Group assertions, edit the Settings of the SAML Service Provider's
+SAML 2.0 configuration. Expand the 'Attributes' section and add a `Group Attribute Statement`.
+
+The name must match the `Group Assertion Name` in the FlowFuse SSO configuration (default: `ff-roles`).
+You can optionally add a filter of `ff-` so that it only returns groups used by FlowFuse.
+

--- a/forge/db/models/TeamMember.js
+++ b/forge/db/models/TeamMember.js
@@ -48,6 +48,22 @@ module.exports = {
                         }
                     })
                 },
+                getTeamsForUser: async (userId, includeTeam = false) => {
+                    if (typeof userId === 'string') {
+                        userId = M.User.decodeHashid(userId)
+                    }
+                    const opts = {
+                        where: {
+                            UserId: userId
+                        }
+                    }
+                    if (includeTeam) {
+                        opts.include = {
+                            model: M.Team
+                        }
+                    }
+                    return this.findAll(opts)
+                },
                 getTeamMembership: async (userId, teamId, includeTeam) => {
                     if (typeof teamId === 'string') {
                         teamId = M.Team.decodeHashid(teamId)

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -256,6 +256,9 @@ module.exports = {
                 getTeamsOwned: async function () {
                     return M.TeamMember.getTeamsOwnedBy(this.id)
                 },
+                getTeamMemberships: async function (includeTeam = false) {
+                    return M.TeamMember.getTeamsForUser(this.id, includeTeam)
+                },
                 teamCount: async function () {
                     return M.TeamMember.count({
                         where: {

--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -163,7 +163,7 @@ module.exports.init = async function (app) {
 
             await Promise.all(promises)
         } else {
-            const missingGroupAssertions = new Error(`SAML response missing ${providerOpts.groupAssertionName} assertion`)
+            const missingGroupAssertions = new Error(`SAML response missing ${providerOpts.groupsAssertionName} assertion`)
             missingGroupAssertions.code = 'unknown_sso_user'
             throw missingGroupAssertions
         }

--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -1,3 +1,5 @@
+const { Roles, TeamRoles } = require('../../../lib/roles')
+
 module.exports.init = async function (app) {
     // Set the SSO feature flag
     app.config.features.register('sso', true, true)
@@ -60,10 +62,118 @@ module.exports.init = async function (app) {
         return false
     }
 
+    /**
+     * Update a user's team memberships according to the SAML Assertions
+     * received when they logged in.
+     *
+     * @param {*} samlUser The user profile object provided by the authentication provider
+     * @param {*} user The FF User object who is logging in
+     * @param {*} providerOpts The SAML Provider configuration object
+     */
+    async function updateTeamMembership (samlUser, user, providerOpts) {
+        // Look for the expected assertion in the SAML profile we have received
+        // This is an array of groups the user belongs to. We expect them to be
+        // of the form 'ff-SLUG-ROLE' - anything else is ignored
+        let groupAssertions = samlUser[providerOpts.groupsAssertionName]
+        if (groupAssertions) {
+            const promises = []
+            if (!Array.isArray(groupAssertions)) {
+                groupAssertions = [groupAssertions]
+            }
+            const desiredTeamMemberships = {}
+            groupAssertions.forEach(ga => {
+                // Parse the group name - format: 'ff-SLUG-ROLE'
+                // Generate a slug->role object (desiredTeamMemberships)
+                const match = /^ff-(.+)-([^-]+)$/.exec(ga)
+                if (match) {
+                    const teamSlug = match[1]
+                    const teamRoleName = match[2]
+                    const teamRole = Roles[teamRoleName]
+                    // Check this role is a valid team role
+                    if (TeamRoles.includes(teamRole)) {
+                        // Check if this team is allowed to be managed for this SSO provider
+                        //  - either `groupAllTeams` is true (allowing all teams to be managed this way)
+                        //  - or `groupTeams` (array) contains the teamSlug
+                        if (providerOpts.groupAllTeams || (providerOpts.groupTeams || []).includes(teamSlug)) {
+                            // In case we have multiple assertions for a single team,
+                            // ensure we keep the highest level of access
+                            desiredTeamMemberships[teamSlug] = Math.max(desiredTeamMemberships[teamSlug] || 0, teamRole)
+                        }
+                    }
+                }
+            })
+
+            // Get the existing memberships and generate a slug->membership object (existingMemberships)
+            const existingMemberships = {}
+            ;((await user.getTeamMemberships(true)) || []).forEach(membership => {
+                existingMemberships[membership.Team.slug] = membership
+            })
+
+            // We now have the list of desiredTeamMemberships and existingMemberships
+
+            // - Check each existing membership
+            //   - if in desired list, update role to match and delete from desired list
+            //   - if not in desired list, delete membership
+            for (const [teamSlug, membership] of Object.entries(existingMemberships)) {
+                if (Object.hasOwn(desiredTeamMemberships, teamSlug)) {
+                    // This team is in the desired list
+                    if (desiredTeamMemberships[teamSlug] !== membership.role) {
+                        // Role has changed - update membership
+                        // console.log(`changing role in team ${teamSlug} from ${membership.role} to ${desiredTeamMemberships[teamSlug]}`)
+
+                        const updates = new app.auditLog.formatters.UpdatesCollection()
+                        const oldRole = app.auditLog.formatters.roleObject(membership.role)
+                        const role = app.auditLog.formatters.roleObject(desiredTeamMemberships[teamSlug])
+                        updates.push('role', oldRole.role, role.role)
+                        membership.role = desiredTeamMemberships[teamSlug]
+                        promises.push(membership.save().then(() => {
+                            return app.auditLog.Team.team.user.roleChanged(user, null, membership.Team, user, updates)
+                        }))
+                    } else {
+                        // Role has not changed - no update needed
+                        // console.log(`no change needed for team ${teamSlug} role ${membership.role}`)
+                    }
+                    // Remove from the desired list as it has been dealt with
+                    delete desiredTeamMemberships[teamSlug]
+                } else {
+                    // console.log(`removing from team ${teamSlug}`)
+                    // This team is not in the desired list - delete the membership
+                    promises.push(membership.destroy().then(() => {
+                        return app.auditLog.Team.team.user.removed(user, null, membership.Team, user)
+                    }))
+                }
+            }
+            // - Check remaining desired memberships
+            //   - create membership
+            for (const [teamSlug, teamRole] of Object.entries(desiredTeamMemberships)) {
+                // This is a new team membership
+                promises.push(app.db.models.Team.bySlug(teamSlug).then(team => {
+                    if (team) {
+                        // console.log(`adding to team ${teamSlug} role ${teamRole}`)
+                        return app.db.controllers.Team.addUser(team, user, teamRole).then(() => {
+                            return app.auditLog.Team.team.user.added(user, null, team, user)
+                        })
+                    } else {
+                        // console.log(`team not found ${teamSlug}`)
+                        // Unrecognised team - ignore
+                        return null
+                    }
+                }))
+            }
+
+            await Promise.all(promises)
+        } else {
+            const missingGroupAssertions = new Error(`SAML response missing ${providerOpts.groupAssertionName} assertion`)
+            missingGroupAssertions.code = 'unknown_sso_user'
+            throw missingGroupAssertions
+        }
+    }
+
     return {
         handleLoginRequest,
         isSSOEnabledForEmail,
         getProviderOptions,
-        getProviderForEmail
+        getProviderForEmail,
+        updateTeamMembership
     }
 }

--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -74,7 +74,7 @@ module.exports.init = async function (app) {
         // Look for the expected assertion in the SAML profile we have received
         // This is an array of groups the user belongs to. We expect them to be
         // of the form 'ff-SLUG-ROLE' - anything else is ignored
-        let groupAssertions = samlUser[providerOpts.groupsAssertionName]
+        let groupAssertions = samlUser[providerOpts.groupAssertionName]
         if (groupAssertions) {
             const promises = []
             if (!Array.isArray(groupAssertions)) {
@@ -163,7 +163,7 @@ module.exports.init = async function (app) {
 
             await Promise.all(promises)
         } else {
-            const missingGroupAssertions = new Error(`SAML response missing ${providerOpts.groupsAssertionName} assertion`)
+            const missingGroupAssertions = new Error(`SAML response missing ${providerOpts.groupAssertionName} assertion`)
             missingGroupAssertions.code = 'unknown_sso_user'
             throw missingGroupAssertions
         }

--- a/forge/lib/roles.js
+++ b/forge/lib/roles.js
@@ -15,6 +15,11 @@ const RoleNames = {
     [Roles.Admin]: 'admin'
 }
 
+// For convenience, we want to be able to look up role values with both 'Role' and 'role'
+Object.keys(RoleNames).forEach(role => {
+    Roles[RoleNames[role]] = parseInt(role)
+})
+
 const TeamRoles = [
     Roles.Dashboard,
     Roles.Viewer,

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -43,7 +43,7 @@
                     </FormRow>
                     <FormRow v-model="input.options.groupMapping" type="checkbox">Manage roles using group assertions</FormRow>
                     <div v-if="input.options.groupMapping" class="pl-4 space-y-6">
-                        <FormRow v-model="input.options.groupsAssertionName" :error="groupAssertionNameError">
+                        <FormRow v-model="input.options.groupAssertionName" :error="groupAssertionNameError">
                             Group Assertion Name
                             <template #description>The name of the SAML Assertion containing group membership details</template>
                         </FormRow>
@@ -118,7 +118,7 @@ export default {
             )
         },
         isGroupAssertionNameValid () {
-            return this.input.options.groupsAssertionName.length > 0
+            return this.input.options.groupAssertionName.length > 0
         },
         groupAssertionNameError () {
             return !this.isGroupAssertionNameValid ? 'Group Asserion name is required' : ''
@@ -175,7 +175,7 @@ export default {
                 }
                 if (!opts.options.groupMapping) {
                     // Remove any group-related config
-                    delete opts.options.groupsAssertionName
+                    delete opts.options.groupAssertionName
                     delete opts.options.groupAllTeams
                     delete opts.options.groupTeams
                     // delete opts.options.groupAdmin
@@ -210,7 +210,7 @@ export default {
                     groupAllTeams: true,
                     // groupAdmin: false,
                     // groupAdminName: 'ff-admins',
-                    groupsAssertionName: 'ff-roles'
+                    groupAssertionName: 'ff-roles'
                 }
             } else {
                 this.loading = true
@@ -224,7 +224,7 @@ export default {
                     this.input.options.groupAllTeams = this.input.options.groupAllTeams ?? false
                     // this.input.options.groupAdmin = this.input.options.groupAdmin ?? false
                     // this.input.options.groupAdminName = this.input.options.groupAdminName || 'ff-admins'
-                    this.input.options.groupsAssertionName = this.input.options.groupsAssertionName || 'ff-roles'
+                    this.input.options.groupAssertionName = this.input.options.groupAssertionName || 'ff-roles'
                     // groupTeams is stored as an array - convert to multi-line string for the edit form
                     this.input.options.groupTeams = (this.input.options.groupTeams || []).join('\n')
                     this.originalValues = JSON.stringify(this.input)

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -8,7 +8,7 @@
             </template>
         </SideNavigation>
     </Teleport>
-    <main>
+    <ff-page>
         <div class="max-w-2xl m-auto">
             <ff-loading v-if="loading && !isCreate" message="Loading SSO Configuration..." />
             <ff-loading v-if="loading && isCreate" message="Creating SSO Configuration..." />
@@ -25,6 +25,7 @@
                     Create configuration
                 </ff-button>
                 <template v-else>
+                    <FormRow v-model="input.active" type="checkbox">Active</FormRow>
                     <FormRow v-model="provider.acsURL" type="uneditable">ACS URL</FormRow>
                     <FormRow v-model="provider.entityID" type="uneditable">Entity ID / Issuer</FormRow>
                     <FormRow v-model="input.options.entryPoint">
@@ -40,14 +41,30 @@
                         <template #description>Supplied by your Identity Provider</template>
                         <template #input><textarea v-model="input.options.cert" class="font-mono w-full" placeholder="---BEGIN CERTIFICATE---&#10;loremipsumdolorsitamet&#10;consecteturadipiscinge&#10;---END CERTIFICATE---&#10;" rows="6" /></template>
                     </FormRow>
-                    <FormRow v-model="input.active" type="checkbox">Active</FormRow>
+                    <FormRow v-model="input.options.groupMapping" type="checkbox">Manage roles using group assertions</FormRow>
+                    <div v-if="input.options.groupMapping" class="pl-4 space-y-6">
+                        <FormRow v-model="input.options.groupsAssertionName" :error="groupAssertionNameError">
+                            Group Assertion Name
+                            <template #description>The name of the SAML Assertion containing group membership details</template>
+                        </FormRow>
+                        <FormRow v-model="input.options.groupAllTeams" :options="[{ value:true, label: 'Apply to all teams' }, { value:false, label: 'Apply to selected teams' }]">
+                            Team Scope
+                            <template #description>Should this apply to all teams on the platform, or just a restricted list of teams</template>
+                        </FormRow>
+                        <FormRow v-if="input.options.groupAllTeams === false" v-model="input.options.groupTeams" class="pl-4">
+                            <template #description>A list of team <b>slugs</b> that will managed by this configuration - one per line</template>
+                            <template #input><textarea v-model="input.options.groupTeams" class="font-mono w-full" rows="6" /></template>
+                        </FormRow>
+                        <!-- <FormRow v-model="input.options.groupAdmin" type="checkbox">Manage Admin roles using group assertions</FormRow>
+                        <FormRow v-if="input.options.groupAdmin" v-model="input.options.groupAdminName" :error="groupAdminNameError" class="pl-4">Admin Users SAML Group name</FormRow> -->
+                    </div>
                     <ff-button :disabled="!formValid" @click="updateProvider()">
                         Update configuration
                     </ff-button>
                 </template>
             </form>
         </div>
-    </main>
+    </ff-page>
 </template>
 
 <script>
@@ -82,7 +99,9 @@ export default {
                 name: '',
                 domainFilter: '',
                 active: false,
-                options: {}
+                options: {
+                    groupMapping: false
+                }
             },
             errors: {}
         }
@@ -92,8 +111,26 @@ export default {
         isCreate () {
             return this.$route.params.id === 'create'
         },
+        isGroupOptionsValid () {
+            return !this.input.options.groupMapping || (
+                this.isGroupAssertionNameValid
+                // && this.isGroupAdminNameValid
+            )
+        },
+        isGroupAssertionNameValid () {
+            return this.input.options.groupsAssertionName.length > 0
+        },
+        groupAssertionNameError () {
+            return !this.isGroupAssertionNameValid ? 'Group Asserion name is required' : ''
+        },
+        // isGroupAdminNameValid () {
+        //     return !this.input.options.groupAdmin || this.input.options.groupAdminName.length > 0
+        // },
+        // groupAdminNameError () {
+        //     return !this.isGroupAdminNameValid ? 'Admin Group name is required' : ''
+        // },
         formValid () {
-            return (this.isCreate && !!this.input.domainFilter) || (!this.isCreate && JSON.stringify(this.input) !== this.originalValues)
+            return this.isGroupOptionsValid && ((this.isCreate && !!this.input.domainFilter) || (!this.isCreate && JSON.stringify(this.input) !== this.originalValues))
         },
         pageTitle () {
             if (this.isCreate) {
@@ -136,6 +173,24 @@ export default {
                 const opts = {
                     ...this.input
                 }
+                if (!opts.options.groupMapping) {
+                    // Remove any group-related config
+                    delete opts.options.groupsAssertionName
+                    delete opts.options.groupAllTeams
+                    delete opts.options.groupTeams
+                    // delete opts.options.groupAdmin
+                    // delete opts.options.groupAdminName
+                } else {
+                    if (opts.options.groupAllTeams) {
+                        delete opts.options.groupTeams
+                    } else {
+                        // groupTeams is stored as an array of team ids.
+                        opts.options.groupTeams = opts.options.groupTeams.split(/(?:\r|\n|\r\n)/).filter(n => n.trim().length > 0)
+                    }
+                    // if (!opts.options.groupAdmin) {
+                    //     delete opts.options.groupAdminName
+                    // }
+                }
                 delete opts.id
                 ssoApi.updateProvider(this.provider.id, opts).then(response => {
                     this.$router.push({ name: 'AdminSettingsSSO' })
@@ -150,7 +205,13 @@ export default {
                 this.input.name = ''
                 this.input.domainFilter = ''
                 this.input.active = false
-                this.input.options = {}
+                this.input.options = {
+                    groupMapping: false,
+                    groupAllTeams: true,
+                    // groupAdmin: false,
+                    // groupAdminName: 'ff-admins',
+                    groupsAssertionName: 'ff-roles'
+                }
             } else {
                 this.loading = true
                 try {
@@ -159,6 +220,13 @@ export default {
                     this.input.domainFilter = this.provider.domainFilter
                     this.input.active = this.provider.active
                     this.input.options = { ...this.provider.options }
+                    this.input.options.groupMapping = this.input.options.groupMapping ?? true
+                    this.input.options.groupAllTeams = this.input.options.groupAllTeams ?? false
+                    // this.input.options.groupAdmin = this.input.options.groupAdmin ?? false
+                    // this.input.options.groupAdminName = this.input.options.groupAdminName || 'ff-admins'
+                    this.input.options.groupsAssertionName = this.input.options.groupsAssertionName || 'ff-roles'
+                    // groupTeams is stored as an array - convert to multi-line string for the edit form
+                    this.input.options.groupTeams = (this.input.options.groupTeams || []).join('\n')
                     this.originalValues = JSON.stringify(this.input)
                 } catch (err) {
                     if (err.response.status === 404) {

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -55,6 +55,13 @@
                             <template #description>A list of team <b>slugs</b> that will managed by this configuration - one per line</template>
                             <template #input><textarea v-model="input.options.groupTeams" class="font-mono w-full" rows="6" /></template>
                         </FormRow>
+                        <FormRow v-if="input.options.groupAllTeams === false" v-model="input.options.groupOtherTeams" type="checkbox" class="pl-4">
+                            Allow users to be in other teams
+                            <template #description>
+                                If enabled, users can be members of any teams not listed above and their membership/roles are not managed
+                                by this SSO configuration.
+                            </template>
+                        </FormRow>
                         <!-- <FormRow v-model="input.options.groupAdmin" type="checkbox">Manage Admin roles using group assertions</FormRow>
                         <FormRow v-if="input.options.groupAdmin" v-model="input.options.groupAdminName" :error="groupAdminNameError" class="pl-4">Admin Users SAML Group name</FormRow> -->
                     </div>
@@ -183,6 +190,7 @@ export default {
                 } else {
                     if (opts.options.groupAllTeams) {
                         delete opts.options.groupTeams
+                        delete opts.options.groupOtherTeams
                     } else {
                         // groupTeams is stored as an array of team ids.
                         opts.options.groupTeams = opts.options.groupTeams.split(/(?:\r|\n|\r\n)/).filter(n => n.trim().length > 0)
@@ -208,6 +216,7 @@ export default {
                 this.input.options = {
                     groupMapping: false,
                     groupAllTeams: true,
+                    groupOtherTeams: false,
                     // groupAdmin: false,
                     // groupAdminName: 'ff-admins',
                     groupAssertionName: 'ff-roles'
@@ -222,6 +231,7 @@ export default {
                     this.input.options = { ...this.provider.options }
                     this.input.options.groupMapping = this.input.options.groupMapping ?? true
                     this.input.options.groupAllTeams = this.input.options.groupAllTeams ?? false
+                    this.input.options.groupOtherTeams = this.input.options.groupOtherTeams ?? false
                     // this.input.options.groupAdmin = this.input.options.groupAdmin ?? false
                     // this.input.options.groupAdminName = this.input.options.groupAdminName || 'ff-admins'
                     this.input.options.groupAssertionName = this.input.options.groupAssertionName || 'ff-roles'

--- a/test/unit/forge/ee/lib/sso/index_spec.js
+++ b/test/unit/forge/ee/lib/sso/index_spec.js
@@ -212,7 +212,10 @@ d
 
         it('errors if samlUser missing group assertions', async function () {
             const result = app.sso.updateTeamMembership({}, app.user, { groupsAssertionName: 'ff-roles' })
-            result.should.be.rejectedWith(/response missing ff-roles assertion/)
+            result.should.be.rejected()
+            await result.catch(err => {
+                err.toString().should.match(/SAML response missing ff-roles assertion/)
+            })
         })
 
         it('applies team membership changes - all teams', async function () {

--- a/test/unit/forge/ee/lib/sso/index_spec.js
+++ b/test/unit/forge/ee/lib/sso/index_spec.js
@@ -211,7 +211,7 @@ d
         })
 
         it('errors if samlUser missing group assertions', async function () {
-            const result = app.sso.updateTeamMembership({}, app.user, { groupsAssertionName: 'ff-roles' })
+            const result = app.sso.updateTeamMembership({}, app.user, { groupAssertionName: 'ff-roles' })
             result.should.be.rejected()
             await result.catch(err => {
                 err.toString().should.match(/SAML response missing ff-roles assertion/)
@@ -246,7 +246,7 @@ d
                     'ff-unknownTeam-viewer'
                 ]
             }, app.user, {
-                groupsAssertionName: 'ff-roles',
+                groupAssertionName: 'ff-roles',
                 groupAllTeams: true
             })
             ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)).should.have.property('role', Roles.Member)
@@ -278,7 +278,7 @@ d
                     'ff-unknownTeam-viewer'
                 ]
             }, app.user, {
-                groupsAssertionName: 'ff-roles',
+                groupAssertionName: 'ff-roles',
                 groupTeams: ['ateam', 'bteam']
             })
             ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)).should.have.property('role', Roles.Member)
@@ -306,7 +306,7 @@ d
                     'ff-dteam-viewer'
                 ]
             }, app.user, {
-                groupsAssertionName: 'ff-roles',
+                groupAssertionName: 'ff-roles',
                 groupAllTeams: true
             })
             ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.CTeam.id)).should.have.property('role', Roles.Owner)
@@ -329,7 +329,7 @@ d
                     'ff-ateam-admin'
                 ]
             }, app.user, {
-                groupsAssertionName: 'ff-roles',
+                groupAssertionName: 'ff-roles',
                 groupAllTeams: true
             })
             ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)).should.have.property('role', Roles.Owner)

--- a/test/unit/forge/ee/lib/sso/index_spec.js
+++ b/test/unit/forge/ee/lib/sso/index_spec.js
@@ -2,6 +2,9 @@ const fastify = require('fastify')
 const should = require('should') // eslint-disable-line
 const setup = require('../../setup')
 
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
 describe('SSO Providers', function () {
     let app
 
@@ -187,6 +190,146 @@ d
                 }
             })
             response.statusCode.should.equal(200)
+        })
+    })
+
+    describe('updateTeamMembership', async function () {
+        const teams = {}
+
+        before(async function () {
+            teams.ATeam = app.team
+            teams.BTeam = await app.factory.createTeam({ name: 'BTeam' })
+            teams.CTeam = await app.factory.createTeam({ name: 'CTeam' })
+            teams.DTeam = await app.factory.createTeam({ name: 'DTeam' })
+        })
+
+        beforeEach(async function () {
+            await app.db.models.TeamMember.truncate()
+            await teams.ATeam.addUser(app.user, { through: { role: Roles.Owner } })
+            await teams.BTeam.addUser(app.user, { through: { role: Roles.Member } })
+            await teams.DTeam.addUser(app.user, { through: { role: Roles.Viewer } })
+        })
+
+        it('errors if samlUser missing group assertions', async function () {
+            const result = app.sso.updateTeamMembership({}, app.user, { groupsAssertionName: 'ff-roles' })
+            result.should.be.rejectedWith(/response missing ff-roles assertion/)
+        })
+
+        it('applies team membership changes - all teams', async function () {
+            // Apply changes to all teams
+            // Covers:
+            //   - Changing existing role
+            //   - Removing from team
+            //   - Adding to team
+            //   - Already has the right role in a team
+
+            // Starting state:
+            // Alice owner ATeam
+            // Alice member BTeam
+            // Alice not in CTeam
+            // Alice viewer in DTeam
+
+            // Expected result:
+            // Alice member ATeam (change role)
+            // Alice not in BTeam (remove from team)
+            // Alice owner CTeam (add to team)
+            // Alice viewer DTeam (unchanged)
+
+            await app.sso.updateTeamMembership({
+                'ff-roles': [
+                    'ff-ateam-member',
+                    'ff-cteam-owner',
+                    'ff-dteam-viewer',
+                    'ff-unknownTeam-viewer'
+                ]
+            }, app.user, {
+                groupsAssertionName: 'ff-roles',
+                groupAllTeams: true
+            })
+            ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)).should.have.property('role', Roles.Member)
+            should.not.exist(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.BTeam.id))
+            ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.CTeam.id)).should.have.property('role', Roles.Owner)
+            ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.DTeam.id)).should.have.property('role', Roles.Viewer)
+        })
+        it('applies team membership changes - restricted teams', async function () {
+            // Only apply changes to teams in the groupTeams list
+            // Ensure they are not in any other teams
+
+            // Starting state:
+            // Alice owner ATeam
+            // Alice member BTeam
+            // Alice not in CTeam
+            // Alice viewer in DTeam
+
+            // Expected result:
+            // Alice member ATeam (change role)
+            // Alice not in BTeam (remove from team - in allowed list)
+            // Alice not in CTeam (not allowed for this SAML user)
+            // Alice viewer DTeam (removed from team - not in allowed list)
+
+            await app.sso.updateTeamMembership({
+                'ff-roles': [
+                    'ff-ateam-member',
+                    'ff-cteam-owner',
+                    'ff-dteam-viewer',
+                    'ff-unknownTeam-viewer'
+                ]
+            }, app.user, {
+                groupsAssertionName: 'ff-roles',
+                groupTeams: ['ateam', 'bteam']
+            })
+            ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)).should.have.property('role', Roles.Member)
+            should.not.exist(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.BTeam.id))
+            should.not.exist(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.CTeam.id))
+            should.not.exist(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.DTeam.id))
+        })
+
+        it('applies highest role when multiple groups provided', async function () {
+            // When multiple groups specify the same team, pick the highest role
+
+            // Starting state:
+            // Alice not in CTeam
+            // Alice viewer in DTeam
+
+            // Expected result:
+            // Alice owner CTeam (add to team as owner)
+            // Alice member DTeam (change to member)
+
+            await app.sso.updateTeamMembership({
+                'ff-roles': [
+                    'ff-cteam-member',
+                    'ff-cteam-owner',
+                    'ff-dteam-member',
+                    'ff-dteam-viewer'
+                ]
+            }, app.user, {
+                groupsAssertionName: 'ff-roles',
+                groupAllTeams: true
+            })
+            ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.CTeam.id)).should.have.property('role', Roles.Owner)
+            ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.DTeam.id)).should.have.property('role', Roles.Member)
+        })
+        it('ignores invalid role in group', async function () {
+            // Validates that it ignores both unknown roles, but also roles that
+            // exist but are not valid for a team membershipt (ie admin)
+
+            // Starting state:
+            // Alice owner ATeam
+
+            // Expected result:
+            // Alice owner ATeam - unchanged
+
+            await app.sso.updateTeamMembership({
+                'ff-roles': [
+                    'ff-ateam-magician',
+                    'ff-ateam-owner',
+                    'ff-ateam-admin'
+                ]
+            }, app.user, {
+                groupsAssertionName: 'ff-roles',
+                groupAllTeams: true
+            })
+            ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)).should.have.property('role', Roles.Owner)
         })
     })
 })


### PR DESCRIPTION
## Description

This allows a user's team membership to be managed by their SSO provider via group assertions.

### Admin configuration

The SSO provider configuration has a new section:

<img width="444" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/ea319bbb-711d-4f21-b64e-4ab446398eb5">

 - **Group Assertion Name** - what property of the SAML response contains the list of groups the user is a member of. This defaults to `ff-roles`.
 - **Team Scope** - whether this config applies to all teams on the platform or a restricted list.
    - If 'All Teams' is selected, then a user can be added/removed to *any* team on the platform via this provider. This is suitable for self-hosted instances where a single SSO provider covers the whole platform. It is *not* suitable for FF Cloud where we have shared tenancy.
   - If 'Apply to selected teams' is selected, a list of teams must be provided. An additional option (not in the screenshot above) is provided as to whether users can be members of other teams unmanaged by the SSO configuration. By default this is disabled meaning users will get removed from any other team - which could lead to orphaned teams as users sign-up, get a personal team, then login via SSO and get removed from the team.
  The list is provided as a list of team slugs. I've done this for usability as that is easier to manage than team hashids - however, a team's slug can be changed which would break this configuration. Need to think about that a bit more

There is *commented out* code in the vue code to allow configuration of a SAML Group to manage admins on the platform - but currently nothing in the platform to handle that. I will follow up either in this PR, or as a followup PR.

### Login behaviour

When a user logs in, we will look for the group assertions in the SAML response. This is a list of the groups the user is a member of. We will look for any group that matches the pattern: `ff-<slug>-<role>` - for example `ff-demoTeam-owner`.

For each group that matches that pattern, we'll ensure the user has the specified role in the specified team. We ignore invalid roles and invalid teams.

If a user is a member of multiple groups identifying the same team - `ff-demoTeam-owner` and `ff-demoTeam-member`, we will apply the higher role (`owner` in this example).

This will allow a team to be left without an owner - see [this comment](https://github.com/FlowFuse/flowfuse/issues/3264#issuecomment-1867578935) for why this is necessary to allow.

---

## Remaining tasks

 - [x] ~Documentation~
 - Allow managing admin users via group membership - probably going to do that in a separate PR to allow this to move forward.


