### PR TITLE
Ensure password reset tokens are cleared on use

### DIFF
--- a/forge/db/controllers/AccessToken.js
+++ b/forge/db/controllers/AccessToken.js
@@ -51,7 +51,7 @@ module.exports = {
         await app.db.models.AccessToken.destroy({
             where: {
                 ownerType: 'user',
-                scope: 'password:Reset',
+                scope: 'password:reset',
                 ownerId: user.hashid
             }
         })

--- a/forge/db/controllers/User.js
+++ b/forge/db/controllers/User.js
@@ -168,6 +168,9 @@ module.exports = {
             requestingUser.email = decodedToken.change // apply new Email Address
             requestingUser.email_verified = true
             await requestingUser.save()
+
+            await app.db.controllers.AccessToken.deleteAllUserPasswordResetTokens(requestingUser)
+
             return requestingUser
         } catch (err) {
             if (err.name === 'TokenExpiredError') {


### PR DESCRIPTION
## Description

This ensures a user can only have a single active password reset token at any one time - and that the token is disposed of at the right times.


Fixes:

 - https://github.com/FlowFuse/security/issues/43
 - https://github.com/FlowFuse/security/issues/46
 - https://github.com/FlowFuse/security/issues/61