### PR TITLE
Show application select dropdown in team -> device -> create dialog

### DIFF
--- a/docs/device-agent/register.md
+++ b/docs/device-agent/register.md
@@ -17,8 +17,9 @@ _for a single device_
 
 1. Go to your teams's **Devices** page.
 2. Click the **Register Device** button.
-3. You will be prompted to give the device a **name** and an optional **type**.
-   The type field can be used to record additional meta information about the device.
+3. You will be prompted to give the device a **name**, an optional **type** and to chose which **Application**, if any, the device should be assigned to.
+   * The **type** field can be used to record additional meta information about the device.
+   * If you do not wish to assign the device to an application at this time, you can do so later.
 4. Click **Register**
 
 Once the device has been registered, you will be shown the **Device Configuration** 
@@ -104,7 +105,8 @@ To assign to a Node-RED instance:
 
 ### Assign the device to an Application
 
-The next step is to assign the device to a FlowFuse Application
+If the device was not assigned to an application when it was registered, the next step
+is to assign it to a FlowFuse Application
 
 1. Go to your teams's **Devices** page.
 2. Open the dropdown menu to the right of the device you want to assign and

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -468,7 +468,8 @@ export default {
         }, 50),
 
         showCreateDeviceDialog () {
-            this.$refs.teamDeviceCreateDialog.show(null, this.instance, this.application)
+            const showApplicationsList = this.displayingTeam
+            this.$refs.teamDeviceCreateDialog.show(null, this.instance, this.application, showApplicationsList)
         },
 
         showEditDeviceDialog (device) {

--- a/test/e2e/frontend/cypress/tests/devices/assignment.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/assignment.spec.js
@@ -39,6 +39,7 @@ describe('FlowForge - Team - Devices - Create', () => {
     })
 
     it('creates the Device unassigned', () => {
+        const deviceName = 'new-device-unassigned--' + Date.now()
         cy.intercept('GET', '/api/v1/teams/*/devices*').as('getDevices')
         cy.intercept('GET', '/api/v1/teams/*/applications*').as('getApplications')
 
@@ -51,7 +52,7 @@ describe('FlowForge - Team - Devices - Create', () => {
         cy.get('[data-el="team-device-create-dialog"]').within(() => {
             // enter a name for the device
             cy.get('[data-form="device-name"] input').click()
-            cy.get('[data-form="device-name"] input').type('new-device-unassigned')
+            cy.get('[data-form="device-name"] input').type(deviceName)
 
             // ensure the application selector is visible (dont select anything)
             cy.get('[data-form="application"]').should('be.visible')
@@ -65,13 +66,15 @@ describe('FlowForge - Team - Devices - Create', () => {
 
         // check the device is in the list
         cy.wait('@getDevices').then(() => {
-            // check the table has a row with the device name and that is is unassigned
-            cy.get('[data-el="devices-browser"] tbody tr td').contains('new-device-unassigned')
-            cy.get('[data-el="devices-browser"] tbody tr td').contains('Unassigned')
+            // check the table (last row) has the device name (1st td)
+            cy.get('[data-el="devices-browser"] tbody tr:last-child td:nth-child(1)').contains(deviceName)
+            // 2nd last column is the application name - should be unassigned
+            cy.get('[data-el="devices-browser"] tbody tr:last-child td:nth-last-child(2)').contains('Unassigned')
         })
     })
 
     it('creates and assigns the Device to the selected Application', () => {
+        const deviceName = 'new-device-assigned--' + Date.now()
         cy.intercept('GET', '/api/v1/teams/*/devices*').as('getDevices')
         cy.intercept('GET', '/api/v1/teams/*/applications*').as('getApplications')
 
@@ -84,7 +87,7 @@ describe('FlowForge - Team - Devices - Create', () => {
         cy.get('[data-el="team-device-create-dialog"]').within(() => {
             // enter a name for the device
             cy.get('[data-form="device-name"] input').click()
-            cy.get('[data-form="device-name"] input').type('new-device-assigned')
+            cy.get('[data-form="device-name"] input').type(deviceName)
 
             // ensure the application selector is visible
             cy.get('[data-form="application"]').should('be.visible')
@@ -108,7 +111,7 @@ describe('FlowForge - Team - Devices - Create', () => {
         // check the device is in the list and is assigned to the application
         cy.wait('@getDevices').then(() => {
             // check the table (last row) has the device name (1st td)
-            cy.get('[data-el="devices-browser"] tbody tr:last-child td:nth-child(1)').contains('new-device-assigned')
+            cy.get('[data-el="devices-browser"] tbody tr:last-child td:nth-child(1)').contains(deviceName)
             // 2nd last column is the application name
             cy.get('[data-el="devices-browser"] tbody tr:last-child td:nth-last-child(2)').contains('application-2')
         })
@@ -138,7 +141,7 @@ describe('FlowForge - Application - Devices - Create', () => {
         cy.login('bob', 'bbPassword')
     })
 
-    it('creates the Device and adds assigned it to the current application', () => {
+    it('creates the Device and assigned it to the current application', () => {
         navigateToApplicationDevices('BTeam', 'application-2')
         const deviceName = 'new-device-auto-assigned--' + Date.now()
         cy.get('[data-action="register-device"]').click()
@@ -164,7 +167,6 @@ describe('FlowForge - Application - Devices - Create', () => {
         // check the device is in the list
         cy.wait('@getApplicationDevices').then(() => {
             // check the table has a row with the device name and that is is unassigned
-            cy.get('[data-el="devices-browser"] tbody tr td').contains('new-device-unassigned')
             cy.get('[data-el="devices-browser"] tbody tr td').contains(deviceName)
         })
     })

--- a/test/e2e/frontend/cypress/tests/devices/assignment.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/assignment.spec.js
@@ -32,6 +32,144 @@ describe('FlowForge - Devices', () => {
     })
 })
 
+describe('FlowForge - Team - Devices - Create', () => {
+    beforeEach(() => {
+        cy.login('bob', 'bbPassword')
+        cy.visit('/team/bteam/devices')
+    })
+
+    it('creates the Device unassigned', () => {
+        cy.intercept('GET', '/api/v1/teams/*/devices*').as('getDevices')
+        cy.intercept('GET', '/api/v1/teams/*/applications*').as('getApplications')
+
+        cy.wait(['@getDevices', '@getApplications'])
+
+        cy.get('[data-action="register-device"]').click()
+
+        // ensure team-device-create-dialog is visible
+        cy.get('[data-el="team-device-create-dialog"]').should('be.visible')
+        cy.get('[data-el="team-device-create-dialog"]').within(() => {
+            // enter a name for the device
+            cy.get('[data-form="device-name"] input').click()
+            cy.get('[data-form="device-name"] input').type('new-device-unassigned')
+
+            // ensure the application selector is visible (dont select anything)
+            cy.get('[data-form="application"]').should('be.visible')
+
+            // click the "Add" button
+            cy.get('[data-action="dialog-confirm"]').click()
+        })
+
+        // check the dialog has closed
+        cy.get('[data-el="platform-dialog"]').should('not.be.visible')
+
+        // check the device is in the list
+        cy.wait('@getDevices').then(() => {
+            // check the table has a row with the device name and that is is unassigned
+            cy.get('[data-el="devices-browser"] tbody tr td').contains('new-device-unassigned')
+            cy.get('[data-el="devices-browser"] tbody tr td').contains('Unassigned')
+        })
+    })
+
+    it('creates and assigns the Device to the selected Application', () => {
+        cy.intercept('GET', '/api/v1/teams/*/devices*').as('getDevices')
+        cy.intercept('GET', '/api/v1/teams/*/applications*').as('getApplications')
+
+        cy.wait(['@getDevices', '@getApplications'])
+
+        cy.get('[data-action="register-device"]').click()
+
+        // ensure team-device-create-dialog is visible
+        cy.get('[data-el="team-device-create-dialog"]').should('be.visible')
+        cy.get('[data-el="team-device-create-dialog"]').within(() => {
+            // enter a name for the device
+            cy.get('[data-form="device-name"] input').click()
+            cy.get('[data-form="device-name"] input').type('new-device-assigned')
+
+            // ensure the application selector is visible
+            cy.get('[data-form="application"]').should('be.visible')
+
+            cy.get('[data-form="application"]').within(() => {
+                // eslint-disable-next-line cypress/require-data-selectors
+                cy.get('.ff-dropdown[disabled=false]').click()
+
+                // Click item with label 'application-2'
+                // eslint-disable-next-line cypress/require-data-selectors
+                cy.get('.ff-dropdown-options > .ff-dropdown-option').contains('application-2').click()
+            })
+
+            // click the "Add" button
+            cy.get('[data-action="dialog-confirm"]').click()
+        })
+
+        // check the dialog has closed
+        cy.get('[data-el="platform-dialog"]').should('not.be.visible')
+
+        // check the device is in the list and is assigned to the application
+        cy.wait('@getDevices').then(() => {
+            // check the table (last row) has the device name (1st td)
+            cy.get('[data-el="devices-browser"] tbody tr:last-child td:nth-child(1)').contains('new-device-assigned')
+            // 2nd last column is the application name
+            cy.get('[data-el="devices-browser"] tbody tr:last-child td:nth-last-child(2)').contains('application-2')
+        })
+    })
+})
+
+describe('FlowForge - Application - Devices - Create', () => {
+    function navigateToApplicationDevices (teamName, appName) {
+        cy.request('GET', '/api/v1/user/teams')
+            .then((response) => {
+                const team = response.body.teams.find(
+                    (team) => team.name === teamName
+                )
+                return cy.request('GET', `/api/v1/teams/${team.id}/applications`)
+            })
+            .then((response) => {
+                const application = response.body.applications.find(
+                    (application) => application.name === appName
+                )
+                cy.visit(`/application/${application.id}/devices`)
+                cy.wait(['@getApplicationDevices'])
+            })
+    }
+
+    beforeEach(() => {
+        cy.intercept('GET', '/api/v1/applications/*/devices').as('getApplicationDevices')
+        cy.login('bob', 'bbPassword')
+    })
+
+    it('creates the Device and adds assigned it to the current application', () => {
+        navigateToApplicationDevices('BTeam', 'application-2')
+        const deviceName = 'new-device-auto-assigned--' + Date.now()
+        cy.get('[data-action="register-device"]').click()
+
+        // ensure team-device-create-dialog is visible
+        cy.get('[data-el="team-device-create-dialog"]').should('be.visible')
+        cy.get('[data-el="team-device-create-dialog"]').within(() => {
+            // enter a name for the device
+            cy.get('[data-form="device-name"] input').click()
+            cy.get('[data-form="device-name"] input').type(deviceName)
+
+            // ensure the application selector does NOT exist in the dialog
+            // (app choice should not be rendered because we are doing this from the app-devices page)
+            cy.get('[data-form="application"]').should('not.exist')
+
+            // click the "Add" button
+            cy.get('[data-action="dialog-confirm"]').click()
+        })
+
+        // check the dialog has closed
+        cy.get('[data-el="platform-dialog"]').should('not.be.visible')
+
+        // check the device is in the list
+        cy.wait('@getApplicationDevices').then(() => {
+            // check the table has a row with the device name and that is is unassigned
+            cy.get('[data-el="devices-browser"] tbody tr td').contains('new-device-unassigned')
+            cy.get('[data-el="devices-browser"] tbody tr td').contains(deviceName)
+        })
+    })
+})
+
 describe('FlowForge - Devices - Assign', () => {
     beforeEach(() => {
         cy.login('bob', 'bbPassword')


### PR DESCRIPTION
## Description

As per discussion in #3295, this PR permits the assignment of a Device to an Application at the time of Device Creation - but only from the Teams -> Devices page.  Additionally, only Application choice is offered (instance choice is not offered)

### Finer details:
The Device Create dialog is shared across the Teams -> Devices, Instance -> Devices and Application -> Devices pages.
Therefore, to satisfy #3295:
* the selection of Application is only to be shown when creating a device from the Teams->Devices pages
* it is not to be displayed when editing a device (not in scope) or from any other of the devices pages

NOTE: The addition of a "- none -" entry included in the Applications dropdown list so that the user can deselect the Application if they change their mind (without having to cancel the device creation and start over) _(our `FormRow` component does not natively support clearing the selection of a dropdown once set)_

## Related Issue(s)

#3295 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [x] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

