### PR TITLE
fix device editor tunnel status indicator

### DIFF
--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -86,7 +86,7 @@ module.exports = function (app) {
         if (app.license.active() && result.mode === 'developer' && app.comms?.devices?.tunnelManager) {
             /** @type {import("../../ee/lib/deviceEditor/DeviceTunnelManager").DeviceTunnelManager} */
             const tunnelManager = app.comms.devices.tunnelManager
-            filtered.editor = tunnelManager.getTunnelStatus(device.id) || {}
+            filtered.editor = tunnelManager.getTunnelStatus(result.hashid) || {}
         }
 
         return filtered
@@ -179,7 +179,7 @@ module.exports = function (app) {
             if (includeEditor && app.license.active() && summary.status === 'running' && summary.mode === 'developer' && app.comms?.devices?.tunnelManager) {
                 /** @type {import("../../ee/lib/deviceEditor/DeviceTunnelManager").DeviceTunnelManager} */
                 const tunnelManager = app.comms.devices.tunnelManager
-                filtered.editor = tunnelManager.getTunnelStatus(device.id) || {}
+                filtered.editor = tunnelManager.getTunnelStatus(summary.hashid) || {}
             }
 
             return filtered

--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -179,7 +179,7 @@ module.exports = function (app) {
             if (includeEditor && app.license.active() && summary.status === 'running' && summary.mode === 'developer' && app.comms?.devices?.tunnelManager) {
                 /** @type {import("../../ee/lib/deviceEditor/DeviceTunnelManager").DeviceTunnelManager} */
                 const tunnelManager = app.comms.devices.tunnelManager
-                filtered.editor = tunnelManager.getTunnelStatus(summary.hashid) || {}
+                filtered.editor = tunnelManager.getTunnelStatus(summary.id) || {}
             }
 
             return filtered

--- a/test/unit/forge/ee/routes/api/team_spec.js
+++ b/test/unit/forge/ee/routes/api/team_spec.js
@@ -95,7 +95,7 @@ describe('Team API - with billing enabled', function () {
 
             const device1 = await app.factory.createDevice({ name: 'device-1', type: 'test-device', lastSeenAt: new Date(), mode: 'developer', state: 'running' }, app.team, null, app.application)
 
-            app.comms.devices.tunnelManager.newTunnel(device1.id, 'token12e')
+            app.comms.devices.tunnelManager.newTunnel(device1.hashid, 'token12e')
             sinon.stub(app.comms.devices.tunnelManager, 'isConnected').returns(true)
 
             const response = await app.inject({

--- a/test/unit/forge/ee/routes/api/team_spec.js
+++ b/test/unit/forge/ee/routes/api/team_spec.js
@@ -118,7 +118,7 @@ describe('Team API - with billing enabled', function () {
             device.should.have.property('mode', 'developer')
             device.should.have.property('editor')
 
-            device.editor.should.have.property('url', '/api/v1/devices/1/editor/proxy/?access_token=token12e')
+            device.editor.should.have.property('url', `/api/v1/devices/${device1.hashid}/editor/proxy/?access_token=token12e`)
             device.editor.should.have.property('enabled', true)
             device.editor.should.have.property('connected', true)
         })


### PR DESCRIPTION
fixes #3473
fixes #3499

## Description

Pass hashid not id in querying tunnel state

Reverts changes made in #3427 7f32d0c


### working demo
![chrome_h8a7o3Ryvn](https://github.com/FlowFuse/flowfuse/assets/44235289/98f9254a-7989-4b73-95d8-1d6d58d570f8)



## Related Issue(s)

#3473 
#3499

## Checklist


 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

