### PR TITLE
Disable housekeeper in testing

### DIFF
--- a/test/unit/forge/configuration/http_security_spec.js
+++ b/test/unit/forge/configuration/http_security_spec.js
@@ -2,8 +2,8 @@ const should = require('should') // eslint-disable-line
 
 const FF_UTIL = require('flowforge-test-utils')
 
-describe('Check HTTP Security Headers set', async () => {
-    describe('CSP Headers', async () => {
+describe('Check HTTP Security Headers set', () => {
+    describe('CSP Headers', () => {
         let app
 
         afterEach(async function () {
@@ -12,6 +12,7 @@ describe('Check HTTP Security Headers set', async () => {
 
         it('CSP Report only should be disabled', async function () {
             const config = {
+                housekeeper: false,
                 content_security_policy: {
                     enabled: false
                 }
@@ -30,6 +31,7 @@ describe('Check HTTP Security Headers set', async () => {
 
         it('CSP Report only should be enabled', async function () {
             const config = {
+                housekeeper: false,
                 content_security_policy: {
                     enabled: true,
                     report_only: true,
@@ -51,6 +53,7 @@ describe('Check HTTP Security Headers set', async () => {
 
         it('CSP should be enabled', async function () {
             const config = {
+                housekeeper: false,
                 content_security_policy: {
                     enabled: true
                 }
@@ -70,6 +73,7 @@ describe('Check HTTP Security Headers set', async () => {
 
         it('CSP should be enabled, custom directives', async function () {
             const config = {
+                housekeeper: false,
                 content_security_policy: {
                     enabled: true,
                     directives: {
@@ -91,6 +95,7 @@ describe('Check HTTP Security Headers set', async () => {
 
         it('CSP should be enabled with plausible', async function () {
             const config = {
+                housekeeper: false,
                 telemetry: {
                     frontend: {
                         plausible: {
@@ -116,6 +121,7 @@ describe('Check HTTP Security Headers set', async () => {
 
         it('CSP should be enabled with posthog', async function () {
             const config = {
+                housekeeper: false,
                 telemetry: {
                     frontend: {
                         posthog: {
@@ -141,6 +147,7 @@ describe('Check HTTP Security Headers set', async () => {
 
         it('CSP should be enabled with hubspot', async function () {
             const config = {
+                housekeeper: false,
                 support: {
                     enabled: true,
                     frontend: {
@@ -167,6 +174,7 @@ describe('Check HTTP Security Headers set', async () => {
 
         it('CSP should be enabled with hubspot and posthog', async function () {
             const config = {
+                housekeeper: false,
                 support: {
                     enabled: true,
                     frontend: {
@@ -199,6 +207,7 @@ describe('Check HTTP Security Headers set', async () => {
         })
         it('CSP should be enabled with hubspot and posthog empty directive', async function () {
             const config = {
+                housekeeper: false,
                 support: {
                     enabled: true,
                     frontend: {
@@ -233,6 +242,7 @@ describe('Check HTTP Security Headers set', async () => {
         })
         it('CSP with sentry.io', async function () {
             const config = {
+                housekeeper: false,
                 telemetry: {
                     frontend: {
                         sentry: 'foo'
@@ -264,6 +274,7 @@ describe('Check HTTP Security Headers set', async () => {
 
         it('HTST not set', async function () {
             const config = {
+                housekeeper: false,
                 base_url: 'http://localhost:9999'
             }
             app = await FF_UTIL.setupApp(config)

--- a/test/unit/forge/containers/setup.js
+++ b/test/unit/forge/containers/setup.js
@@ -5,6 +5,7 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
 // Should pull out the common bits to one place
 
 module.exports = async function (config = {}) {
+    config.housekeeper = config.housekeeper || false
     const forge = await FF_UTIL.setupApp(config)
     /*
         alice (admin)

--- a/test/unit/forge/db/setup.js
+++ b/test/unit/forge/db/setup.js
@@ -4,6 +4,7 @@ const FF_UTIL = require('flowforge-test-utils')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
 
 module.exports = async function (config = {}) {
+    config.housekeeper = config.housekeeper || false
     const forge = await FF_UTIL.setupApp(config)
     const factory = new TestModelFactory(forge)
     /*

--- a/test/unit/forge/ee/lib/alerts/setup.js
+++ b/test/unit/forge/ee/lib/alerts/setup.js
@@ -7,6 +7,7 @@ module.exports = async function (config = {
     license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwiZGV2Ijp0cnVlLCJpYXQiOjE2NjI0ODI5ODd9.e8Jeppq4aURwWYz-rEpnXs9RY2Y7HF7LJ6rMtMZWdw2Xls6-iyaiKV1TyzQw5sUBAhdUSZxgtiFH5e_cNJgrUg'
 
 }) {
+    config.housekeeper = config.housekeeper || false
     const forge = await FF_UTIL.setupApp(config)
     const factory = new TestModelFactory(forge)
 

--- a/test/unit/forge/ee/setup.js
+++ b/test/unit/forge/ee/setup.js
@@ -7,6 +7,7 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
 
 async function setup (config = {}) {
     config = {
+        housekeeper: false,
         license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwiZGV2Ijp0cnVlLCJpYXQiOjE2NjI0ODI5ODd9.e8Jeppq4aURwWYz-rEpnXs9RY2Y7HF7LJ6rMtMZWdw2Xls6-iyaiKV1TyzQw5sUBAhdUSZxgtiFH5e_cNJgrUg',
         billing: {
             stripe: {

--- a/test/unit/forge/licensing/index_spec.js
+++ b/test/unit/forge/licensing/index_spec.js
@@ -93,7 +93,7 @@ describe('License API', async function () {
      * @returns the forge application
      */
     async function getApp (license) {
-        return await FF_UTIL.setupApp({ license })
+        return await FF_UTIL.setupApp({ housekeeper: false, license })
     }
 
     describe('unlicensed', function () {

--- a/test/unit/forge/routes/setup.js
+++ b/test/unit/forge/routes/setup.js
@@ -3,6 +3,7 @@ const TestModelFactory = require('../../../lib/TestModelFactory')
 const FF_UTIL = require('flowforge-test-utils')
 
 module.exports = async function (config = {}) {
+    config.housekeeper = config.housekeeper || false
     const forge = await FF_UTIL.setupApp(config)
     await forge.db.models.PlatformSettings.upsert({ key: 'setup:initialised', value: true })
 


### PR DESCRIPTION
## Description

There's no need to run housekeeper in most tests.
Previously the startup tasks were running for each time the app was setup. They ran async.

Theoretically speeds up the tests...

## Related Issue(s)

Discovered as part of trying to fix test failures in https://github.com/FlowFuse/flowfuse/pull/3481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

