### PR TITLE
Ensure device agent gets feature flags

### DIFF
--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -223,6 +223,11 @@ module.exports = async function (app) {
                 response[key] = settings[key]
             }
         })
+        const teamType = await request.device.Team.getTeamType()
+        response.features = {
+            'shared-library': !!(app.config.features.enabled('shared-library') && teamType.getFeatureProperty('shared-library', true)),
+            projectComms: !!(app.config.features.enabled('projectComms') && teamType.getFeatureProperty('projectComms', true))
+        }
         reply.send(response)
     })
 }


### PR DESCRIPTION
_Part one of three_

## Description

* Provides feature flags relevant to a device  in `GET /api/v1/devices/:deviceId/live/settings`
* Adds / updates tests


## Related Issue(s)

#3560

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

