### PR TITLE
Replace helm upgrade instructions with link to Helm documentation

### DIFF
--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -209,6 +209,6 @@ forge:
 
 ## Upgrade
 
-All technical aspects of the upgrade Flowfuse on Kubernetes managed by Helm are maintained in our repository.
+All technical aspects of the upgrade process of Flowfuse application running on Kubernetes and managed by Helm chart are maintained in our repository.
 Please refer to the [Flowfuse Helm Chart documentation](https://github.com/FlowFuse/helm/blob/main/helm/flowforge/README.md#upgrading-chart) for more details
 about the upgrade process.

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -209,63 +209,6 @@ forge:
 
 ## Upgrade
 
-### Upgrading to 2.0
-
-Together with new application features, this release updates the Helm sub-chart, Bitnami's Postgresql, version.
-If local PostgreSQL database instance is used, upgrading to this version, using our Helm chart, requires additional steps.
-
-1. Backup the database ([yq](https://mikefarah.gitbook.io/yq/#install) and [ghead](https://formulae.brew.sh/formula/coreutils) (part of `coreutils` package, MacOS only) tools are required)
-
-   For linux:
-      
-      ```bash
-      DBPASSWORD=$(kubectl get cm flowforge-config -o jsonpath='{.data.flowforge\.yml}' | yq ".db.password") 
-      kubectl run -it --rm db-backup --env="PGPASSWORD=$DBPASSWORD" --image ubuntu/postgres:14-22.04_edge -- bash -c "pg_dump -h flowforge-postgresql -U forge flowforge" | head -n -2 > db.sql
-      ```
-
-   For macOS/BSD:
-
-      ```bash
-      DBPASSWORD=$(kubectl get cm flowforge-config -o jsonpath='{.data.flowforge\.yml}' | yq ".db.password")
-      kubectl run -it --rm db-backup --env="PGPASSWORD=$DBPASSWORD" --image ubuntu/postgres:14-22.04_edge -- bash -c "pg_dump -h flowforge-postgresql -U forge flowforge" | ghead -n -2 > db.sql
-      ```
-
-2. Obtain the PVC name which stores the database data
-
-   ```bash
-   export POSTGRESQL_PVC=$(kubectl --namespace default get pvc -l app.kubernetes.io/name=postgresql,role=primary -o jsonpath="{.items[0].metadata.name}")
-   ```
-
-3. Delete postgresql statefulset and secret
-
-   ```bash
-   kubectl --namespace default delete statefulset.app flowforge-postgresql
-   kubectl --namespace default delete secret flowforge-postgresql
-   ```
-
-4. Get database image version and perform the upgrade  
-
-   ```bash
-   CURRENT_VERSION=$(kubectl --namespace defualt exec postgresql-postgresql-0 -- bash -c 'echo $BITNAMI_IMAGE_VERSION')
-
-   helm upgrade --install --atomic \
-      --namespace default  \ 
-      --values $path/to/your/values.yaml \
-      --set postgresql.primary.persistance.existingClaim=$POSTGRESQL_PVC \
-      --set postgresql.image.tag=$CURRENT_VERSION \
-      flowforge flowforge/flowforge
-   ```
-
-### Upgrading to 1.12
-
-As of FlowFuse v1.12.0 the URL used to host the helm chart changed, so in order to upgrade from a previous 
-version you will need to update the repo.
-
- - Run `helm repo remove flowforge`
- - Run `helm repo add flowforge https://flowfuse.github.io/helm`
-
- You can then run the following:
-
-- Run `helm repo update flowforge` to pull the latest version
-- Check the [README.md](https://github.com/FlowFuse/helm/blob/main/helm/flowforge/README.md) for any new options to configure in `customization.yml`
-- Run the `helm upgrade --install flowforge flowforge -f customization.yml`
+All technical aspects of the upgrade Flowfuse on Kubernetes managed by Helm are maintained in our repository.
+Please refer to the [Flowfuse Helm Chart documentation](https://github.com/FlowFuse/helm/blob/main/helm/flowforge/README.md#upgrading-chart) for more details
+about the upgrade process.


### PR DESCRIPTION
## Description

This PR replaces technical aspects of the upgrade process of Flowfuse application running on Kubernetes in a favor of general description with the link to the Helm Chart README file.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

