### PR TITLE
Add SSO CTA to Team Settings page

### DIFF
--- a/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
+++ b/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
@@ -43,7 +43,7 @@ export default {
             required: true
         },
         userCount: {
-            type: Object,
+            type: Number,
             required: true
         },
         inviteCount: {


### PR DESCRIPTION
Closes #3377 

## Description

This adds a call to action on the Team Settings page to invite users to contact us to help setup SSO for their team.

As part of this, I've given the Team Settings page a quick refresh to bring it inline with other views - this also made it easier to give the SSO CTA a home.

Had to get a little hacky with the logic on whether to show the button or not - sso is a property of the user not the team. So I'm using the following set of rules to display the button:

1. The current user is a Team Owner (they have to be in order to get to the settings page)
2. The current user is not sso enabled
3. The team type is 'Enterprise' - this is hardcoded to the Team Type name, rather than a TeamType feature flag as we'd normally do... as this is quite specific to FF Cloud, it seemed appropriate in order to get this done.

**Before**

![Image](https://github.com/FlowFuse/flowfuse/assets/51083/7ad10c32-3e94-40b1-9f88-9636c0640d35)

**After - viewing settings**

![Image](https://github.com/FlowFuse/flowfuse/assets/51083/6e1caa64-f1a5-4461-b095-212f8cd5097b)

**After - editing settings**

![Image](https://github.com/FlowFuse/flowfuse/assets/51083/ad88e716-24a8-4011-8432-3cdc58eecbb1)

