### PR TITLE
Remove email from UserSummary view

### DIFF
--- a/forge/db/views/User.js
+++ b/forge/db/views/User.js
@@ -4,6 +4,7 @@ module.exports = function (app) {
         type: 'object',
         allOf: [{ $ref: 'UserSummary' }],
         properties: {
+            email: { type: 'string' },
             email_verified: { type: 'boolean' },
             defaultTeam: { type: 'string' },
             sso_enabled: { type: 'boolean' },
@@ -16,6 +17,9 @@ module.exports = function (app) {
     })
     function userProfile (user) {
         const result = userSummary(user)
+        if (user.email) {
+            result.email = user.email
+        }
         if (user.password_expired) {
             result.password_expired = true
         }
@@ -43,7 +47,6 @@ module.exports = function (app) {
             id: { type: 'string' },
             username: { type: 'string' },
             name: { type: 'string' },
-            email: { type: 'string' },
             avatar: { type: 'string' },
             admin: { type: 'boolean' },
             createdAt: { type: 'string' },
@@ -57,7 +60,6 @@ module.exports = function (app) {
         [
             'username',
             'name',
-            'email',
             'avatar',
             'admin',
             'createdAt',


### PR DESCRIPTION
The `UserSummary` view is used when providing a summary of a user on the platform, such as when listing team members, or invitations.

We generally have a higher level of trust between team members in terms of information disclosure, however we don't want to provide any more information than is strictly necessary. This PR removes the user's email from the summary view and moves it to the full `User` view (which is only used when a user is viewing themselves or an admin is querying a user).

I have checked all routes that use the `UserSummary` view and none depends on the `email` field being present.

- https://github.com/FlowFuse/security/issues/65