### PR TITLE
Implement blueprint availability to team type option 

### DIFF
--- a/docs/user/concepts.md
+++ b/docs/user/concepts.md
@@ -75,6 +75,11 @@ plugins to integrate it with the platform.
 A number of the standard Node-RED settings are exposed for customisation, and they
 can be preset by applying a Template when creating the Instance.
 
+When an instance is being created, the user can select a blueprint to use. This
+blueprint is a combination of a modules and flows that are pre-set to give the
+user a head start in their development. Blueprints are created by the platform
+Administrator and can be limited to specific team tiers.
+
 When running in Docker or Kubernetes (such as FlowFuse Cloud), the instance names
 are used as the hostname to access the instance. This means that the names must
 be DNS safe (made up of a-z, 0-9 and -) and not start with a number. Currently

--- a/docs/user/introduction.md
+++ b/docs/user/introduction.md
@@ -23,6 +23,8 @@ This guide will help you learn how to use the FlowFuse platform to quickly creat
 
 ![Blueprint selection](./images/blueprint-selection.png)
 
+NOTE: _Some blueprints may only be available on certain tiers_
+
 ## Creating Your First Flow
 
 If you are already familiar with Node-RED, you can [skip this section](#creating-your-first-devops-pipeline).

--- a/forge/db/migrations/20240325-01-add-availability-col-to-FlowTemplates.js
+++ b/forge/db/migrations/20240325-01-add-availability-col-to-FlowTemplates.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-unused-vars */
+/**
+ * Add availability column to FlowTemplates table
+ */
+
+const { DataTypes, QueryInterface } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        await context.addColumn('FlowTemplates', 'availability', {
+            type: DataTypes.TEXT,
+            allowNull: true,
+            defaultValue: null
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/ee/db/models/FlowTemplate.js
+++ b/forge/ee/db/models/FlowTemplate.js
@@ -63,6 +63,19 @@ module.exports = {
                 const rawValue = this.getDataValue('modules') || '{}'
                 return JSON.parse(rawValue)
             }
+        },
+        // The availability column is a JSON array that contains a the teamtype id to signify which teamtypes this template is available on
+        // a null value signifies that the template is available to all teamtypes (current and future ones)
+        availability: {
+            type: DataTypes.TEXT,
+            defaultValue: null,
+            set (value) {
+                this.setDataValue('availability', value ? JSON.stringify(value) : null)
+            },
+            get () {
+                const rawValue = this.getDataValue('availability') || null
+                return JSON.parse(rawValue)
+            }
         }
     },
     hooks: {
@@ -99,6 +112,22 @@ module.exports = {
                             { model: M.User, as: 'createdBy' }
                         ]
                     })
