### PR TITLE
Show dashboard link on instances when dashboard-2 is installed

### DIFF
--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -176,6 +176,7 @@ module.exports = function (app) {
                 }
             }
             if (hasDashboard2UI(settingsSettingsRow.value)) {
+                result.settings = result.settings || {} // Ensure settings exists
                 result.settings.dashboard2UI = '/dashboard'
             }
         }

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -55,6 +55,9 @@ module.exports = function (app) {
                     // Only return whether a password is set or not
                     result.settings.httpNodeAuth.pass = !!result.settings.httpNodeAuth.pass
                 }
+                if (hasDashboard2UI(settingsSettingsRow.value)) {
+                    result.settings.dashboard2UI = '/dashboard'
+                }
             } else {
                 result.settings = {}
             }
@@ -172,6 +175,9 @@ module.exports = function (app) {
                     disableEditor: settingsSettingsRow.value.disableEditor
                 }
             }
+            if (hasDashboard2UI(settingsSettingsRow.value)) {
+                result.settings.dashboard2UI = '/dashboard'
+            }
         }
         if (app.config.features.enabled('ha')) {
             const settingsHARow = project.ProjectSettings?.find(row => row.key === KEY_HA)
@@ -252,4 +258,11 @@ module.exports = function (app) {
         projectSummary,
         userProjectList
     }
+}
+
+function hasDashboard2UI (settings) {
+    if (Array.isArray(settings?.palette?.modules)) {
+        return settings.palette.modules.find((module) => module.name === '@flowfuse/node-red-dashboard')
+    }
+    return false
 }

--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -103,6 +103,7 @@ import SectionTopMenu from '../../components/SectionTopMenu.vue'
 
 import permissionsMixin from '../../mixins/Permissions.js'
 import InstanceStatusBadge from '../instance/components/InstanceStatusBadge.vue'
+import DashboardLinkCell from '../instance/components/cells/DashboardLink.vue'
 import InstanceEditorLinkCell from '../instance/components/cells/InstanceEditorLink.vue'
 
 import DeploymentName from './components/cells/DeploymentName.vue'
@@ -132,10 +133,11 @@ export default {
         ...mapState('account', ['team', 'teamMembership']),
         cloudColumns () {
             return [
-                { label: 'Name', class: ['w-64'], component: { is: markRaw(DeploymentName) } },
-                { label: 'Instance Status', class: ['w-48'], component: { is: markRaw(InstanceStatusBadge), map: { status: 'meta.state' } } },
-                { label: 'Last Deployed', class: ['w-48'], component: { is: markRaw(LastSeen), map: { lastSeenSince: 'flowLastUpdatedSince' } } },
-                { label: '', class: ['w-20'], component: { is: markRaw(InstanceEditorLinkCell) } }
+                { label: 'Name', class: ['w-1/2'], component: { is: markRaw(DeploymentName) } },
+                { label: 'Instance Status', class: ['w-1/5'], component: { is: markRaw(InstanceStatusBadge), map: { status: 'meta.state' } } },
+                { label: 'Last Deployed', class: ['w-1/5'], component: { is: markRaw(LastSeen), map: { lastSeenSince: 'flowLastUpdatedSince' } } },
+                { label: '', component: { is: markRaw(DashboardLinkCell), map: { instance: '_self', hidden: 'hideDashboard2Button' } } },
+                { label: '', component: { is: markRaw(InstanceEditorLinkCell) } }
             ]
         },
         cloudRows () {
@@ -144,7 +146,8 @@ export default {
                 instance.notSuspended = instance.meta?.state !== 'suspended'
                 instance.isHA = instance.ha?.replicas !== undefined
                 instance.disabled = !instance.running || this.isVisitingAdmin || instance.isHA
-
+                instance._self = instance
+                instance.hideDashboard2Button = !instance.settings?.dashboard2UI
                 return instance
             })
         },

