### PR TITLE
Fix GA tracking on create account

### DIFF
--- a/forge/routes/ui/index.js
+++ b/forge/routes/ui/index.js
@@ -61,7 +61,7 @@ module.exports = async function (app) {
             if (telemetry.frontend.google?.tag) {
                 const tag = telemetry.frontend.google.tag
                 injection += `<script async src="https://www.googletagmanager.com/gtag/js?id=${tag}"></script>`
-                injection += `<script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '${tag}'); </script>`
+                injection += `<script> window.dataLayer = window.dataLayer || []; window.gtag = function (){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '${tag}'); </script>`
             }
 
             if (support?.enabled && support.frontend?.hubspot?.trackingcode) {

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -194,11 +194,11 @@ export default {
                     this.emailSent = true
                 }
                 this.busy = false
-                if (gtag && this.settings.adwords?.events?.conversion) { // eslint-disable-line no-undef
-                    gtag('event', 'conversion', this.settings.adwords.events.conversion) // eslint-disable-line no-undef
+                if (window.gtag && this.settings.adwords?.events?.conversion) {
+                    window.gtag('event', 'conversion', this.settings.adwords.events.conversion)
                 }
             }).catch(err => {
-                console.error(err.response.data)
+                console.error(err)
                 this.busy = false
                 if (err.response?.data) {
                     if (err.response.data.code === 'invalid_request') {


### PR DESCRIPTION
Noticed whilst debugging HS form tracking the recently added GA tracking was causing an error to be thrown if GA wasn't enabled.

The `gtag` function needed to be explicitly added to `window` so that it would be visible to code inside vue.