### PR TITLE
Update branch-deploy.yaml to use custom broker domain

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'FlowFuse/helm'
-          ref: 'feat-custom-broker-domain'
+          ref: 'main'
           path: 'helm-repo'
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'FlowFuse/helm'
-          ref: 'main'
+          ref: 'feat-custom-broker-domain'
           path: 'helm-repo'
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -149,6 +149,7 @@ jobs:
             --values ci/ci-values.yaml \
             --set forge.image=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ env.tagged_image }}-${{ env.timestamp }} \
             --set forge.entryPoint=${{ env.PR_NUMBER }}.flowfuse.dev \
+            --set forge.broker.domain=${{ env.PR_NUMBER }}-mqtt.flowfuse.dev \
             --set forge.projectNamespace=pr-${{ env.PR_NUMBER }}-projects \
             --set forge.clusterRole.name=pr-${{ env.PR_NUMBER }}-clusterrole \
             flowfuse-pr-${{ env.PR_NUMBER }} ./helm-repo/helm/flowforge

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -149,7 +149,7 @@ jobs:
             --values ci/ci-values.yaml \
             --set forge.image=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ env.tagged_image }}-${{ env.timestamp }} \
             --set forge.entryPoint=${{ env.PR_NUMBER }}.flowfuse.dev \
-            --set forge.broker.domain=${{ env.PR_NUMBER }}-mqtt.flowfuse.dev \
+            --set forge.broker.hostname=${{ env.PR_NUMBER }}-mqtt.flowfuse.dev \
             --set forge.projectNamespace=pr-${{ env.PR_NUMBER }}-projects \
             --set forge.clusterRole.name=pr-${{ env.PR_NUMBER }}-clusterrole \
             --set forge.license=${{ secrets.PRE_STAGING_LICENSE }} \

--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -2,6 +2,8 @@ forge:
   domain: flowfuse.dev
   https: false
   localPostgresql: true
+  broker:
+    enabled: true
 
 postgresql:
   persistence:


### PR DESCRIPTION
## Description

This pull request updates the branch-deploy.yaml file to use a custom broker domain for the Forge deployment. The `forge.broker.domain` parameter is set to `${{ env.PR_NUMBER }}-mqtt.flowfuse.dev`. This change ensures that each pull request has its own unique broker domain for MQTT communication.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/3681

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

