### PR TITLE
Enforce username rules on create

### DIFF
--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -174,7 +174,7 @@ module.exports = async function (app) {
             email: request.body.email,
             admin: !!request.body.isAdmin
         }
-        if (/^(admin|root)$/.test(request.body.username)) {
+        if (/^(admin|root)$/.test(request.body.username) || !/^[a-z0-9-_]+$/.test(request.body.username)) {
             const resp = { code: 'invalid_username', error: 'invalid username' }
             await app.auditLog.User.users.userCreated(request.session.User, resp, logUserInfo)
             reply.code(400).send(resp)

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -389,7 +389,7 @@ async function init (app, opts) {
             return
         }
 
-        if (/^(admin|root)$/.test(request.body.username)) {
+        if (/^(admin|root)$/.test(request.body.username) || !/^[a-z0-9-_]+$/.test(request.body.username)) {
             const resp = { code: 'invalid_username', error: 'invalid username' }
             await app.auditLog.User.account.register(userInfo, resp, userInfo)
             reply.code(400).send(resp)

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -134,7 +134,7 @@ describe('Accounts API', async function () {
 
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
         })
-        it.only('rejects bad username', async function () {
+        it('rejects bad username', async function () {
             app.settings.set('user:signup', true)
 
             await expectRejection({

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -134,6 +134,16 @@ describe('Accounts API', async function () {
 
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
         })
+        it.only('rejects bad username', async function () {
+            app.settings.set('user:signup', true)
+
+            await expectRejection({
+                username: 'bad@user!',
+                password: '12345678',
+                name: 'u1.2',
+                email: 'u1@example.com'
+            }, /invalid username/)
+        })
 
         it('Limits how many users can be created when unlicensed', async function () {
             app.settings.set('user:signup', true)


### PR DESCRIPTION
fixes FlowFuse/security#76
## Description

<!-- Describe your changes in detail -->
Ensure that username rules are enforced by the API as well as the UI

## Related Issue(s)
FlowFuse/security#76

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

