### PR TITLE
Move oauth session state to the database

### DIFF
--- a/forge/db/migrations/20240131-01-add-oauth-sessions-table.js
+++ b/forge/db/migrations/20240131-01-add-oauth-sessions-table.js
@@ -1,0 +1,20 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.createTable('OAuthSessions', {
+            id: {
+                type: DataTypes.STRING,
+                primaryKey: true
+            },
+            value: {
+                type: DataTypes.TEXT,
+                allowNull: false
+            },
+            createdAt: { type: DataTypes.DATE, allowNull: false },
+            updatedAt: { type: DataTypes.DATE, allowNull: false }
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/OAuthSession.js
+++ b/forge/db/models/OAuthSession.js
@@ -1,0 +1,42 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    name: 'OAuthSession',
+    schema: {
+        id: {
+            type: DataTypes.STRING,
+            primaryKey: true
+        },
+        value: {
+            type: DataTypes.TEXT,
+            get () {
+                const rawValue = this.getDataValue('value')
+                return JSON.parse(rawValue)
+            },
+            set (value) {
+                this.setDataValue('value', JSON.stringify(value))
+            }
+        }
+    },
+    finders: function (M) {
+        return {
+            static: {
+                getAndRemoveById: async (id) => {
+                    const cachedValue = await this.findOne({
+                        where: { id }
+                    })
+                    let result = null
+                    if (cachedValue) {
+                        // Only return values if this object was created under five minutes ago
+                        if (Date.now() - cachedValue.createdAt.getTime() < 1000 * 60 * 5) {
+                            result = cachedValue.value
+                        }
+                        // These are single use - so always destroy
+                        await cachedValue.destroy()
+                    }
+                    return result
+                }
+            }
+        }
+    }
+}

--- a/forge/db/models/index.js
+++ b/forge/db/models/index.js
@@ -77,7 +77,8 @@ const modelTypes = [
     'StorageSession',
     'StorageLibrary',
     'AuditLog',
-    'BrokerClient'
+    'BrokerClient',
+    'OAuthSession'
 ]
 
 // A local map of the known models.

--- a/forge/housekeeper/tasks/expireTokens.js
+++ b/forge/housekeeper/tasks/expireTokens.js
@@ -11,5 +11,7 @@ module.exports = {
     run: async function (app) {
         await app.db.models.Session.destroy({ where: { expiresAt: { [Op.lt]: Date.now() } } })
         await app.db.models.AccessToken.destroy({ where: { expiresAt: { [Op.lt]: Date.now() } } })
+        // Remove any OAuthSession objects that were created more than 5 minutes ago
+        await app.db.models.OAuthSession.destroy({ where: { createdAt: { [Op.lt]: Date.now() - 1000 * 60 * 5 } } })
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
                 "hashids": "^2.3.0",
                 "jsonwebtoken": "^9.0.0",
                 "lottie-web-vue": "^2.0.7",
-                "lru-cache": "^10.0.0",
                 "marked": "^11.2.0",
                 "mqtt": "^5.1.1",
                 "nodemailer": "^6.9.3",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
         "hashids": "^2.3.0",
         "jsonwebtoken": "^9.0.0",
         "lottie-web-vue": "^2.0.7",
-        "lru-cache": "^10.0.0",
         "marked": "^11.2.0",
         "mqtt": "^5.1.1",
         "nodemailer": "^6.9.3",


### PR DESCRIPTION
Part of #2782 

## Description

Our oauth implementation for authenticating access to the Instance editor (and used by nr-tools-plugin) tracks inflight oauth exchanges in memory. That won't work when the app is scaled up - as later requests in the oauth flow may hit a different platform node.

This moves that state management to a new db table - `OAuthSessions`.

As with the previous `lru-cache` usage, the objects are only valid for 5 minutes and they are deleted when they are retrieved. Our existing housekeeping task has been updated to remove any old session objects.

I have tests this change with a single-instance localfs setup as well as a dual-instance localfs setup behind nginx; with a verification that a single oauth request that hit both of the nodes for the two steps of the flow succeeded.
