### PR TITLE
Ensure InstanceForm applies InstanceType availability for manual billing teams

### DIFF
--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -503,14 +503,16 @@ export default {
         this.templates = (await templateListPromise).templates.filter(template => template.active)
 
         this.activeProjectTypeCount = projectTypes.length
-        if (this.billingEnabled && !this.team.billing?.unmanaged) {
-            try {
-                this.subscription = await billingApi.getSubscriptionInfo(this.team.id)
-            } catch (err) {
-                if (err.response?.data?.code === 'not_found') {
-                    // This team has no subscription.
-                    if (!this.team.billing?.trial || this.team.billing?.trialEnded) {
-                        throw err
+        if (this.billingEnabled) {
+            if (!this.team.billing?.unmanaged) {
+                try {
+                    this.subscription = await billingApi.getSubscriptionInfo(this.team.id)
+                } catch (err) {
+                    if (err.response?.data?.code === 'not_found') {
+                        // This team has no subscription.
+                        if (!this.team.billing?.trial || this.team.billing?.trialEnded) {
+                            throw err
+                        }
                     }
                 }
             }
@@ -536,7 +538,7 @@ export default {
                         pt.disabled = true
                     }
                 }
-                if (!pt.disabled) {
+                if (!pt.disabled && !this.team.billing?.unmanaged) {
                     let billingDescription
                     if (teamTypeInstanceProperties) {
                         // TeamType provides meta data to use - do not fall back to instanceType


### PR DESCRIPTION
If a team was set to manual billing, the code to filter the list of available instance types was being skipped. This hadn't been an issue because only Starter teams had a restricted selection of types and they don't ever get put into manual billing mode.

But as we now want to apply some restrictions to Team/Enterprise teams, this needs to work.