### PR TITLE
Improve performance of Audit Log entry page

### DIFF
--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -95,31 +95,9 @@ module.exports = {
                         if (associationsLimit) {
                             include.limit = associationsLimit
                             include.order = [['updatedAt', 'DESC']]
-                            /*
                             include.attributes = {
-                                include: [...include.attributes, [
-                                    literal(`(
-                                        SELECT "createdAt"
-                                        FROM "AuditLogs"
-                                        WHERE "AuditLogs"."entityId" = cast("Project"."id" as VARCHAR)
-                                        AND "AuditLogs"."entityType" = 'project'
-                                        ORDER BY "createdAt" DESC
-                                        LIMIT 1
-                                    )`),
-                                    'mostRecentAuditLogCreatedAt'
-                                ], [
-                                    literal(`(
-                                        SELECT "event"
-                                        FROM "AuditLogs"
-                                        WHERE "AuditLogs"."entityId" = cast("Project"."id" as VARCHAR)
-                                        AND "AuditLogs"."entityType" = 'project'
-                                        ORDER BY "createdAt" DESC
-                                        LIMIT 1
-                                    )`),
-                                    'mostRecentAuditLogEvent'
-                                ]
-                                ]
-                            } */
+                                include: [...include.attributes]
+                            }
                         }
 
                         includes.push(include)
@@ -134,29 +112,6 @@ module.exports = {
                         if (associationsLimit) {
                             include.limit = associationsLimit
                             include.order = [['lastSeenAt', 'DESC NULLS LAST'], ['updatedAt', 'DESC']]
-                            /* include.attributes = {
-                                include: [...include.attributes, [
-                                    literal(`(
-                                        SELECT "createdAt"
-                                        FROM "AuditLogs"
-                                        WHERE "AuditLogs"."entityId" = cast("Device"."id" as VARCHAR)
-                                        AND "AuditLogs"."entityType" = 'device'
-                                        ORDER BY "createdAt" DESC
-                                        LIMIT 1
-                                    )`),
-                                    'mostRecentAuditLogCreatedAt'
-                                ], [
-                                    literal(`(
-                                        SELECT "event"
-                                        FROM "AuditLogs"
-                                        WHERE "AuditLogs"."entityId" = cast("Device"."id" as VARCHAR)
-                                        AND "AuditLogs"."entityType" = 'device'
-                                        ORDER BY "createdAt" DESC
-                                        LIMIT 1
-                                    )`),
-                                    'mostRecentAuditLogEvent'
-                                ]]
-                            } */
                         }
 
                         includes.push(include)

--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -94,7 +94,8 @@ module.exports = {
 
                         if (associationsLimit) {
                             include.limit = associationsLimit
-                            include.order = [['mostRecentAuditLogCreatedAt', 'DESC NULLS LAST'], ['updatedAt', 'DESC']]
+                            include.order = [['updatedAt', 'DESC']]
+                            /*
                             include.attributes = {
                                 include: [...include.attributes, [
                                     literal(`(
@@ -118,7 +119,7 @@ module.exports = {
                                     'mostRecentAuditLogEvent'
                                 ]
                                 ]
-                            }
+                            } */
                         }
 
                         includes.push(include)
@@ -127,13 +128,13 @@ module.exports = {
                     if (includeApplicationDevices) {
                         const include = {
                             model: M.Device,
-                            attributes: ['hashid', 'id', 'name', 'links', 'state', 'mode', 'updatedAt']
+                            attributes: ['hashid', 'id', 'name', 'links', 'state', 'mode', 'updatedAt', 'lastSeenAt']
                         }
 
                         if (associationsLimit) {
                             include.limit = associationsLimit
-                            include.order = [['mostRecentAuditLogCreatedAt', 'DESC NULLS LAST'], ['updatedAt', 'DESC']]
-                            include.attributes = {
+                            include.order = [['lastSeenAt', 'DESC NULLS LAST'], ['updatedAt', 'DESC']]
+                            /* include.attributes = {
                                 include: [...include.attributes, [
                                     literal(`(
                                         SELECT "createdAt"
@@ -155,7 +156,7 @@ module.exports = {
                                     )`),
                                     'mostRecentAuditLogEvent'
                                 ]]
-                            }
+                            } */
                         }
 
                         includes.push(include)

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -437,12 +437,14 @@ describe('Team API', function () {
 
                 // Most recent audit log included
                 const instanceOneSummary = applicationOne.instancesSummary.instances.find((instance) => instance.name === 'application-1-instance-1')
-                instanceOneSummary.should.have.property('mostRecentAuditLogCreatedAt')
-                instanceOneSummary.should.have.property('mostRecentAuditLogEvent', 'project.suspended')
+                should(instanceOneSummary).not.be.null()
+                /* instanceOneSummary.should.have.property('mostRecentAuditLogCreatedAt')
+                instanceOneSummary.should.have.property('mostRecentAuditLogEvent', 'project.suspended') */
 
                 const instanceThreeSummary = applicationOne.instancesSummary.instances.find((instance) => instance.name === 'application-1-instance-3')
-                instanceThreeSummary.should.have.property('mostRecentAuditLogCreatedAt')
-                instanceThreeSummary.should.have.property('mostRecentAuditLogEvent', 'project.created')
+                should(instanceThreeSummary).not.be.null()
+                /* instanceThreeSummary.should.have.property('mostRecentAuditLogCreatedAt')
+                instanceThreeSummary.should.have.property('mostRecentAuditLogEvent', 'project.created') */
             })
 
             it('with all a subset of application devices including most recent audit log', async function () {
@@ -472,12 +474,14 @@ describe('Team API', function () {
 
                 // Most recent audit log included
                 const deviceOneSummary = applicationOne.devicesSummary.devices.find((device) => device.name === 'device-1')
-                deviceOneSummary.should.have.property('mostRecentAuditLogCreatedAt')
-                deviceOneSummary.should.have.property('mostRecentAuditLogEvent', 'device.assigned')
+                should(deviceOneSummary).not.be.null()
+                // deviceOneSummary.should.have.property('mostRecentAuditLogCreatedAt')
+                // deviceOneSummary.should.have.property('mostRecentAuditLogEvent', 'device.assigned')
 
                 const deviceThreeSummary = applicationOne.devicesSummary.devices.find((device) => device.name === 'device-3')
-                deviceThreeSummary.should.have.property('mostRecentAuditLogCreatedAt')
-                deviceThreeSummary.should.have.property('mostRecentAuditLogEvent', 'device.developer-mode.enabled')
+                should(deviceThreeSummary).not.be.null()
+                // deviceThreeSummary.should.have.property('mostRecentAuditLogCreatedAt')
+                // deviceThreeSummary.should.have.property('mostRecentAuditLogEvent', 'device.developer-mode.enabled')
             })
         })
     })


### PR DESCRIPTION
## Description

Temporary fix for slowdowns for #3427, this PR removes the audit log entry lookup entirely from the home page.
The hope is the removal of the four subqueries will significantly improve performance.

Longer term, this should be split into separate API requests or a series of SQL queries, rather than one inline.

The UI falls back to showing the last flows updated at time and device last seen time:

<img width="1263" alt="Screenshot 2024-02-08 at 16 22 08" src="https://github.com/FlowFuse/flowfuse/assets/507155/3b2d49e6-f8cc-4cdf-9878-204493e52e81">

## Related Issue(s)

#3427 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

