### PR TITLE
fix: Allow mixed case in username in admin create api

### DIFF
--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -174,7 +174,7 @@ module.exports = async function (app) {
             email: request.body.email,
             admin: !!request.body.isAdmin
         }
-        if (/^(admin|root)$/.test(request.body.username) || !/^[a-z0-9-_]+$/.test(request.body.username)) {
+        if (/^(admin|root)$/.test(request.body.username) || !/^[a-z0-9-_]+$/i.test(request.body.username)) {
             const resp = { code: 'invalid_username', error: 'invalid username' }
             await app.auditLog.User.users.userCreated(request.session.User, resp, logUserInfo)
             reply.code(400).send(resp)


### PR DESCRIPTION
Missed this when reviewing #3537 - the admin route for creating users also needed fixing.