### PR TITLE
Disable "add device" when at limit

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -122,6 +122,7 @@
                                 v-if="hasPermission('device:create')"
                                 class="font-normal"
                                 kind="primary"
+                                :disabled="teamDeviceLimitReached || teamRuntimeLimitReached"
                                 data-action="register-device"
                                 @click="showCreateDeviceDialog"
                             >


### PR DESCRIPTION
closes #3605

## Description

disabled "add device" in the empty state when the device or runtime limit is reached

## Related Issue(s)

#3605

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

