### PR TITLE
Add team invitations to dropdown

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -56,11 +56,9 @@
     </div>
 </template>
 <script>
-import { AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIcon, QuestionMarkCircleIcon } from '@heroicons/vue/solid'
+import { AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIcon, QuestionMarkCircleIcon, UserGroupIcon } from '@heroicons/vue/solid'
 import { ref } from 'vue'
 import { mapGetters, mapState } from 'vuex'
-
-import router from '../routes.js'
 
 import NavItem from './NavItem.vue'
 import TeamSelection from './TeamSelection.vue'
@@ -83,7 +81,14 @@ export default {
                     icon: CogIcon,
                     tag: 'user-settings',
                     onclick: this.$router.push,
-                    onclickparams: { name: 'User Settings' },
+                    onclickparams: { name: 'User Settings' }
+                },
+                {
+                    label: 'Team Invitations',
+                    icon: UserGroupIcon,
+                    tag: 'team-invitations',
+                    onclick: this.$router.push,
+                    onclickparams: { name: 'User Invitations' },
                     notifications: this.notifications.invitations
                 },
                 this.user.admin

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -18,7 +18,7 @@
         <!-- Mobile: User Options -->
         <div class="ff-navigation ff-navigation-right" :class="{'open': mobileUserOptionsOpen}" data-action="user-options">
             <nav-item
-                v-for="option in options" :key="option.label"
+                v-for="option in navigationOptions" :key="option.label"
                 :label="option.label" :icon="option.icon" :notifications="option.notifications"
                 @click="mobileUserOptionsOpen = false; option.onclick(option.onclickparams)"
             />
@@ -47,7 +47,7 @@
                     </div>
                 </template>
                 <template #default>
-                    <ff-dropdown-option v-for="option in options" :key="option.label" @click="option.onclick(option.onclickparams)">
+                    <ff-dropdown-option v-for="option in navigationOptions" :key="option.label" @click="option.onclick(option.onclickparams)">
                         <nav-item :label="option.label" :icon="option.icon" :notifications="option.notifications" :data-nav="option.tag" />
                     </ff-dropdown-option>
                 </template>
