### PR TITLE
Add CommandResponse pattern for handling scalable platform

### DIFF
--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -104,15 +104,18 @@ module.exports = function (app) {
         forge_platform: {
             sub: [
                 // Receive status events from project launchers
-                // - ff/v1/+/l/+/status
-                { topic: /^ff\/v1\/[^/]+\/l\/[^/]+\/status$/ },
+                // - ff/v1/<team>/l/<instance>/status
+                { topic: /^ff\/v1\/[^/]+\/l\/[^/]+\/status$/, shared: true },
                 // Receive status events, logs and command responses from devices
-                // - ff/v1/+/d/+/status
-                { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/status$/ },
-                // - ff/v1/+/d/+/logs
+                // - ff/v1/<team>/d/<device>/status
+                { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/status$/, shared: true },
+                // - ff/v1/<team>/d/<device>/logs
                 { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/logs$/ },
-                // - ff/v1/+/d/+/logs
-                { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/response$/ }
+                // - ff/v1/<team>/d/<device>/response
+                { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/response$/, shared: true },
+
+                // Receive broadcast response notification
+                { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/response\/broadcast$/ }
             ],
             pub: [
                 // Send commands to project launchers
@@ -126,7 +129,10 @@ module.exports = function (app) {
                 { topic: /^ff\/v1\/[^/]+\/p\/[^/]+\/command$/ },
                 // Send commands to all application-assigned devices
                 // - ff/v1/+/a/+/command
-                { topic: /^ff\/v1\/[^/]+\/a\/[^/]+\/command$/ }
+                { topic: /^ff\/v1\/[^/]+\/a\/[^/]+\/command$/ },
+
+                // Publish broadcast response to all platform instances
+                { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/response\/broadcast$/ }
             ]
         },
         project: {
@@ -198,7 +204,7 @@ module.exports = function (app) {
                         isSharedSub = true
                         // This is a shared sub - validate the share group name
                         const shareGroup = sharedSubParts[1]
-                        if (shareGroup !== usernameParts[2]) {
+                        if (shareGroup !== 'platform' && shareGroup !== usernameParts[2]) {
                             return false
                         }
                         topic = sharedSubParts[2]

--- a/forge/comms/commsClient.js
+++ b/forge/comms/commsClient.js
@@ -64,19 +64,26 @@ class CommsClient extends EventEmitter {
                             id: ownerId,
                             message: message.toString()
                         }
-                        this.emit('response/device', response)
+                        if (topicParts[6] === 'broadcast') {
+                            response.correlationData = response.message
+                            delete response.message
+                        }
+                        this.emit('response/device', response, topic)
                     }
                 }
             })
             this.client.subscribe([
                 // Launcher status
-                'ff/v1/+/l/+/status',
+                '$share/platform/ff/v1/+/l/+/status',
                 // Device status
-                'ff/v1/+/d/+/status',
+                '$share/platform/ff/v1/+/d/+/status',
                 // Device logs
                 'ff/v1/+/d/+/logs',
                 // Device response
-                'ff/v1/+/d/+/response'
+                '$share/platform/ff/v1/+/d/+/response',
+                // Device response broadcast - used by the platform to notify all
+                // platform instances there is a response available
+                'ff/v1/+/d/+/response/broadcast'
             ])
         }
     }

--- a/forge/db/migrations/20240112-01-add-commandresponse-table.js
+++ b/forge/db/migrations/20240112-01-add-commandresponse-table.js
@@ -1,0 +1,25 @@
+/* eslint-disable no-unused-vars */
+
+const { DataTypes, QueryInterface } = require('sequelize')
+
+module.exports = {
+    /**
+     * Add FlowTemplate table
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        await context.sequelize.transaction(async (transaction) => {
+            await context.createTable('CommandResponses', {
+                id: {
+                    type: DataTypes.UUID,
+                    primaryKey: true
+                },
+                payload: { type: DataTypes.TEXT },
+                createdAt: { type: DataTypes.DATE, allowNull: false },
+                updatedAt: { type: DataTypes.DATE, allowNull: false }
+            }, { transaction })
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/CommandResponse.js
+++ b/forge/db/models/CommandResponse.js
@@ -1,0 +1,22 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    name: 'CommandResponse',
+    schema: {
+        id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+        payload: {
+            type: DataTypes.TEXT
+        }
+    },
+    finders: function (M) {
+        return {
+            static: {
+                byId: async (id) => {
+                    return this.findOne({
+                        where: { id }
+                    })
+                }
+            }
+        }
+    }
+}

--- a/forge/db/models/index.js
+++ b/forge/db/models/index.js
@@ -77,7 +77,8 @@ const modelTypes = [
     'StorageSession',
     'StorageLibrary',
     'AuditLog',
-    'BrokerClient'
+    'BrokerClient',
+    'CommandResponse'
 ]
 
 // A local map of the known models.


### PR DESCRIPTION
Closes #2792 

## Description

This modifies our command/response messaging pattern to support horizontal scaling of the forge app.

In summary - once scaled, we cannot guarantee the response message comes back to the specific app instance that published the request and that is holding an unresolved promise. In that scenario, we store the message in the database and republish a notification message that is received by all forge app instances - whichever one recognises the correlationData value can retrieve the message from the db and continue processing as normal.

### Summary of changes
 - Change core platform subscriptions (and ACL checks) to use `$share/platform/` shared-subscription prefix (all except the logs end point.. that needs more work in a separate item)
 - Add `CommandResponse` table and migration
 - Add logic to store the response in the db if not recognised as a 'local' item
 - Add handling for new `.../response/broadcast` topic used to prompt the platform to process a stored response if it recognises it

### Remaining tasks

 - Add a TimerTask to periodically clean up the `CommandResponse` table of anything stale - just in case they are orphaned
 - Add unit tests - I cannot see any tests for the existing command/response flows so need to add something in that area first


