### PR TITLE
Fix NOT NULL constraint on `ProjectSnapshots.UserId`

### DIFF
--- a/forge/db/migrations/20240220-01-fix-projectSnapshot-constraint.js
+++ b/forge/db/migrations/20240220-01-fix-projectSnapshot-constraint.js
@@ -1,0 +1,57 @@
+/**
+ * Remove NOT NULL on ProjectSnapshots.UserId
+ */
+// eslint-disable-next-line no-unused-vars
+const { DataTypes, QueryInterface } = require('sequelize')
+
+module.exports = {
+    /**
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        const dialect = context.sequelize.options.dialect
+        if (dialect === 'sqlite') {
+            // We have to do this the hard way due to limitations of sqlite and
+            // changing table constraints. The changeColumn approach causes all
+            // table constraints to be lost. We can keep them on the one column
+            // we're modifying, but it also strips them for the others.
+
+            // get the current DDL for the ProjectSnapshots table
+            const sqlFind = "select sql from SQLITE_MASTER where name = 'ProjectSnapshots' and type = 'table';"
+            const [results] = await context.sequelize.query(sqlFind)
+            if (results.length === 0) {
+                return // Nothing to do
+            }
+
+            // check if the UserId column has a NOT NULL constraint
+            const ddl = results[0].sql
+            const re = /(UserId[^,]+?NOT NULL)/.exec(ddl)
+            if (!re || re.length < 2) {
+                return // Nothing to do
+            }
+
+            // remove NOT NULL from the UserId column definition
+            const currentColDef = re[1]
+            const newColDef = currentColDef.replace('NOT NULL', '')
+
+            // update the table with the new column definition
+            await context.sequelize.query('pragma writable_schema=1;')
+            const sqlUpdate = `update SQLITE_MASTER set sql = replace(sql, '${currentColDef}', '${newColDef}') where name = 'ProjectSnapshots' and type = 'table';`
+            context.sequelize.query(sqlUpdate)
+            await context.sequelize.query('pragma writable_schema=0;')
+        } else {
+            // Postgres allows us to modify a constraint without breaking other properties
+            // set the column to match the exact same definition in the rollup migration 20231005-01-update-projectSnapshot-constraint.js
+            await context.changeColumn('ProjectSnapshots', 'UserId', {
+                type: DataTypes.INTEGER,
+                allowNull: true,
+                defaultValue: null,
+                references: { model: 'Users', key: 'id' },
+                onDelete: 'SET NULL',
+                onUpdate: 'CASCADE'
+            })
+        }
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/migrations/20240220-01-fix-projectSnapshot-constraint.js
+++ b/forge/db/migrations/20240220-01-fix-projectSnapshot-constraint.js
@@ -45,10 +45,7 @@ module.exports = {
             await context.changeColumn('ProjectSnapshots', 'UserId', {
                 type: DataTypes.INTEGER,
                 allowNull: true,
-                defaultValue: null,
-                references: { model: 'Users', key: 'id' },
-                onDelete: 'SET NULL',
-                onUpdate: 'CASCADE'
+                defaultValue: null
             })
         }
     },


### PR DESCRIPTION
fixes #3500

## Description

Update constraint on  `ProjectSnapshots.UserId` to allow NULL

NOTE: Unlike similar migration  in `forge/db/migrations/20231005-01-update-projectSnapshot-constraint.js` which is a basic column change where the column did not have any foreign key constraints, I found through dry running this on a windows box that there are in-fact no backtick quotes on the field names.  to be safe, this migration takes a slightly different approach in that it:
1. first checks for `NOT NULL` (returns cleanly if not found)
2. extracts the current column definition from the DDL and replaces `NOT NULL` portion with `''`
3. then replaces the `currentColDef` with the `newColDef` 



### PG Specific
For the PR migration, this is the result of checking before and after with a PG database that had the same DDL as production:

#### Before:
```sql
-- Generated by the database client.
CREATE TABLE "ProjectSnapshots"(
    id SERIAL NOT NULL,
    name varchar(255) NOT NULL,
    description text,
    settings text,
    flows text,
    "createdAt" timestamp with time zone NOT NULL,
    "updatedAt" timestamp with time zone NOT NULL,
    "ProjectId" uuid,
    "UserId" integer NOT NULL,
    "DeviceId" integer,
    PRIMARY KEY(id),
    CONSTRAINT ProjectSnapshots_ProjectId_fkey FOREIGN key("ProjectId") REFERENCES "Projects"(id),
    CONSTRAINT ProjectSnapshots_UserId_fkey FOREIGN key("UserId") REFERENCES "Users"(id),
    CONSTRAINT ProjectSnapshots_DeviceId_fkey FOREIGN key("DeviceId") REFERENCES "Devices"(id)
);
```

#### Reproduced error:
```log
original: error: null value in column "UserId" of relation "ProjectSnapshots" violates not-null constraint
      at Parser.parseErrorMessage (C:\Users\Stephen\repos\github\flowfuse\dev-env\packages\flowfuse\node_modules\pg-protocol\dist\parser.js:287:98)
      at Parser.handlePacket (C:\Users\Stephen\repos\github\flowfuse\dev-env\packages\flowfuse\node_modules\pg-protocol\dist\parser.js:126:29)
      at Parser.parse (C:\Users\Stephen\repos\github\flowfuse\dev-env\packages\flowfuse\node_modules\pg-protocol\dist\parser.js:39:38)
      at Socket.<anonymous> (C:\Users\Stephen\repos\github\flowfuse\dev-env\packages\flowfuse\node_modules\pg-protocol\dist\index.js:11:42)
      at Socket.emit (node:events:517:28)
      at Socket.emit (node:domain:489:12)
      at addChunk (node:internal/streams/readable:368:12)
      at readableAddChunk (node:internal/streams/readable:341:9)
      at Readable.push (node:internal/streams/readable:278:10)
      at TCP.onStreamRead (node:internal/stream_base_commons:190:23)
```

#### After migration:
```sql
-- Generated by the database client.
CREATE TABLE "ProjectSnapshots"(
    id SERIAL NOT NULL,
    name varchar(255) NOT NULL,
    description text,
    settings text,
    flows text,
    "createdAt" timestamp with time zone NOT NULL,
    "updatedAt" timestamp with time zone NOT NULL,
    "ProjectId" uuid,
    "UserId" integer,
    "DeviceId" integer,
    PRIMARY KEY(id),
    CONSTRAINT ProjectSnapshots_ProjectId_fkey FOREIGN key("ProjectId") REFERENCES "Projects"(id),
    CONSTRAINT ProjectSnapshots_DeviceId_fkey FOREIGN key("DeviceId") REFERENCES "Devices"(id),
    CONSTRAINT ProjectSnapshots_UserId_fkey FOREIGN key("UserId") REFERENCES "Users"(id)
);
```

#### Result - successful auto snapshot on PG DB
![image](https://github.com/FlowFuse/flowfuse/assets/44235289/537a58e9-68d0-4767-9d3f-c463de8ed9cc)




_See full details in #3500 on how this situation came to be._

## Related Issue(s)

#3500 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [x] Includes a DB migration? -> add the `area:migration` label

