### PR TITLE
Allow telemetry ping to be disabled by tests

### DIFF
--- a/forge/housekeeper/tasks/telemetryMetrics.js
+++ b/forge/housekeeper/tasks/telemetryMetrics.js
@@ -46,6 +46,10 @@ async function gather (app) {
 }
 
 async function ping (app) {
+    if (process.env.FF_TELEMETRY_DISABLED) {
+        // Allow our tests/CI to disable telemetry
+        return
+    }
     // Only do the ping if:
     // - The licence is active (EE)
     // OR

--- a/test/e2e/frontend/environments/empty.js
+++ b/test/e2e/frontend/environments/empty.js
@@ -5,6 +5,7 @@ const Forge = FF_UTIL.require('forge/forge.js')
 const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 
 module.exports = async function (settings = {}, config = {}) {
+    process.env.FF_TELEMETRY_DISABLED = true
     config = {
         ...config,
         telemetry: { enabled: false },

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -7,6 +7,7 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
 const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 
 module.exports = async function (settings = {}, config = {}) {
+    process.env.FF_TELEMETRY_DISABLED = true
     config = {
         ...config,
         telemetry: { enabled: false },

--- a/test/node_modules/flowforge-test-utils/index.js
+++ b/test/node_modules/flowforge-test-utils/index.js
@@ -5,6 +5,7 @@ const { LocalTransport } = require('./forge/postoffice/localTransport.js')
 const Forge = FFRequire('forge/forge.js')
 
 async function setupApp (config = {}) {
+    process.env.FF_TELEMETRY_DISABLED = true
     config = {
         telemetry: { enabled: false },
         logging: {


### PR DESCRIPTION
Closes #3360 

We made a change a while ago that if a platform is running with a license then it cannot disable telemetry.

A side-effect of that was that more of our local development instances running with a dev license are pinging telemetry and generating noise. Also, the move to minimise how much are tests restart the app means the app is running for longer during test runs and reaching the point where the startup telemetry ping is triggered - particularly in the UI tests.

This PR adds the ability to disable telemetry via an env var - and updates all of our test runners to set that env var.