### PR TITLE
ci: Add initial FlowFuse platform setup when deployed from feature branch

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -66,7 +66,7 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set variables
         run: | 

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -4,11 +4,11 @@ on:
   pull_request:
     branches:
       - main
-    # types: 
-    #   - synchronize
-    #   - reopened
-    #   - closed
-    #   - labeled
+    types: 
+      - synchronize
+      - reopened
+      - closed
+      - labeled
 
 jobs:
   build:

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -2,8 +2,6 @@ name: Create fresh app instance for PR
 
 on:
   pull_request:
-    branches:
-      - main
     types: 
       - synchronize
       - reopened

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -144,6 +144,35 @@ jobs:
             --set forge.clusterRole.name=pr-${{ env.PR_NUMBER }}-clusterrole \
             flowfuse-pr-${{ env.PR_NUMBER }} ./helm-repo/helm/flowforge
 
+      - name: Initial setup
+        run: |
+          DBPASSWORD=$(kubectl get secret flowforge-postgresql -o jsonpath='{.data.password}' | base64 -d)
+          kubectl run flowfuse-setup-0 \
+            -it --rm \
+            --restart=Never \
+            --env="PGPASSWORD=$DBPASSWORD" \
+            --image bitnami/postgresql:14.10.0-debian-11-r3 \
+            -- psql -h flowforge-postgresql -U forge -d flowforge -c \
+            "INSERT INTO public.\"Users\" (username,name,email,email_verified,sso_enabled,mfa_enabled,\"password\",password_expired,\"admin\",avatar,tcs_accepted,suspended,\"createdAt\",\"updatedAt\",\"defaultTeamId\") \
+              VALUES ('flowfusedeveloper','flowfusedeveloper','noreply@flowfuse.dev',true,false,false,'${{ secrets.INIT_CONFIG_PASSWORD_HASH }}',false,true,'/avatar/Zmxvd2Z1c2VkZXZlbG9wZXI',NULL,false,'2024-03-15 19:51:49.449+01','2024-03-15 19:51:49.449+01',NULL);"
+          kubectl run flowfuse-setup-1 \
+            -it --rm \
+            --restart=Never \
+            --env="PGPASSWORD=$DBPASSWORD" \
+            --image bitnami/postgresql:14.10.0-debian-11-r3 \
+            -- psql -h flowforge-postgresql -U forge -d flowforge -c \
+            "INSERT INTO public.\"PlatformSettings\" (\"key\",value,\"valueType\",\"createdAt\",\"updatedAt\")\
+              VALUES ('setup:initialised','true',1,'2024-03-15 19:51:52.287','2024-03-15 19:51:52.287')"
+          kubectl run flowfuse-setup-2 \
+            -it --rm \
+            --restart=Never \
+            --env="PGPASSWORD=$DBPASSWORD" \
+            --image bitnami/postgresql:14.10.0-debian-11-r3 \
+            -- psql -h flowforge-postgresql -U forge -d flowforge -c \
+            "INSERT INTO public.\"AccessTokens\" (token,\"expiresAt\",scope,\"ownerId\",\"ownerType\",\"refreshToken\",name,\"createdAt\",\"updatedAt\") \
+              VALUES ('${{ secrets.INIT_CONFIG_ACCESS_TOKEN_HASH }}',NULL,'','1','user',NULL,'setup','2024-03-18 10:46:54.055+01','2024-03-18 10:46:54.055+01');"
+
+
       - name: Summary
         run: |
           echo "### :rocket: Deployment succeeded" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -137,7 +137,7 @@ jobs:
           if helm status --namespace "pr-${{ env.PR_NUMBER }}" flowfuse-pr-${{ env.PR_NUMBER }} &> /dev/null; then
             echo "initialSetup=true" >> $GITHUB_ENV
           else
-            echo "initialSetup=true" >> $GITHUB_ENV"
+            echo "initialSetup=true" >> $GITHUB_ENV
           fi
 
       - name: Deploy

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -155,7 +155,7 @@ jobs:
             --restart=Never \
             --env="PGPASSWORD=$DBPASSWORD" \
             --image bitnami/postgresql:14.10.0-debian-11-r3 \
