### PR TITLE
Be less specific if username or email is unavailable on registration

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -173,10 +173,6 @@ async function init (app, opts) {
         }
     })
 
-    // app.post('/account/register', (request, reply) => {
-    //
-    // })
-
     /**
      * Login a user.
      *
@@ -460,11 +456,11 @@ async function init (app, opts) {
             let responseMessage
             let responseCode = 'unexpected_error'
             if (/user_username_lower_unique|Users_username_key/.test(err.parent?.toString())) {
-                responseMessage = 'username not available'
-                responseCode = 'invalid_username'
+                responseMessage = 'Username or email not available'
+                responseCode = 'invalid_request'
             } else if (/user_email_lower_unique|Users_email_key/.test(err.parent?.toString())) {
-                responseMessage = 'email not available'
-                responseCode = 'invalid_email'
+                responseMessage = 'Username or email not available'
+                responseCode = 'invalid_request'
             } else if (err.errors) {
                 responseMessage = err.errors.map(err => err.message).join(',')
             } else {

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -188,16 +188,10 @@ export default {
                 console.error(err.response.data)
                 this.busy = false
                 if (err.response?.data) {
-                    if (/username/.test(err.response.data.error)) {
-                        this.errors.username = 'Username unavailable'
-                    }
-                    if (/password/.test(err.response.data.error)) {
-                        this.errors.password = 'Invalid username'
-                    }
-                    if (err.response.data.code === 'invalid_sso_email') {
+                    if (err.response.data.code === 'invalid_request') {
+                        this.errors.username = err.response.data.error || 'Invalid request'
+                    } else if (err.response.data.code === 'invalid_sso_email') {
                         this.errors.email = err.response.data.error
-                    } else if (/email/.test(err.response.data.error)) {
-                        this.errors.email = 'Email unavailable'
                     } else if (err.response.data.statusCode === 429) {
                         this.errors.general = 'Too many attempts. Try again later.'
                         this.tooManyRequests = true
@@ -205,7 +199,6 @@ export default {
                             this.tooManyRequests = false
                         }, 10000)
                     } else if (err.response.data.error === 'user registration not enabled') {
-                        // TODO Where to show this error?
                         this.errors.general = 'User registration is not enabled'
                     }
                 }

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -111,7 +111,7 @@ describe('Accounts API', async function () {
                 password: '12345678',
                 name: 'u1.2',
                 email: 'u1-2@example.com'
-            }, /username not available/)
+            }, /Username or email not available/)
 
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
         })
@@ -130,7 +130,7 @@ describe('Accounts API', async function () {
                 password: '12345678',
                 name: 'u1.2',
                 email: 'u1@example.com'
-            }, /email not available/)
+            }, /Username or email not available/)
 
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
         })


### PR DESCRIPTION
## Description

If a user tries to register with an unavailable username or email, we would report back the problem specifically identifying which was unavailable. This isn't ideal as it reveals if a given username/email is in use on the platform already.

This PR modifies it slightly so we return the same error for both cases.

Part of https://github.com/FlowFuse/security/issues/48