### PR TITLE
Do not allow password to be same as email/username

### DIFF
--- a/forge/db/controllers/User.js
+++ b/forge/db/controllers/User.js
@@ -30,6 +30,11 @@ module.exports = {
             if (zxcvbn(newPassword).score < 3) {
                 throw new Error('Password Too Weak')
             }
+            if (newPassword === user.username) {
+                throw new Error('Password must not match username')
+            } else if (newPassword === user.email) {
+                throw new Error('Password must not match email')
+            }
             user.password = newPassword
             user.password_expired = false
             return user.save()
@@ -39,9 +44,14 @@ module.exports = {
     },
 
     resetPassword: async function (app, user, newPassword) {
-        // if (zxcvbn(newPassword.score < 3)) {
-        //     throw new Error('Password Too Weak')
-        // }
+        if (zxcvbn(newPassword).score < 3) {
+            throw new Error('Password Too Weak')
+        }
+        if (newPassword === user.username) {
+            throw new Error('Password must not match username')
+        } else if (newPassword === user.email) {
+            throw new Error('Password must not match email')
+        }
         user.password = newPassword
         user.password_expired = false
         return user.save()

--- a/forge/db/controllers/User.js
+++ b/forge/db/controllers/User.js
@@ -44,7 +44,7 @@ module.exports = {
     },
 
     resetPassword: async function (app, user, newPassword) {
-        if (zxcvbn(newPassword).score < 3) {
+        if (zxcvbn(newPassword).score < 2) {
             throw new Error('Password Too Weak')
         }
         if (newPassword === user.username) {

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -119,6 +119,8 @@ export default {
             return (this.input.email && !this.errors.email) &&
                    (this.input.username && !this.errors.username) &&
                    this.input.password.length >= 8 &&
+                   this.input.password !== this.input.email &&
+                   this.input.password !== this.input.username &&
                    zxcvbn(this.input.password).score >= 2 &&
                    (this.askJoinReason ? this.input.join_reason : true) &&
                    (this.settings['user:tcs-required'] ? this.input.tcs_accepted : true) &&
@@ -148,6 +150,14 @@ export default {
                 this.errors.password = ''
             } else {
                 this.errors.password = 'Password needs to be longer than 8 chars'
+                return
+            }
+            if (v === this.input.username) {
+                this.errors.password = 'Password must not match username'
+                return
+            }
+            if (v === this.input.email) {
+                this.errors.password = 'Password must not match email'
                 return
             }
             if (zxcvbn(v).score >= 2) {

--- a/frontend/src/pages/account/Security/ChangePassword.vue
+++ b/frontend/src/pages/account/Security/ChangePassword.vue
@@ -5,7 +5,7 @@
         <FormRow id="old_password" v-model="input.old_password" type="password" :error="errors.old_password">Old Password</FormRow>
         <FormRow id="password" v-model="input.password" type="password" :error="errors.password">New Password</FormRow>
         <FormRow id="password_confirm" v-model="input.password_confirm" type="password" :error="errors.password_confirm">Confirm</FormRow>
-        <ff-button @click="changePassword">
+        <ff-button :disabled="!formValid" @click="changePassword">
             Change password
         </ff-button>
         <div v-if="errors.password_change" class="ml-4 text-red-400 font-medium inline text-sm">{{ errors.password_change }}</div>
@@ -14,6 +14,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import userApi from '../../../api/user.js'
 import FormHeading from '../../../components/FormHeading.vue'
 import FormRow from '../../../components/FormRow.vue'
@@ -43,11 +45,39 @@ export default {
             }
         }
     },
+    computed: {
+        ...mapState('account', ['user']),
+        formValid () {
+            return this.input.old_password &&
+                   this.input.password &&
+                   this.input.password === this.input.password_confirm &&
+                   !this.errors.password
+        }
+    },
     watch: {
         'input.password': function (v) {
-            if (this.errors.password && v.length >= 8 && this.zxcvbn(v).score >= 2) {
-                this.errors.password = ''
+            if (this.input.password.length < 8) {
+                this.errors.password = 'Password must be at least 8 characters'
+                return
             }
+            if (this.input.password.length > 1024) {
+                this.errors.password = 'Password too long'
+                return
+            }
+            if (this.input.password === this.user.username) {
+                this.errors.password = 'Password must not match username'
+                return
+            }
+            if (this.input.password === this.user.email) {
+                this.errors.password = 'Password must not match email'
+                return
+            }
+            const zxcvbnResult = zxcvbn(this.input.password)
+            if (zxcvbnResult.score < 2) {
+                this.errors.password = `Password too weak, ${zxcvbnResult.feedback.suggestions[0]}`
+                return
+            }
+            this.errors.password = ''
         }
     },
     async mounted () {
@@ -56,32 +86,6 @@ export default {
     },
     methods: {
         changePassword () {
-            this.errors.old_password = ''
-            this.errors.password = ''
-            this.errors.password_confirm = ''
-            this.errors.password_change = ''
-
-            if (this.input.old_password === '') {
-                this.errors.old_password = 'Enter your current password'
-                return false
-            }
-            if (this.input.password === '') {
-                this.errors.password = 'Enter a new password'
-                return false
-            }
-            if (this.input.password.length < 8) {
-                this.errors.password = 'Password too short (min. 8 characters)'
-                return false
-            }
-            if (this.input.password !== this.input.password_confirm) {
-                this.errors.password_confirm = 'Passwords do not match'
-                return false
-            }
-            const zxcvbnResult = zxcvbn(this.input.password)
-            if (zxcvbnResult.score < 2) {
-                this.errors.password = `Password too weak, ${zxcvbnResult.feedback.suggestions[0]}`
-                return false
-            }
             this.loading = true
             userApi.changePassword(this.input.old_password, this.input.password).then(() => {
                 this.input.password = ''

--- a/frontend/src/pages/setup/CreateAdminUser.vue
+++ b/frontend/src/pages/setup/CreateAdminUser.vue
@@ -74,7 +74,8 @@ export default {
             return this.input.email &&
                    (this.input.username && !this.errors.username) &&
                    this.input.password !== '' &&
-                   this.input.password === this.input.password_confirm
+                   this.input.password === this.input.password_confirm &&
+                   !this.errors.password
         }
     },
     watch: {
@@ -96,6 +97,12 @@ export default {
             if (this.errors.password && v.length >= 8 && zxcvbn(v).score >= 2) {
                 this.errors.password = ''
             }
+            if (v === this.input.username) {
+                this.errors.password = 'Password must not match username'
+            }
+            if (v === this.input.email) {
+                this.errors.password = 'Password must not match email'
+            }
         }
     },
     async mounted () {
@@ -109,13 +116,23 @@ export default {
         checkPassword () {
             if (this.input.password && this.input.password.length < 8) {
                 this.errors.password = 'Password must be at least 8 characters'
+                return
             } else {
                 this.errors.password = ''
             }
             if (this.input.password && this.input.password.length > 1024) {
                 this.errors.password = 'Password too long'
+                return
             } else {
                 this.errors.password = ''
+            }
+            if (this.input.password === this.input.username) {
+                this.errors.password = 'Password must not match username'
+                return
+            }
+            if (this.input.password === this.input.email) {
+                this.errors.password = 'Password must not match email'
+                return
             }
             const zxcvbnResult = zxcvbn(this.input.password)
             if (zxcvbnResult.score < 2) {

--- a/test/unit/forge/db/controllers/User_spec.js
+++ b/test/unit/forge/db/controllers/User_spec.js
@@ -112,6 +112,20 @@ describe('User controller', function () {
             }
             throw new Error('Allowed bad password')
         })
+        it('fails if password matches username or email', async function () {
+            // Need a user with a username/email that'll pass the general length/weakness checks
+            const userComplexUsername = await app.db.models.User.create({ username: 'BluePianoLampshade', name: '', email: 'BluePianoLampshade@example.com', email_verified: true, password: 'aaPassword' })
+            try {
+                await app.db.controllers.User.changePassword(userComplexUsername, 'aaPassword', 'BluePianoLampshade')
+            } catch (err) {
+                err.message.should.equal('Password must not match username')
+            }
+            try {
+                await app.db.controllers.User.changePassword(userComplexUsername, 'aaPassword', 'BluePianoLampshade@example.com')
+            } catch (err) {
+                err.message.should.equal('Password must not match email')
+            }
+        })
     })
 
     describe('change email address', function () {

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -840,7 +840,7 @@ describe('Accounts API', async function () {
             const resetResponse = await app.inject({
                 method: 'POST',
                 url: `/account/reset_password/${token}`,
-                payload: { password: 'newPassword' }
+                payload: { password: 'BoatShelfLegoDroid' }
             })
             resetResponse.statusCode.should.equal(200)
 
@@ -864,12 +864,12 @@ describe('Accounts API', async function () {
             const resetResponse2 = await app.inject({
                 method: 'POST',
                 url: `/account/reset_password/${token}`,
-                payload: { password: 'newPassword2' }
+                payload: { password: 'BoatShelfLegoDroidAgain' }
             })
             resetResponse2.statusCode.should.equal(400)
 
             // Should be able to login with new password
-            await login('testUser', 'newPassword')
+            await login('testUser', 'BoatShelfLegoDroid')
         })
 
         it('Password reset for an unknown user does not error', async function () {


### PR DESCRIPTION
## Description

This adds an additional requirement for passwords to not match a user's email/username.

I've tried to standardise the various forms which allows a user to enter/change their password to be consistent in feedback.

Fixes https://github.com/FlowFuse/security/issues/47