### PR TITLE
Validate kb and km for `apiMaxLength`

### DIFF
--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -199,7 +199,7 @@ module.exports = {
             result.httpNodeAuth.pass = hash(result.httpNodeAuth.pass)
         }
         if (result.apiMaxLength) {
-            if (!/^[0-9]+[km]?$/.test(result.apiMaxLength)) {
+            if (!/^\d+(?:kb|mb)$/.test(result.apiMaxLength)) {
                 throw new Error('Invalid settings.apiMaxLength')
             }
         }

--- a/forge/lib/templates.js
+++ b/forge/lib/templates.js
@@ -58,7 +58,7 @@ module.exports = {
         emailAlerts_safe: false,
         emailAlerts_recipients: 'owners',
         debugMaxLength: 1000,
-        apiMaxLength: '5m'
+        apiMaxLength: '5mb'
     },
     defaultTemplatePolicy: {
         disableEditor: true,

--- a/frontend/src/pages/admin/Template/sections/Editor.vue
+++ b/frontend/src/pages/admin/Template/sections/Editor.vue
@@ -96,7 +96,7 @@
                         <FormRow v-model="editable.settings.apiMaxLength" :disabled="apiLimitDisabled" type="text">
                             Max HTTP Payload Size
                             <template #description>
-                                The maximum number of bytes allowed in a HTTP Request in bytes ('k','m' modifiers allowed)
+                                The maximum number of bytes allowed in a HTTP Request in bytes ('kb','mb' modifiers allowed)
                             </template>
                             <template #append><ChangeIndicator :value="editable.changed.settings.apiMaxLength" /></template>
                         </FormRow>

--- a/test/unit/forge/db/controllers/ProjectTemplate_spec.js
+++ b/test/unit/forge/db/controllers/ProjectTemplate_spec.js
@@ -22,7 +22,7 @@ describe('Project Template controller', function () {
                 dashboardUI: '/dashfoo',
                 codeEditor: 'monaco',
                 debugMaxLength: 999,
-                apiMaxLength: '9m',
+                apiMaxLength: '9mb',
                 palette: {
                     allowInstall: true,
                     nodesExcludes: 'ex.js',
@@ -41,7 +41,7 @@ describe('Project Template controller', function () {
             result.should.have.property('dashboardUI', '/dashfoo')
             result.should.have.property('codeEditor', 'monaco')
             result.should.have.property('debugMaxLength', 999)
-            result.should.have.property('apiMaxLength', '9m')
+            result.should.have.property('apiMaxLength', '9mb')
             result.should.have.property('palette')
             result.palette.should.have.property('allowInstall', true)
             result.palette.should.have.property('nodesExcludes', 'ex.js')
@@ -64,7 +64,7 @@ describe('Project Template controller', function () {
                     dashboardUI: '/dashfoo',
                     codeEditor: 'monaco',
                     debugMaxLength: 999,
-                    apiMaxLength: '9g',
+                    apiMaxLength: '9m',
                     palette: {
                         allowInstall: true,
                         nodesExcludes: 'ex.js',
@@ -88,7 +88,7 @@ describe('Project Template controller', function () {
                     dashboardUI: '/dashfoo',
                     codeEditor: 'monaco',
                     debugMaxLength: '999m',
-                    apiMaxLength: '9m',
+                    apiMaxLength: '9mb',
                     palette: {
                         allowInstall: true,
                         nodesExcludes: 'ex.js',


### PR DESCRIPTION
## Description

Ensures user input is `nkb` or `nmb` for `apiMaxLength`

## Related Issue(s)

#3577

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