--- a/frontend/src/pages/instance/components/DashboardLink.vue
+++ b/frontend/src/pages/instance/components/DashboardLink.vue
@@ -1,0 +1,64 @@
+<template>
+    <ff-button
+        v-if="!hidden"
+        kind="secondary"
+        data-action="open-dashboard"
+        :disabled="buttonDisabled"
+        @click.stop="openDashboard()"
+    >
+        <template #icon-right>
+            <ExternalLinkIcon />
+        </template>
+        Dashboard
+    </ff-button>
+</template>
+
+<script>
+import { ExternalLinkIcon } from '@heroicons/vue/solid'
+
+// utility function to remove leading and trailing slashes
+const removeSlashes = (str, leading = true, trailing = true) => {
+    if (leading && str.startsWith('/')) {
+        str = str.slice(1)
+    }
+    if (trailing && str.endsWith('/')) {
+        str = str.slice(0, -1)
+    }
+    return str
+}
+
+export default {
+    name: 'DashboardLink',
+    components: { ExternalLinkIcon },
+    inheritAttrs: false,
+    props: {
+        disabled: {
+            default: false,
+            type: Boolean
+        },
+        hidden: {
+            default: false,
+            type: Boolean
+        },
+        instance: {
+            default: null,
+            type: Object
+        }
+    },
+    computed: {
+        buttonDisabled () {
+            return this.disabled || !this.instance?.settings?.dashboard2UI
+        }
+    },
+    methods: {
+        openDashboard () {
+            if (this.disabled || !this.instance?.settings?.dashboard2UI) {
+                return
+            }
+            const url = `${removeSlashes(this.instance.url, false, true)}/${removeSlashes(this.instance.settings.dashboard2UI, true, false)}`
+            const fixedTarget = '_db2_' + this.instance.id
+            window.open(url, fixedTarget)
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -4,6 +4,7 @@
         kind="secondary"
         data-action="open-editor"
         :disabled="editorDisabled || disabled || !url"
+        class="whitespace-nowrap"
         @click.stop="openEditor()"
     >
         <template #icon-right>

--- a/frontend/src/pages/instance/components/cells/DashboardLink.vue
+++ b/frontend/src/pages/instance/components/cells/DashboardLink.vue
@@ -1,0 +1,33 @@
+<template>
+    <div v-if="!hidden" class="flex justify-end">
+        <DashboardLink :disabled="disabled" :disabledReason="disabledReason" :instance="instance" />
+    </div>
+</template>
+
+<script>
+import DashboardLink from '../DashboardLink.vue'
+
+export default {
+    name: 'DashboardLinkCell',
+    components: { DashboardLink },
+    inheritAttrs: false,
+    props: {
+        instance: {
+            default: null,
+            type: Object
+        },
+        disabled: {
+            default: false,
+            type: Boolean
+        },
+        disabledReason: {
+            default: null,
+            type: String
+        },
+        hidden: {
+            default: false,
+            type: Boolean
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -27,6 +27,11 @@
                 </template>
                 <template #tools>
                     <div class="space-x-2 flex align-center">
+                        <DashboardLink
+                            v-if="hasDashboard2"
+                            :instance="instance"
+                            :disabled="!editorAvailable"
+                        />
                         <InstanceEditorLink
                             :url="instance.url"
                             :editorDisabled="instance.settings.disableEditor || isHA"
@@ -82,6 +87,7 @@ import Dialog from '../../services/dialog.js'
 import { InstanceStateMutator } from '../../utils/InstanceStateMutator.js'
 
 import ConfirmInstanceDeleteDialog from './Settings/dialogs/ConfirmInstanceDeleteDialog.vue'
+import DashboardLink from './components/DashboardLink.vue'
 import InstanceEditorLink from './components/EditorLink.vue'
 import InstanceStatusBadge from './components/InstanceStatusBadge.vue'
 
@@ -89,6 +95,7 @@ export default {
     name: 'InstancePage',
     components: {
         ConfirmInstanceDeleteDialog,
+        DashboardLink,
         DropdownMenu,
         InstanceStatusPolling,
         InstanceStatusBadge,
@@ -131,6 +138,9 @@ export default {
         },
         editorAvailable () {
             return !this.isHA && this.instanceRunning
+        },
+        hasDashboard2 () {
+            return !!this.instance?.settings?.dashboard2UI
         },
         actionsDropdownOptions () {
             const flowActionsDisabled = !(this.instance.meta && this.instance.meta.state !== 'suspended')

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -69,13 +69,20 @@
                                         Flows never deployed
                                     </span>
                                 </div>
-                                <InstanceEditorLinkCell
-                                    :id="instance.id"
-                                    :url="instance.url"
-                                    :editorDisabled="!!(instance.settings?.disableEditor)"
-                                    :disabled="instance.meta?.state !== 'running'"
-                                    :isHA="instance.ha?.replicas !== undefined"
-                                />
+                                <div class="grid grid-flow-col">
+                                    <DashboardLinkCell
+                                        v-if="instance.settings?.dashboard2UI"
+                                        :disabled="instance.meta?.state !== 'running'"
+                                        :instance="instance"
+                                    />
+                                    <InstanceEditorLinkCell
+                                        :id="instance.id"
+                                        :url="instance.url"
+                                        :editorDisabled="!!(instance.settings?.disableEditor)"
+                                        :disabled="instance.meta?.state !== 'running'"
+                                        :isHA="instance.ha?.replicas !== undefined"
+                                    />
+                                </div>
                                 <InstanceStatusPolling :instance="instance" @instance-updated="instanceUpdated" />
                             </li>
                         </ul>
@@ -184,6 +191,7 @@ import DaysSince from '../application/Snapshots/components/cells/DaysSince.vue'
 import DeviceModeBadge from '../device/components/DeviceModeBadge.vue'
 import EditorLink from '../instance/components/EditorLink.vue'
 import InstanceStatusBadge from '../instance/components/InstanceStatusBadge.vue'
+import DashboardLinkCell from '../instance/components/cells/DashboardLink.vue'
 import InstanceEditorLinkCell from '../instance/components/cells/InstanceEditorLink.vue'
 
 import ApplicationSummaryLabel from './components/ApplicationSummaryLabel.vue'
@@ -194,6 +202,7 @@ export default {
     name: 'TeamApplications',
     components: {
         ApplicationSummaryLabel,
+        DashboardLinkCell,
         DaysSince,
         DeviceModeBadge,
         EditorLink,

--- a/frontend/src/stylesheets/components/applications-list.scss
+++ b/frontend/src/stylesheets/components/applications-list.scss
@@ -83,7 +83,7 @@
         padding: 12px;
         display: grid;
         align-items: center;
-        grid-template-columns: 40px 1fr 100px minmax(auto, 250px) 140px;
+        grid-template-columns: 40px 1fr 100px minmax(auto, 220px) 240px;
         &:hover {
             cursor: pointer;
             border-color: $ff-blue-600;

--- a/frontend/src/stylesheets/components/applications-list.scss
+++ b/frontend/src/stylesheets/components/applications-list.scss
@@ -3,6 +3,7 @@
 .ff-applications-list {
     display: flex;
     flex-direction: column;
+    min-width: fit-content; // prevent content poking out of the container
     gap: 18px;
     > li {
         > * {

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -2181,6 +2181,45 @@ describe('Project API', function () {
             const { settings: settingsAfter } = await getSettings()
             settingsAfter.should.have.property('theme', 'forge-dark') // should now be forge-dark
         })
+
+        it('Dashboard URL is provided in the instance.settings if flowfuse dashboard is installed', async function () {
+            // GET instance
+            const response1 = await app.inject({
+                method: 'GET',
+                url: `/api/v1/projects/${app.project.id}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            const data1 = response1.json()
+            data1.should.have.property('settings')
+            data1.settings.should.not.have.property('dashboard2UI')
+
+            // Update project settings to add flowfuse dashboard
+            const response2 = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/projects/${app.project.id}`,
+                payload: {
+                    settings: {
+                        palette: {
+                            modules: [
+                                { name: '@flowfuse/node-red-dashboard', version: '~1.5.1', local: true }
+                            ]
+                        }
+                    }
+                },
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response2.statusCode.should.equal(200)
+
+            // GET new settings & check dashboard2UI is now populated
+            const response3 = await app.inject({
+                method: 'GET',
+                url: `/api/v1/projects/${app.project.id}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            const data3 = response3.json()
+            data3.should.have.property('settings')
+            data3.settings.should.have.property('dashboard2UI')
+        })
     })
 
     describe('Project import flows & credentials', function () {


### PR DESCRIPTION
## Description

Adds a Dashboard button adjacent to "Open Editor" button when dashboard 2 is present in palette modules array

In this MVP, the URL is fixed as `/dashboard` Any changes to the dashboard code will require changes here.



## Related Issue(s)

#3611

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

