### PR TITLE
Fix link to API docs to flowfuse.com

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -9,7 +9,7 @@ navTitle: FlowFuse API
 The platform provides a REST API that makes it possible to create integrations and
 custom workflows.
 
-The API comes with an OpenAPI 3.0 Specification that can be viewed [here](https://app.flowforge.com/api/),
+The API comes with an OpenAPI 3.0 Specification that can be viewed [here](https://app.flowfuse.com/api/),
 or on any FlowFuse instance on the path `/api/`.
 
 ### Accessing the API


### PR DESCRIPTION
## Description
link still pointed to flowforge.com
<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

