### PR TITLE
Quieten down `Device.Team` is `null` exceptions

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -80,7 +80,20 @@ module.exports = {
             } else {
                 delete payload.application // exclude application property to avoid triggering the wrong kind of update on the device
             }
-            app.comms.devices.sendCommand(device.Team.hashid, device.hashid, 'update', payload)
+
+            // ensure the device has a team association
+            let team = device.Team
+            if (!team) {
+                // reload the device with the team association
+                const _device = await app.db.models.Device.byId(device.id)
+                team = _device?.Team
+                if (!team) {
+                    app.log.warn(`Failed to send update command to device ${device.hashid} as it has no team association`)
+                    return
+                }
+            }
+            // send out update command
+            app.comms.devices.sendCommand(team.hashid, device.hashid, 'update', payload)
         }
     },
     /**


### PR DESCRIPTION
closes #3221

## Description

The PR aims to simply remove the exceptions (currently flooding sentry) by _handling_ the situation and logging out the problem device(s) hashID in `app.warn`. 

### Background

I have checked through the calls to `app.comms.devices.sendCommand` via `sendDeviceUpdateCommand` in forge/app/node_modules/@flowforge/flowforge/forge/db/controllers/Device.js"

As far as I can see `device` is always a fully loaded model (e.g. loaded via await `app.db.models.Device.byId(targetDevice.id)`) with the required associations

So if these ARE orphaned devices (no `Team` associated) we should at least prevent the exceptions and extensive sentry logging (the orphaned devices part of this was raised in https://github.com/FlowFuse/flowfuse/issues/2569)


## Related Issue(s)

#3221

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