-            -- psql -h flowforge-postgresql -U forge -d flowforge -c \
+            -- psql -h flowfuse-pr-${{ env.PR_NUMBER }}-postgresql -U forge -d flowforge -c \
             "INSERT INTO public.\"Users\" (username,name,email,email_verified,sso_enabled,mfa_enabled,\"password\",password_expired,\"admin\",avatar,tcs_accepted,suspended,\"createdAt\",\"updatedAt\",\"defaultTeamId\") \
               VALUES ('flowfusedeveloper','flowfusedeveloper','noreply@flowfuse.dev',true,false,false,'${{ secrets.INIT_CONFIG_PASSWORD_HASH }}',false,true,'/avatar/Zmxvd2Z1c2VkZXZlbG9wZXI',NULL,false,'2024-03-15 19:51:49.449+01','2024-03-15 19:51:49.449+01',NULL);"
           kubectl run flowfuse-setup-1 \
@@ -164,7 +164,7 @@ jobs:
             --restart=Never \
             --env="PGPASSWORD=$DBPASSWORD" \
             --image bitnami/postgresql:14.10.0-debian-11-r3 \
-            -- psql -h flowforge-postgresql -U forge -d flowforge -c \
+            -- psql -h flowfuse-pr-${{ env.PR_NUMBER }}-postgresql -U forge -d flowforge -c \
             "INSERT INTO public.\"PlatformSettings\" (\"key\",value,\"valueType\",\"createdAt\",\"updatedAt\")\
               VALUES ('setup:initialised','true',1,'2024-03-15 19:51:52.287','2024-03-15 19:51:52.287')"
           kubectl run flowfuse-setup-2 \
@@ -173,7 +173,7 @@ jobs:
             --restart=Never \
             --env="PGPASSWORD=$DBPASSWORD" \
             --image bitnami/postgresql:14.10.0-debian-11-r3 \
-            -- psql -h flowforge-postgresql -U forge -d flowforge -c \
+            -- psql -h flowfuse-pr-${{ env.PR_NUMBER }}-postgresql -U forge -d flowforge -c \
             "INSERT INTO public.\"AccessTokens\" (token,\"expiresAt\",scope,\"ownerId\",\"ownerType\",\"refreshToken\",name,\"createdAt\",\"updatedAt\") \
               VALUES ('${{ secrets.INIT_CONFIG_ACCESS_TOKEN_HASH }}',NULL,'','1','user',NULL,'setup','2024-03-18 10:46:54.055+01','2024-03-18 10:46:54.055+01');"
 

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -148,8 +148,9 @@ jobs:
 
       - name: Initial setup
         run: |
-          DBPASSWORD=$(kubectl get secret flowforge-postgresql -o jsonpath='{.data.password}' | base64 -d)
+          DBPASSWORD=$(kubectl --namespace "pr-${{ env.PR_NUMBER }}" get secret flowfuse-pr-${{ env.PR_NUMBER }}-postgresql -o jsonpath='{.data.password}' | base64 -d)
           kubectl run flowfuse-setup-0 \
+            --namespace "pr-${{ env.PR_NUMBER }}" \
             -it --rm \
             --restart=Never \
             --env="PGPASSWORD=$DBPASSWORD" \
@@ -158,6 +159,7 @@ jobs:
             "INSERT INTO public.\"Users\" (username,name,email,email_verified,sso_enabled,mfa_enabled,\"password\",password_expired,\"admin\",avatar,tcs_accepted,suspended,\"createdAt\",\"updatedAt\",\"defaultTeamId\") \
               VALUES ('flowfusedeveloper','flowfusedeveloper','noreply@flowfuse.dev',true,false,false,'${{ secrets.INIT_CONFIG_PASSWORD_HASH }}',false,true,'/avatar/Zmxvd2Z1c2VkZXZlbG9wZXI',NULL,false,'2024-03-15 19:51:49.449+01','2024-03-15 19:51:49.449+01',NULL);"
           kubectl run flowfuse-setup-1 \
