### PR TITLE
Add billing status check when creating device

### DIFF
--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -339,6 +339,18 @@ module.exports = {
                     await this.ensureTeamTypeExists()
                     return this.TeamType.getProperty('devices.limit', -1)
                 },
+                checkDeviceCreateAllowed: async function () {
+                    const deviceLimit = await this.getDeviceLimit()
+                    if (deviceLimit > -1) {
+                        const currentDeviceCount = await this.deviceCount()
+                        if (currentDeviceCount >= deviceLimit) {
+                            const err = new Error()
+                            err.code = 'device_limit_reached'
+                            err.error = 'Team device limit reached'
+                            throw err
+                        }
+                    }
+                },
                 isInstanceTypeAvailable: async function (instanceType) {
                     await this.ensureTeamTypeExists()
                     return this.TeamType.getInstanceTypeProperty(instanceType, 'active', false)

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -234,13 +234,15 @@ module.exports = async function (app) {
             team = teamMembership.get('Team')
         }
 
-        const teamDeviceLimit = await team.getDeviceLimit()
-        if (teamDeviceLimit > -1) {
-            const currentDeviceCount = await team.deviceCount()
-            if (currentDeviceCount >= teamDeviceLimit) {
-                reply.code(400).send({ code: 'device_limit_reached', error: 'Team device limit reached' })
-                return
-            }
+        try {
+            await team.checkDeviceCreateAllowed()
+        } catch (err) {
+            return reply
+                .code(err.statusCode || 400)
+                .send({
+                    code: err.code || 'unexpected_error',
+                    error: err.error || err.message
+                })
         }
 
         try {

--- a/test/unit/forge/ee/db/controllers/Subscription_spec.js
+++ b/test/unit/forge/ee/db/controllers/Subscription_spec.js
@@ -3,12 +3,15 @@ const setup = require('../../setup')
 
 describe('Subscription controller', function () {
     let app
+    let stripe
     beforeEach(async function () {
+        setup.setupStripe()
         app = await setup()
     })
 
     afterEach(async function () {
         await app.close()
+        setup.resetStripe()
     })
 
     describe('createSubscription', function () {

--- a/test/unit/forge/ee/db/controllers/Subscription_spec.js
+++ b/test/unit/forge/ee/db/controllers/Subscription_spec.js
@@ -3,7 +3,7 @@ const setup = require('../../setup')
 
 describe('Subscription controller', function () {
     let app
-    let stripe
+
     beforeEach(async function () {
         setup.setupStripe()
         app = await setup()

--- a/test/unit/forge/ee/setup.js
+++ b/test/unit/forge/ee/setup.js
@@ -12,7 +12,9 @@ async function setup (config = {}) {
         billing: {
             stripe: {
                 key: 1234,
-                new_customer_free_credit: 1000
+                new_customer_free_credit: 1000,
+                device_price: 'd123',
+                device_product: 'd456'
             }
         },
         ...config


### PR DESCRIPTION
Fixes https://github.com/FlowFuse/security/issues/75

## Description

This adds a check that a team's subscription is in a valid state when trying to create a device.

This mirrors the approach already taken for creating instances; where a `checkDeviceCreateAllowed` function is added to the `Team` model - and overloaded when billing is enabled.

