### PR TITLE
Ensure Admin Settings page only shown to Admin users

### DIFF
--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -77,7 +77,7 @@ export default {
             this.stats = await adminApi.getStats()
             this.license = await adminApi.getLicenseDetails()
         } catch (err) {
-            if (err.response.status == 403) {
+            if (err.response.status === 403) {
                 this.$router.push('/')
             } else {
                 throw err

--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -73,8 +73,16 @@ export default {
         }
     },
     async mounted () {
-        this.stats = await adminApi.getStats()
-        this.license = await adminApi.getLicenseDetails()
+        try {
+            this.stats = await adminApi.getStats()
+            this.license = await adminApi.getLicenseDetails()
+        } catch (err) {
+            if (err.response.status == 403) {
+                this.$router.push('/')
+            } else {
+                throw err
+            }
+        }
         this.settings = await Settings.getSettings()
     }
 }


### PR DESCRIPTION
part of FlowFuse/security#74

## Description

<!-- Describe your changes in detail -->
Ensure Admin settings UI pages only shown to Admin users.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
 FlowFuse/security#74

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

