### PR TITLE
Add apiMaxLength & debugMaxLength settings

### DIFF
--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -204,7 +204,7 @@ module.exports = {
             }
         }
         if (result.debugMaxLenth) {
-            if (!Number.isInteger(result.debugMaxLength)) {
+            if (!Number.isInteger(result.debugMaxLength) || result.debugMaxLength < 0) {
                 throw new Error('Invalid settings.debugMaxLength')
             }
         }

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -198,6 +198,16 @@ module.exports = {
         if (typeof result.httpNodeAuth?.pass === 'string' && result.httpNodeAuth.pass.length > 0) {
             result.httpNodeAuth.pass = hash(result.httpNodeAuth.pass)
         }
+        if (result.apiMaxLength) {
+            if (!/^[0-9]+[km]?$/.test(result.apiMaxLength)) {
+                throw new Error('Invalid settings.apiMaxLength')
+            }
+        }
+        if (result.debugMaxLenth) {
+            if (!Number.isInteger(result.debugMaxLength)) {
+                throw new Error('Invalid settings.debugMaxLength')
+            }
+        }
         return result
     },
 

--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -32,4 +32,7 @@ module.exports = fp(async function (app, opts) {
 
     // Set the Instance Auto Snapshot Feature Flag
     app.config.features.register('instanceAutoSnapshot', true, true)
+
+    // Set the Editor Limits Feature Flag
+    app.config.features.register('editorLimits', true, true)
 }, { name: 'app.ee.lib' })

--- a/forge/lib/templates.js
+++ b/forge/lib/templates.js
@@ -24,7 +24,9 @@ module.exports = {
         'httpNodeAuth_pass',
         'emailAlerts_crash',
         'emailAlerts_safe',
-        'emailAlerts_recipients'
+        'emailAlerts_recipients',
+        'debugMaxLength',
+        'apiMaxLength'
     ],
     passwordTypes: [
         'httpNodeAuth_pass'
@@ -54,7 +56,9 @@ module.exports = {
         httpNodeAuth_pass: '',
         emailAlerts_crash: false,
         emailAlerts_safe: false,
-        emailAlerts_recipients: 'owners'
+        emailAlerts_recipients: 'owners',
+        debugMaxLength: 1000,
+        apiMaxLength: '5m'
     },
     defaultTemplatePolicy: {
         disableEditor: true,
@@ -81,6 +85,8 @@ module.exports = {
         httpNodeAuth_pass: true,
         emailAlerts_crash: true,
         emailAlerts_safe: true,
-        emailAlerts_recipients: true
+        emailAlerts_recipients: true,
+        debugMaxLength: true,
+        apiMaxLength: true
     }
 }

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -82,7 +82,8 @@
                     <FormRow v-model="input.properties.features.deviceAutoSnapshot" type="checkbox">Device Auto Snapshot</FormRow>
                     <FormRow v-model="input.properties.features.protectedInstance" type="checkbox">Protected Instances</FormRow>
                     <FormRow v-model="input.properties.features.instanceAutoSnapshot" type="checkbox">Instance Auto Snapshot</FormRow>
-                    <!-- <span /> to make the grid work nicely, only needed if there is an odd number of checkbox features -->
+                    <FormRow v-model="input.properties.features.editorLimits" type="checkbox">API/Debug Length Limits</FormRow>
+                    <span /> <!-- to make the grid work nicely, only needed if there is an odd number of checkbox features above-->
                     <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
                     <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow>
                 </div>

--- a/frontend/src/pages/admin/Template/sections/Editor.vue
+++ b/frontend/src/pages/admin/Template/sections/Editor.vue
@@ -195,7 +195,7 @@ export default {
             }
         },
         limitAvailable () {
-            if (!this.team) {
+            if (!this.team && this.features.editorLimits) {
                 // If on the Admin Template view, then this option is available
                 return true
             }

--- a/frontend/src/pages/admin/Template/sections/Editor.vue
+++ b/frontend/src/pages/admin/Template/sections/Editor.vue
@@ -88,6 +88,34 @@
             </div>
             <LockSetting v-model="editable.policy.timeZone" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.timeZone" />
         </div>
+        <FormHeading class="pt-8">Limits</FormHeading>
+        <div v-if="limitAvailable">
+            <div class="flex flex-col sm:flex-row">
+                <div class="w-full max-w-md sm:mr-8">
+                    <FormRow v-model="editable.settings.apiMaxLength" :disabled="apiLimitDisabled" type="text">
+                        Max HTTP Payload Size
+                        <template #description>
+                            The maximum number of bytes allowed in a HTTP Request in bytes ('k','m' modifiers allowed)
+                        </template>
+                        <template #append><ChangeIndicator :value="editable.changed.settings.apiMaxLength" /></template>
+                    </FormRow>
+                </div>
+                <LockSetting v-model="editable.policy.apiMaxLength" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.apiMaxLength" />
+            </div>
+            <div class="flex flex-col sm:flex-row">
+                <div class="w-full max-w-md sm:mr-8">
+                    <FormRow v-model="editable.settings.debugMaxLength" :disabled="debugLimitDisabled" type="number">
+                        Max Debug Message Size
+                        <template #description>
+                            The maximum number of characters to show of a message in the Debug Sidebar
+                        </template>
+                        <template #append><ChangeIndicator :value="editable.changed.settings.debugMaxLength" /></template>
+                    </FormRow>
+                </div>
+                <LockSetting v-model="editable.policy.debugMaxLength" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.debugMaxLength" />
+            </div>
+        </div>
+        <FeatureUnavailableToTeam v-if="!limitAvailable" featureName="Set API and Debug Size Limits" />
         <FormHeading class="pt-8">External Modules</FormHeading>
         <div class="flex flex-col sm:flex-row">
             <div class="space-y-4 w-full max-w-md sm:mr-8">
@@ -115,8 +143,11 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import FormHeading from '../../../../components/FormHeading.vue'
 import FormRow from '../../../../components/FormRow.vue'
+import FeatureUnavailableToTeam from '../../../../components/banners/FeatureUnavailableToTeam.vue'
 import timezonesData from '../../../../data/timezones.json'
 import ChangeIndicator from '../components/ChangeIndicator.vue'
 import LockSetting from '../components/LockSetting.vue'
@@ -125,6 +156,7 @@ export default {
     components: {
         FormRow,
         FormHeading,
+        FeatureUnavailableToTeam,
         LockSetting,
         ChangeIndicator
     },
@@ -134,6 +166,10 @@ export default {
             default: false
         },
         modelValue: {
+            type: Object,
+            default: null
+        },
+        team: {
             type: Object,
             default: null
         }
@@ -149,6 +185,7 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['features']),
         editable: {
             get () {
                 return this.modelValue
@@ -156,6 +193,20 @@ export default {
             set (localValue) {
                 this.$emit('update:modelValue', localValue)
             }
+        },
+        limitAvailable () {
+            if (!this.team) {
+                // If on the Admin Template view, then this option is available
+                return true
+            }
+            const flag = this.features.editorLimits && this.team.type.properties.features?.editorLimits
+            return !!flag
+        },
+        apiLimitDisabled () {
+            return !this.editTemplate && !this.editable.policy.apiMaxLength
+        },
+        debugLimitDisabled () {
+            return !this.editTemplate && !this.editable.policy.debugMaxLength
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Editor.vue
+++ b/frontend/src/pages/instance/Settings/Editor.vue
@@ -1,6 +1,6 @@
 <template>
     <form class="space-y-6">
-        <TemplateSettingsEditor v-model="editable" :editTemplate="false" :team="team" />
+        <TemplateSettingsEditor v-model="editable" :editTemplate="false" :team="team" :instance="project" />
         <div class="space-x-4 whitespace-nowrap">
             <ff-button size="small" :disabled="!unsavedChanges" @click="saveSettings()">Save settings</ff-button>
         </div>

--- a/frontend/src/pages/instance/Settings/Editor.vue
+++ b/frontend/src/pages/instance/Settings/Editor.vue
@@ -1,6 +1,6 @@
 <template>
     <form class="space-y-6">
-        <TemplateSettingsEditor v-model="editable" :editTemplate="false" />
+        <TemplateSettingsEditor v-model="editable" :editTemplate="false" :team="team" />
         <div class="space-x-4 whitespace-nowrap">
             <ff-button size="small" :disabled="!unsavedChanges" @click="saveSettings()">Save settings</ff-button>
         </div>

--- a/test/unit/forge/db/controllers/ProjectTemplate_spec.js
+++ b/test/unit/forge/db/controllers/ProjectTemplate_spec.js
@@ -21,6 +21,8 @@ describe('Project Template controller', function () {
                 httpAdminRoot: '/foo',
                 dashboardUI: '/dashfoo',
                 codeEditor: 'monaco',
+                debugMaxLength: 999,
+                apiMaxLength: '9m',
                 palette: {
                     allowInstall: true,
                     nodesExcludes: 'ex.js',
@@ -38,6 +40,8 @@ describe('Project Template controller', function () {
             result.should.have.property('httpAdminRoot', '/foo')
             result.should.have.property('dashboardUI', '/dashfoo')
             result.should.have.property('codeEditor', 'monaco')
+            result.should.have.property('debugMaxLength', 999)
+            result.should.have.property('apiMaxLength', '9m')
             result.should.have.property('palette')
             result.palette.should.have.property('allowInstall', true)
             result.palette.should.have.property('nodesExcludes', 'ex.js')
@@ -50,6 +54,56 @@ describe('Project Template controller', function () {
             result.should.not.have.property('NOT_ALLOWED')
             result.palette.should.not.have.property('NOT_ALLOWED')
             result.modules.should.not.have.property('NOT_ALLOWED')
+        })
+
+        it('only allow valid values for template values', async function () {
+            try {
+                const result = app.db.controllers.ProjectTemplate.validateSettings({
+                    disableEditor: true,
+                    httpAdminRoot: '/foo',
+                    dashboardUI: '/dashfoo',
+                    codeEditor: 'monaco',
+                    debugMaxLength: 999,
+                    apiMaxLength: '9g',
+                    palette: {
+                        allowInstall: true,
+                        nodesExcludes: 'ex.js',
+                        NOT_ALLOWED: true
+                    },
+                    modules: {
+                        allowInstall: true,
+                        NOT_ALLOWED: true
+                    },
+                    env: [{ name: 'ONE', value: 'FOO' }],
+                    NOT_ALLOWED: true
+                })
+            } catch (err) {
+                err.message.should.eql('Invalid settings.apiMaxLength')
+            }
+
+            try {
+                const result = app.db.controllers.ProjectTemplate.validateSettings({
+                    disableEditor: true,
+                    httpAdminRoot: '/foo',
+                    dashboardUI: '/dashfoo',
+                    codeEditor: 'monaco',
+                    debugMaxLength: '999m',
+                    apiMaxLength: '9m',
+                    palette: {
+                        allowInstall: true,
+                        nodesExcludes: 'ex.js',
+                        NOT_ALLOWED: true
+                    },
+                    modules: {
+                        allowInstall: true,
+                        NOT_ALLOWED: true
+                    },
+                    env: [{ name: 'ONE', value: 'FOO' }],
+                    NOT_ALLOWED: true
+                })
+            } catch (err) {
+                err.message.should.eql('Invalid settings.debugMaxLength')
+            }
         })
 
         it('only passes through settings a template policy allows', async function () {

--- a/test/unit/forge/db/controllers/ProjectTemplate_spec.js
+++ b/test/unit/forge/db/controllers/ProjectTemplate_spec.js
@@ -58,7 +58,7 @@ describe('Project Template controller', function () {
 
         it('only allow valid values for template values', async function () {
             try {
-                const result = app.db.controllers.ProjectTemplate.validateSettings({
+                app.db.controllers.ProjectTemplate.validateSettings({
                     disableEditor: true,
                     httpAdminRoot: '/foo',
                     dashboardUI: '/dashfoo',
@@ -82,7 +82,7 @@ describe('Project Template controller', function () {
             }
 
             try {
-                const result = app.db.controllers.ProjectTemplate.validateSettings({
+                app.db.controllers.ProjectTemplate.validateSettings({
                     disableEditor: true,
                     httpAdminRoot: '/foo',
                     dashboardUI: '/dashfoo',


### PR DESCRIPTION
part of #3577 and #3581

## Description

<!-- Describe your changes in detail -->
This adds the option to configure the apiMaxLength and debugMaxLength Node-RED settings from the template.

This only available to Team/Enterprise licensed instances

Requires "API/Debug Length Limits" to be enabled for team types.

Has a paired nr-launcher PR https://github.com/FlowFuse/nr-launcher/pull/217

![image](https://github.com/FlowFuse/flowfuse/assets/1800845/058bdfef-6214-4d8c-aff6-00b6163c5ed1)

![image](https://github.com/FlowFuse/flowfuse/assets/1800845/deb3c371-d538-46e3-bdee-903a8c804d44)


Staging/Prod config change Issue: https://github.com/FlowFuse/CloudProject/issues/377

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#3577 and #3581


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

