### PR TITLE
Allow for combined device/instance team limits

### DIFF
--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -19,7 +19,7 @@
                     <template #description>Use markdown for formatting</template>
                     <template #input><textarea v-model="input.description" class="w-full" rows="6" /></template>
                 </FormRow>
-                <template v-if="features.billing">
+                <template v-if="billingEnabled">
                     <FormHeading>Billing</FormHeading>
                     <div class="grid gap-2 grid-cols-3">
                         <FormRow v-model="input.properties.billing.productId" :type="editDisabled?'uneditable':''">Product Id</FormRow>
@@ -42,9 +42,10 @@
                         </div>
                     </div>
                 </template>
-                <FormHeading>Users</FormHeading>
-                <div class="grid gap-3 grid-cols-8">
-                    <FormRow v-model="input.properties.users.limit"># Limit</FormRow>
+                <FormHeading>Limits</FormHeading>
+                <div class="grid gap-3 grid-cols-3">
+                    <FormRow v-model="input.properties.users.limit"># Users</FormRow>
+                    <FormRow v-model="input.properties.runtimes.limit"># Instances + Devices</FormRow>
                 </div>
                 <div v-for="(instanceType, index) in instanceTypes" :key="index">
                     <FormHeading>Instance Type: {{ instanceType.name }}</FormHeading>
@@ -52,22 +53,22 @@
                     <div v-if="input.properties.instances[instanceType.id].active" class="grid gap-3 grid-cols-4 pl-4">
                         <div class="grid gap-3 grid-cols-2">
                             <FormRow v-model="input.properties.instances[instanceType.id].limit"># Limit</FormRow>
-                            <FormRow v-if="features.billing" v-model="input.properties.instances[instanceType.id].free"># Free</FormRow>
+                            <FormRow v-if="billingEnabled" v-model="input.properties.instances[instanceType.id].free"># Free</FormRow>
                         </div>
-                        <FormRow v-if="features.billing" v-model="input.properties.instances[instanceType.id].productId" :type="editDisabled?'uneditable':''">Product Id</FormRow>
-                        <FormRow v-if="features.billing" v-model="input.properties.instances[instanceType.id].priceId" :type="editDisabled?'uneditable':''">Price Id</FormRow>
-                        <FormRow v-if="features.billing" v-model="input.properties.instances[instanceType.id].description" placeholder="eg. $10/month" :type="editDisabled?'uneditable':''">Description</FormRow>
+                        <FormRow v-if="billingEnabled" v-model="input.properties.instances[instanceType.id].productId" :type="editDisabled?'uneditable':''">Product Id</FormRow>
+                        <FormRow v-if="billingEnabled" v-model="input.properties.instances[instanceType.id].priceId" :type="editDisabled?'uneditable':''">Price Id</FormRow>
+                        <FormRow v-if="billingEnabled" v-model="input.properties.instances[instanceType.id].description" placeholder="eg. $10/month" :type="editDisabled?'uneditable':''">Description</FormRow>
                     </div>
                 </div>
                 <FormHeading>Devices</FormHeading>
                 <div class="grid gap-3 grid-cols-4">
                     <div class="grid gap-3 grid-cols-2">
                         <FormRow v-model="input.properties.devices.limit"># Limit</FormRow>
-                        <FormRow v-if="features.billing" v-model="input.properties.devices.free"># Free</FormRow>
+                        <FormRow v-if="billingEnabled" v-model="input.properties.devices.free"># Free</FormRow>
                     </div>
-                    <FormRow v-if="features.billing" v-model="input.properties.devices.productId" :type="editDisabled?'uneditable':''">Product Id</FormRow>
-                    <FormRow v-if="features.billing" v-model="input.properties.devices.priceId" :type="editDisabled?'uneditable':''">Price Id</FormRow>
-                    <FormRow v-if="features.billing" v-model="input.properties.devices.description" placeholder="eg. $10/month" :type="editDisabled?'uneditable':''">Description</FormRow>
+                    <FormRow v-if="billingEnabled" v-model="input.properties.devices.productId" :type="editDisabled?'uneditable':''">Product Id</FormRow>
+                    <FormRow v-if="billingEnabled" v-model="input.properties.devices.priceId" :type="editDisabled?'uneditable':''">Price Id</FormRow>
+                    <FormRow v-if="billingEnabled" v-model="input.properties.devices.description" placeholder="eg. $10/month" :type="editDisabled?'uneditable':''">Description</FormRow>
                 </div>
 
                 <FormHeading>Features</FormHeading>
