### PR TITLE
Ensure swagger-ui baseDir is set to non-existent directory

### DIFF
--- a/forge/routes/api-docs.js
+++ b/forge/routes/api-docs.js
@@ -66,6 +66,13 @@ module.exports = fp(async function (app, opts, done) {
         },
         logLevel: 'silent',
         hideUntagged: true,
+        staticCSP: true,
+        transformStaticCSP: header => {
+            header.replace(
+                /script-src 'self'/,
+                "script-src 'self' 'unsafe-inline'"
+            )
+        },
         uiConfig: {
             defaultModelsExpandDepth: -1,
             operationsSorter: 'alpha',
@@ -93,6 +100,7 @@ module.exports = fp(async function (app, opts, done) {
             content: readFileSync(logoPath)
         }
     }
+
     // Fully built path
     let faviconPath = path.join(__dirname, '../../frontend/dist/favicon-32x32.png')
     if (!existsSync(faviconPath)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@fastify/routes": "^5.1.0",
                 "@fastify/static": "^6.10.2",
                 "@fastify/swagger": "^8.10.1",
-                "@fastify/swagger-ui": "^1.9.0",
+                "@fastify/swagger-ui": "^2.1.0",
                 "@fastify/websocket": "^8.1.0",
                 "@flowfuse/driver-localfs": "^1.15.0",
                 "@headlessui/vue": "1.7.16",
@@ -4058,9 +4058,9 @@
             }
         },
         "node_modules/@fastify/swagger-ui": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-1.10.1.tgz",
-            "integrity": "sha512-u3EJqNKvVr3X+6jY5i6pbs6/tXCrSlqc2Y+PVjnHBTOGh/d36uHMz+z4jPFy9gie2my6iHUrAdM8itlVmoUjog==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-2.1.0.tgz",
+            "integrity": "sha512-mu0C28kMEQDa3miE8f3LmI/OQSmqaKS3dYhZVFO5y4JdgBIPbzZj6COCoRU/P/9nu7UogzzcCJtg89wwLwKtWg==",
             "dependencies": {
                 "@fastify/static": "^6.0.0",
                 "fastify-plugin": "^4.0.0",
@@ -25486,9 +25486,9 @@
             }
         },
         "@fastify/swagger-ui": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-1.10.1.tgz",
-            "integrity": "sha512-u3EJqNKvVr3X+6jY5i6pbs6/tXCrSlqc2Y+PVjnHBTOGh/d36uHMz+z4jPFy9gie2my6iHUrAdM8itlVmoUjog==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-2.1.0.tgz",
+            "integrity": "sha512-mu0C28kMEQDa3miE8f3LmI/OQSmqaKS3dYhZVFO5y4JdgBIPbzZj6COCoRU/P/9nu7UogzzcCJtg89wwLwKtWg==",
             "requires": {
                 "@fastify/static": "^6.0.0",
                 "fastify-plugin": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "@fastify/routes": "^5.1.0",
         "@fastify/static": "^6.10.2",
         "@fastify/swagger": "^8.10.1",
-        "@fastify/swagger-ui": "^1.9.0",
+        "@fastify/swagger-ui": "^2.1.0",
         "@fastify/websocket": "^8.1.0",
         "@flowfuse/driver-localfs": "^1.15.0",
         "@headlessui/vue": "1.7.16",


### PR DESCRIPTION
~This sets the `baseDir` option of swagger-ui to *disable* its default behaviour that leads to it exposing its own source code on the routes it serves up. By setting it to a non-existent directory it won't serve up unexpected content.~

Fixes https://github.com/FlowFuse/security/issues/52

This upgrades to the latest release of swagger-ui that addresses the above issue.