### PR TITLE
Set disableRequestedAuthnContext in SAML strategy

### DIFF
--- a/forge/ee/routes/sso/auth.js
+++ b/forge/ee/routes/sso/auth.js
@@ -34,6 +34,7 @@ module.exports = fp(async function (app, opts) {
 
     fastifyPassport.use(new MultiSamlStrategy({
         passReqToCallback: true, // makes req available in callback,
+        disableRequestedAuthnContext: true, // Helps make things work with Entra
         wantAssertionsSigned: false, // TODO: allow this to be set per provider
         async getSamlOptions (request, done) {
             if (request.body?.RelayState) {


### PR DESCRIPTION
This prevents our SAML implementation from sending the _optional_  `RequestedAuthnContext` value in the SAML request. This can cause issues when using Entra - as documented here: https://github.com/node-saml/passport-saml/issues/226

I have not been able to reproduce the original issue (https://github.com/FlowFuse/flowfuse/issues/3518) as the precise Entra configuration is not clear. However, from the information provided by MS in that issue, and the linked issue above, I'm confident this will address the problem.

I've gone for disabling it be default. We *may* need to make it configurable in the future, but for now, I have tested against Okta, OneLogin and Entra with success.

