### PR TITLE
Support both snapshot schemas

### DIFF
--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -164,7 +164,25 @@ module.exports = async function (app) {
                 properties: {
                     name: { type: 'string' },
                     description: { type: 'string' },
-                    flows: { type: 'array', items: { type: 'object' } },
+                    flows: {
+                        oneOf: [
+                            {
+                                // This format matches the snapshot object in the database, the schema `ExportedSnapshot` and the
+                                // original snapshot object format returned by `createSnapshot` function in `controllers/ProjectSnapshot.js`
+                                type: 'object',
+                                properties: {
+                                    flows: { type: 'array', items: { type: 'object' } },
+                                    credentials: { type: 'object' }
+                                }
+                            },
+                            {
+                                // Alt API format
+                                // This format matches the format of the exported project object created by `exportProject` function in `controllers/Project.js`
+                                // and supports the format expected by `createSnapshot` function in `services/snapshots.js`
+                                type: 'array', items: { type: 'object' }
+                            }
+                        ]
+                    },
                     credentials: { type: 'object' },
                     credentialSecret: { type: 'string' },
                     settings: {

--- a/forge/services/snapshots.js
+++ b/forge/services/snapshots.js
@@ -81,6 +81,14 @@ module.exports.generateDeploySnapshotDescription = (
 
 module.exports.createSnapshot = async (app, instance, user, snapshotProps) => {
     const fullInstanceObject = await app.db.models.Project.byId(instance.id)
+    if (snapshotProps.flows && typeof snapshotProps.flows === 'object' && Array.isArray(snapshotProps.flows.flows)) {
+        // ProjectSnapshot.createSnapshot function in `controllers/ProjectSnapshot.js`
+        // expects the flows and credentials to be separate properties
+        const credentials = snapshotProps.flows.credentials
+        const flows = snapshotProps.flows.flows
+        snapshotProps.credentials = credentials
+        snapshotProps.flows = flows
+    }
 
     const snapShot = await app.db.controllers.ProjectSnapshot.createSnapshot(
         fullInstanceObject, // expects Project.byId for all extra props


### PR DESCRIPTION
## Description

* Updates the route API to permit `flows` as an object (with `flows` and `credentials`) or `flows` and `credentials` as separate properties in the body.
* Updates the controller fn to accept both formats
* Adds test to check both formats work

## Related Issue(s)

#3510

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

