### PR TITLE
fix: allow mixed-case usernames in backend validation

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -389,7 +389,7 @@ async function init (app, opts) {
             return
         }
 
-        if (/^(admin|root)$/.test(request.body.username) || !/^[a-z0-9-_]+$/.test(request.body.username)) {
+        if (/^(admin|root)$/.test(request.body.username) || !/^[a-z0-9-_]+$/i.test(request.body.username)) {
             const resp = { code: 'invalid_username', error: 'invalid username' }
             await app.auditLog.User.account.register(userInfo, resp, userInfo)
             reply.code(400).send(resp)

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -132,7 +132,7 @@ export default {
     },
     watch: {
         'input.username': function (v) {
-            if (v && !/^[a-z0-9-_]+$/i.test(v)) {
+            if (v && !/^[a-z0-9-_]+$/.test(v)) {
                 this.errors.username = 'Must only contain a-z 0-9 - _'
             } else {
                 this.errors.username = ''

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -132,8 +132,8 @@ export default {
     },
     watch: {
         'input.username': function (v) {
-            if (v && !/^[a-z0-9-_]+$/.test(v)) {
-                this.errors.username = 'Must only contain a-z 0-9 - _'
+            if (v && !/^[a-z0-9-_]+$/i.test(v)) {
+                this.errors.username = 'Must only contain a-z A-Z 0-9 - _'
             } else {
                 this.errors.username = ''
             }

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -76,6 +76,20 @@ describe('Accounts API', async function () {
             // TODO: check user audit logs - expect 'account.xxx-yyy' { status: 'okay', ... }
         })
 
+        it('allows user to register - mixed case username', async function () {
+            app.settings.set('user:signup', true)
+
+            const response = await registerUser({
+                username: 'MixedCaseUserName',
+                password: '12345678',
+                name: 'MixedCaseUserName',
+                email: 'MixedCaseUserName@example.com'
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('username', 'MixedCaseUserName')
+            result.should.have.property('id')
+        })
         it('rejects reserved user names', async function () {
             app.settings.set('user:signup', true)
 
@@ -111,6 +125,14 @@ describe('Accounts API', async function () {
                 password: '12345678',
                 name: 'u1.2',
                 email: 'u1-2@example.com'
+            }, /Username or email not available/)
+
+            // Try with uppercase
+            await expectRejection({
+                username: 'U1',
+                password: '12345678',
+                name: 'u1.3',
+                email: 'u1-3@example.com'
             }, /Username or email not available/)
 
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Backend username validation enforces lowercase only, front end is case insensitive, but the error message if tripped is for lowercase only.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

