### PR TITLE
Clear Device Group when device owner is changed

### DIFF
--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -442,6 +442,8 @@ module.exports = async function (app) {
                     // Clear its target snapshot, so the next time it calls home
                     // it will stop the current snapshot
                     await device.setTargetSnapshot(null)
+                    // Since the project/application is being cleared, clear the deviceGroup
+                    device.DeviceGroupId = null
                     sendDeviceUpdate = true
                     // disable developer mode
                     device.mode = 'autonomous'
@@ -935,14 +937,13 @@ module.exports = async function (app) {
         // Set the target snapshot to match the project's one
         const deviceSettings = await project.getSetting('deviceSettings')
         device.targetSnapshotId = deviceSettings?.targetSnapshot
+        device.DeviceGroupId = null // not relevant to instances at this time, but no harm in clearing it
         return true
     }
     async function assignDeviceToApplication (device, application) {
         await device.setApplication(application)
-        // Set the target snapshot to match the project's one
-        // TODO
-        // const deviceSettings = await application.getSetting('deviceSettings')
-        // device.targetSnapshotId = deviceSettings?.targetSnapshot
+        // Since the application is being changed, clear the deviceGroup
+        device.DeviceGroupId = null
         return true
     }
     // #endregion


### PR DESCRIPTION
fixes #3613

## Description

Clears devices DeviceGroup when the device owner is changed

Includes tests:
```
  Application Device Groups API
    Update Device Group Membership
      Changing a device owner removes the device from the group
        ✔ Changing a device owner application removes the device from the group (168ms)
        ✔ Clearing device owner removes the device from the group (122ms)
```

## Related Issue(s)

#3613

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

