### PR TITLE
fix bash command formatting in Testing against PostgreSQL

### DIFF
--- a/docs/contribute/introduction.md
+++ b/docs/contribute/introduction.md
@@ -264,22 +264,24 @@ By default, the tests use an in-memory sqlite database to test against. This is
 the most self-contained way of testing the platform. But it is also necessary to
 test against PostgreSQL. To enable the use of PostgreSQL in the tests:
 
-1. Ensure you have an instance of PostgreSQL running locally. For example, via
-   docker:
-
-        docker run -it -p 5432:5432 --name ff-postgres -e POSTGRES_PASSWORD=secret postgres:14
+1. Ensure you have an instance of PostgreSQL running locally. For example, via docker:
+   ```bash
+      docker run -it -p 5432:5432 --name ff-postgres -e POSTGRES_PASSWORD=secret postgres:14
+   ```
 
 2. Enable PostgreSQL mode by setting the following environment variable:
-
-        export FF_TEST_DB_POSTGRES=true
+   ```bash
+      export FF_TEST_DB_POSTGRES=true
+   ```
 
    The database connection can be set using the following env vars (default values shown)
-
-        export FF_TEST_DB_POSTGRES_HOST=localhost
-        export FF_TEST_DB_POSTGRES_PORT=5432
-        export FF_TEST_DB_POSTGRES_USER=postgres
-        export FF_TEST_DB_POSTGRES_PASSWORD=secret
-        export FF_TEST_DB_POSTGRES_DATABASE=flowforge_test
+   ```bash
+      export FF_TEST_DB_POSTGRES_HOST=localhost
+      export FF_TEST_DB_POSTGRES_PORT=5432
+      export FF_TEST_DB_POSTGRES_USER=postgres
+      export FF_TEST_DB_POSTGRES_PASSWORD=secret
+      export FF_TEST_DB_POSTGRES_DATABASE=flowforge_test
+    ```
 
 #### Reporting code coverage
 


### PR DESCRIPTION

## Description

fix bash command formatting in Testing against PostgreSQL

## Related Issue(s)

#3389 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

