### PR TITLE
Remove blueprints from instance duplication

### DIFF
--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -130,6 +130,7 @@ export default {
         createInstance (instanceDetails, copyParts) {
             const createPayload = { ...instanceDetails, applicationId: this.application.id }
             if (this.sourceInstance?.id) {
+                delete createPayload.flowBlueprintId
                 createPayload.sourceProject = {
                     id: this.sourceInstanceId,
                     options: { ...copyParts }

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -77,7 +77,7 @@
                 <BlueprintSelection :blueprints="blueprints" @selected="selectBlueprint" />
             </template>
             <template v-else>
-                <div v-if="creatingNew && flowBlueprintsEnabled && atLeastOneFlowBlueprint">
+                <div v-if="creatingNew && flowBlueprintsEnabled && atLeastOneFlowBlueprint && !isCopyProject">
                     <div class="max-w-sm" data-form="blueprint">
                         <label class="block text-sm font-medium text-gray-800 mb-2">Blueprint:</label>
                         <BlueprintTileSmall :blueprint="selectedBlueprint" />

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -673,7 +673,7 @@ export default {
             this.input.stack = this.stacks[0]?.id
         },
         async loadBlueprints () {
-            if (!this.flowBlueprintsEnabled) {
+            if (!this.flowBlueprintsEnabled || this.isCopyProject) {
                 return []
             }
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
When duplicating an instance don't show the Blueprint selector and don't pass a Blueprint id to the API

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

