### PR TITLE
Enforce Username constraint in both front and backend

### DIFF
--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -102,6 +102,11 @@ module.exports = {
                 }
             }
             if (request.body.username) {
+                if (!request.body.username.match(/^[a-z0-9-_]+$/)) {
+                    const err = new Error('Invalid username')
+                    err.code = 'invalid_user'
+                    throw err
+                }
                 user.username = request.body.username
             }
             if (request.body.tcs_accepted) {

--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -102,7 +102,7 @@ module.exports = {
                 }
             }
             if (request.body.username) {
-                if (!request.body.username.match(/^[a-z0-9-_]+$/)) {
+                if (!/^[a-z0-9-_]+$/.test(request.body.username)) {
                     const err = new Error('Invalid username')
                     err.code = 'invalid_user'
                     throw err

--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -104,7 +104,7 @@ module.exports = {
             if (request.body.username) {
                 if (!/^[a-z0-9-_]+$/.test(request.body.username)) {
                     const err = new Error('Invalid username')
-                    err.code = 'invalid_user'
+                    err.code = 'invalid_request'
                     throw err
                 }
                 user.username = request.body.username

--- a/forge/routes/setup/index.js
+++ b/forge/routes/setup/index.js
@@ -80,7 +80,7 @@ module.exports = async function (app) {
             reply.code(404).send()
             return
         }
-        if (/^(admin|root)$/.test(request.body.username)) {
+        if (/^(admin|root)$/.test(request.body.username) || !/^[a-z0-9-_]+$/.test(request.body.username)) {
             reply.code(400).send({ error: 'invalid username' })
             return
         }

--- a/test/system/001-setup_spec.js
+++ b/test/system/001-setup_spec.js
@@ -127,6 +127,23 @@ describe('First run setup', function () {
             adminUser.email.should.equal('alice@example.com')
             adminUser.email_verified.should.equal(true)
         })
+        it('should reject admin username', async function () {
+            const response = await forge.inject({
+                method: 'POST',
+                url: '/setup/create-user',
+                payload: {
+                    _csrf: CSRF_TOKEN,
+                    name: 'Alice Skywalker',
+                    email: 'alice@example.com',
+                    username: 'alice <test>',
+                    password: '12345678'
+                },
+                cookies: CSRF_COOKIE
+            })
+            const body = response.json()
+            response.statusCode.should.equal(400)
+            body.should.have.property('error', 'invalid username')
+        })
         it('status should report admin created', async function () {
             const response = await forge.inject({
                 method: 'GET',

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -351,6 +351,20 @@ describe('Users API', async function () {
 
                 await harry.destroy()
             })
+            it('user can not set invalid username', async function () {
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/users/${TestObjects.alice.hashid}`,
+                    payload: {
+                        username: '<img src="foo.png">'
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(400)
+                const body = response.json()
+                body.should.have.property('code', 'invalid_request')
+                body.should.have.property('error', 'Error: Invalid username')
+            })
         })
     })
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Enforce the same constraints in both front and backend

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/security/issues/73

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

