### PR TITLE
Identify user to hubspot api if tracking enabled

### DIFF
--- a/forge/routes/ui/index.js
+++ b/forge/routes/ui/index.js
@@ -61,6 +61,7 @@ module.exports = async function (app) {
             if (support?.enabled && support.frontend?.hubspot?.trackingcode) {
                 const trackingCode = support.frontend.hubspot.trackingcode
                 injection += `<!-- Start of HubSpot Embed Code -->
+                <script type="text/javascript">window._ffhstc = "${trackingCode}"</script>
                 <script type="text/javascript" id="hs-script-loader" async defer src="//js-eu1.hs-scripts.com/${trackingCode}.js"></script>
               <!-- End of HubSpot Embed Code -->`
             }

--- a/frontend/src/services/product.js
+++ b/frontend/src/services/product.js
@@ -14,6 +14,11 @@ function identify (userId, set, setonce) {
             ...setonce
         })
     }
+    const _hsq = window._hsq = window._hsq || []
+    _hsq.push(['identify', {
+        id: userId,
+        email: set.email
+    }])
 }
 
 /**

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -148,6 +148,13 @@ const actions = {
             const user = await userApi.getUser()
             state.commit('login', user)
 
+            if (window._ffhstc) {
+                const _hsq = window._hsq = window._hsq || []
+                _hsq.push(['identify', {
+                    email: user.email,
+                    id: user.id
+                }])
+            }
             // User is logged in
             if (router.currentRoute.value.name === 'VerifyEmail' && user.email_verified === false) {
                 // This page has `meta.requiresLogin = false` as it needs to be
@@ -278,6 +285,9 @@ const actions = {
         userApi.logout()
             .catch(_ => {})
             .finally(() => {
+                if (window._hsq) {
+                    window._hsq.push(['revokeCookieConsent'])
+                }
                 window.location = '/'
             })
     },

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -148,13 +148,6 @@ const actions = {
             const user = await userApi.getUser()
             state.commit('login', user)
 
-            if (window._ffhstc) {
-                const _hsq = window._hsq = window._hsq || []
-                _hsq.push(['identify', {
-                    email: user.email,
-                    id: user.id
-                }])
-            }
             // User is logged in
             if (router.currentRoute.value.name === 'VerifyEmail' && user.email_verified === false) {
                 // This page has `meta.requiresLogin = false` as it needs to be


### PR DESCRIPTION
Alternative to #3407 

Moves the logic to identify to the HS api into the Vue code that holds the user identity already.

I have had mixed results in testing locally - although doing so on http (not https) and localhost could well impact the results.

On one occassion HS properly identified my logged in user and created a new contact for the chat. On any subsequent attempt (incognito window etc), it didn't identify me.

Given the hubspot api is a blackbox, it's hard to know if this is having the intended result. I suggest we get this into production and see what we get.