+            --namespace "pr-${{ env.PR_NUMBER }}" \
             -it --rm \
             --restart=Never \
             --env="PGPASSWORD=$DBPASSWORD" \
@@ -166,6 +168,7 @@ jobs:
             "INSERT INTO public.\"PlatformSettings\" (\"key\",value,\"valueType\",\"createdAt\",\"updatedAt\")\
               VALUES ('setup:initialised','true',1,'2024-03-15 19:51:52.287','2024-03-15 19:51:52.287')"
           kubectl run flowfuse-setup-2 \
+            --namespace "pr-${{ env.PR_NUMBER }}" \
             -it --rm \
             --restart=Never \
             --env="PGPASSWORD=$DBPASSWORD" \

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -176,8 +176,40 @@ jobs:
             -- psql -h flowfuse-pr-${{ env.PR_NUMBER }}-postgresql -U forge -d flowforge -c \
             "INSERT INTO public.\"AccessTokens\" (token,\"expiresAt\",scope,\"ownerId\",\"ownerType\",\"refreshToken\",name,\"createdAt\",\"updatedAt\") \
               VALUES ('${{ secrets.INIT_CONFIG_ACCESS_TOKEN_HASH }}',NULL,'','1','user',NULL,'setup','2024-03-18 10:46:54.055+01','2024-03-18 10:46:54.055+01');"
-
-
+          curl -k -XPOST \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" \
+            -d '{"name":"Default", "description":"InitialProject","active": true}' \
+            https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/project-types/
+          projectTypeId=$(curl -k -XGET -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/project-types/ | jq -r '.types[].id')
+          curl -k -XPOST \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" \
+            -d '{"name":"Default","label":"Default", "projectType":"'"$projectTypeId"'","properties":{ "cpu":10,"memory":256,"container":"flowfuse/node-red"}}' \
+            https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/stacks/
+          stackId=$(curl -k -XGET -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/stacks/ | jq -r '.stacks[].id')
+          curl -k -XPUT \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" \
+            -d '{"properties":{"instances":{"'"$stackId"'":{"active":true}}}}' \
+            https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/project-types/$projectTypeId
+          teamTypeId=$(curl -k -XGET -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/team-types/ | jq -r '.types[].id')
+          curl -k -XPUT \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" \
+            -d '{"properties":{"users":{"limit":5},"devices":{"limit":10},"instances":{"'"$projectTypeId"'":{"active":true}}}}' \
+            https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/team-types/$teamTypeId
+          curl -k -XPOST \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" \
+            -d '{"name":"pp-template", "active":true, "settings":{"disableEditor":false,"disableTours":false,"httpAdminRoot":"","dashboardUI":"/ui","codeEditor":"monaco","theme":"forge-light","page":{"title":"FlowFuse","favicon":""},"header":{"title":"FlowFuse","url":""},"timeZone":"UTC","palette":{"allowInstall":true,"nodesExcludes":"","denyList":"","modules":[],"catalogue":["https://catalogue.nodered.org/catalogue.json"],"npmrc":""},"modules":{"allowInstall":true,"denyList":""},"httpNodeAuth":{"type":"","user":"","pass":""},"emailAlerts":{"crash":false,"safe":false,"recipients":"owners"}}, "policy":{"disableEditor":true,"disableTours":true,"httpAdminRoot":true,"dashboardUI":true,"codeEditor":true,"theme":true,"page":{"title":false,"favicon":false},"header":{"title":true,"url":false},"timeZone":true,"palette":{"allowInstall":true,"nodesExcludes":false,"denyList":false,"modules":true,"catalogue":true,"npmrc":true},"modules":{"allowInstall":true,"denyList":false},"httpNodeAuth":{"type":true,"user":true,"pass":true},"emailAlerts":{"crash":true,"safe":true,"recipients":true}}}' \
+            https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/templates/
+          curl -k -XPOST \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" \
+            -d '{"name":"devteam", "type":"'"$teamTypeId"'"}' \
+            https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/teams/
+          
       - name: Summary
         run: |
           echo "### :rocket: Deployment succeeded" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -131,6 +131,15 @@ jobs:
           path: 'helm-repo'
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if deployment exists
+        id: check-initial-setup
+        run: |
+          if helm status --namespace "pr-${{ env.PR_NUMBER }}" flowfuse-pr-${{ env.PR_NUMBER }} &> /dev/null; then
+            echo "initialSetup=true" >> $GITHUB_ENV
+          else
+            echo "initialSetup=true" >> $GITHUB_ENV"
+          fi
+
       - name: Deploy
         run: |
           helm upgrade --install \
