### PR TITLE
Add credentialSecret to snapshot model and update logic to use it

### DIFF
--- a/forge/db/controllers/ProjectSnapshot.js
+++ b/forge/db/controllers/ProjectSnapshot.js
@@ -364,9 +364,12 @@ module.exports = {
     createSnapshot: async function (app, project, user, options) {
         const projectExport = await app.db.controllers.Project.exportProject(project)
 
+        const credentialSecret = await project.getCredentialSecret()
+
         const snapshotOptions = {
             name: options.name || '',
             description: options.description || '',
+            credentialSecret,
             settings: {
                 settings: projectExport.settings || {},
                 env: projectExport.env || {},
@@ -380,9 +383,8 @@ module.exports = {
             UserId: user.id
         }
         if (options.flows) {
-            const projectSecret = await project.getCredentialSecret()
             snapshotOptions.flows.flows = options.flows
-            snapshotOptions.flows.credentials = app.db.controllers.Project.exportCredentials(options.credentials || {}, options.credentialSecret, projectSecret)
+            snapshotOptions.flows.credentials = app.db.controllers.Project.exportCredentials(options.credentials || {}, options.credentialSecret, credentialSecret)
         }
         if (options.settings?.modules) {
             snapshotOptions.settings.modules = options.settings.modules
@@ -416,9 +418,12 @@ module.exports = {
     createSnapshotFromDevice: async function (app, project, device, user, options) {
         const projectExport = await app.db.controllers.Project.exportProject(project)
         const deviceConfig = await app.db.controllers.Device.exportConfig(device)
+        const credentialSecret = await project.getCredentialSecret()
+
         const snapshotOptions = {
             name: options.name || '',
             description: options.description || '',
+            credentialSecret,
             settings: {
                 settings: projectExport.settings || {},
                 env: projectExport.env || {},
@@ -432,9 +437,8 @@ module.exports = {
             UserId: user.id
         }
         if (deviceConfig?.flows) {
-            const projectSecret = await project.getCredentialSecret()
             snapshotOptions.flows.flows = deviceConfig.flows
-            snapshotOptions.flows.credentials = app.db.controllers.Project.exportCredentials(deviceConfig.credentials || {}, device.credentialSecret, projectSecret)
+            snapshotOptions.flows.credentials = app.db.controllers.Project.exportCredentials(deviceConfig.credentials || {}, device.credentialSecret, credentialSecret)
         }
         if (deviceConfig?.package?.modules) {
             snapshotOptions.settings.modules = deviceConfig.package.modules
@@ -458,6 +462,7 @@ module.exports = {
         const snapshotOptions = {
             name: options.name || '',
             description: options.description || '',
+            credentialSecret: device.credentialSecret,
             settings: {
                 settings: {}, // TODO: when device settings at application level are implemented
                 env: {}, // TODO: when device settings at application level are implemented

--- a/forge/db/migrations/20240327-01-add-credentialSecret-to-snapshots.js
+++ b/forge/db/migrations/20240327-01-add-credentialSecret-to-snapshots.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ * Add credentialSecret to Snapshots table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        await context.addColumn('ProjectSnapshots', 'credentialSecret', {
+            type: DataTypes.STRING,
+            allowNull: true,
+            defaultValue: ''
+        })
+        context.sequelize.query(`
+            update "ProjectSnapshots"
+              set "credentialSecret" = "ProjectSettings"."value"
+              from "ProjectSettings"
+              where 
+                "ProjectSettings"."ProjectId" = "ProjectSnapshots"."ProjectId" and
+                "ProjectSettings"."key" = 'credentialSecret'
+        `)
+        context.sequelize.query(`
+            update "ProjectSnapshots"
+              set "credentialSecret" = "Devices"."credentialSecret"
+              from "Devices"
+              where "Devices".id = "ProjectSnapshots"."DeviceId"
+        `)
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/ProjectSnapshot.js
+++ b/forge/db/models/ProjectSnapshot.js
@@ -9,6 +9,7 @@ module.exports = {
     schema: {
         name: { type: DataTypes.STRING, allowNull: false },
         description: { type: DataTypes.TEXT, allowNull: true, default: '' },
+        credentialSecret: { type: DataTypes.STRING, allowNull: true, default: '' },
         settings: {
             type: DataTypes.TEXT,
             set (value) {
@@ -174,16 +175,6 @@ module.exports = {
                         },
                         count,
                         snapshots: rows
-                    }
-                }
-            },
-            instance: {
-                getCredentialSecret: async function () {
-                    // default to project in the absence of ownerType
-                    if (this.ownerType === 'instance' || !this.ownerType) {
-                        return await (await this.getProject()).getCredentialSecret()
-                    } else {
-                        return (await this.getDevice()).credentialSecret
                     }
                 }
             }

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -380,13 +380,11 @@ module.exports = {
                 const targetSnapshot = await copySnapshot(app, sourceSnapshot, targetInstance, {
                     importSnapshot: true, // target instance should import the snapshot
                     setAsTarget: setAsTargetForDevices,
-                    decryptAndReEncryptCredentialsSecret: await sourceSnapshot.getCredentialSecret(),
                     targetSnapshotProperties: {
                         name: generateDeploySnapshotName(sourceSnapshot),
                         description: generateDeploySnapshotDescription(sourceStage, targetStage, pipeline, sourceSnapshot)
                     }
                 })
-
                 if (restartTargetInstance) {
                     await targetInstance.reload({ include: [app.db.models.Team] })
                     await app.containers.restartFlows(targetInstance)

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -194,7 +194,7 @@ module.exports = async function (app) {
                 if (result.credentials) {
                     // Need to re-encrypt these credentials from the source secret
                     // to the target Device secret
-                    const secret = await snapshot.getCredentialSecret()
+                    const secret = snapshot.credentialSecret
                     const deviceSecret = device.credentialSecret
                     result.credentials = app.db.controllers.Project.exportCredentials(result.credentials, secret, deviceSecret)
                 }

--- a/test/unit/forge/db/controllers/ProjectSnapshot_spec.js
+++ b/test/unit/forge/db/controllers/ProjectSnapshot_spec.js
@@ -2,7 +2,7 @@ const crypto = require('crypto')
 
 const sinon = require('sinon')
 const should = require('should') // eslint-disable-line
-const { decryptCreds } = require('../../../../lib/credentials')
+const { encryptCreds, decryptCreds } = require('../../../../lib/credentials')
 const setup = require('../setup')
 
 describe('ProjectSnapshot controller', function () {
@@ -237,16 +237,18 @@ describe('ProjectSnapshot controller', function () {
     describe('createSnapshot (device)', function () {
         before(async function () {
             // mock app.comms.devices.sendCommandAwaitReply(device_Team_hashid, device_hashid, ...) so that it returns a valid config
-            sinon.stub(app.comms.devices, 'sendCommandAwaitReply').resolves({
-                flows: [{ id: '123', type: 'newNode' }],
-                credentials: {
-                    $: {
-                        key: 'value'
-                    }
-                },
-                package: {
-                    modules: {
-                        foo: '1.2.3'
+            sinon.stub(app.comms.devices, 'sendCommandAwaitReply').callsFake(async function (teamId, deviceId) {
+                const device = await app.db.models.Device.byId(deviceId)
+                return {
+                    flows: [{ id: '123', type: 'newNode' }],
+                    credentials: encryptCreds(
+                        crypto.createHash('sha256').update(device.credentialSecret).digest(),
+                        { key: 'value' }
+                    ),
+                    package: {
+                        modules: {
+                            foo: '1.2.3'
+                        }
                     }
                 }
             })
@@ -268,6 +270,8 @@ describe('ProjectSnapshot controller', function () {
             const device = await factory.createDevice({ name: 'device-1' }, team, null, application)
             // get db Device with all associations
             const dbDevice = await app.db.models.Device.byId(device.id)
+            // Ensure device has credentialSecret
+            await dbDevice.refreshAuthTokens()
 
             const snapshot = await app.db.controllers.ProjectSnapshot.createDeviceSnapshot(application, dbDevice, user, options)
             snapshot.should.have.property('name', 'snapshot1')
@@ -280,6 +284,10 @@ describe('ProjectSnapshot controller', function () {
             snapshot.flows.should.have.only.keys('flows', 'credentials')
             snapshot.flows.flows.should.have.length(1)
             snapshot.flows.flows[0].should.have.property('id', '123')
+
+            const keyHash = crypto.createHash('sha256').update(snapshot.credentialSecret).digest()
+            const decrypted = decryptCreds(keyHash, snapshot.flows.credentials)
+            decrypted.should.have.property('key', 'value')
         })
 
         describe('auto snapshots', function () {
@@ -329,7 +337,11 @@ describe('ProjectSnapshot controller', function () {
                     const device1 = await factory.createDevice({ name: 'device 1' }, team, null, application)
                     const device2 = await factory.createDevice({ name: 'device 2' }, team, null, application)
                     app.TestObjects.device1 = await app.db.models.Device.byId(device1.id, { include: app.db.models.Team })
+                    // Ensure device has credentialSecret
+                    await app.TestObjects.device1.refreshAuthTokens()
                     app.TestObjects.device2 = await app.db.models.Device.byId(device2.id, { include: app.db.models.Team })
+                    // Ensure device has credentialSecret
+                    await app.TestObjects.device2.refreshAuthTokens()
                 })
 
                 after(async function () {
@@ -350,6 +362,15 @@ describe('ProjectSnapshot controller', function () {
                     snapshot.name.should.match(/Auto Snapshot - \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)
                     snapshot.should.have.a.property('description')
                     snapshot.description.should.match(/Device Auto Snapshot taken following a Full deployment/)
+
+                    snapshot.should.have.property('flows')
+                    snapshot.flows.should.have.only.keys('flows', 'credentials')
+                    snapshot.flows.flows.should.have.length(1)
+                    snapshot.flows.flows[0].should.have.property('id', '123')
+
+                    const keyHash = crypto.createHash('sha256').update(snapshot.credentialSecret).digest()
+                    const decrypted = decryptCreds(keyHash, snapshot.flows.credentials)
+                    decrypted.should.have.property('key', 'value')
                 })
 
                 it('only keeps 10 autoSnapshots for a device', async function () {

--- a/test/unit/forge/db/controllers/ProjectSnapshot_spec.js
+++ b/test/unit/forge/db/controllers/ProjectSnapshot_spec.js
@@ -382,7 +382,7 @@ describe('ProjectSnapshot controller', function () {
                         const ss = await app.db.controllers.ProjectSnapshot.doDeviceAutoSnapshot(device, 'full', options, meta)
                         await ss.update({ description: `Auto Snapshot - ${i}` }) // update description to make it clear the round-robin cleanup is working
                     }
-                    const snapshots = await app.db.models.ProjectSnapshot.findAll({ where: { DeviceId: device.id } })
+                    const snapshots = await app.db.models.ProjectSnapshot.findAll({ where: { DeviceId: device.id }, order: [['id', 'ASC']] })
                     // even though 12 snapshots were created in total, only 10 are kept
                     snapshots.should.have.length(10)
                     snapshots[0].description.should.equal('Auto Snapshot - 3') // note ss 1 & 2 were auto cleaned up


### PR DESCRIPTION
Fixes #3644 

## Description

This adds `credentialSecret` to the snapshot model so we no longer depend on the parent of the snapshot existing. This makes it easier to reason about the snapshots as they get moved around.

The db migration will populate the new column with the appropriate value from with the Device or ProjectSettings tables. I've tested this migration in both sqlite and postgres.

I have looked at many of the pipeline tests that relate to snapshots. They checked the result had a credentials property, but didn't try to validate the value. I've updated the tests in a few places to validate the credentials are properly encrypted with the expected key.

I've also done various bits of manual testing with rollbacks, instance-assigned devices, app-assigned devices, pipeline deploys to instances and devices/device groups.

