### PR TITLE
Adds validation on PipelineStage create api

### DIFF
--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -120,6 +120,35 @@ module.exports = {
         } else if (idCount === 0) {
             throw new PipelineControllerError('invalid_input', 'An instance, device or device group is required when creating a new pipeline stage', 400)
         }
+        if (options.instanceId) {
+            const instance = await app.db.models.Project.findOne({
+                where: { id: options.instanceId, ApplicationId: pipeline.ApplicationId },
+                attributes: ['id']
+            })
+            if (!instance) {
+                throw new PipelineControllerError('invalid_input', 'Invalid instance')
+            }
+        }
+        if (options.deviceId) {
+            const deviceId = (typeof options.deviceId === 'string') ? app.db.models.Device.decodeHashid(options.deviceId) : options.deviceId
+            const device = await app.db.models.Device.findOne({
+                where: { id: deviceId, ApplicationId: pipeline.ApplicationId },
+                attributes: ['id']
+            })
+            if (!device) {
+                throw new PipelineControllerError('invalid_input', 'Invalid device')
+            }
+        }
+        if (options.deviceGroupId) {
+            const deviceGroupId = (typeof options.deviceGroupId === 'string') ? app.db.models.DeviceGroup.decodeHashid(options.deviceGroupId) : options.deviceGroupId
+            const deviceGroup = await app.db.models.DeviceGroup.findOne({
+                where: { id: deviceGroupId, ApplicationId: pipeline.ApplicationId },
+                attributes: ['id']
+            })
+            if (!deviceGroup) {
+                throw new PipelineControllerError('invalid_input', 'Invalid device group')
+            }
+        }
 
         let source
         options.PipelineId = pipeline.id
@@ -147,7 +176,6 @@ module.exports = {
         const transaction = await app.db.sequelize.transaction()
         try {
             const stage = await app.db.models.PipelineStage.create(options, { transaction })
-
             if (options.instanceId) {
                 await stage.addInstanceId(options.instanceId, { transaction })
             } else if (options.deviceId) {

--- a/test/unit/forge/services/snapshots_spec.js
+++ b/test/unit/forge/services/snapshots_spec.js
@@ -103,11 +103,10 @@ describe('Snapshots Service', function () {
 
         before(async function () {
             const application = await FACTORY.createApplication({ name: 'application1' }, TEAM)
-
-            const instance = await APP.db.models.Project.create({ name: 'snaphot-instance-1', type: '', url: '' })
-            const instanceTwo = await APP.db.models.Project.create({ name: 'snaphot-instance-2', type: '', url: '' })
-            const instanceThree = await APP.db.models.Project.create({ name: 'snaphot-instance-3', type: '', url: '' })
-            const instanceFlour = await APP.db.models.Project.create({ name: 'snaphot-instance-4', type: '', url: '' })
+            const instance = await APP.db.models.Project.create({ name: 'snaphot-instance-1', type: '', url: '', ApplicationId: application.id })
+            const instanceTwo = await APP.db.models.Project.create({ name: 'snaphot-instance-2', type: '', url: '', ApplicationId: application.id })
+            const instanceThree = await APP.db.models.Project.create({ name: 'snaphot-instance-3', type: '', url: '', ApplicationId: application.id })
+            const instanceFlour = await APP.db.models.Project.create({ name: 'snaphot-instance-4', type: '', url: '', ApplicationId: application.id })
 
             pipeline = await FACTORY.createPipeline({ name: 'pipeline-1' }, application)
 


### PR DESCRIPTION
Closes https://github.com/FlowFuse/security/issues/77

## Description

The validators on the PipelineStage model do not get applied when creating a new stage. I *think* it is because the PipelineStage creation is done under a transaction, but the validation does look-ups outside of that transaction so do not 'see' the what we're trying to create.

I've added explicit validation in the create function and tests to cover it.

The update function already had tests to validate this scenario - and the validation works there