@@ -147,6 +156,7 @@ jobs:
             flowfuse-pr-${{ env.PR_NUMBER }} ./helm-repo/helm/flowforge
 
       - name: Initial setup
+        if: steps.check-initial-setup.outputs.initialSetup == 'true'
         run: |
           DBPASSWORD=$(kubectl --namespace "pr-${{ env.PR_NUMBER }}" get secret flowfuse-pr-${{ env.PR_NUMBER }}-postgresql -o jsonpath='{.data.password}' | base64 -d)
           kubectl run flowfuse-setup-0 \
@@ -202,13 +212,16 @@ jobs:
           curl -k -XPOST \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" \
-            -d '{"name":"pp-template", "active":true, "settings":{"disableEditor":false,"disableTours":false,"httpAdminRoot":"","dashboardUI":"/ui","codeEditor":"monaco","theme":"forge-light","page":{"title":"FlowFuse","favicon":""},"header":{"title":"FlowFuse","url":""},"timeZone":"UTC","palette":{"allowInstall":true,"nodesExcludes":"","denyList":"","modules":[],"catalogue":["https://catalogue.nodered.org/catalogue.json"],"npmrc":""},"modules":{"allowInstall":true,"denyList":""},"httpNodeAuth":{"type":"","user":"","pass":""},"emailAlerts":{"crash":false,"safe":false,"recipients":"owners"}}, "policy":{"disableEditor":true,"disableTours":true,"httpAdminRoot":true,"dashboardUI":true,"codeEditor":true,"theme":true,"page":{"title":false,"favicon":false},"header":{"title":true,"url":false},"timeZone":true,"palette":{"allowInstall":true,"nodesExcludes":false,"denyList":false,"modules":true,"catalogue":true,"npmrc":true},"modules":{"allowInstall":true,"denyList":false},"httpNodeAuth":{"type":true,"user":true,"pass":true},"emailAlerts":{"crash":true,"safe":true,"recipients":true}}}' \
+            -d '{"name":"initial-template", "active":true, "settings":{"disableEditor":false,"disableTours":false,"httpAdminRoot":"","dashboardUI":"/ui","codeEditor":"monaco","theme":"forge-light","page":{"title":"FlowFuse","favicon":""},"header":{"title":"FlowFuse","url":""},"timeZone":"UTC","palette":{"allowInstall":true,"nodesExcludes":"","denyList":"","modules":[],"catalogue":["https://catalogue.nodered.org/catalogue.json"],"npmrc":""},"modules":{"allowInstall":true,"denyList":""},"httpNodeAuth":{"type":"","user":"","pass":""},"emailAlerts":{"crash":false,"safe":false,"recipients":"owners"}}, "policy":{"disableEditor":true,"disableTours":true,"httpAdminRoot":true,"dashboardUI":true,"codeEditor":true,"theme":true,"page":{"title":false,"favicon":false},"header":{"title":true,"url":false},"timeZone":true,"palette":{"allowInstall":true,"nodesExcludes":false,"denyList":false,"modules":true,"catalogue":true,"npmrc":true},"modules":{"allowInstall":true,"denyList":false},"httpNodeAuth":{"type":true,"user":true,"pass":true},"emailAlerts":{"crash":true,"safe":true,"recipients":true}}}' \
             https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/templates/
           curl -k -XPOST \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" \
             -d '{"name":"devteam", "type":"'"$teamTypeId"'"}' \
             https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/teams/
