### PR TITLE
Update sign-up form to use submit event

### DIFF
--- a/forge/routes/ui/index.js
+++ b/forge/routes/ui/index.js
@@ -61,7 +61,7 @@ module.exports = async function (app) {
             if (telemetry.frontend.google?.tag) {
                 const tag = telemetry.frontend.google.tag
                 injection += `<script async src="https://www.googletagmanager.com/gtag/js?id=${tag}"></script>`
-                injection += `<script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '${tag}'); </script>`
+                injection += `<script> window.dataLayer = window.dataLayer || []; window.gtag = function (){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '${tag}'); </script>`
             }
 
             if (support?.enabled && support.frontend?.hubspot?.trackingcode) {

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -194,11 +194,11 @@ export default {
                     this.emailSent = true
                 }
                 this.busy = false
-                if (gtag && this.settings.adwords?.events?.conversion) { // eslint-disable-line no-undef
-                    gtag('event', 'conversion', this.settings.adwords.events.conversion) // eslint-disable-line no-undef
+                if (window.gtag && this.settings.adwords?.events?.conversion) {
+                    window.gtag('event', 'conversion', this.settings.adwords.events.conversion)
                 }
             }).catch(err => {
-                console.error(err.response.data)
+                console.error(err)
                 this.busy = false
                 if (err.response?.data) {
                     if (err.response.data.code === 'invalid_request') {

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -5,7 +5,7 @@
         <template v-if="splash" #splash-content>
             <div data-el="splash" v-html="splash" />
         </template>
-        <form v-if="!emailSent && !ssoCreated" class="max-w-md m-auto">
+        <form v-if="!emailSent && !ssoCreated" id="ff-sign-up" class="max-w-md m-auto" @submit.prevent="registerUser()">
             <p
                 v-if="settings['branding:account:signUpTopBanner']"
                 data-el="banner-text"
@@ -42,7 +42,7 @@
             </div>
             <label v-if="errors.general" class="pt-3 ff-error-inline">{{ errors.general }}</label>
             <div class="ff-actions pt-2">
-                <ff-button :disabled="!formValid || busy || tooManyRequests" data-action="sign-up" @click="registerUser()">
+                <ff-button type="submit" :disabled="!formValid || busy || tooManyRequests" data-action="sign-up">
                     <span>Sign Up</span>
                     <span class="w-4">
                         <SpinnerIcon v-if="busy || tooManyRequests" class="ff-icon ml-3 !w-3.5" />


### PR DESCRIPTION
ref https://github.com/FlowFuse/customer/issues/127

We are not getting any hubspot form captures from the sign-up form.

Having examined the hs form tracker, my best theory is it hooks into the form's submit event - which our sign up form never triggers.

This PR changes the handling so the button becomes a submit button, and the form's own on-submit handler that triggers the sign up function.

I've tested this locally by manually adding a second listener on the form's submit event via the js console:
```
document.getElementById('ff-sign-up').addEventListener('submit', function () { console.log('hi there')})
```
And seen this handler is triggered when I click the create button.

If my theory is correct, this should get us reattached to the hubspot form tracking. I've also added an `id` to the form to make it easier to identify within hubspot.

