### PR TITLE
Make limits tougher on common auth routes

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -628,8 +628,8 @@ async function init (app, opts) {
         config: {
             rateLimit: app.config.rate_limits
                 ? {
-                    max: 5,
-                    timeWindow: 30000,
+                    max: 2,
+                    timeWindow: 60000,
                     keyGenerator: app.config.rate_limits.keyGenerator,
                     hard: true
                 }
@@ -717,8 +717,8 @@ async function init (app, opts) {
         config: {
             rateLimit: app.config.rate_limits
                 ? {
-                    max: 5,
-                    timeWindow: 30000,
+                    max: 2,
+                    timeWindow: 60000,
                     keyGenerator: app.config.rate_limits.keyGenerator,
                     hard: true
                 }

--- a/frontend/src/pages/account/ForgotPassword.vue
+++ b/frontend/src/pages/account/ForgotPassword.vue
@@ -50,7 +50,11 @@ export default {
                 this.flash = 'We have sent you an email with instructions to reset your password'
             }).catch(e => {
                 this.errors.email = ''
-                console.error(e)
+                if (e.response?.status === 429) {
+                    this.errors.email = 'Try again in 5 minutes'
+                } else {
+                    console.error(e)
+                }
             })
         }
     }

--- a/test/unit/forge/routes/api/rateLimits/rateLimits_spec.js
+++ b/test/unit/forge/routes/api/rateLimits/rateLimits_spec.js
@@ -282,8 +282,10 @@ describe('Endpoint Rate Limiting', () => {
                         const routeConfig = route.fastifyRoute.config
                         routeConfig.should.have.property('rateLimit').and.be.an.Object()
                         if (routeConfig.rateLimit.hard) {
-                            routeConfig.rateLimit.should.have.property('max', 5)
-                            routeConfig.rateLimit.should.have.property('timeWindow', 30000)
+                            routeConfig.rateLimit.should.have.property('max')
+                            routeConfig.rateLimit.max.should.be.equalOneOf(5, 2)
+                            routeConfig.rateLimit.should.have.property('timeWindow')
+                            routeConfig.rateLimit.timeWindow.should.be.equalOneOf(30000, 60000)
                         } else {
                             routeConfig.rateLimit.should.have.property('enabled', true)
                             routeConfig.rateLimit.should.have.property('global', true)
@@ -394,8 +396,10 @@ describe('Endpoint Rate Limiting', () => {
                         const routeConfig = route.fastifyRoute.config
                         routeConfig.should.have.property('rateLimit').and.be.an.Object()
                         if (routeConfig.rateLimit.hard) {
-                            routeConfig.rateLimit.should.have.property('max', 5)
-                            routeConfig.rateLimit.should.have.property('timeWindow', 30000)
+                            routeConfig.rateLimit.should.have.property('max')
+                            routeConfig.rateLimit.max.should.be.equalOneOf(5, 2)
+                            routeConfig.rateLimit.should.have.property('timeWindow')
+                            routeConfig.rateLimit.timeWindow.should.be.equalOneOf(30000, 60000)
                         } else {
                             routeConfig.rateLimit.should.have.property('enabled', true)
                             routeConfig.rateLimit.should.have.property('global', false)


### PR DESCRIPTION
## Description

This makes the limits tougher on the forgot-email and verify-email routes - 2 requests/minute. That should be more than enough for any human interaction with the routes. Also added a 'try again later' message to the UI in case of a human being too quick.

This should reduce some of the noise we get on the security mailing list.