### PR TITLE
DeviceEditor: clear request cache when reply handled

### DIFF
--- a/forge/ee/lib/deviceEditor/DeviceTunnelManager.js
+++ b/forge/ee/lib/deviceEditor/DeviceTunnelManager.js
@@ -178,6 +178,7 @@ class DeviceTunnelManager {
             // Otherwise, it's a websocket message, so forward it to the device editor websocket
             const reply = tunnel.requests[response.id]
             if (reply) {
+                delete tunnel.requests[response.id]
                 reply.headers(response.headers ? response.headers : {})
                 reply.code(response.status)
                 if (response.body) {


### PR DESCRIPTION
## Description

The DeviceTunnelManager is responsible for tunnelling requests over the websocket connection back to a device. It stores the pending request until a response is received, at which point it completes the request.

Whilst working on other state-management issues I noticed the request cache isn't being cleared once the response has been sent. Given my other work is going to take more time to sort out, I wanted to get this fix in sooner.
