### PR TITLE
Use Alert.emit instead of $toast

### DIFF
--- a/frontend/src/pages/application/DeviceGroup/devices.vue
+++ b/frontend/src/pages/application/DeviceGroup/devices.vue
@@ -325,7 +325,7 @@ export default {
                         this.editMode = false
                     })
                     .catch((err) => {
-                        this.$toast.error('Failed to update Device Group')
+                        Alerts.emit('Failed to update Device Group: ' + err.toString(), 'warning')
                         console.error(err)
                     })
             })


### PR DESCRIPTION

## Description

Fix error alert for failed Device Group update that slipped in in  #3330 

## Related Issue(s)

#3260  #3330 

