### PR TITLE
Ensure device group data loaded on direct navigation

### DIFF
--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -77,7 +77,7 @@ export default {
     computed: {
         ...mapState('account', ['teamMembership', 'team']),
         isVisitingAdmin () {
-            return this.teamMembership.role === Roles.Admin
+            return this.teamMembership?.role === Roles.Admin
         },
         navigation () {
             const routes = [

--- a/frontend/src/pages/application/DeviceGroups.vue
+++ b/frontend/src/pages/application/DeviceGroups.vue
@@ -135,13 +135,18 @@ export default {
     computed: {
         ...mapState('account', ['features']),
         featureEnabledForTeam () {
-            return !!this.team.type.properties.features?.deviceGroups
+            return !!this.team?.type?.properties?.features?.deviceGroups
         },
         featureEnabledForPlatform () {
-            return this.features.deviceGroups
+            return this.features?.deviceGroups
         },
         featureEnabled () {
             return this.featureEnabledForTeam && this.featureEnabledForPlatform
+        }
+    },
+    watch: {
+        featureEnabled: function (v) {
+            this.loadDeviceGroups()
         }
     },
     mounted () {


### PR DESCRIPTION
Fixes https://github.com/FlowFuse/flowfuse/issues/3612

Guards access to computed props and ensures device-group data is loaded on direct-navigation to the dg page.