### PR TITLE
Limit referers to just origin for cross origin

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -315,7 +315,9 @@ module.exports = async (options = {}) => {
             frameguard: {
                 action: 'deny'
             },
-            referrerPolicy: 'origin-when-cross-origin'
+            referrerPolicy: {
+                policy: 'origin-when-cross-origin'
+            }
         })
 
         // Routes : the HTTP routes

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -314,7 +314,8 @@ module.exports = async (options = {}) => {
             strictTransportSecurity,
             frameguard: {
                 action: 'deny'
-            }
+            },
+            referrerPolicy: 'origin-when-cross-origin'
         })
 
         // Routes : the HTTP routes


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Set the Referer-Policy flag in helmet to `origin-when-cross-orgin` so no query string parameters are shared

## Related Issue(s)

<!-- What issue does this PR relate to? -->
part of FlowFuse/security#67

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

