### PR TITLE
Handle null status events from devices

### DIFF
--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -75,6 +75,11 @@ class DeviceCommsHandler {
                 const payload = JSON.parse(status.status)
                 await this.app.db.controllers.Device.updateState(device, payload)
 
+                if (payload === null) {
+                    // This device is busy updating - don't interrupt it
+                    return
+                }
+
                 // If the status state===unknown, the device is waiting for confirmation
                 // it has the right details. Always response with an 'update' command in
                 // this scenario

--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -15,7 +15,7 @@ module.exports = {
         device.set('lastSeenAt', literal('CURRENT_TIMESTAMP'))
         if (!state) {
             // We have received a `null` state from the device. That means it
-            // is busy updating itself. Update out local state to infer as much
+            // is busy updating itself. Update our local state to infer as much
             // as we can from that
             device.set('state', 'updating')
         } else {


### PR DESCRIPTION
## Description

Devices can publish a `null` status update after then reconnect their MQTT connection (https://github.com/FlowFuse/device-agent/blob/93e7b488271c7241df4a6e42db80ef074c84458d/lib/mqtt.js#L66) - as this call is unguarded unlike other status checkins.

There is a question on whether the device should be doing that, but given its the current behaviour, we need to handle it.

This PR updates the code to deal with a null payload - inferring its an `updating` device - and skips any further checks. The device will finish updating and its regular checkin will resync its state.