+                },
+                forTeamType: async (teamTypeId, pagination, where = {}) => {
+                    // since sqlite does not support json queries, we have to get all rows and filter them in memory
+                    if (typeof teamTypeId === 'string') {
+                        teamTypeId = M.TeamType.decodeHashid(teamTypeId)
+                    }
+                    const data = await self.getAll(pagination, where)
+                    const rows = data.templates.filter(template => {
+                        if (!template.availability || template.availability.length === 0) {
+                            return true // by default, all templates are available to all teamtypes
+                        }
+                        return template.availability.includes(teamTypeId)
+                    })
+                    data.templates = rows
+                    data.count = rows.length
+                    return data
                 },
                 getAll: async (pagination = {}, where = {}) => {
                     const limit = parseInt(pagination.limit) || 1000

--- a/forge/ee/db/models/FlowTemplate.js
+++ b/forge/ee/db/models/FlowTemplate.js
@@ -120,8 +120,8 @@ module.exports = {
                     }
                     const data = await self.getAll(pagination, where)
                     const rows = data.templates.filter(template => {
-                        if (!template.availability || template.availability.length === 0) {
-                            return true // by default, all templates are available to all teamtypes
+                        if (!template.availability) {
+                            return true // by default (null), all templates are available to all teamtypes
                         }
                         return template.availability.includes(teamTypeId)
                     })

--- a/forge/ee/db/views/FlowTemplate.js
+++ b/forge/ee/db/views/FlowTemplate.js
@@ -36,11 +36,22 @@ module.exports = function (app) {
         allOf: [{ $ref: 'FlowBlueprintSummary' }],
         properties: {
             flows: { type: 'object', additionalProperties: true },
-            modules: { type: 'object', additionalProperties: true }
+            modules: { type: 'object', additionalProperties: true },
+            availability: {
+                type: ['array', 'null'],
+                items: {
+                    type: 'string'
+                }
+            }
         }
     })
     function flowBlueprint (blueprint) {
         const result = flowBlueprintSummary(blueprint)
+        if (Array.isArray(blueprint.availability)) {
+            result.availability = blueprint.availability.map(id => app.db.models.TeamType.encodeHashid(id))
+        } else {
+            result.availability = null // default (allow all)
+        }
         result.flows = blueprint.flows
         result.modules = blueprint.modules
         return result

--- a/forge/ee/routes/flowBlueprints/index.js
+++ b/forge/ee/routes/flowBlueprints/index.js
@@ -45,9 +45,21 @@ module.exports = async function (app) {
         } else if (request.query.filter === 'inactive') {
             filter = { active: false }
         }
-        const flowTemplates = await app.db.models.FlowTemplate.getAll(paginationOptions, filter)
-        flowTemplates.blueprints = flowTemplates.templates.map(ft => app.db.views.FlowTemplate.flowBlueprintSummary(ft))
-        reply.send(flowTemplates)
+
+        if (request.query.team) {
+            const team = await app.db.models.Team.byId(request.query.team)
+            if (!team) {
+                return reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+            }
+            const flowTemplates = await app.db.models.FlowTemplate.forTeamType(team.TeamTypeId, paginationOptions, filter)
+            flowTemplates.blueprints = flowTemplates.templates.map(ft => app.db.views.FlowTemplate.flowBlueprintSummary(ft))
+            reply.send(flowTemplates)
+        } else {
+            // get all flow templates - typically for administration purposes
+            const flowTemplates = await app.db.models.FlowTemplate.getAll(paginationOptions, filter)
+            flowTemplates.blueprints = flowTemplates.templates.map(ft => app.db.views.FlowTemplate.flowBlueprintSummary(ft))
+            reply.send(flowTemplates)
+        }
     })
 
     app.get('/:flowBlueprintId', {
@@ -140,7 +152,8 @@ module.exports = async function (app) {
             order: request.body.order,
             default: request.body.default,
             flows: request.body.flows,
-            modules: request.body.modules
+            modules: request.body.modules,
+            availability: await sanitiseAvailability(request.body.availability)
         }
         try {
             const flowTemplate = await app.db.models.FlowTemplate.create(properties)
@@ -211,6 +224,7 @@ module.exports = async function (app) {
         if (request.body.modules !== undefined) {
             flowTemplate.modules = request.body.modules
         }
+        flowTemplate.availability = await sanitiseAvailability(request.body.availability)
 
         try {
             await flowTemplate.save()
@@ -228,4 +242,24 @@ module.exports = async function (app) {
             reply.code(400).send(resp)
         }
     })
+
+    /**
+     * Sanitise the availability array before saving to the database
+     */
+    async function sanitiseAvailability (availability) {
+        // An array signifies that this template is only available to specific teamTypes
+        // An empty array signifies that this template is not available to any teamTypes
+        // A `null` value signifies that this template is available to all teamTypes (current and future ones)
+        try {
+            if (Array.isArray(availability)) {
+                const teamTypeIds = availability.map(id => Number(app.db.models.TeamType.decodeHashid(id))).filter(id => id)
+                const matchingTeamTypes = await app.db.models.TeamType.findAll({ where: { id: teamTypeIds } })
+                return matchingTeamTypes ? [...matchingTeamTypes.map(tt => tt.id)] : []
+            }
+        } catch (_err) {
+            // If there are any errors, just return null
+            return null
+        }
+        return null
+    }
 }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -168,6 +168,12 @@ module.exports = async function (app) {
                 reply.code(400).send({ code: 'invalid_flow_blueprint', error: 'Flow Blueprint not found' })
                 return
             }
+            // ensure this teams type is allowed to use this blueprint
+            const teamType = await team.getTeamType()
+            if (flowBlueprint.teamTypeScope && !flowBlueprint.teamTypeScope.includes(teamType.id)) {
+                reply.code(400).send({ code: 'invalid_flow_blueprint', error: 'Flow Blueprint not allowed for this team' })
+                return
+            }
         }
         // Read in any source to copy from
         let sourceProject

--- a/frontend/src/api/flowBlueprints.js
+++ b/frontend/src/api/flowBlueprints.js
@@ -14,21 +14,46 @@ import client from './client.js'
  */
 
 /**
- * @typedef {object} FlowBlueprint
- * @extends FlowBlueprintSummary
- * @property {object} flows
- * @property {object} modules
+ * @typedef {Object} FlowBlueprintDetails
+ * @property {object} flows - Flow definition
+ * @property {object} modules - Modules used in the flow
+ * @property {Array.<string>} availability - Team types allowed to use this blueprint
+ */
+
+/**
+ * @typedef {FlowBlueprintSummary & FlowBlueprintDetails } FlowBlueprint
  */
 
 /**
  * Get all flow blueprints from the backend
- * @param {string} filter - 'active' (default), 'all' or 'inactive'
- * @param {G} cursor
- * @param {number} limit
+ * @param {object} options
+ * @param {object} options.filter - 'active' (default), 'all' or 'inactive'
+ * @param {number} cursor - Cursor for pagination
+ * @param {number} limit - Limit for pagination
  * @returns {Array.<FlowBlueprintSummary>}
  */
 const getFlowBlueprints = async (options = { filter: 'active' }, cursor, limit) => {
     const url = paginateUrl('/api/v1/flow-blueprints', cursor, limit, null, { filter: options.filter })
+    return client.get(url).then(res => {
+        return res.data
+    })
+}
+
+/**
+ * Get flow blueprints available to the current team
+ * @param {string} team - Team ID
+ * @param {object} options
+ * @param {object} options.filter - 'active' (default), 'all' or 'inactive'
+ * @param {number} cursor - Cursor for pagination
+ * @param {number} limit - Limit for pagination
+ * @returns {Array.<FlowBlueprintSummary>}
+ */
+const getFlowBlueprintsForTeam = async (team, options = { filter: 'active' }, cursor, limit) => {
+    const extraParams = {
+        filter: options.filter,
+        team
+    }
+    const url = paginateUrl('/api/v1/flow-blueprints', cursor, limit, null, extraParams)
     return client.get(url).then(res => {
         return res.data
     })
@@ -76,6 +101,7 @@ const updateFlowBlueprint = async (flowBlueprintId, options) => {
 
 export default {
     getFlowBlueprints,
+    getFlowBlueprintsForTeam,
     getFlowBlueprint,
     createFlowBlueprint,
     deleteFlowBlueprint,

--- a/frontend/src/pages/admin/FlowBlueprints/index.vue
+++ b/frontend/src/pages/admin/FlowBlueprints/index.vue
@@ -49,6 +49,7 @@ import { markRaw } from 'vue'
 import { mapState } from 'vuex'
 
 import FlowBlueprintsApi from '../../../api/flowBlueprints.js'
+import teamTypesApi from '../../../api/teamTypes.js'
 
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
 
@@ -72,6 +73,7 @@ export default {
     data () {
         return {
             flowBlueprints: new Map(),
+            teamTypes: [],
             loading: false,
             nextCursor: null,
             columns: [
@@ -111,10 +113,10 @@ export default {
         async showBlueprintForm (flowBlueprint) {
             if (flowBlueprint) {
                 const fullFlowBlueprint = await FlowBlueprintsApi.getFlowBlueprint(flowBlueprint.id)
-                return this.$refs.adminFlowBlueprintDialog.show(fullFlowBlueprint)
+                return this.$refs.adminFlowBlueprintDialog.show(fullFlowBlueprint, this.teamTypes)
             }
 
-            this.$refs.adminFlowBlueprintDialog.show()
+            this.$refs.adminFlowBlueprintDialog.show(null, this.teamTypes)
         },
         showDeleteBlueprint (flowBlueprint) {
             Dialog.show({
@@ -140,6 +142,15 @@ export default {
             result.blueprints.forEach(flowBlueprint => {
                 this.flowBlueprints.set(flowBlueprint.id, flowBlueprint)
             })
+            const teamTypes = (await teamTypesApi.getTeamTypes()).types
+            this.teamTypes = teamTypes.map(tt => {
+                return {
+                    order: tt.order,
+                    id: tt.id,
+                    name: tt.name
+                }
+            })
+            this.teamTypes.sort((A, B) => { return A.order - B.order })
         }
     }
 }

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -684,8 +684,7 @@ export default {
             if (!this.flowBlueprintsEnabled || this.isCopyProject) {
                 return []
             }
-
-            const response = await flowBlueprintsApi.getFlowBlueprints()
+            const response = await flowBlueprintsApi.getFlowBlueprintsForTeam(this.team.id)
             const blueprints = response.blueprints
 
             const defaultBlueprint = blueprints.find((blueprint) => blueprint.default) || blueprints[0]

--- a/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
+++ b/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
@@ -149,6 +149,26 @@ describe('Flow Blueprints API', function () {
             const [statusCode1] = await createBlueprint({ name: generateName('bp'), modules: [] }, TestObjects.tokens.alice)
             statusCode1.should.equal(400)
         })
+
+        it('Availability is null by default (available to all team types)', async function () {
+            const [statusCode, resp] = await createBlueprint({ name: generateName('bp') }, TestObjects.tokens.alice)
+            statusCode.should.equal(200)
+            const bp1 = await app.db.models.FlowTemplate.byId(resp.id)
+            bp1.should.have.property('availability', null)
+        })
+        it('Availability is set to empty array', async function () {
+            const [statusCode, resp] = await createBlueprint({ name: generateName('bp'), availability: [] }, TestObjects.tokens.alice)
+            statusCode.should.equal(200)
+            const bp1 = await app.db.models.FlowTemplate.byId(resp.id)
+            bp1.should.have.property('availability').and.be.an.Array().and.have.length(0)
+        })
+        it('Availability is set to an array of team types', async function () {
+            const [statusCode, resp] = await createBlueprint({ name: generateName('bp'), availability: [TestObjects.team.TeamType.hashid] }, TestObjects.tokens.alice)
+            statusCode.should.equal(200)
+            const bp1 = await app.db.models.FlowTemplate.byId(resp.id)
+            bp1.should.have.property('availability').and.be.an.Array().and.have.length(1)
+            bp1.availability[0].should.equal(TestObjects.team.TeamType.id) // note id not hashid
+        })
     })
 
     describe('Get Flow Template', function () {


### PR DESCRIPTION
## Description

### High level
* Adds a default [x] Available to all team types UI dialog
* When selected, a list of check boxes and team types are presented, permitting availability to be turned on/off by team type/tier

![chrome_bCv41o6ftd](https://github.com/FlowFuse/flowfuse/assets/44235289/220184e1-50e1-4d72-8fb0-1b4868db40dd)


### Details
* Adds DB field `FlowTemplates.teamTypeScope` which is a JSON field (type TEXT, parsed)
   * Default value `null` means "available to all, current and future team types"
   * when configured, the array will hold teamtype IDs that the blueprint can used
* Adds query param `team` to the existing GET `/api/v1/flow-blueprints/` route
   * Specifying a team returns only blueprints that are applicable to that teams tier
* Adds front end API fn `getFlowBlueprintsForTeam`
* Adds elements in `frontend/src/pages/admin/FlowBlueprints/dialogs/FlowBlueprintFormDialog.vue` for configuring the blueprint availability
* Adds tests (listed below)

### Tests
```
  Flow Blueprints API
    Create Flow Blueprints
      ✔ Availability is null by default (available to all team types)
      ✔ Availability is set to empty array when no team types are selected
      ✔ Availability is set to an array of team types
    List Flow Blueprints
      Blueprint availability
        ✔ Lists blueprints available to a starter tier
        ✔ Lists blueprints available to an enterprise tier
    Update Flow Template
      ✔ Updates availability
      ✔ Discards invalid team types
```

### TODO
- [ ] docs

## Related Issue(s)

#3599

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [x] Includes a DB migration? -> add the `area:migration` label

