### PR TITLE
Adjust kebab menu x/y if out of viewport when rendered

### DIFF
--- a/frontend/src/ui-components/components/KebabMenu.vue
+++ b/frontend/src/ui-components/components/KebabMenu.vue
@@ -2,10 +2,10 @@
     <div class="ff-kebab-menu" :class="{'active': open}">
         <!-- using this v-if hack in order to enable both
         the button and click-outside to work when closing the menu -->
-        <DotsVerticalIcon v-if="!open" @click.stop="openOptions()" />
-        <DotsVerticalIcon v-if="open" @click.stop="closeOptions()" />
+        <DotsVerticalIcon v-if="!open" @click.stop="openOptions" />
+        <DotsVerticalIcon v-if="open" @click.stop="closeOptions" />
         <template v-if="open">
-            <ul v-click-outside="closeOptions" class="ff-kebab-options"
+            <ul :ref="menuOpening" v-click-outside="closeOptions" class="ff-kebab-options"
                 :class="'ff-kebab-options--' + menuAlign"
             >
                 <slot></slot>
@@ -32,15 +32,56 @@ export default {
     },
     data () {
         return {
-            open: false
+            open: false,
+            openEvent: null,
+            viewport: {
+                width: window.innerWidth,
+                height: window.innerHeight
+            },
+            mouse: {
+                x: 0,
+                y: 0
+            }
         }
     },
     methods: {
-        openOptions () {
+        openOptions (event) {
+            // update the viewport variable - BEFORE opening the menu
+            this.viewport.width = window.innerWidth
+            this.viewport.height = window.innerHeight
+
+            // update the mouse position - BEFORE opening the menu
+            this.mouse.x = event.clientX
+            this.mouse.y = event.clientY
+
+            // open the menu - this will cause the menu to render and the ref to be come available
+            // which will in-turn trigger the menuOpening method
             this.open = !this.open
         },
         closeOptions () {
+            this.openEvent = null
             this.open = false
+        },
+        menuOpening (el) {
+            // get the height of the menu el
+            const menu = {
+                width: el.offsetWidth,
+                height: el.offsetHeight
+            }
+
+            // check if the menu would be out of the viewport
+            const left = this.mouse.x + menu.width + 20 > this.viewport.width // + 20 for padding
+            const top = this.mouse.y + menu.height + 20 > this.viewport.height // + 20 for padding
+
+            // if the menu would be out of the viewport, nudge it in a negative direction
+            // (menu is positioned absolute, so we only need to change the top/left values as a negative offset)
+            if (left && this.menuAlign !== 'right') {
+                el.style.left = '-' + menu.width + 'px'
+            }
+
+            if (top) {
+                el.style.top = '-' + menu.height + 'px'
+            }
         }
     }
 }


### PR DESCRIPTION
fixes #3339

## Description

Checks if the kebab menu will appear off screen, negative offset left/top by menu negative width/height accordingly

### Before:
![chrome_Lel1VwlVgN](https://github.com/FlowFuse/flowfuse/assets/44235289/623ab2e4-214f-4261-b532-47c051e8c368)

### After:
![chrome_CnuPnxd4Ds](https://github.com/FlowFuse/flowfuse/assets/44235289/8c626bfe-c4ae-4bc2-a6d8-8c0107f8f50f)



## Related Issue(s)

#3339 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