+          
+          kubectl rollout restart deployment flowforge
+          kubectl rollout status deployment flowforge
           
       - name: Summary
         run: |

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -135,7 +135,7 @@ jobs:
         id: check-initial-setup
         run: |
           if helm status --namespace "pr-${{ env.PR_NUMBER }}" flowfuse-pr-${{ env.PR_NUMBER }} &> /dev/null; then
-            echo "initialSetup=true" >> $GITHUB_ENV
+            echo "initialSetup=false" >> $GITHUB_ENV
           else
             echo "initialSetup=true" >> $GITHUB_ENV
           fi

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set variables
         run: | 
@@ -46,7 +46,7 @@ jobs:
           outputs: type=docker,dest=/tmp/k8s-forge.tar
       
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: k8s-forge
           path: /tmp/k8s-forge.tar
@@ -74,7 +74,7 @@ jobs:
           echo "timestamp=$(date +%s)" >> $GITHUB_ENV
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: k8s-forge
           path: /tmp
@@ -85,7 +85,7 @@ jobs:
           docker image ls -a
 
       - name: Delete artifact
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
           name: k8s-forge
           failOnError: false
@@ -101,7 +101,7 @@ jobs:
         
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: true
 
@@ -111,7 +111,7 @@ jobs:
           docker push ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ env.tagged_image }}-${{ env.timestamp }}
 
       - name: Configure AWS credentials for EKS interaction
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
@@ -124,7 +124,7 @@ jobs:
           aws eks update-kubeconfig --region eu-west-1 --name ${{ secrets.EKS_CLUSTER_NAME }}
 
       - name: Check out FlowFuse/helm repository (to access latest helm chart)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'FlowFuse/helm'
           ref: 'main'

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -220,8 +220,8 @@ jobs:
             -d '{"name":"devteam", "type":"'"$teamTypeId"'"}' \
             https://${{ env.PR_NUMBER }}.flowfuse.dev/api/v1/teams/
           
-          kubectl rollout restart deployment flowforge
-          kubectl rollout status deployment flowforge
+          kubectl --namespace "pr-${{ env.PR_NUMBER }}" rollout restart deployment flowforge
+          kubectl --namespace "pr-${{ env.PR_NUMBER }}" rollout status deployment flowforge
           
       - name: Summary
         run: |

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -156,7 +156,7 @@ jobs:
             flowfuse-pr-${{ env.PR_NUMBER }} ./helm-repo/helm/flowforge
 
       - name: Initial setup
-        if: ${{ env.initialSetup }} == 'true'
+        if: ${{ env.initialSetup == 'true' }}
         run: |
           DBPASSWORD=$(kubectl --namespace "pr-${{ env.PR_NUMBER }}" get secret flowfuse-pr-${{ env.PR_NUMBER }}-postgresql -o jsonpath='{.data.password}' | base64 -d)
           kubectl run flowfuse-setup-0 \

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -156,7 +156,7 @@ jobs:
             flowfuse-pr-${{ env.PR_NUMBER }} ./helm-repo/helm/flowforge
 
       - name: Initial setup
-        if: steps.check-initial-setup.outputs.initialSetup == 'true'
+        if: ${{ env.initialSetup }} == 'true'
         run: |
           DBPASSWORD=$(kubectl --namespace "pr-${{ env.PR_NUMBER }}" get secret flowfuse-pr-${{ env.PR_NUMBER }}-postgresql -o jsonpath='{.data.password}' | base64 -d)
           kubectl run flowfuse-setup-0 \

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -2,11 +2,13 @@ name: Create fresh app instance for PR
 
 on:
   pull_request:
-    types: 
-      - synchronize
-      - reopened
-      - closed
-      - labeled
+    branches:
+      - main
+    # types: 
+    #   - synchronize
+    #   - reopened
+    #   - closed
+    #   - labeled
 
 jobs:
   build:


### PR DESCRIPTION
## Description

This PR extends the existing `branch-deploy` workflow for the initial platform setup. As a result, the FlowFuse instance deployed from the feature branch is ready to use and a developer does not have to spend additional time on the manual initial setup of the platform.
Additionally, it updates several actions to latest versions.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/368

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

