### PR TITLE
Improve scalability of device editor

### DIFF
--- a/forge/db/migrations/20240221-01-add-editor-state-to-Devices.js
+++ b/forge/db/migrations/20240221-01-add-editor-state-to-Devices.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ * Add ProjectSnapshots table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        await context.addColumn('Devices', 'editorAffinity', {
+            type: DataTypes.STRING,
+            defaultValue: ''
+        })
+        await context.addColumn('Devices', 'editorToken', {
+            type: DataTypes.STRING,
+            defaultValue: ''
+        })
+        await context.addColumn('Devices', 'editorConnected', {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/migrations/20240221-01-add-editor-state-to-Devices.js
+++ b/forge/db/migrations/20240221-01-add-editor-state-to-Devices.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 
 /**
- * Add ProjectSnapshots table
+ * Add editorAffinity details to Devices table
  */
 const { DataTypes } = require('sequelize')
 

--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -106,7 +106,7 @@ module.exports = {
                     if (includeApplicationDevices) {
                         const include = {
                             model: M.Device,
-                            attributes: ['hashid', 'id', 'name', 'links', 'state', 'mode', 'updatedAt', 'lastSeenAt']
+                            attributes: ['hashid', 'id', 'name', 'links', 'state', 'mode', 'updatedAt', 'lastSeenAt', 'editorConnected', 'editorToken']
                         }
 
                         if (associationsLimit) {

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -29,6 +29,9 @@ module.exports = {
         settingsHash: { type: DataTypes.STRING, allowNull: true },
         agentVersion: { type: DataTypes.STRING, allowNull: true },
         mode: { type: DataTypes.STRING, allowNull: true, defaultValue: 'autonomous' },
+        editorAffinity: { type: DataTypes.STRING, defaultValue: '' },
+        editorToken: { type: DataTypes.STRING, defaultValue: '' },
+        editorConnected: { type: DataTypes.BOOLEAN, defaultValue: false },
         /** @type {'instance'|'application'|null} a virtual column that signifies the parent type e.g. `"instance"`, `"application"` */
         ownerType: {
             type: DataTypes.VIRTUAL(DataTypes.ENUM('instance', 'application', null)),

--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -86,7 +86,7 @@ module.exports = function (app) {
         if (app.license.active() && result.mode === 'developer' && app.comms?.devices?.tunnelManager) {
             /** @type {import("../../ee/lib/deviceEditor/DeviceTunnelManager").DeviceTunnelManager} */
             const tunnelManager = app.comms.devices.tunnelManager
-            filtered.editor = tunnelManager.getTunnelStatus(result.hashid) || {}
+            filtered.editor = tunnelManager.getTunnelStatus(device) || {}
         }
 
         return filtered

--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -179,7 +179,7 @@ module.exports = function (app) {
             if (includeEditor && app.license.active() && summary.status === 'running' && summary.mode === 'developer' && app.comms?.devices?.tunnelManager) {
                 /** @type {import("../../ee/lib/deviceEditor/DeviceTunnelManager").DeviceTunnelManager} */
                 const tunnelManager = app.comms.devices.tunnelManager
-                filtered.editor = tunnelManager.getTunnelStatus(summary.id) || {}
+                filtered.editor = tunnelManager.getTunnelStatus(device) || {}
             }
 
             return filtered

--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -146,6 +146,19 @@ module.exports = async function (app) {
     })
 
     /**
+     * Get device editor state and url
+     * @name /api/v1/devices/:deviceId/editor
+     * @memberof module:forge/routes/api/device
+     */
+    app.get('/', {
+        preHandler: app.needsPermission('device:editor'),
+        config: { rateLimit: false } // never rate limit this route
+    }, async (request, reply) => {
+        const tunnelManager = getTunnelManager()
+        reply.send(tunnelManager.getTunnelStatus(request.device))
+    })
+
+    /**
      * HTTP GET: verify adminAuth token
      * As this will be called by NR auth, this endpoint cannot be protected by the
      * normal forge auth middleware

--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -85,43 +85,43 @@ module.exports = async function (app) {
         const deviceId = request.device.hashid
         const teamId = team.hashid
 
-        const currentState = tunnelManager.getTunnelStatus(deviceId)
-        if (currentState.enabled === mode) {
+        if (request.device.editorEnabled === mode) {
             // if this request is to `enable` tunnel and the tunnel is already enabled, return the current state
             // however, if it is not `connected`, then we need to refresh the tunnel
-            if (mode === true && currentState.connected === false) {
+            if (mode === true) {
                 // close any existing tunnel from this side
                 // then skip through to the next block of code to permit the connection to be refreshed
                 tunnelManager.closeTunnel(deviceId)
             } else {
-                reply.send(currentState)
+                reply.send(tunnelManager.getTunnelStatus(request.device))
                 return
             }
         }
 
         if (mode) {
-            // Generate a random access token for editor, open a tunnel and start the editor
-            const accessToken = await generateToken(16, `ffde_${deviceId}`)
-            // prepare the tunnel but dont start it (the remote device will initiate the connection)
-            // * Enable Device Editor (Step 3) - (frontendApi:HTTP->forge) Create Tunnel
-            tunnelManager.newTunnel(deviceId, accessToken)
+            // Generate an access token for the device and store on the Device object itself.
+            // The format of the token (ffde_<deviceHash>_<random>) is required by the Device Agent - do not change it
+            request.device.editorToken = generateToken(16, `ffde_${request.device.hashid}`)
+            await request.device.save()
             let err = null
             try {
                 // * Enable Device Editor (Step 4) - (forge) Enable Editor Request. This call resolves after steps 5 ~ 10
-                const cmdResponse = await app.comms.devices.enableEditor(teamId, deviceId, accessToken)
+                const cmdResponse = await app.comms.devices.enableEditor(teamId, deviceId, request.device.editorToken)
                 if (cmdResponse.error) {
                     throw new Error('No Node-RED running on Device')
                 }
+                // The device tells us what affinity cookie it received (if any)
                 if (cmdResponse.affinity) {
-                    tunnelManager.setTunnelAffinity(deviceId, cmdResponse.affinity)
+                    request.device.editorAffinity = cmdResponse.affinity
+                    await request.device.save()
                 }
             } catch (error) {
-                // ensure any attempt to enable the editor is cleaned up if an error occurs
-                tunnelManager.closeTunnel(deviceId)
                 err = error
             }
+            await request.device.reload()
             // * Enable Device Editor (Step 11) - (forge:HTTP->frontendApi) Send tunnel status back to frontend
-            const tunnelStatus = tunnelManager.getTunnelStatus(deviceId) || {}
+            const tunnelStatus = tunnelManager.getTunnelStatus(request.device) || {}
+
             if (err) {
                 tunnelStatus.error = err.message
                 tunnelStatus.code = err.code || 'enable_editor_failed'
@@ -134,25 +134,15 @@ module.exports = async function (app) {
                 reply.send(tunnelStatus)
             }
         } else if (!mode) {
+            request.device.editorToken = ''
+            request.device.editorAffinity = ''
+            await request.device.save()
             await app.comms.devices.disableEditor(teamId, deviceId)
             tunnelManager.closeTunnel(deviceId)
             await app.auditLog.Team.team.device.remoteAccess.disabled(request.session.User, null, team, request.device)
             await app.auditLog.Device.device.remoteAccess.disabled(request.session.User, null, request.device)
             reply.send({ enabled: false })
         }
-    })
-
-    /**
-     * Get device editor state and url
-     * @name /api/v1/devices/:deviceId/editor
-     * @memberof module:forge/routes/api/device
-     */
-    app.get('/', {
-        preHandler: app.needsPermission('device:editor'),
-        config: { rateLimit: false } // never rate limit this route
-    }, async (request, reply) => {
-        const tunnelManager = getTunnelManager()
-        reply.send(tunnelManager.getTunnelStatus(request.device.hashid))
     })
 
     /**
@@ -166,9 +156,8 @@ module.exports = async function (app) {
             allowAnonymous: true,
             rateLimit: false // never rate limit this route
         }
-    }, async (request, reply) => {
-        const tunnelManager = getTunnelManager()
-        if (tunnelManager.verifyToken(request.params.deviceId, request.headers['x-access-token'])) {
+    }, (request, reply) => {
+        if (request.device.editorToken === request.headers['x-access-token']) {
             reply.code(200).send({ username: 'forge', permissions: '*' })
             return
         }
@@ -186,16 +175,18 @@ module.exports = async function (app) {
             rateLimit: false // never rate limit this route
         },
         websocket: true
-    }, (connection, request) => {
-        // * Enable Device Editor (Step 9) - (device:WS->forge) websocket connect request from device
+    }, async (connection, request) => {
         // This is the inbound websocket connection from the device
-        const deviceId = request.params.deviceId
         const token = request.params.access_token
-        const tunnelManager = getTunnelManager()
-        const tunnelInfo = tunnelManager.getTunnelStatus(deviceId)
-        if (tunnelInfo && tunnelInfo.enabled) {
-            if (tunnelManager.verifyToken(deviceId, token)) {
-                const tunnelSetupOK = tunnelManager.initTunnel(deviceId, token, connection)
+        if (request.device.editorToken) {
+            if (token === request.device.editorToken) {
+                const tunnelManager = getTunnelManager()
+                const tunnel = tunnelManager.getTunnel(request.device.hashid)
+                if (!tunnel) {
+                    // Create the tunnel object
+                    tunnelManager.newTunnel(request.device.hashid, request.device.editorToken)
+                }
+                const tunnelSetupOK = await tunnelManager.initTunnel(request.device, connection)
                 if (!tunnelSetupOK) {
                     connection.socket.close(4000, 'Tunnel setup failed')
                 }
@@ -234,7 +225,7 @@ module.exports = async function (app) {
             } else {
                 // For a websocket comms request
                 if (/\/comms$/.test(request.url)) {
-                    const status = getTunnelManager().getTunnelStatus(request.params.deviceId)
+                    const status = getTunnelManager().getTunnelStatus(request.device)
                     if (!status?.connected) {
                         reply.code(502).send('The connection to the editor is currently unavailable')
                     }
@@ -247,7 +238,7 @@ module.exports = async function (app) {
             const tunnelManager = getTunnelManager()
             if (tunnelManager.handleHTTP(request.params.deviceId, request, reply)) {
                 return
-            } else if (tunnelManager.getTunnelStatus(request.params.deviceId)?.enabled) {
+            } else if (tunnelManager.getTunnelStatus(request.device)?.enabled) {
                 // Enabled, but not connected
                 reply.code(502).send('The connection to the editor is currently unavailable') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
                 return
@@ -287,7 +278,7 @@ module.exports = async function (app) {
             } else {
                 // For a websocket comms request
                 if (/\/comms$/.test(request.url)) {
-                    const status = getTunnelManager().getTunnelStatus(request.params.deviceId)
+                    const status = getTunnelManager().getTunnelStatus(request.device)
                     if (!status?.connected) {
                         reply.code(502).send('The connection to the editor is currently unavailable')
                     }
@@ -299,7 +290,7 @@ module.exports = async function (app) {
             const tunnelManager = getTunnelManager()
             if (tunnelManager.handleHTTP(request.params.deviceId, request, reply)) {
                 return // handled
-            } else if (tunnelManager.getTunnelStatus(request.params.deviceId)?.enabled) {
+            } else if (tunnelManager.getTunnelStatus(request.device)?.enabled) {
                 reply.code(502).send() // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
                 return
             }

--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -84,8 +84,7 @@ module.exports = async function (app) {
         const tunnelManager = getTunnelManager()
         const deviceId = request.device.hashid
         const teamId = team.hashid
-
-        if (request.device.editorEnabled === mode) {
+        if (!!request.device.editorToken === mode) {
             // if this request is to `enable` tunnel and the tunnel is already enabled, return the current state
             // however, if it is not `connected`, then we need to refresh the tunnel
             if (mode === true) {
@@ -116,12 +115,13 @@ module.exports = async function (app) {
                     await request.device.save()
                 }
             } catch (error) {
+                request.device.editorToken = ''
+                await request.device.save()
                 err = error
             }
             await request.device.reload()
             // * Enable Device Editor (Step 11) - (forge:HTTP->frontendApi) Send tunnel status back to frontend
             const tunnelStatus = tunnelManager.getTunnelStatus(request.device) || {}
-
             if (err) {
                 tunnelStatus.error = err.message
                 tunnelStatus.code = err.code || 'enable_editor_failed'

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -101,11 +101,9 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const result = app.db.views.Device.device(request.device)
-        app.log.info(`NOL: Clearing top-level FFSESSION cookie for device ${request.device.hashid}`)
         // ingress-nginx will set a cookie on /api/v1/devices - which will cannot allow to override
         // that of the device-specific cookie. So clear it out.
         if (request.cookies.FFSESSION) {
-            app.log.info('NOL: Clearing FFSESSION cookie on generic path')
             reply.clearCookie('FFSESSION', { path: '/api/v1/devices/' })
         }
         if (result.editor && result.editor.enabled) {
@@ -118,8 +116,6 @@ module.exports = async function (app) {
                         // In this case, we *know* the cookie used by the device, so
                         // use that.
 
-                        // TODO: remove before shipping
-                        app.log.info(`NOL: Setting FFSESSION cookies to known affinity for device ${request.device.hashid} : ${request.device.editorAffinity}`)
                         reply.setCookie('FFSESSION', request.device.editorAffinity, {
                             httpOnly: true,
                             path: request.url,
@@ -129,8 +125,6 @@ module.exports = async function (app) {
                             encode: s => s
                         })
                     } else {
-                        // TODO: remove before shipping
-                        app.log.info(`NOL: Clearing FFSESSION cookies as we don't have affinity for device ${request.device.hashid}`)
                         // An older device agent doesn't tell us about its affinity cookie
                         // So the best we can do is clear the session cookies and have
                         // the load balancer pick another route to try

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -115,7 +115,11 @@ module.exports = async function (app) {
 
                     reply.setCookie('FFSESSION', request.device.editorAffinity, {
                         httpOnly: true,
-                        path: request.url
+                        path: request.url,
+                        // By default, it will uriEncode the value, which changes | to %7C
+                        // We don't want that change to happen, so provide a cleaner
+                        // encode function
+                        encode: s => s
                     })
                 } else {
                     // TODO: remove before shipping

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -106,7 +106,7 @@ module.exports = async function (app) {
         // that of the device-specific cookie. So clear it out.
         if (request.cookies.FFSESSION) {
             app.log.info('NOL: Clearing FFSESSION cookie on generic path')
-            reply.clearCookie('FFSESSION', { path: '/api/v1/devices' })
+            reply.clearCookie('FFSESSION', { path: '/api/v1/devices/' })
         }
         if (result.editor && result.editor.enabled) {
             if (result.editor.connected && !result.editor.local) {

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -310,46 +310,57 @@ export default {
             window.open(this.deviceEditorURL, `device-editor-${this.device.id}`)
         },
         async openTunnel (launchEditor = false) {
-            if (this.device.status === 'running') {
-                if (this.device.editor?.enabled && this.device.editor?.connected && this.device.editor?.local) {
-                    this.openEditor()
-                } else {
-                    this.openingTunnel = true
-                    this.$refs.dialog.show()
+            try {
+                console.warn(`openTunnel launchEditor:${launchEditor} ${JSON.stringify(this.device.editor)}`)
+                if (this.device.status === 'running') {
+                    if (this.device.editor?.enabled && this.device.editor?.connected && this.device.editor?.local) {
+                        console.warn(' - open editor')
+                        this.openEditor()
+                    } else {
+                        console.warn(' - show dialog')
+                        this.openingTunnel = true
+                        this.$refs.dialog.show()
 
-                    // Polls the tunnel status until we see it connected to the
-                    // 'local' platform instance - will give up after 10 attempts
-                    const pollTunnelStatus = (attempt = 0, timeout = 500) => {
-                        if (attempt < 10) {
-                            this.openTunnelTimeout = setTimeout(async () => {
-                                await this.loadDevice()
-                                if (this.device.editor?.enabled && this.device.editor?.connected) {
-                                    if (this.device.editor?.local) {
-                                        if (launchEditor) {
-                                            this.openEditor()
+                        // Polls the tunnel status until we see it connected to the
+                        // 'local' platform instance - will give up after 10 attempts
+                        const pollTunnelStatus = (attempt = 0, timeout = 500) => {
+                            console.warn(' - pollTunnelStatus', attempt, timeout)
+                            if (attempt < 10) {
+                                this.openTunnelTimeout = setTimeout(async () => {
+                                    await this.loadDevice()
+                                    console.warn(` - poll result ${JSON.stringify(this.device.editor)}`)
+                                    if (this.device.editor?.enabled && this.device.editor?.connected) {
+                                        if (this.device.editor?.local) {
+                                            if (launchEditor) {
+                                                console.warn(' - open editor')
+                                                this.openEditor()
+                                            }
+                                        } else {
+                                            pollTunnelStatus(attempt + 1, 200)
                                         }
-                                    } else {
-                                        pollTunnelStatus(attempt + 1, 200)
                                     }
-                                }
-                            }, timeout)
+                                }, timeout)
+                            }
                         }
-                    }
 
-                    try {
-                        if (!this.device.editor?.enabled || !this.device.editor?.connected) {
-                            // * Enable Device Editor (Step 1) - (browser->frontendApi) User clicks button to "Enable Editor"
-                            const result = await deviceApi.enableEditorTunnel(this.device.id)
-                            this.updateTunnelStatus(result)
+                        try {
+                            if (!this.device.editor?.enabled || !this.device.editor?.connected) {
+                                console.warn(' - enabling editor tunnel')
+                                // * Enable Device Editor (Step 1) - (browser->frontendApi) User clicks button to "Enable Editor"
+                                const result = await deviceApi.enableEditorTunnel(this.device.id)
+                                this.updateTunnelStatus(result)
+                            }
+                            pollTunnelStatus()
+                        } finally {
+                            this.$refs.dialog.close()
+                            this.openingTunnel = false
                         }
-                        pollTunnelStatus()
-                    } finally {
-                        this.$refs.dialog.close()
-                        this.openingTunnel = false
                     }
+                } else {
+                    Alerts.emit('Unable to establish a connection to the device. Please check it is connected and running then try again', 'warning', 7500)
                 }
-            } else {
-                Alerts.emit('Unable to establish a connection to the device. Please check it is connected and running then try again', 'warning', 7500)
+            } catch (err) {
+                console.warn('Error in openTunnel', err)
             }
         },
         async closeTunnel () {

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -113,7 +113,7 @@
                                     <EditorLink
                                         :url="device.editor?.url"
                                         :editorDisabled="false"
-                                        :disabled="!device.editor?.enabled || !device.editor?.connected"
+                                        :disabled="!device.editor?.enabled || !device.editor?.connected || !device.editor?.local"
                                         disabledReason="Device must be running, in developer mode and have the editor enabled and connected"
                                     />
                                 </div>

--- a/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
@@ -50,7 +50,8 @@ describe('FlowForge - Team Overview (Home) - With License', () => {
                         deviceOne.editor = {
                             url: 'http://editor.example.com',
                             enabled: true,
-                            connected: true
+                            connected: true,
+                            local: true
                         }
 
                         const deviceTwo = res.body.applications[0].devices.find((device) => device.id === deviceTwoId)

--- a/test/unit/forge/ee/routes/api/team_spec.js
+++ b/test/unit/forge/ee/routes/api/team_spec.js
@@ -1,5 +1,6 @@
 const sinon = require('sinon')
 
+const should = require('should')  // eslint-disable-line
 const setup = require('../../setup')
 
 describe('Team API - with billing enabled', function () {
@@ -95,8 +96,12 @@ describe('Team API - with billing enabled', function () {
 
             const device1 = await app.factory.createDevice({ name: 'device-1', type: 'test-device', lastSeenAt: new Date(), mode: 'developer', state: 'running' }, app.team, null, app.application)
 
-            app.comms.devices.tunnelManager.newTunnel(device1.hashid, 'token12e')
-            sinon.stub(app.comms.devices.tunnelManager, 'isConnected').returns(true)
+            // app.comms.devices.tunnelManager.newTunnel(device1.hashid, 'token12e')
+            sinon.stub(app.comms.devices.tunnelManager, 'getTunnelStatus').returns({
+                enabled: true,
+                url: `/api/v1/devices/${device1.hashid}/editor/proxy/?access_token=token12e`,
+                connected: true
+            })
 
             const response = await app.inject({
                 method: 'GET',


### PR DESCRIPTION
This updates the Device Editor tunnel handling to make it scalable.

Closes:
 - #2514 
 - #3367 


# Summary of changes

 - Adds news fields to the Device model to store editor tunnel state:
    - `editorToken` - the access token to be used. Unlike other tokens, this has to be stored in the clear as it needs to be retrievable to give to both the device and frontend when someone tries to access the editor
    - `editorAffinity` - if set, this is the value of the `FFSESSION` affinity cookie the device has been given by the `ingress-nginx` load balancer. This allows us to set a matching cookie on any api request for this device's details.
    - `editorConnected` - whether the editor tunnel is currently connected or not

 - Adds a new `local` property to the device editor status object. This is a boolean flag that indicates if the device agent websocket is connected to the instance that is servicing the api request.

The key logic is all around the `editorAffinity` property and the `FFSESSION` cookie.

When a user enables the Device Editor, the device agent will connect to the platform and the ingress will give it a cookie to ensure affinity with a particular upstream platform instance. The Device Agent communicates the value of that cookie back to the platform (both in response to the MQTT command to enable the editor, *and* as part of its regular status checkin).

The load balancer is configured to set the path of the `FFSESSION` cookie to `/api/v1/device` (because we cannot do wildcard locations in the nginx config).

Any api request to `/api/v1/device/<hashid>` will get its own `FFSESSION` cookie set to match that of the device (if the device is connected). This means subsequent rquests from the client should hit the *same* instance the device is connected to.

### Older Device Agent support

Older device agents do not know about the affinity cookie - they will connect without the cookie and end up wherever the load balancer puts them.

To try to cater for that, the `local` property on the device editor status object is used. If the frontend wants to connect to the device it can check the `local` property. If its false, it knows it is not talking to the instance that holds the connection. But in making that request, the server will also notice the same thing and attempt to set/clear the FFSESSION cookie. The frontend can then retry - hopefully to get load balanced to a different instance. We optimistically hope it will eventually get load-balanced to the right instance (it tries 10 times before stopping.. the user can retry themselves).


### Testing

This has been tested in our scaling environment using `ingress-nginx` with 2 instances of the forge app, with both older device agents and the ones with the improved cookie handling.

My main goal is two-fold; keep things working in the non-scaled case (so these changes to ship asap), and have confidence they will work when we scale the platform.