@@ -142,6 +143,7 @@ export default {
                     this.input.active = teamType.active
                     this.input.description = teamType.description
                     this.input.properties.users = teamType.properties?.users || {}
+                    this.input.properties.runtimes = teamType.properties?.runtimes || {}
                     this.input.properties.devices = teamType.properties?.devices || {}
                     this.input.properties.instances = teamType.properties?.instances || {}
                     this.input.properties.features = teamType.properties?.features || {}
@@ -195,6 +197,7 @@ export default {
                             billing: {},
                             trial: {},
                             users: {},
+                            runtimes: {},
                             devices: {},
                             instances: {},
                             features: {}
@@ -233,6 +236,7 @@ export default {
                 order: '0',
                 properties: {
                     billing: {},
+                    runtimes: {},
                     devices: {},
                     users: {},
                     instances: {},
@@ -258,6 +262,9 @@ export default {
             } else {
                 return 'Create team type'
             }
+        },
+        billingEnabled () {
+            return !!this.features.billing
         }
     },
     methods: {
@@ -270,6 +277,7 @@ export default {
                     order: parseInt(this.input.order),
                     properties: {
                         users: { ...this.input.properties.users },
+                        runtimes: { ...this.input.properties.runtimes },
                         devices: { ...this.input.properties.devices },
                         instances: { ...this.input.properties.instances },
                         features: { ...this.input.properties.features }
@@ -287,6 +295,7 @@ export default {
                 }
                 // Ensure all numbers are numbers not strings, and strip any blank values
                 formatNumber(opts.properties.users, 'limit')
+                formatNumber(opts.properties.runtimes, 'limit')
                 formatNumber(opts.properties.devices, 'limit')
                 for (const instanceProperties of Object.values(opts.properties.instances)) {
                     formatNumber(instanceProperties, 'limit')

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -461,6 +461,8 @@ export default {
                 try {
                     await deviceApi.deleteDevice(this.device.id)
                     Alerts.emit('Successfully deleted the device', 'confirmation')
+                    // Trigger a refresh of team info to resync following device changes
+                    await this.$store.dispatch('account/refreshTeam')
                     this.$router.push({ name: 'TeamDevices', params: { team_slug: this.team.slug } })
                 } catch (err) {
                     Alerts.emit('Failed to delete device: ' + err.toString(), 'warning', 7500)

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -1,5 +1,6 @@
 <template>
-    <FeatureUnavailableToTeam v-if="teamInstanceLimitReached" fullMessage="You have reached the instance limit for this team." />
+    <FeatureUnavailableToTeam v-if="teamRuntimeLimitReached" fullMessage="You have reached the runtime limit for this team." />
+    <FeatureUnavailableToTeam v-else-if="teamInstanceLimitReached" fullMessage="You have reached the instance limit for this team." />
     <form
         class="space-y-6"
         @submit.prevent="$emit('on-submit', input, copyParts)"
@@ -457,6 +458,10 @@ export default {
                 )
             )
         },
+        teamRuntimeLimitReached () {
+            const teamTypeRuntimeLimit = this.team.type.properties?.runtimes?.limit
+            return (teamTypeRuntimeLimit > 0 && (this.team.deviceCount + this.team.instanceCount) >= teamTypeRuntimeLimit)
+        },
         teamInstanceLimitReached () {
             return this.projectTypes.length > 0 && this.activeProjectTypeCount === 0
         },
@@ -519,7 +524,10 @@ export default {
                 pt.priceInterval = ''
                 pt.currency = ''
                 pt.cost = 0
-                if (teamTypeInstanceProperties) {
+                if (this.teamRuntimeLimitReached) {
+                    // The overall limit has been reached
+                    pt.disabled = true
+                } else if (teamTypeInstanceProperties) {
                     if (!teamTypeInstanceProperties.active) {
                         // This instanceType is disabled for this teamType
                         pt.disabled = true

--- a/test/unit/forge/db/models/Team_spec.js
+++ b/test/unit/forge/db/models/Team_spec.js
@@ -10,6 +10,7 @@ describe('Team model', function () {
         let ATeam
         let smallerTeamType
         let biggerTeamType
+        let combinedLimitsTeamType
         before(async function () {
             app = await setup({})
 
@@ -70,6 +71,25 @@ describe('Team model', function () {
                     features: { }
                 }
             })
+
+            // Create a new teamType with combined limits
+            combinedLimitsTeamType = await app.db.models.TeamType.create({
+                name: 'combined-limits-team-type',
+                description: 'team type description',
+                active: true,
+                order: 1,
+                properties: {
+                    instances: {
+                        limit: 3,
+                        [pt1.hashid]: { active: true },
+                        [pt2.hashid]: { active: true },
+                        [pt3.hashid]: { active: true }
+                    },
+                    devices: { },
+                    users: { limit: 3 },
+                    features: { }
+                }
+            })
         })
         after(async function () {
             if (app) {
@@ -114,6 +134,11 @@ describe('Team model', function () {
             const deviceLimit = await ATeam.getDeviceLimit()
             deviceLimit.should.equal(2)
         })
+        it('getRuntimeLimit', async function () {
+            const runtimeLimit = await ATeam.getRuntimeLimit()
+            runtimeLimit.should.equal(-1)
+        })
+
         it('isInstanceTypeAvailable', async function () {
             // Check the function handles all the ways an instance type
             // might be provided - object, id or hashid.
@@ -182,6 +207,76 @@ describe('Team model', function () {
             await ATeam.updateTeamType(biggerTeamType)
             const reloadedTeam = await app.db.models.Team.findOne({ where: { name: 'ATeam' } })
             reloadedTeam.TeamTypeId.should.equal(biggerTeamType.id)
+        })
+
+        describe('Combined limits', function () {
+            let CombinedTeam
+            before(async function () {
+                CombinedTeam = await app.db.models.Team.create({ name: 'CombinedTeam', TeamTypeId: combinedLimitsTeamType.id })
+                // Limit of 3 runtimes
+                const application = await app.factory.createApplication({ name: 'ct-app' }, CombinedTeam)
+                // Predefine 1 device and 1 instance
+                const d1 = await app.db.models.Device.create({ name: 'ct-d1', type: 't1', credentialSecret: '' })
+                await CombinedTeam.addDevice(d1)
+
+                await app.db.models.Project.create({
+                    name: 'ct-p1',
+                    type: pt1.id,
+                    url: 'foo',
+                    ApplicationId: application.id,
+                    TeamId: CombinedTeam.id
+                })
+            })
+            it('getRuntimeLimit', async function () {
+                const runtimeLimit = await CombinedTeam.getRuntimeLimit()
+                runtimeLimit.should.equal(3)
+            })
+            it('checkDeviceCreateAllowed', async function () {
+                // Starting with 1 device, 1 instance and limit of 3.
+                // Create is allowed at this point
+                await CombinedTeam.checkDeviceCreateAllowed().should.be.resolved()
+
+                // Create a 3rd runtime
+                const d2 = await app.db.models.Device.create({ name: 'ct-d2', type: 't1', credentialSecret: '' })
+                await CombinedTeam.addDevice(d2)
+
+                // Verify checkDevice rejects request
+                let error
+                try {
+                    await CombinedTeam.checkDeviceCreateAllowed()
+                } catch (err) {
+                    error = err
+                }
+                should.exist(error, 'error not thrown')
+                error.code.should.equal('device_limit_reached')
+
+                await d2.destroy()
+                // Back to 2 runtimes - create should be allowed again
+                await CombinedTeam.checkDeviceCreateAllowed().should.be.resolved()
+            })
+            it('checkInstanceTypeCreateAllowed', async function () {
+                // Starting with 1 device, 1 instance and limit of 3.
+                // Create is allowed at this point
+                await CombinedTeam.checkInstanceTypeCreateAllowed(pt1).should.be.resolved()
+
+                // Create a 3rd runtime
+                const d2 = await app.db.models.Device.create({ name: 'ct-d2', type: 't1', credentialSecret: '' })
+                await CombinedTeam.addDevice(d2)
+
+                // Verify checkDevice rejects request
+                let error
+                try {
+                    await CombinedTeam.checkInstanceTypeCreateAllowed(pt1)
+                } catch (err) {
+                    error = err
+                }
+                should.exist(error, 'error not thrown')
+                error.code.should.equal('instance_limit_reached')
+
+                await d2.destroy()
+                // Back to 2 runtimes - create should be allowed again
+                await CombinedTeam.checkInstanceTypeCreateAllowed(pt1).should.be.resolved()
+            })
         })
     })
     describe('License limits', function () {

--- a/test/unit/forge/db/models/Team_spec.js
+++ b/test/unit/forge/db/models/Team_spec.js
@@ -12,7 +12,7 @@ describe('Team model', function () {
         let biggerTeamType
         let combinedLimitsTeamType
         before(async function () {
-            app = await setup({})
+            app = await setup({ limits: { instances: 100 } })
 
             pt1 = await app.db.models.ProjectType.create({ name: 'pt1', properties: {}, active: true })
             pt2 = await app.db.models.ProjectType.create({ name: 'pt2', properties: {}, active: true })
@@ -79,8 +79,8 @@ describe('Team model', function () {
                 active: true,
                 order: 1,
                 properties: {
+                    runtimes: { limit: 3 },
                     instances: {
-                        limit: 3,
                         [pt1.hashid]: { active: true },
                         [pt2.hashid]: { active: true },
                         [pt3.hashid]: { active: true }


### PR DESCRIPTION
Closes #3534 

## Description

This allows a TeamType to be configured with a combined 'runtime' limit, rather than individual instance/device limits.

When a runtime limit is applied, the api will prevent creation of devices/instances that will exceed the limit.

In the UI, the existing 'you have reached your limit' checks have been extended to check for the runtime limit if set.


 - The new limit is stored in the TeamType properties as `runtimes.limit` (as is consistent with `users.limit` etc)
 - Updated the `Team.checkDeviceCreateAllowed` and `Team.checkInstanceCreateAllowed` functions to incorporate the logic around this new limit - no other changes are needed as these functions are the only place limits are checked.
 - Updated the `Team.checkTeamTypeUpdateAllowed` function which validates a team can upgrade to a new team type based on the limits.