### PR TITLE
Update licensing to combine device and instance limits

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -66,9 +66,8 @@ module.exports = {
                 // if the product is licensed, we permit overage
                 const isLicensed = app.license.active()
                 if (isLicensed !== true) {
-                    const deviceLimit = app.license.get('devices')
-                    const deviceCount = await M.Device.count()
-                    if (deviceCount >= deviceLimit) {
+                    const { devices } = await app.license.usage('devices')
+                    if (devices.count >= devices.limit) {
                         throw new Error('license limit reached')
                     }
                 }

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -122,17 +122,16 @@ module.exports = {
                 // if the product is licensed, we permit overage
                 const isLicensed = app.license.active()
                 if (isLicensed !== true) {
-                    const projectLimit = app.license.get('projects')
-                    const projectCount = await M.Project.count()
-                    if (projectCount >= projectLimit) {
+                    const { instances } = await app.license.usage('instances')
+                    if (instances.count >= instances.limit) {
                         throw new Error('license limit reached')
                     }
                 }
             },
             afterCreate: async (project, opts) => {
-                const { projects } = await app.license.usage('projects')
-                if (projects.count > projects.limit) {
-                    await app.auditLog.Platform.platform.license.overage('system', null, projects)
+                const { instances } = await app.license.usage('instances')
+                if (instances.count > instances.limit) {
+                    await app.auditLog.Platform.platform.license.overage('system', null, instances)
                 }
             },
             afterDestroy: async (project, opts) => {

--- a/forge/housekeeper/tasks/licenseOverage.js
+++ b/forge/housekeeper/tasks/licenseOverage.js
@@ -3,15 +3,15 @@ module.exports = {
     startup: true,
     schedule: '@weekly', // Run once a week, sunday midnight
     run: async function (app) {
-        const { users, teams, projects, devices } = await app.license.usage()
+        const { users, teams, instances, devices } = await app.license.usage()
         if (users?.count > users?.limit) {
             await app.auditLog.Platform.platform.license.overage('system', null, users)
         }
         if (teams?.count > teams?.limit) {
             await app.auditLog.Platform.platform.license.overage('system', null, teams)
         }
-        if (projects?.count > projects?.limit) {
-            await app.auditLog.Platform.platform.license.overage('system', null, projects)
+        if (instances?.count > instances?.limit) {
+            await app.auditLog.Platform.platform.license.overage('system', null, instances)
         }
         if (devices?.count > devices?.limit) {
             await app.auditLog.Platform.platform.license.overage('system', null, devices)

--- a/forge/licensing/license-generator.js
+++ b/forge/licensing/license-generator.js
@@ -58,10 +58,9 @@ const { v4: uuidv4 } = require('uuid')
 
         const licenseHolder = await promptly.prompt('License holder name: ')
 
-        const maxUsers = parseInt(await promptly.prompt('Max allowed users: ', { default: '150' }))
-        const maxTeams = parseInt(await promptly.prompt('Max allowed teams: ', { default: '50' }))
-        const maxProjects = parseInt(await promptly.prompt('Max allowed projects: ', { default: '50' }))
-        const maxDevices = parseInt(await promptly.prompt('Max allowed devices: ', { default: '50' }))
+        const maxUsers = parseInt(await promptly.prompt('Max allowed users: ', { default: '5' }))
+        const maxTeams = parseInt(await promptly.prompt('Max allowed teams: ', { default: '5' }))
+        const maxInstances = parseInt(await promptly.prompt('Max allowed instances (hosted + devices): ', { default: '5' }))
 
         const licenseNotes = devLicense
             ? 'Development-mode Only. Not for production'
@@ -96,6 +95,7 @@ const { v4: uuidv4 } = require('uuid')
 
         const licenseDetails = {
             id: licenseId,
+            ver: '2024-03-04', // Used to determined the format of the license.
             iss: 'FlowForge Inc.', // DO NOT CHANGE
             sub: licenseHolder, // Name of the license holder
             nbf: validFrom,
@@ -103,8 +103,7 @@ const { v4: uuidv4 } = require('uuid')
             note: licenseNotes, // Freeform text to associate with license
             users: maxUsers,
             teams: maxTeams,
-            projects: maxProjects,
-            devices: maxDevices,
+            instances: maxInstances,
             tier: licenseTier
         }
 

--- a/forge/licensing/loader.js
+++ b/forge/licensing/loader.js
@@ -10,14 +10,19 @@ class LicenseDetails {
     constructor (license, claims) {
         // this.license = license;
         this.id = claims.id
+        this.version = claims.ver || ''
         this.note = claims.note
         this.organisation = claims.sub
         this.validFrom = new Date(claims.nbf * 1000)
         this.expiresAt = new Date(claims.exp * 1000)
         this.dev = claims.dev
         this.users = claims.users || 0
-        this.projects = claims.projects || 0
-        this.devices = claims.devices || 0
+        if (Object.hasOwn(claims, 'instances')) {
+            this.instances = claims.instances || 0
+        } else {
+            this.projects = claims.projects || 0
+            this.devices = claims.devices || 0
+        }
         this.teams = claims.teams || 0
         this.tier = claims.tier || 'enterprise'
         Object.freeze(this)

--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -20,11 +20,13 @@ module.exports = async function (app) {
             maxTeams: license.teams,
             teamsByType: {},
             instanceCount: 0,
-            maxInstances: license.projects,
+            maxInstances: license.projects || license.instances,
             instancesByState: {},
             deviceCount: await app.db.models.Device.count(),
-            maxDevices: license.devices,
             devicesByMode: {}
+        }
+        if (Object.hasOwn(license, 'devices')) {
+            result.maxDevices = license.devices
         }
         userCount.forEach(u => {
             result.userCount += u.count

--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -1,55 +1,90 @@
 <template>
     <SectionTopMenu hero="Admin Settings" />
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-gray-700">
-        <div class="border rounded px-4 py-2 text-center">
-            <router-link to="/admin/users/general">
-                <div class="text-xl">{{ stats.userCount }}/{{ stats.maxUsers }}</div>
-                <div>Users</div>
-            </router-link>
-            <div class="w-full grid grid-cols-2 pt-1 mt-2 border-t">
-                <div>{{ stats.adminCount }} {{ $filters.pluralize(stats.adminCount,'admin') }}</div>
-                <div><router-link to="/admin/users/invitations">{{ stats.inviteCount }} {{ $filters.pluralize(stats.inviteCount,'invite') }}</router-link></div>
+    <div class="ff-instance-info space-y-4">
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-gray-700">
+            <div class="border rounded px-4 py-2 text-center">
+                <router-link to="/admin/users/general">
+                    <div class="text-xl">{{ stats.userCount }}</div>
+                    <div>Users</div>
+                </router-link>
+                <div class="w-full grid grid-cols-2 pt-1 mt-2 border-t">
+                    <div>{{ stats.adminCount }} {{ $filters.pluralize(stats.adminCount,'admin') }}</div>
+                    <div><router-link to="/admin/users/invitations">{{ stats.inviteCount }} {{ $filters.pluralize(stats.inviteCount,'invite') }}</router-link></div>
+                </div>
             </div>
-        </div>
-        <div class="border rounded p-4 text-center">
-            <router-link to="/admin/teams">
-                <div class="text-xl">{{ stats.teamCount }}/{{ stats.maxTeams }}</div>
-                <div>{{ $filters.pluralize(stats.teamCount,'Team') }}</div>
-            </router-link>
-        </div>
-        <div class="border rounded p-4 text-center">
-            <div class="text-xl">{{ stats.instanceCount }}/{{ stats.maxInstances }}</div>
-            <div>{{ $filters.pluralize(stats.instanceCount,'Project') }}</div>
-            <div v-if="stats.instancesByState && Object.keys(stats.instancesByState).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
-                <div v-for="(count, state) in stats.instancesByState" :key="state">
-                    {{ count }} {{ state }}
+            <div class="border rounded p-4 text-center">
+                <router-link to="/admin/teams">
+                    <div class="text-xl">{{ stats.teamCount }}</div>
+                    <div>{{ $filters.pluralize(stats.teamCount,'Team') }}</div>
+                </router-link>
+            </div>
+            <div class="border rounded p-4 text-center">
+                <div class="text-xl">{{ stats.instanceCount }}</div>
+                <div>{{ $filters.pluralize(stats.instanceCount,'Instance') }}</div>
+                <div v-if="stats.instancesByState && Object.keys(stats.instancesByState).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
+                    <div v-for="(count, state) in stats.instancesByState" :key="state">
+                        {{ count }} {{ state }}
+                    </div>
+                </div>
+            </div>
+
+            <div class="border rounded p-4 text-center">
+                <div class="text-xl">{{ stats.deviceCount }}</div>
+                <div>{{ $filters.pluralize(stats.deviceCount,'Device') }}</div>
+                <div v-if="stats.devicesByLastSeen && Object.keys(stats.devicesByLastSeen).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
+                    <div> {{ stats.devicesByLastSeen.day || 0 }} connected</div>
                 </div>
             </div>
         </div>
-
-        <div class="border rounded p-4 text-center">
-            <div class="text-xl">{{ stats.deviceCount }}/{{ stats.maxDevices }}</div>
-            <div>{{ $filters.pluralize(stats.deviceCount,'Device') }}</div>
-        </div>
-        <div class="border rounded p-4 col-span-2 md:col-span-4">
-            <div class="text-xl mb-1 border-b">License</div>
-            <table v-if="license">
-                <tr><td class="font-medium p-2 pr-4 align-top">Type</td><td class="p-2"><span v-if="!license.dev">FlowFuse Enterprise Edition</span><span v-else class="font-bold">FlowFuse Development Only</span></td></tr>
-                <tr><td class="font-medium p-2 pr-4 align-top">Organisation</td><td class="p-2">{{ license.organisation }}</td></tr>
-                <tr><td class="font-medium p-2 pr-4 align-top">Tier</td><td class="p-2">{{ license.tier }}</td></tr>
-                <tr><td class="font-medium p-2 pr-4 align-top">Expires</td><td class="p-2">{{ license.expires }}<br><span class="text-xs">{{ license.expiresAt }}</span></td></tr>
+        <div>
+            <FormHeading>License</FormHeading>
+            <table class="w-full">
+                <tr>
+                    <td class="w-40">Type</td>
+                    <td>
+                        <span v-if="!license">FlowFuse Community Edition</span>
+                        <span v-else-if="!license.dev">FlowFuse Enterprise Edition</span>
+                        <span v-else class="font-bold">FlowFuse Development Only</span>
+                    </td>
+                </tr>
+                <template v-if="license">
+                    <tr><td class="w-40 font-medium">Organisation</td><td>{{ license.organisation }}</td></tr>
+                    <tr><td class="w-40 font-medium">Tier</td><td>{{ license.tier }}</td></tr>
+                    <tr><td>Expires</td><td>{{ license.expires }}<br><span class="text-xs">{{ license.expiresAt }}</span></td></tr>
+                </template>
+                <tr>
+                    <td class="w-40">Users</td>
+                    <td>{{ stats.userCount }} / {{ stats.maxUsers }}</td>
+                </tr>
+                <tr>
+                    <td class="w-40">Teams</td>
+                    <td>{{ stats.teamCount }} / {{ stats.maxTeams }}</td>
+                </tr>
+                <template v-if="stats.maxDevices">
+                    <tr>
+                        <td class="w-40">Instances</td>
+                        <td>{{ stats.instanceCount }} / {{ stats.maxInstances }}</td>
+                    </tr>
+                    <tr>
+                        <td class="w-40">Devices</td>
+                        <td>
+                            <div>{{ stats.deviceCount }} / {{ stats.maxDevices }}</div>
+                        </td>
+                    </tr>
+                </template>
+                <template v-else>
+                    <tr>
+                        <td class="w-40">Instances + Devices</td>
+                        <td>{{ stats.instanceCount + stats.deviceCount }} / {{ stats.maxInstances }}</td>
+                    </tr>
+                </template>
             </table>
-            <div v-else>
-                <table>
-                    <tr><td class="font-medium p-2 pr-4 align-top">Type</td><td class="p-2">FlowFuse Community Edition</td></tr>
-                </table>
-            </div>
         </div>
-        <div class="border rounded p-4 col-span-2 md:col-span-4">
-            <div class="text-xl mb-1 border-b">Version</div>
-            <table>
-                <tr><td class="font-medium p-2 pr-4 align-top">Forge Application</td><td class="p-2">{{ settings['version:forge'] }}</td></tr>
-                <tr><td class="font-medium p-2 pr-4 align-top">NodeJS</td><td class="p-2">{{ settings['version:node'] }}</td></tr>
+        <div>
+            <FormHeading>Version</FormHeading>
+            <table class="w-full">
+                <tr><td class="w-40">Forge Application</td><td>{{ settings['version:forge'] }}</td></tr>
+                <tr><td>NodeJS</td><td>{{ settings['version:node'] }}</td></tr>
             </table>
         </div>
     </div>
@@ -58,11 +93,13 @@
 <script>
 import adminApi from '../../api/admin.js'
 import Settings from '../../api/settings.js'
+import FormHeading from '../../components/FormHeading.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
 
 export default {
     name: 'AdminSettingsGeneral',
     components: {
+        FormHeading,
         SectionTopMenu
     },
     data: function () {

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -41,6 +41,10 @@ module.exports = async function (settings = {}, config = {}) {
 
     const forge = await Forge({ config })
     await forge.settings.set('setup:initialised', true)
+    forge.license.defaults.users = 50
+    forge.license.defaults.teams = 50
+    forge.license.defaults.instances = 50
+
     const factory = new TestModelFactory(forge)
 
     const projectType = await factory.createProjectType({ name: 'type1' })

--- a/test/node_modules/flowforge-test-utils/index.js
+++ b/test/node_modules/flowforge-test-utils/index.js
@@ -28,6 +28,9 @@ async function setupApp (config = {}) {
         ...config
     }
 
+    const testLimits = config.limits
+    delete config.limits
+
     if (process.env.FF_TEST_DB_POSTGRES) {
         config.db.type = 'postgres'
         config.db.host = process.env.FF_TEST_DB_POSTGRES_HOST || 'localhost'
@@ -58,7 +61,15 @@ async function setupApp (config = {}) {
         }
     }
 
-    return await Forge({ config })
+    const app = await Forge({ config })
+
+    // Allow platform limits to be overriden by tests
+    if (testLimits) {
+        for (const [key, value] of Object.entries(testLimits)) {
+            app.license.defaults[key] = value
+        }
+    }
+    return app
 }
 
 

--- a/test/unit/forge/db/controllers/Device_spec.js
+++ b/test/unit/forge/db/controllers/Device_spec.js
@@ -11,7 +11,11 @@ describe('Device controller', function () {
     const TestObjects = {}
 
     async function setupCE () {
-        app = await setup()
+        app = await setup({
+            limits: {
+                instances: 50
+            }
+        })
         factory = new TestModelFactory(app)
         await setupTestObjects()
     }

--- a/test/unit/forge/db/controllers/ProjectSnapshot_spec.js
+++ b/test/unit/forge/db/controllers/ProjectSnapshot_spec.js
@@ -13,7 +13,11 @@ describe('ProjectSnapshot controller', function () {
     let factory
 
     before(async function () {
-        app = await setup()
+        app = await setup({
+            limits: {
+                instances: 50
+            }
+        })
         factory = app.factory
         app.TestObjects.application1 = await factory.createApplication({ name: 'application-1' }, app.TestObjects.team1)
     })

--- a/test/unit/forge/db/controllers/Project_spec.js
+++ b/test/unit/forge/db/controllers/Project_spec.js
@@ -10,7 +10,11 @@ describe('Project controller', function () {
     // Use standard test data.
     let app
     before(async function () {
-        app = await setup()
+        app = await setup({
+            limits: {
+                instances: 50
+            }
+        })
     })
 
     after(async function () {

--- a/test/unit/forge/db/models/Device_spec.js
+++ b/test/unit/forge/db/models/Device_spec.js
@@ -24,7 +24,7 @@ describe('Device model', function () {
 
         it('Does not permit overage when unlicensed', async function () {
             app = await setup({ })
-            app.license.defaults.devices = 2
+            app.license.defaults.instances = 2
 
             ;(await app.db.models.Device.count()).should.equal(0)
 

--- a/test/unit/forge/db/models/Project_spec.js
+++ b/test/unit/forge/db/models/Project_spec.js
@@ -35,7 +35,7 @@ describe('Project model', function () {
             })
         })
         it('Does not permit overage when unlicensed', async function () {
-            app.license.defaults.projects = 2 // override default
+            app.license.defaults.instances = 2 // override default
             ;(await app.db.models.Project.count()).should.equal(0)
             await app.db.models.Project.create({ name: 'p1', type: '', url: '' })
             ;(await app.db.models.Project.count()).should.equal(1)

--- a/test/unit/forge/db/models/User_spec.js
+++ b/test/unit/forge/db/models/User_spec.js
@@ -10,7 +10,11 @@ describe('User model', function () {
 
     describe('Model properties', function () {
         before(async function () {
-            app = await setup()
+            app = await setup({
+                limits: {
+                    users: 50
+                }
+            })
         })
         after(async function () {
             await app.close()

--- a/test/unit/forge/licensing/index_spec.js
+++ b/test/unit/forge/licensing/index_spec.js
@@ -25,6 +25,25 @@ describe('License API', async function () {
     const TEST_LICENSE_4u_5t_6p_7d = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo0LCJ0ZWFtcyI6NSwicHJvamVjdHMiOjYsImRldmljZXMiOjcsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNDc2OTg5fQ.XJfAKSKH0ndmrD8z-GX1eWr7OdMnStIdP0ebtC3mKWvnT22TZK0pUx0jDMPFRROFDAJo_eh50T5OUHHfwSp1YQ' // eslint-disable-line camelcase
 
     /**
+     * Test license: users 4, teams 5, instances 13
+     * {
+            "id": "87f0474c-c721-4332-851f-3cd92736497f",
+            "ver": "2024-03-04",
+            "iss": "FlowForge Inc.",
+            "sub": "FlowFuse Development",
+            "nbf": 1709596800,
+            "exp": 4107888000,
+            "note": "Development-mode Only. Not for production",
+            "users": 4,
+            "teams": 5,
+            "instances": 13,
+            "tier": "enterprise",
+            "dev": true
+        }
+    */
+    const TEST_LICENSE_4u_5t_13i = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Ijg3ZjA0NzRjLWM3MjEtNDMzMi04NTFmLTNjZDkyNzM2NDk3ZiIsInZlciI6IjIwMjQtMDMtMDQiLCJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGdXNlIERldmVsb3BtZW50IiwibmJmIjoxNzA5NTk2ODAwLCJleHAiOjQxMDc4ODgwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo0LCJ0ZWFtcyI6NSwiaW5zdGFuY2VzIjoxMywidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTcwOTY0NjI1M30.X-m4iLzXc5ivBABljZT6pMvYNoqhGYQHU1dMfPVhahkekRPZVSZT1IGKjMMBc8YVZwRoHYuoxjiOmpPyto6_CA' // eslint-disable-line camelcase
+
+    /**
     * Test license (does not include any claims)
     *
     * Details:
@@ -106,19 +125,18 @@ describe('License API', async function () {
         it('Uses default limits when no license applied', async function () {
             app.license.get('users').should.equal(app.license.defaults.users)
             app.license.get('teams').should.equal(app.license.defaults.teams)
-            app.license.get('projects').should.equal(app.license.defaults.projects)
-            app.license.get('devices').should.equal(app.license.defaults.devices)
+            app.license.get('instances').should.equal(app.license.defaults.instances)
         })
 
         it('Gets all usage count and limits (unlicensed)', async function () {
             const usage = await app.license.usage()
             // check usage contains the correct keys
-            usage.should.only.have.keys('users', 'teams', 'projects', 'devices')
+            usage.should.only.have.keys('users', 'teams', 'instances')
             // check each item has the correct keys
             usage.users.should.only.have.keys('resource', 'count', 'limit')
             usage.teams.should.only.have.keys('resource', 'count', 'limit')
-            usage.projects.should.only.have.keys('resource', 'count', 'limit')
-            usage.devices.should.only.have.keys('resource', 'count', 'limit')
+            usage.instances.should.only.have.keys('resource', 'count', 'limit')
+
             // check usage values are correct
             usage.users.count.should.equal(0)
             usage.users.limit.should.equal(app.license.defaults.users)
@@ -128,13 +146,9 @@ describe('License API', async function () {
             usage.teams.limit.should.equal(app.license.defaults.teams)
             usage.teams.resource.should.equal('teams')
 
-            usage.projects.count.should.equal(0)
-            usage.projects.limit.should.equal(app.license.defaults.projects)
-            usage.projects.resource.should.equal('projects')
-
-            usage.devices.count.should.equal(0)
-            usage.devices.limit.should.equal(app.license.defaults.devices)
-            usage.devices.resource.should.equal('devices')
+            usage.instances.count.should.equal(0)
+            usage.instances.limit.should.equal(app.license.defaults.instances)
+            usage.instances.resource.should.equal('instances')
         })
         it('Gets users usage count and limit only (unlicensed)', async function () {
             const usage = await app.license.usage('users')
@@ -156,15 +170,15 @@ describe('License API', async function () {
             usage.teams.limit.should.equal(app.license.defaults.teams)
             usage.teams.resource.should.equal('teams')
         })
-        it('Gets projects usage count and limit only (unlicensed)', async function () {
-            const usage = await app.license.usage('projects')
+        it('Gets instance usage count and limit only (unlicensed)', async function () {
+            const usage = await app.license.usage('instances')
             // check usage contains the correct keys
-            usage.should.only.have.keys('projects')
+            usage.should.only.have.keys('instances')
             // check item has the correct keys
-            usage.projects.should.only.have.keys('resource', 'count', 'limit')
-            usage.projects.count.should.equal(0)
-            usage.projects.limit.should.equal(app.license.defaults.projects)
-            usage.projects.resource.should.equal('projects')
+            usage.instances.should.only.have.keys('resource', 'count', 'limit')
+            usage.instances.count.should.equal(0)
+            usage.instances.limit.should.equal(app.license.defaults.instances)
+            usage.instances.resource.should.equal('instances')
         })
         it('Gets devices usage count and limit only (unlicensed)', async function () {
             const usage = await app.license.usage('devices')
@@ -173,12 +187,12 @@ describe('License API', async function () {
             // check item has the correct keys
             usage.devices.should.only.have.keys('resource', 'count', 'limit')
             usage.devices.count.should.equal(0)
-            usage.devices.limit.should.equal(app.license.defaults.devices)
+            usage.devices.limit.should.equal(app.license.defaults.instances)
             usage.devices.resource.should.equal('devices')
         })
     })
 
-    describe('licensed', function () {
+    describe('licensed - separate projects/devices claims', function () {
         before(async function () {
             app = await getApp(TEST_LICENSE_4u_5t_6p_7d)
         })
@@ -188,11 +202,11 @@ describe('License API', async function () {
         it('Gets all usage count and limits (licensed)', async function () {
             const usage = await app.license.usage()
             // check usage contains the correct keys
-            usage.should.only.have.keys('users', 'teams', 'projects', 'devices')
+            usage.should.only.have.keys('users', 'teams', 'instances', 'devices')
             // check each item has the correct keys
             usage.users.should.only.have.keys('resource', 'count', 'limit')
             usage.teams.should.only.have.keys('resource', 'count', 'limit')
-            usage.projects.should.only.have.keys('resource', 'count', 'limit')
+            usage.instances.should.only.have.keys('resource', 'count', 'limit')
             usage.devices.should.only.have.keys('resource', 'count', 'limit')
             // check usage values are correct
             usage.users.count.should.equal(0)
@@ -203,9 +217,9 @@ describe('License API', async function () {
             usage.teams.limit.should.equal(5)
             usage.teams.resource.should.equal('teams')
 
-            usage.projects.count.should.equal(0)
-            usage.projects.limit.should.equal(6)
-            usage.projects.resource.should.equal('projects')
+            usage.instances.count.should.equal(0)
+            usage.instances.limit.should.equal(6)
+            usage.instances.resource.should.equal('instances')
 
             usage.devices.count.should.equal(0)
             usage.devices.limit.should.equal(7)
@@ -231,15 +245,15 @@ describe('License API', async function () {
             usage.teams.limit.should.equal(5)
             usage.teams.resource.should.equal('teams')
         })
-        it('Gets projects usage count and limit only (licensed)', async function () {
-            const usage = await app.license.usage('projects')
+        it('Gets instance usage count and limit only (licensed)', async function () {
+            const usage = await app.license.usage('instances')
             // check usage contains the correct keys
-            usage.should.only.have.keys('projects')
+            usage.should.only.have.keys('instances')
             // check item has the correct keys
-            usage.projects.should.only.have.keys('resource', 'count', 'limit')
-            usage.projects.count.should.equal(0)
-            usage.projects.limit.should.equal(6)
-            usage.projects.resource.should.equal('projects')
+            usage.instances.should.only.have.keys('resource', 'count', 'limit')
+            usage.instances.count.should.equal(0)
+            usage.instances.limit.should.equal(6)
+            usage.instances.resource.should.equal('instances')
         })
         it('Gets devices usage count and limit only (licensed)', async function () {
             const usage = await app.license.usage('devices')
@@ -260,6 +274,88 @@ describe('License API', async function () {
             app.license.get('devices').should.equal(7)
         })
     })
+
+    describe('licensed - combined instances claims', function () {
+        before(async function () {
+            app = await getApp(TEST_LICENSE_4u_5t_13i)
+        })
+        after(async function () {
+            await app.close()
+        })
+        it('Gets all usage count and limits (licensed)', async function () {
+            const usage = await app.license.usage()
+            // check usage contains the correct keys
+            usage.should.only.have.keys('users', 'teams', 'instances')
+            // check each item has the correct keys
+            usage.users.should.only.have.keys('resource', 'count', 'limit')
+            usage.teams.should.only.have.keys('resource', 'count', 'limit')
+            usage.instances.should.only.have.keys('resource', 'count', 'limit')
+            // check usage values are correct
+            usage.users.count.should.equal(0)
+            usage.users.limit.should.equal(4)
+            usage.users.resource.should.equal('users')
+
+            usage.teams.count.should.equal(0)
+            usage.teams.limit.should.equal(5)
+            usage.teams.resource.should.equal('teams')
+
+            usage.instances.count.should.equal(0)
+            usage.instances.limit.should.equal(13)
+            usage.instances.resource.should.equal('instances')
+        })
+        it('Gets users usage count and limit only (licensed)', async function () {
+            const usage = await app.license.usage('users')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('users')
+            // check item has the correct keys
+            usage.users.should.only.have.keys('resource', 'count', 'limit')
+            usage.users.count.should.equal(0)
+            usage.users.limit.should.equal(4)
+            usage.users.resource.should.equal('users')
+        })
+        it('Gets teams usage count and limit only (licensed)', async function () {
+            const usage = await app.license.usage('teams')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('teams')
+            // check item has the correct keys
+            usage.teams.should.only.have.keys('resource', 'count', 'limit')
+            usage.teams.count.should.equal(0)
+            usage.teams.limit.should.equal(5)
+            usage.teams.resource.should.equal('teams')
+        })
+        it('Gets instance usage count and limit only (licensed)', async function () {
+            const usage = await app.license.usage('instances')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('instances')
+            // check item has the correct keys
+            usage.instances.should.only.have.keys('resource', 'count', 'limit')
+            usage.instances.count.should.equal(0)
+            usage.instances.limit.should.equal(13)
+            usage.instances.resource.should.equal('instances')
+        })
+        it('Gets devices usage count and limit only (licensed)', async function () {
+            // For a combined license, querying the devices usage gives the instances
+            // usage and limits.
+            const usage = await app.license.usage('devices')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('devices')
+            // check item has the correct keys
+            usage.devices.should.only.have.keys('resource', 'count', 'limit')
+            usage.devices.count.should.equal(0)
+            usage.devices.limit.should.equal(13)
+            usage.devices.resource.should.equal('devices')
+        })
+
+        it('Uses license provided limits', async function () {
+            app.license.get('organisation').should.equal('FlowFuse Development')
+            app.license.get('users').should.equal(4)
+            app.license.get('teams').should.equal(5)
+            app.license.get('instances').should.equal(13)
+            should.not.exist(app.license.get('projects'))
+            should.not.exist(app.license.get('devices'))
+        })
+    })
+
     describe('licensed - 0 claims', function () {
         before(async function () {
             app = await getApp(TEST_LICENSE_0_CLAIMS)
@@ -270,10 +366,10 @@ describe('License API', async function () {
         it('Returns 0 as the limit property when querying usage data for a license without claims', async function () {
             app.license.get('organisation').should.equal('FlowForge Inc.')
             const usage = await app.license.usage()
-            usage.should.only.have.keys('users', 'teams', 'projects', 'devices')
+            usage.should.only.have.keys('users', 'teams', 'instances', 'devices')
             usage.users.limit.should.equal(0)
             usage.teams.limit.should.equal(0)
-            usage.projects.limit.should.equal(0)
+            usage.instances.limit.should.equal(0)
             usage.devices.limit.should.equal(0)
         })
 

--- a/test/unit/forge/routes/api/application_spec.js
+++ b/test/unit/forge/routes/api/application_spec.js
@@ -27,7 +27,12 @@ describe('Application API', function () {
     const generateName = (root = 'object') => `${root}-${objectCount++}`
 
     before(async function () {
-        app = await setup()
+        app = await setup({
+            limits: {
+                users: 10,
+                instances: 50
+            }
+        })
 
         // ATeam ( alice  (owner), bob )
         // BTeam ( bob (owner), chris )

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -69,7 +69,11 @@ describe('Device API', async function () {
     }
 
     async function setupApp (license) {
-        const setupConfig = { }
+        const setupConfig = {
+            limits: {
+                instances: 50
+            }
+        }
         if (license) {
             setupConfig.license = license
         }
@@ -357,9 +361,9 @@ describe('Device API', async function () {
             })
             it('Limits how many devices can be created when unlicensed', async function () {
                 // Limited to 2 devices
-                app.license.defaults.devices = 2
-                // Check we're at the starting point we expect
-                ;(await app.db.models.Device.count()).should.equal(0)
+                app.license.defaults.instances = 3
+                // Check we're at the starting point we expect - combined device+instance count = 1
+                ;(await app.license.usage()).instances.count.should.equal(1)
 
                 for (let i = 0; i < 2; i++) {
                     const response = await createDevice({ name: `D${i + 1}`, type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })

--- a/test/unit/forge/routes/api/projectDevices_spec.js
+++ b/test/unit/forge/routes/api/projectDevices_spec.js
@@ -26,7 +26,7 @@ describe('Project/Device API', async function () {
     }
 
     before(async function () {
-        app = await setup({ features: { devices: true } })
+        app = await setup({ limits: { instances: 50 }, features: { devices: true } })
 
         // alice : admin
         // bob

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -20,7 +20,7 @@ describe('Project API', function () {
     const TestObjects = {}
 
     async function setupApp (license) {
-        const setupConfig = { domain: 'flowforge.dev' }
+        const setupConfig = { limits: { instances: 50 }, domain: 'flowforge.dev' }
         if (license) {
             setupConfig.license = license
         }

--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -26,7 +26,7 @@ describe('Team Devices API', function () {
     }
 
     before(async function () {
-        const opts = {}
+        const opts = { limits: { instances: 50 } }
         app = await setup(opts)
         AccessTokenController = app.db.controllers.AccessToken
 

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -10,7 +10,7 @@ describe('Team API', function () {
     let app
     const TestObjects = {}
     beforeEach(async function () {
-        const opts = {}
+        const opts = { limits: { teams: 50, instances: 50 } }
         if (this.currentTest.license) {
             opts.license = this.currentTest.license
         }

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -9,7 +9,7 @@ describe('User API', async function () {
     const TestObjects = {}
 
     async function setupApp (license) {
-        const setupConfig = { features: { devices: true } }
+        const setupConfig = { limits: { instances: 50, users: 50 }, features: { devices: true } }
         if (license) {
             setupConfig.license = license
         }

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -16,6 +16,7 @@ describe('Users API', async function () {
 
     before(async function () {
         app = await setup({
+            limits: { users: 50, instances: 50 },
             features: { devices: true }
         })
 


### PR DESCRIPTION
Closes #3533
## Description

With this change, newly generated licenses will have a single instance/device count - rather than two separate limits.

It also reduces the limits of the unlicensed code to 5 users, 5 teams and 5 devices.

Existing licenses will continue to be honoured with their separate instance and device counts.

