### PR TITLE
Create Device Groups from the Pipeline Stage Form

### DIFF
--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -23,7 +23,7 @@
                 </template>
                 copy over all flows, nodes and credentials to "{{ target?.name }}".
             </p>
-            <template v-if="target.stageType === StageType.DEVICEGROUP">
+            <template v-if="target?.stageType === StageType.DEVICEGROUP">
                 <p class="my-4">
                     All devices in the target group will be notified and this may result in them re-loading with a new configuration.
                 </p>
@@ -213,9 +213,9 @@ export default {
         },
 
         targetTypeName () {
-            if (this.target.stageType === StageType.DEVICE) {
+            if (this.target?.stageType === StageType.DEVICE) {
                 return 'device'
-            } else if (this.target.stageType === StageType.DEVICEGROUP) {
+            } else if (this.target?.stageType === StageType.DEVICEGROUP) {
                 return 'groups devices'
             }
             return 'instance'

--- a/frontend/src/pages/application/PipelineStage/create.vue
+++ b/frontend/src/pages/application/PipelineStage/create.vue
@@ -15,6 +15,7 @@
 <script>
 import { ChevronLeftIcon } from '@heroicons/vue/solid'
 
+import ApplicationAPI from '../../../api/application.js'
 import PipelinesAPI from '../../../api/pipeline.js'
 
 import Alerts from '../../../services/alerts.js'
@@ -66,13 +67,27 @@ export default {
                 name: input.name,
                 instanceId: input.instanceId,
                 deviceId: input.deviceId,
-                deviceGroupId: input.deviceGroupId,
                 deployToDevices: input.deployToDevices,
                 action: input.action
             }
             if (this.$route.query.sourceStage) {
                 options.source = this.$route.query.sourceStage
             }
+
+            // Set the device group, new, existing or null
+            if (input.deviceGroupId === 'new') {
+                try {
+                    const result = await ApplicationAPI.createDeviceGroup(this.application.id, input.newDeviceGroup.name, input.newDeviceGroup.description)
+                    options.deviceGroupId = result.id
+                } catch (err) {
+                    console.error(err)
+                    Alerts.emit('Failed to create Device Group, stage was not created. Check the console for more details', 'error', 7500)
+                    return
+                }
+            } else {
+                options.deviceGroupId = input.deviceGroupId
+            }
+
             await PipelinesAPI.addPipelineStage(this.pipeline.id, options)
             Alerts.emit('Pipeline stage successfully added.', 'confirmation')
 

--- a/frontend/src/pages/application/PipelineStage/edit.vue
+++ b/frontend/src/pages/application/PipelineStage/edit.vue
@@ -19,6 +19,7 @@
 <script>
 import { ChevronLeftIcon } from '@heroicons/vue/solid'
 
+import ApplicationAPI from '../../../api/application.js'
 import PipelinesAPI from '../../../api/pipeline.js'
 
 import Alerts from '../../../services/alerts.js'
@@ -82,9 +83,22 @@ export default {
                 name: input.name,
                 instanceId: input.instanceId,
                 deviceId: input.deviceId,
-                deviceGroupId: input.deviceGroupId,
                 deployToDevices: input.deployToDevices,
                 action: input.action
+            }
+
+            // Set the device group, new, existing or null
+            if (input.deviceGroupId === 'new') {
+                try {
+                    const result = await ApplicationAPI.createDeviceGroup(this.application.id, input.newDeviceGroup.name, input.newDeviceGroup.description)
+                    options.deviceGroupId = result.id
+                } catch (err) {
+                    console.error(err)
+                    Alerts.emit('Failed to create Device Group, stage was not updated. Check the console for more details', 'error', 7500)
+                    return
+                }
+            } else {
+                options.deviceGroupId = input.deviceGroupId
             }
 
             await PipelinesAPI.updatePipelineStage(this.pipeline.id, this.stage.id, options)

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -15,13 +15,13 @@
             <div v-if="isVisitingAdmin" class="ff-banner" data-el="banner-project-as-admin">
                 You are viewing this application as an Administrator
             </div>
-            <SubscriptionExpiredBanner :team="team" />
-            <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
+            <SubscriptionExpiredBanner v-if="team" :team="team" />
+            <TeamTrialBanner v-if="team && team.billing?.trial" :team="team" />
         </Teleport>
         <div class="ff-instance-header">
             <ff-page-header :title="application.name" :tabs="navigation">
                 <template #breadcrumbs>
-                    <ff-nav-breadcrumb :to="{name: 'Applications', params: {team_slug: team.slug}}">Applications</ff-nav-breadcrumb>
+                    <ff-nav-breadcrumb v-if="team" :to="{name: 'Applications', params: {team_slug: team.slug}}">Applications</ff-nav-breadcrumb>
                 </template>
             </ff-page-header>
         </div>
@@ -102,7 +102,7 @@ export default {
     computed: {
         ...mapState('account', ['teamMembership', 'team', 'features']),
         isVisitingAdmin () {
-            return this.teamMembership.role === Roles.Admin
+            return this.teamMembership?.role === Roles.Admin
         },
         isLoading () {
             return this.loading.deleting || this.loading.suspend

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -646,7 +646,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         })
     })
 
-    it.only('can create a new device group', () => {
+    it('can create a new device group', () => {
         cy.intercept('GET', '/api/v1/applications/*/pipelines').as('getPipelines')
         cy.intercept('POST', '/api/v1/pipelines').as('createPipeline')
 

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -640,7 +640,84 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
 
         cy.get('[data-action="add-stage"]').click()
 
-        // now there is a device group at the end stage, check to ensure add-stage is not be present
-        cy.get('[data-action="add-stage"]').should('not.exist')
+        cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+            // now there is a device group at the end stage, check to ensure add-stage is not be present
+            cy.get('[data-action="add-stage"]').should('not.exist')
+        })
+    })
+
+    it.only('can create a new device group', () => {
+        cy.intercept('GET', '/api/v1/applications/*/pipelines').as('getPipelines')
+        cy.intercept('POST', '/api/v1/pipelines').as('createPipeline')
+
+        /// Create stages ready to push between
+        cy.visit(`/application/${application.id}/pipelines`)
+        cy.wait('@getPipelines')
+
+        const PIPELINE_NAME = `My New Pipeline - ${Math.random().toString(36).substring(2, 7)}`
+        const GROUP_NAME = `Group 1 - ${Math.random().toString(36).substring(2, 7)}`
+
+        // Add pipeline
+        cy.get('[data-action="pipeline-add"]').click()
+        cy.get('[data-form="pipeline-form"]').should('be.visible')
+
+        cy.get('[data-form="pipeline-name"] input').type(PIPELINE_NAME)
+        cy.get('[data-action="create-pipeline"]').click()
+
+        cy.wait('@createPipeline')
+
+        // Add stage 1
+        cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+            cy.get('[data-action="add-stage"]').click()
+        })
+
+        cy.get('[data-form="stage-name"] input[type="text"]').type('Stage 1')
+
+        cy.get('[data-form="stage-instance"] .ff-dropdown').click()
+        cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
+        cy.get('[data-form="stage-action"] .ff-dropdown').click()
+        cy.get('[data-form="stage-action"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-action"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
+        cy.get('[data-action="add-stage"]').click()
+
+        // Add stage 2 with device group
+        cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+            cy.get('[data-action="add-stage"]').click()
+        })
+
+        cy.get('[data-form="stage-name"] input[type="text"]').type('Stage 2')
+
+        // Device groups field hidden to start
+        cy.get('[data-form="stage-device-group-name"]').should('not.exist')
+        cy.get('[data-form="stage-device-group-description"]').should('not.exist')
+
+        // Select device Group
+        cy.get('[data-form="stage-type"]').find('.ff-tile-selection-option[data-form="tile-selection-option-device-group"]').click()
+
+        // Select create new
+        cy.get('[data-form="stage-device-group"] .ff-dropdown').click()
+        cy.get('[data-form="stage-device-group"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-device-group"] .ff-dropdown-options > .ff-dropdown-option:contains("Create")').click()
+
+        // Device groups field hidden to start
+        cy.get('[data-form="stage-device-group-name"]').type(GROUP_NAME)
+        cy.get('[data-form="stage-device-group-description"]').type(`Description for group ${GROUP_NAME}`)
+
+        cy.get('[data-action="add-stage"]').click()
+
+        cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+            cy.get('[data-el="ff-pipeline-stage"]:contains("Stage 2")').within(() => {
+                cy.contains('Group 1').click()
+            })
+        })
+
+        // On device group page
+        cy.get('[data-nav="application-device-group-settings"]').click()
+
+        cy.get('[data-el="application-device-group-name"] input').should('have.value', GROUP_NAME)
+        cy.get('[data-el="application-device-group-description"] input').should('have.value', `Description for group ${GROUP_NAME}`)
     })
 })


### PR DESCRIPTION
## Description

This is a quick win for #3183 that adds support for creating _empty_ device groups in the pipeline stages form.

Further iteration possibilities include:

 - Moving this to a popup
 - Being able to create _and_ assign

![Screenshot 2024-01-11 at 15 19 42](https://github.com/FlowFuse/flowfuse/assets/507155/5dd797ac-931e-4b9e-a1ea-e3fd188c6053)

https://github.com/FlowFuse/flowfuse/assets/507155/9a589bac-1f08-4bc9-a0c0-7503d5be60b3

~**Downing tools and marking this as draft** as there is discussion in #3183 on other possible approaches which needs input from @MarianRaphael.~

## Related Issue(s)

Fixes #3183

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass - TO DO before marking non-draft
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