@@ -74,17 +74,41 @@ export default {
     },
     emits: ['menu-toggle'],
     computed: {
-        profile: function () {
-            const profileLinks = router.options.routes.filter(r => {
-                return r.profileLink && (!r.adminOnly || this.user.admin)
-            })
-            profileLinks.sort((A, B) => {
-                return (A.profileMenuIndex || 0) - (B.profileMenuIndex || 0)
-            })
-            return profileLinks
-        },
         ...mapState('account', ['user', 'team', 'teams']),
-        ...mapGetters('account', ['notifications'])
+        ...mapGetters('account', ['notifications']),
+        navigationOptions () {
+            return [
+                {
+                    label: 'User Settings',
+                    icon: CogIcon,
+                    tag: 'user-settings',
+                    onclick: this.$router.push,
+                    onclickparams: { name: 'User Settings' },
+                    notifications: this.notifications.invitations
+                },
+                this.user.admin
+                    ? {
+                        label: 'Admin Settings',
+                        icon: AdjustmentsIcon,
+                        tag: 'admin-settings',
+                        onclick: this.$router.push,
+                        onclickparams: { name: 'Admin Settings' }
+                    }
+                    : undefined,
+                {
+                    label: 'Documentation',
+                    icon: QuestionMarkCircleIcon,
+                    tag: 'documentation',
+                    onclick: this.to,
+                    onclickparams: { url: 'https://flowfuse.com/docs/' }
+                }, {
+                    label: 'Sign Out',
+                    icon: LogoutIcon,
+                    tag: 'sign-out',
+                    onclick: this.signout
+                }
+            ].filter(option => option !== undefined)
+        }
     },
     watch: {
         notifications: {
@@ -102,25 +126,7 @@ export default {
     data () {
         return {
             mobileTeamSelectionOpen: false,
-            mobileUserOptionsOpen: false,
-            options: [{
-                label: 'User Settings',
-                icon: CogIcon,
-                tag: 'user-settings',
-                onclick: this.$router.push,
-                onclickparams: { name: 'User Settings' }
-            }, {
-                label: 'Documentation',
-                icon: QuestionMarkCircleIcon,
-                tag: 'documentation',
-                onclick: this.to,
-                onclickparams: { url: 'https://flowfuse.com/docs/' }
-            }, {
-                label: 'Sign Out',
-                icon: LogoutIcon,
-                tag: 'sign-out',
-                onclick: this.signout
-            }]
+            mobileUserOptionsOpen: false
         }
     },
     setup () {
@@ -129,18 +135,6 @@ export default {
             open,
             plusIcon: PlusIcon
         }
-    },
-    mounted () {
-        if (this.user.admin) {
-            this.options.splice(1, 0, {
-                label: 'Admin Settings',
-                icon: AdjustmentsIcon,
-                tag: 'admin-settings',
-                onclick: this.$router.push,
-                onclickparams: { name: 'Admin Settings' }
-            })
-        }
-        this.options[0].notifications = this.notifications.invitations
     },
     methods: {
         home () {

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="space-y-6">
         <ff-data-table data-el="table" :columns="inviteColumns" :rows="invitations">
-            <template #context-menu="{row}">
-                <ff-list-item data-action="accept" label="Accept" @click="acceptInvite(row)" />
-                <ff-list-item data-action="reject" label="Reject" kind="danger" @click="rejectInvite(row)" />
+            <template #row-actions="{row}">
+                <ff-button kind="secondary-danger" @click="rejectInvite(row)">Reject</ff-button>
+                <ff-button @click="acceptInvite(row)">Accept</ff-button>
             </template>
         </ff-data-table>
     </div>
@@ -15,6 +15,7 @@ import { markRaw } from 'vue'
 import userApi from '../../../api/user.js'
 import InviteUserCell from '../../../components/tables/cells/InviteUserCell.vue'
 import TeamCell from '../../../components/tables/cells/TeamCell.vue'
+import Alerts from '../../../services/alerts.js'
 
 export default {
     name: 'UserInviteTable',

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -45,6 +45,7 @@ export default {
             await userApi.acceptTeamInvitation(invite.id, invite.team.id)
             await this.fetchData()
             await this.$store.dispatch('account/refreshTeams')
+            Alerts.emit(`Invite to "${invite.team.name}" has been accepted.`, 'confirmation')
             // navigate to team dashboad once invite accepted
             this.$router.push({
                 name: 'Team',
@@ -56,6 +57,7 @@ export default {
         async rejectInvite (invite) {
             await userApi.rejectTeamInvitation(invite.id, invite.team.id)
             await this.fetchData()
+            Alerts.emit(`Invite to "${invite.team.name}" has been rejected.`, 'confirmation')
         },
         async fetchData () {
             const invitations = await userApi.getTeamInvitations()

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -2,8 +2,8 @@
     <div class="space-y-6">
         <ff-data-table data-el="table" :columns="inviteColumns" :rows="invitations">
             <template #row-actions="{row}">
-                <ff-button kind="secondary-danger" @click="rejectInvite(row)">Reject</ff-button>
-                <ff-button @click="acceptInvite(row)">Accept</ff-button>
+                <ff-button data-action="invite-reject" kind="secondary-danger" @click="rejectInvite(row)">Reject</ff-button>
+                <ff-button data-action="invite-accept" @click="acceptInvite(row)">Accept</ff-button>
             </template>
         </ff-data-table>
     </div>

--- a/frontend/src/pages/account/routes.js
+++ b/frontend/src/pages/account/routes.js
@@ -64,7 +64,7 @@ export default [
                 },
                 children: [
                     { path: '', component: AccountTeamTeams },
-                    { path: 'invitations', component: AccountTeamInvitations }
+                    { name: 'User Invitations', path: 'invitations', component: AccountTeamInvitations }
 
                 ]
             },

--- a/frontend/src/ui-components/components/data-table/DataTable.vue
+++ b/frontend/src/ui-components/components/data-table/DataTable.vue
@@ -32,6 +32,7 @@
                                 </div>
                             </ff-data-table-cell>
 
+                            <ff-data-table-cell v-if="hasRowActions" />
                             <ff-data-table-cell v-if="hasContextMenu" />
                         </ff-data-table-row>
                     </slot>
@@ -47,6 +48,9 @@
                                 v-for="(r, $index) in filteredRows" :key="$index" :data="r" :columns="columns"
                                 :selectable="rowsSelectable" :highlight-cell="sort.highlightColumn" @selected="rowClick(r)"
                             >
+                                <template v-if="hasRowActions" #row-actions="{row}">
+                                    <slot name="row-actions" :row="row" />
+                                </template>
                                 <template v-if="hasContextMenu" #context-menu="{row}">
                                     <slot name="context-menu" :row="row" />
                                 </template>
@@ -199,6 +203,9 @@ export default {
                     this.$emit('update:search', value)
                 }
             }
+        },
+        hasRowActions: function () {
+            return this.$slots['row-actions']
         },
         hasContextMenu: function () {
             return this.$slots['context-menu']

--- a/frontend/src/ui-components/components/data-table/DataTableRow.vue
+++ b/frontend/src/ui-components/components/data-table/DataTableRow.vue
@@ -13,6 +13,11 @@
                 </template>
             </ff-data-table-cell>
         </slot>
+        <ff-data-table-cell v-if="hasRowActions" style="width: 1px; white-space: nowrap;">
+            <div class="ff-data-table--row-actions">
+                <slot name="row-actions" :row="data" />
+            </div>
+        </ff-data-table-cell>
         <ff-data-table-cell v-if="hasContextMenu" style="width: 50px" @click="$refs.kebab.openOptions()">
             <ff-kebab-menu ref="kebab" menu-align="right">
                 <slot name="context-menu" :row="data" message="hello world" />
@@ -44,6 +49,9 @@ export default {
     },
     emits: ['selected'],
     computed: {
+        hasRowActions: function () {
+            return this.$slots['row-actions']
+        },
         hasContextMenu: function () {
             return this.$slots['context-menu']
         }

--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -137,6 +137,15 @@
       color: $ff-white;
     }
   }
+  &--secondary-danger {
+    color: $ff-color--danger;
+    background-color: $ff-white;
+    border: 1px solid $ff-color--danger;
+    &:hover {
+      background-color: $ff-color--danger--dark;
+      color: $ff-white;
+    }
+  }
 
   &.ff-btn-small {
     .ff-btn--icon,
@@ -782,6 +791,11 @@ li.ff-list-item {
       &:last-child {
         border-right-width: 1px;
       }
+    }
+    &-actions {
+      display: flex;
+      gap: 12px;
+      justify-content: flex-end;
     }
   }
 }

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -14,8 +14,8 @@ describe('FlowFuse platform admin users', () => {
         cy.get('[data-cy="user-options"]').get('.ff-dropdown-options').should('not.be.visible')
         cy.get('[data-cy="user-options"]').click()
         cy.get('[data-cy="user-options"] .ff-dropdown-options').should('be.visible')
-        cy.get('[data-cy="user-options"] .ff-dropdown-options > .ff-dropdown-option').eq(1).contains('Admin Settings').should('be.visible')
-        cy.get('[data-cy="user-options"] .ff-dropdown-options > .ff-dropdown-option').eq(1).click()
+        cy.get('[data-cy="user-options"] .ff-dropdown-options > .ff-dropdown-option').eq(2).contains('Admin Settings').should('be.visible')
+        cy.get('[data-cy="user-options"] .ff-dropdown-options > .ff-dropdown-option').eq(2).click()
 
         // wait for APIs to return
         cy.wait('@getSettings')

--- a/test/e2e/frontend/cypress/tests/invitations.spec.js
+++ b/test/e2e/frontend/cypress/tests/invitations.spec.js
@@ -33,11 +33,8 @@ describe('FlowFuse platform invitees', () => {
         // should have 2 pending invites
         cy.get('[data-el="table"] tbody').find('tr').should('have.length', 2)
 
-        // click the kebab menu of the first item
-        cy.get('[data-el="table"] tbody').find('.ff-kebab-menu').eq(0).click()
-
-        // accept the invite
-        cy.get('[data-el="table"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').contains('Reject').click()
+        // reject the invite
+        cy.get('[data-el="table"] tbody').find('[data-action="invite-reject"]').eq(0).click()
 
         cy.get('[data-el="table"] tbody').find('tr').should('have.length', 1)
 
@@ -57,10 +54,8 @@ describe('FlowFuse platform invitees', () => {
 
         cy.url().should('include', '/account/teams/invitations')
 
-        // click the kebab menu of the first item
-        cy.get('[data-el="table"] tbody').find('.ff-kebab-menu').eq(0).click()
         // accept the invite
-        cy.get('[data-el="table"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').contains('Accept').click()
+        cy.get('[data-el="table"] tbody').find('[data-action="invite-accept"]').eq(0).click()
 
         cy.get('[data-action="team-selection"]').should('be.visible')
         // should have navigated to the team dashboard

--- a/test/e2e/frontend/cypress/tests/team/team-membership.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/team-membership.spec.js
@@ -48,11 +48,8 @@ describe('FlowForge - Team Membership', () => {
         cy.get('[data-el="table"] tbody tr').should('have.length', 1)
         cy.get('[data-el="table"] tbody tr td.status-message').should('have.length', 0)
 
-        // click kebab menu
-        cy.get('[data-el="table"] tbody').find('.ff-kebab-menu').click()
-
-        // click accept
-        cy.get('[data-action="accept"]').click()
+        // click "Accept"
+        cy.get('[data-el="table"] tbody').find('[data-action="invite-accept"]').click()
 
         // wait for invitation to be accepted and reloaded
         cy.wait('@acceptInvite')


### PR DESCRIPTION
## Description

Adds team invitations as a separate option in the user menu. To date, there is only one form of notification (despite the code being written to support other menu items), so this effectively moves the icon into the separate team invitations row.

#### Admin user

![Screenshot 2024-01-08 at 16 57 43](https://github.com/FlowFuse/flowfuse/assets/507155/a1ba37c9-6ff4-4c69-bf98-6e4fbe01e3cb)

#### Normal user (with notification)

![Screenshot 2024-01-08 at 16 54 34](https://github.com/FlowFuse/flowfuse/assets/507155/2f0908c4-bdce-4363-b006-073d5bae92cb)

## Related Issue(s)

Fix #3039

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

