### PR TITLE
Only show http bearer when licensed

### DIFF
--- a/forge/ee/routes/httpTokens/index.js
+++ b/forge/ee/routes/httpTokens/index.js
@@ -1,5 +1,4 @@
 module.exports = async function (app) {
-
     app.config.features.register('httpBearerTokens', true, true)
 
     app.addHook('preHandler', app.verifySession)

--- a/forge/ee/routes/httpTokens/index.js
+++ b/forge/ee/routes/httpTokens/index.js
@@ -1,4 +1,7 @@
 module.exports = async function (app) {
+
+    app.config.features.register('httpBearerTokens', true, true)
+
     app.addHook('preHandler', app.verifySession)
     app.addHook('preHandler', async (request, reply) => {
         if (request.params.projectId !== undefined) {

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -157,7 +157,7 @@ export default {
     mounted () {
         this.checkAccess()
         this.getSettings()
-        if (!!this.settings.features.httpBearerTokens) {
+        if (this.settings.features.httpBearerTokens) {
             this.getTokens()
         }
     },

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -1,7 +1,7 @@
 <template>
     <form class="space-y-6">
         <TemplateSettingsSecurity v-model="editable" :editTemplate="false" :team="team" />
-        <div v-if="editable.settings.httpNodeAuth_type === 'flowforge-user' ">
+        <div v-if="!!settings.features.httpBearerTokens && editable.settings.httpNodeAuth_type === 'flowforge-user'">
             <FormHeading>HTTP Node Bearer Tokens</FormHeading>
             <div v-if="projectLauncherCompatible">
                 <ff-data-table
@@ -116,7 +116,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership']),
+        ...mapState('account', ['team', 'teamMembership', 'settings']),
         projectLauncherCompatible () {
             const launcherVersion = this.project?.meta?.versions?.launcher
             if (!launcherVersion) {
@@ -157,7 +157,9 @@ export default {
     mounted () {
         this.checkAccess()
         this.getSettings()
-        this.getTokens()
+        if (!!this.settings.features.httpBearerTokens) {
+            this.getTokens()
+        }
     },
     methods: {
         checkAccess: async function () {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
When enabled FF User authentication for an Instance the UI to create HTTP Bearer tokens was being shown on on licensed FF instances. This feature is EE only so needs to be hidden on CE instances.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

