### PR TITLE
Change type param to required while creating a team

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -387,7 +387,7 @@ module.exports = async function (app) {
             tags: ['Teams'],
             body: {
                 type: 'object',
-                required: ['name'],
+                required: ['name', 'type'],
                 properties: {
                     name: { type: 'string' },
                     type: { type: 'string' },


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
- Changes `type` param in the swagger docs to be required while creating a team.
- This was not required earlier and would return a HTTP `500` error when trying to create a team without the type parameter.
## Related Issue(s)

<!-- What issue does this PR relate to? -->
Fixes #3596 
## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Documentation has been updated