### PR TITLE
HTTP Bearer Tokens test for correct flag

### DIFF
--- a/forge/ee/routes/httpTokens/index.js
+++ b/forge/ee/routes/httpTokens/index.js
@@ -10,7 +10,7 @@ module.exports = async function (app) {
                         return
                     }
                     const teamType = await request.project.Team.getTeamType()
-                    if (!teamType.getFeatureProperty('teamHttpSecurity', true)) {
+                    if (!teamType.getFeatureProperty('teamHttpSecurity', false)) {
                         reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return // eslint-disable-line no-useless-return
                     }

--- a/forge/ee/routes/httpTokens/index.js
+++ b/forge/ee/routes/httpTokens/index.js
@@ -10,7 +10,7 @@ module.exports = async function (app) {
                         return
                     }
                     const teamType = await request.project.Team.getTeamType()
-                    if (!teamType.getFeatureProperty('ha', true)) {
+                    if (!teamType.getFeatureProperty('teamHttpSecurity', true)) {
                         reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return // eslint-disable-line no-useless-return
                     }

--- a/test/e2e/frontend/test_environment_ee.js
+++ b/test/e2e/frontend/test_environment_ee.js
@@ -44,6 +44,7 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
     const defaultTeamTypeProperties = defaultTeamType.properties
     defaultTeamTypeProperties.features.deviceGroups = true
     defaultTeamTypeProperties.features.protectedInstance = true
+    defaultTeamTypeProperties.features.teamHttpSecurity = true
     defaultTeamType.properties = defaultTeamTypeProperties
     await defaultTeamType.save()
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
The preHAndler was coppied from the ha feature and missed changing flag

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

