### PR TITLE
3672 snapshot visibility on groups

### DIFF
--- a/forge/db/models/DeviceGroup.js
+++ b/forge/db/models/DeviceGroup.js
@@ -84,6 +84,13 @@ module.exports = {
                     const [rows, count] = await Promise.all([
                         this.findAll({
                             where: buildPaginationSearchClause(pagination, where, ['DeviceGroup.name', 'DeviceGroup.description']),
+                            include: [
+                                {
+                                    model: M.ProjectSnapshot,
+                                    as: 'targetSnapshot',
+                                    attributes: ['hashid', 'id', 'name']
+                                }
+                            ],
                             attributes: {
                                 include: [
                                     [

--- a/forge/db/views/DeviceGroup.js
+++ b/forge/db/views/DeviceGroup.js
@@ -6,7 +6,11 @@ module.exports = function (app) {
             id: { type: 'string' },
             name: { type: 'string' },
             description: { type: 'string' },
-            deviceCount: { type: 'number' }
+            deviceCount: { type: 'number' },
+            targetSnapshot: {
+                nullable: true,
+                allOf: [{ $ref: 'SnapshotSummary' }]
+            }
         }
     })
     function deviceGroupSummary (group) {
@@ -17,7 +21,8 @@ module.exports = function (app) {
             id: group.hashid,
             name: group.name,
             description: group.description,
-            deviceCount: group.deviceCount || 0
+            deviceCount: group.deviceCount || 0,
+            targetSnapshot: app.db.views.ProjectSnapshot.snapshotSummary(group.targetSnapshot)
         }
         return result
     }
@@ -74,7 +79,8 @@ module.exports = function (app) {
             createdAt: { type: 'string' },
             updatedAt: { type: 'string' },
             application: { $ref: 'ApplicationSummary' },
-            devices: { type: 'array', items: { $ref: 'Device' } }
+            devices: { type: 'array', items: { $ref: 'Device' } },
+            targetSnapshot: { $ref: 'SnapshotSummary' }
         },
         additionalProperties: true
     })
@@ -90,7 +96,8 @@ module.exports = function (app) {
                 description: item.description,
                 application: item.Application ? app.db.views.Application.applicationSummary(item.Application) : null,
                 deviceCount: item.deviceCount || 0,
-                devices: item.Devices ? item.Devices.map(app.db.views.Device.device) : []
+                devices: item.Devices ? item.Devices.map(app.db.views.Device.device) : [],
+                targetSnapshot: app.db.views.ProjectSnapshot.snapshotSummary(item.targetSnapshot)
             }
             return filtered
         } else {

--- a/forge/db/views/ProjectSnapshot.js
+++ b/forge/db/views/ProjectSnapshot.js
@@ -58,7 +58,7 @@ module.exports = function (app) {
     })
     function snapshotSummary (snapshot) {
         if (snapshot) {
-            const result = snapshot.toJSON()
+            const result = snapshot.toJSON ? snapshot.toJSON() : snapshot
             const filtered = {
                 id: result.hashid,
                 name: result.name,

--- a/frontend/src/pages/application/DeviceGroup/devices.vue
+++ b/frontend/src/pages/application/DeviceGroup/devices.vue
@@ -55,6 +55,7 @@
                     :show-search="true"
                     search-placeholder="Search..."
                     :no-data-message="localMemberDevices?.length ? 'No Devices found, try another search term' : 'No Devices assigned to this group'"
+                    data-el="device-group-members"
                     @update:search="updateMemberDevicesListDebounced"
                     @update:sort="updateMemberDevicesSort"
                 >

--- a/frontend/src/pages/application/DeviceGroup/devices.vue
+++ b/frontend/src/pages/application/DeviceGroup/devices.vue
@@ -64,7 +64,10 @@
                                 <ff-checkbox v-model="device.selected" class="inline" />
                             </ff-data-table-cell>
                             <ff-data-table-cell class="w-1/3">{{ device.name }}</ff-data-table-cell>
-                            <ff-data-table-cell class="w-2/3">{{ device.type }}</ff-data-table-cell>
+                            <ff-data-table-cell class="w-1/3">{{ device.name }}</ff-data-table-cell>
+                            <ff-data-table-cell v-if="!editMode" class="w-1/3">
+                                <ActiveSnapshotCell :activeSnapshot="getDeviceActiveSnapshot(device)" :targetSnapshot="targetSnapshot" />
+                            </ff-data-table-cell>
                         </ff-data-table-row>
                     </template>
                 </ff-data-table>
@@ -83,9 +86,12 @@ import Dialog from '../../../services/dialog.js'
 
 import { debounce } from '../../../utils/eventHandling.js'
 
+import ActiveSnapshotCell from '../components/cells/Snapshot.vue'
+
 export default {
     name: 'DeviceGroupDevices',
     components: {
+        ActiveSnapshotCell,
         FormHeading
     },
     inheritAttrs: false,
@@ -124,7 +130,8 @@ export default {
             },
             tableColsRO: [
                 { label: 'Name', key: 'name', sortable: true, class: 'w-1/3' },
-                { label: 'Type', key: 'type', sortable: true, class: 'w-2/3' }
+                { label: 'Type', key: 'type', sortable: true, class: 'w-1/3' },
+                { label: 'Active Snapshot', key: 'type', sortable: true, class: 'w-1/3' }
             ],
             tableColsRW: [
                 { label: '', key: 'selected', sortable: true },
@@ -140,6 +147,9 @@ export default {
         },
         selectedMemberDevices () {
             return this.localMemberDevices.filter((device) => device.selected)
+        },
+        targetSnapshot () {
+            return this.deviceGroup?.targetSnapshot || null
         }
     },
     watch: {
@@ -329,6 +339,13 @@ export default {
                         console.error(err)
                     })
             })
+        },
+        getDeviceActiveSnapshot (device) {
+            if (!device?.id) {
+                return null
+            }
+            const appDevice = this.applicationDevices?.find((d) => d.id === device.id)
+            return appDevice?.activeSnapshot || null
         }
     }
 }

--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -19,6 +19,32 @@
                 <template #breadcrumbs>
                     <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'ApplicationDeviceGroups', params: {id: application?.id}}">Device Groups</ff-nav-breadcrumb>
                 </template>
+                <template #tools>
+                    <InfoCard header="">
+                        <template #content>
+                            <InfoCardRow property="Target Snapshot:">
+                                hello
+                                <template #value>
+                                    <span class="flex gap-2 pr-2">
+                                        <span class="flex items-center space-x-2 text-gray-500 italic">
+                                            <ExclamationIcon v-if="!targetSnapshot" class="text-yellow-600 w-4" />
+                                            <CheckCircleIcon v-else class="text-green-700 w-4" />
+                                        </span>
+                                        <template v-if="targetSnapshot">
+                                            <div class="flex flex-col">
+                                                <span>{{ targetSnapshot.name }}</span>
+                                                <span class="text-xs text-gray-500">{{ targetSnapshot.id }}</span>
+                                            </div>
+                                        </template>
+                                        <template v-else>
+                                            No Target Snapshot Set
+                                        </template>
+                                    </span>
+                                </template>
+                            </InfoCardRow>
+                        </template>
+                    </InfoCard>
+                </template>
                 <template #context>
                     <div>
                         Application:
@@ -43,7 +69,7 @@
 </template>
 
 <script>
-import { CogIcon } from '@heroicons/vue/solid'
+import { CheckCircleIcon, CogIcon, ExclamationIcon } from '@heroicons/vue/outline'
 
 import { mapState } from 'vuex'
 
@@ -51,6 +77,8 @@ import { Roles } from '../../../../../forge/lib/roles.js'
 
 import ApplicationApi from '../../../api/application.js'
 
+import InfoCard from '../../../components/InfoCard.vue'
+import InfoCardRow from '../../../components/InfoCardRow.vue'
 import SideNavigationTeamOptions from '../../../components/SideNavigationTeamOptions.vue'
 import SubscriptionExpiredBanner from '../../../components/banners/SubscriptionExpired.vue'
 import TeamTrialBanner from '../../../components/banners/TeamTrial.vue'
@@ -61,6 +89,10 @@ import permissionsMixin from '../../../mixins/Permissions.js'
 export default {
     name: 'DeviceGroup',
     components: {
+        CheckCircleIcon,
+        ExclamationIcon,
+        InfoCard,
+        InfoCardRow,
         SideNavigationTeamOptions,
         SubscriptionExpiredBanner,
         TeamTrialBanner
@@ -113,6 +145,9 @@ export default {
         },
         devicesArray () {
             return this.applicationDevices
+        },
+        targetSnapshot () {
+            return this.deviceGroup?.targetSnapshot || null
         }
     },
     async created () {

--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -26,7 +26,7 @@
                                 hello
                                 <template #value>
                                     <span class="flex gap-2 pr-2">
-                                        <span class="flex items-center space-x-2 text-gray-500 italic">
+                                        <span class="flex items-center space-x-2 pt-1 text-gray-500 italic">
                                             <ExclamationIcon v-if="!targetSnapshot" class="text-yellow-600 w-4" />
                                             <CheckCircleIcon v-else class="text-green-700 w-4" />
                                         </span>

--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -25,20 +25,16 @@
                             <InfoCardRow property="Target Snapshot:">
                                 hello
                                 <template #value>
-                                    <span class="flex gap-2 pr-2">
+                                    <span class="flex gap-2 pr-2" data-el="device-group-target-snapshot">
                                         <span class="flex items-center space-x-2 pt-1 text-gray-500 italic">
                                             <ExclamationIcon v-if="!targetSnapshot" class="text-yellow-600 w-4" />
                                             <CheckCircleIcon v-else class="text-green-700 w-4" />
                                         </span>
-                                        <template v-if="targetSnapshot">
-                                            <div class="flex flex-col">
-                                                <span>{{ targetSnapshot.name }}</span>
-                                                <span class="text-xs text-gray-500">{{ targetSnapshot.id }}</span>
-                                            </div>
-                                        </template>
-                                        <template v-else>
-                                            No Target Snapshot Set
-                                        </template>
+                                        <div class="flex flex-col">
+                                            <span v-if="targetSnapshot" data-el="snapshot-name">{{ targetSnapshot.name }}</span>
+                                            <span v-else data-el="snapshot-name">No Target Snapshot Set</span>
+                                            <span v-if="targetSnapshot" class="text-xs text-gray-500" data-el="snapshot-id">{{ targetSnapshot.id }}</span>
+                                        </div>
                                     </span>
                                 </template>
                             </InfoCardRow>

--- a/frontend/src/pages/application/DeviceGroups.vue
+++ b/frontend/src/pages/application/DeviceGroups.vue
@@ -16,8 +16,8 @@
         v-if="loading"
         message="Loading Device Groups..."
     />
-    <div v-else-if="deviceGroups?.length > 0" class="pt-4 space-y-6" data-el="pipelines-list">
-        <ff-data-table v-model:search="tableSearch" :columns="tableColumns" :rows="deviceGroups" :show-search="true" search-placeholder="Filter..." :rows-selectable="true" @row-selected="editDeviceGroup">
+    <div v-else-if="deviceGroups?.length > 0" class="pt-4 space-y-6" data-el="device-group-list">
+        <ff-data-table v-model:search="tableSearch" :columns="tableColumns" :rows="deviceGroups" :show-search="true" search-placeholder="Filter..." data-el="device-groups-table" :rows-selectable="true" @row-selected="editDeviceGroup">
             <template #actions>
                 <ff-button data-action="create-device-group" :disabled="!featureEnabled" @click="showCreateDeviceGroupDialog">
                     <template #icon-left><PlusSmIcon /></template>

--- a/frontend/src/pages/application/DeviceGroups.vue
+++ b/frontend/src/pages/application/DeviceGroups.vue
@@ -64,6 +64,7 @@
 
 <script>
 import { PlusSmIcon } from '@heroicons/vue/outline'
+import { markRaw } from 'vue'
 import { mapState } from 'vuex'
 
 import ApplicationAPI from '../../api/application.js'
@@ -74,12 +75,13 @@ import SectionTopMenu from '../../components/SectionTopMenu.vue'
 
 import Alerts from '../../services/alerts.js'
 
+import TargetSnapshotCell from './components/cells/TargetSnapshot.vue'
+
 export default {
     name: 'ApplicationDeviceGroups',
     components: {
         EmptyState,
         FormRow,
-        // eslint-disable-next-line vue/no-unused-components
         PlusSmIcon,
         SectionTopMenu
     },
@@ -120,7 +122,14 @@ export default {
                     label: 'Description',
                     key: 'description',
                     sortable: true,
-                    class: 'w-full'
+                    class: 'w-1/3'
+                },
+                {
+                    label: 'Target Snapshot',
+                    key: 'description',
+                    sortable: true,
+                    class: 'w-full',
+                    component: { is: markRaw(TargetSnapshotCell) }
                 },
                 {
                     label: 'Device count',
@@ -190,6 +199,12 @@ export default {
             ApplicationAPI.getDeviceGroups(this.application.id)
                 .then((groups) => {
                     this.deviceGroups = groups.groups
+                    if (this.deviceGroups?.length > 0) {
+                        // if there is no target snapshot set, set it to an empty object so that the `markRaw` function renders _something_ in the table cell
+                        this.deviceGroups.forEach((group) => {
+                            group.targetSnapshot = group.targetSnapshot || {}
+                        })
+                    }
                 })
                 .catch((err) => {
                     console.error(err)

--- a/frontend/src/pages/application/components/cells/Snapshot.vue
+++ b/frontend/src/pages/application/components/cells/Snapshot.vue
@@ -14,8 +14,15 @@
                 class="text-green-700 w-4"
             />
         </span>
-        <template v-if="activeSnapshot"><div class="flex flex-col"><span>{{ activeSnapshot?.name }}</span><span class="text-xs text-gray-500">{{ activeSnapshot.id }}</span></div></template>
-        <template v-else><span class="italic text-gray-500">none</span></template>
+        <template v-if="activeSnapshot">
+            <div class="flex flex-col">
+                <span data-el="snapshot-name">{{ activeSnapshot?.name }}</span>
+                <span class="text-xs text-gray-500" data-el="snapshot-id">{{ activeSnapshot.id }}</span>
+            </div>
+        </template>
+        <template v-else>
+            <span class="italic text-gray-500" data-el="snapshot-name">none</span>
+        </template>
     </span>
 </template>
 

--- a/frontend/src/pages/application/components/cells/Snapshot.vue
+++ b/frontend/src/pages/application/components/cells/Snapshot.vue
@@ -23,7 +23,7 @@
 import { CheckCircleIcon, ExclamationIcon } from '@heroicons/vue/outline'
 
 export default {
-    name: 'CloudLink',
+    name: 'SnapshotCell',
     components: {
         ExclamationIcon,
         CheckCircleIcon

--- a/frontend/src/pages/application/components/cells/TargetSnapshot.vue
+++ b/frontend/src/pages/application/components/cells/TargetSnapshot.vue
@@ -13,8 +13,13 @@
                 class="text-green-700 w-4"
             />
         </span>
-        <template v-if="targetSnapshot?.id"><div class="flex flex-col"><span>{{ targetSnapshot?.name }}</span><span class="text-xs text-gray-500">{{ targetSnapshot?.id }}</span></div></template>
-        <template v-else><span class="italic text-gray-500">none</span></template>
+        <template v-if="targetSnapshot?.id"><div class="flex flex-col">
+            <span data-el="snapshot-name">{{ targetSnapshot?.name }}</span>
+            <span class="text-xs text-gray-500" data-el="snapshot-id">{{ targetSnapshot?.id }}</span></div>
+        </template>
+        <template v-else>
+            <span class="italic text-gray-500" data-el="snapshot-name">none</span>
+        </template>
     </span>
 </template>
 

--- a/frontend/src/pages/application/components/cells/TargetSnapshot.vue
+++ b/frontend/src/pages/application/components/cells/TargetSnapshot.vue
@@ -1,0 +1,38 @@
+<template>
+    <span class="flex space-x-4">
+        <span
+            v-ff-tooltip:left="targetSnapshot.description"
+            class="flex items-center space-x-2 text-gray-500 italic"
+        >
+            <ExclamationIcon
+                v-if="!targetSnapshot?.id"
+                class="text-yellow-600 w-4"
+            />
+            <CheckCircleIcon
+                v-else
+                class="text-green-700 w-4"
+            />
+        </span>
+        <template v-if="targetSnapshot?.id"><div class="flex flex-col"><span>{{ targetSnapshot?.name }}</span><span class="text-xs text-gray-500">{{ targetSnapshot?.id }}</span></div></template>
+        <template v-else><span class="italic text-gray-500">none</span></template>
+    </span>
+</template>
+
+<script>
+import { CheckCircleIcon, ExclamationIcon } from '@heroicons/vue/outline'
+
+export default {
+    name: 'TargetSnapshotCell',
+    components: {
+        ExclamationIcon,
+        CheckCircleIcon
+    },
+    inheritAttrs: false,
+    props: {
+        targetSnapshot: {
+            default: null,
+            type: Object
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -70,7 +70,7 @@
                 <InfoCardRow property="Target Snapshot:">
                     <template #value>
                         <span class="flex gap-2 pr-2">
-                            <span class="flex items-center space-x-2 text-gray-500 italic">
+                            <span class="flex items-center space-x-2 pt-1 text-gray-500 italic">
                                 <ExclamationIcon class="text-yellow-600 w-4" v-if="!device.targetSnapshot" />
                                 <CheckCircleIcon class="text-green-700 w-4" v-else />
                             </span>

--- a/test/e2e/frontend/cypress/fixtures/device-groups/application-devices.json
+++ b/test/e2e/frontend/cypress/fixtures/device-groups/application-devices.json
@@ -1,0 +1,132 @@
+{
+    "meta": {},
+    "count": 3,
+    "devices": [
+        {
+            "id": "jKJ1KBnDPq",
+            "ownerType": "application",
+            "name": "Device 1",
+            "type": "NUC-V1.2",
+            "createdAt": "2024-03-04T09:58:40.035Z",
+            "updatedAt": "2024-04-02T13:45:54.649Z",
+            "lastSeenAt": "2024-03-06T14:01:52.000Z",
+            "lastSeenMs": 2427365989,
+            "activeSnapshot": {
+                "id": "snapv1",
+                "name": "V1",
+                "description": ""
+            },
+            "targetSnapshot": {
+                "id": "snapv1",
+                "name": "V1",
+                "description": ""
+            },
+            "status": "running",
+            "isDeploying": true,
+            "agentVersion": "",
+            "mode": "developer",
+            "team": {
+                "id": "2VJ1bDYopr",
+                "name": "Team team",
+                "slug": "team1"
+            },
+            "application": {
+                "id": "QJRYOX1ej8",
+                "name": "App 1"
+            },
+            "editor": {
+                "enabled": false
+            },
+            "deviceGroup": {
+                "id": "kYd1OXDJ2l",
+                "name": "Device Group 1",
+                "description": "A group with 2 devices",
+                "deviceCount": 2,
+                "targetSnapshot": null
+            }
+        },
+        {
+            "id": "36LO0L3Odb",
+            "ownerType": "application",
+            "name": "Device 2",
+            "type": "NUC-V1.2",
+            "createdAt": "2024-03-04T09:58:40.035Z",
+            "updatedAt": "2024-04-02T13:45:54.649Z",
+            "lastSeenAt": "2024-03-06T14:01:52.000Z",
+            "lastSeenMs": 2427365989,
+            "activeSnapshot": {
+                "id": "snapv2",
+                "name": "V2",
+                "description": ""
+            },
+            "targetSnapshot": {
+                "id": "snapv2",
+                "name": "V2",
+                "description": ""
+            },
+            "status": "running",
+            "isDeploying": true,
+            "agentVersion": "",
+            "mode": "developer",
+            "team": {
+                "id": "2VJ1bDYopr",
+                "name": "Team team",
+                "slug": "team1"
+            },
+            "application": {
+                "id": "QJRYOX1ej8",
+                "name": "App 1"
+            },
+            "editor": {
+                "enabled": false
+            },
+            "deviceGroup": {
+                "id": "kYd1OXDJ2l",
+                "name": "Device Group 1",
+                "description": "A group with 2 devices",
+                "deviceCount": 2,
+                "targetSnapshot": null
+            }
+        },
+        {
+            "id": "RgeDWe29az",
+            "ownerType": "application",
+            "name": "Device 3",
+            "type": "",
+            "createdAt": "2024-04-02T14:23:03.063Z",
+            "updatedAt": "2024-04-02T15:40:29.957Z",
+            "lastSeenAt": "2024-04-02T14:29:52.000Z",
+            "lastSeenMs": 92885989,
+            "activeSnapshot": {
+                "id": "r4VOl5Dm7X",
+                "name": "V2",
+                "description": ""
+            },
+            "targetSnapshot": {
+                "id": "r4VOl5Dm7X",
+                "name": "V2",
+                "description": ""
+            },
+            "status": "stopped",
+            "isDeploying": false,
+            "agentVersion": "2.3.1",
+            "mode": "autonomous",
+            "team": {
+                "id": "2VJ1bDYopr",
+                "name": "Team team",
+                "slug": "team1"
+            },
+            "application": {
+                "id": "QJRYOX1ej8",
+                "name": "App 1"
+            },
+            "deviceGroup": {
+                "id": "NeYpM5pxak",
+                "name": "Device Group 2",
+                "description": "A group with 1 device",
+                "deviceCount": 1,
+                "targetSnapshot": null
+            }
+        }
+    ]
+}

--- a/test/e2e/frontend/cypress/fixtures/device-groups/device-group-1.json
+++ b/test/e2e/frontend/cypress/fixtures/device-groups/device-group-1.json
@@ -1,0 +1,37 @@
+{
+    "application": {
+        "id": "QJRYOX1ej8",
+        "name": "App 1"
+    },
+    "devices": [
+        {
+            "id": "jKJ1KBnDPq",
+            "ownerType": "application",
+            "name": "Device 1",
+            "type": "NUC-V1.2",
+            "lastSeenMs": null,
+            "status": "offline",
+            "isDeploying": false,
+            "mode": "autonomous"
+        },
+        {
+            "id": "36LO0L3Odb",
+            "ownerType": "application",
+            "name": "Device 2",
+            "type": "",
+            "lastSeenMs": null,
+            "status": "offline",
+            "isDeploying": false,
+            "mode": "autonomous"
+        }
+    ],
+    "targetSnapshot": {
+        "id": "snapv1",
+        "name": "V1",
+        "description": ""
+    },
+    "id": "kYd1OXDJ2l",
+    "name": "Device Group 1",
+    "description": "A group of devices",
+    "deviceCount": 2
+}

--- a/test/e2e/frontend/cypress/tests-ee/applications/device-groups.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/device-groups.spec.js
@@ -1,0 +1,132 @@
+import applicationDevices from '../../fixtures/device-groups/application-devices.json'
+import deviceGroup1 from '../../fixtures/device-groups/device-group-1.json'
+
+describe('FlowForge - Application - Device Groups', () => {
+    let application
+    function loadApplication (teamName, applicationName) {
+        cy.request('GET', '/api/v1/user/teams')
+            .then((response) => {
+                const team = response.body.teams.find(
+                    (team) => team.name === teamName
+                )
+                return cy.request('GET', `/api/v1/teams/${team.id}/applications`)
+            })
+            .then((response) => {
+                application = response.body.applications.find(
+                    (app) => app.name === applicationName
+                )
+                applicationDevices.devices.forEach((device) => {
+                    device.application.id = application.id
+                    device.application.name = application.name
+                })
+                deviceGroup1.application.id = application.id
+                deviceGroup1.application.name = application.name
+            })
+    }
+
+    beforeEach(() => {
+        cy.intercept('GET', '/api/*/applications/*').as('getApplication')
+
+        cy.login('bob', 'bbPassword')
+        cy.home()
+        loadApplication('BTeam', 'application-2')
+    })
+
+    describe('Device Groups Overview', () => {
+        it('can navigate to the /device-groups page with EE license', () => {
+            // // provide the device groups fixture
+            // cy.intercept('GET', '/api/*/applications/*/device-groups', groups).as('getDeviceGroups')
+            cy.visit(`/application/${application.id}`) // open the application page
+            // navigate to the device groups tab
+            cy.get('[data-nav="application-devices-groups-overview"]').should('exist').click()
+            // check the url is correct
+            cy.url().should('include', `/application/${application.id}/device-groups`)
+            // check the device groups are displayed
+            cy.get('[data-el="device-groups-table"] tbody').find('tr').should('have.length', 1)
+            // check the column data is present & correct
+            cy.get('[data-el="device-groups-table"] tbody').find('tr').eq(0).find('td').eq(0).should('have.text', 'application-device-group-a')
+            cy.get('[data-el="device-groups-table"] tbody').find('tr').eq(0).find('td').eq(1).should('have.text', 'an unnamed device group')
+            // the next cell has the snapshot it contains spans with the name and the id
+            cy.get('[data-el="device-groups-table"] tbody > tr:nth-child(1) > td [data-el="snapshot-name"]').should('have.text', 'none')
+            cy.get('[data-el="device-groups-table"] tbody > tr:nth-child(1) > td [data-el="snapshot-id"]').should('not.exist')
+            // last cell has the count of devices in the group
+            cy.get('[data-el="device-groups-table"] tbody').find('tr').eq(0).find('td').eq(3).should('have.text', '1')
+        })
+
+        it.skip('can create device-group', () => {
+            // TODO
+        })
+    })
+
+    describe('Device Group', () => {
+        it('can navigate to the /device-group/xxxxxxxx/devices page with EE license', () => {
+            cy.visit(`/application/${application.id}`) // open the application page
+            // navigate to the device groups tab
+            cy.get('[data-nav="application-devices-groups-overview"]').should('exist').click()
+            // check the url is correct
+            cy.url().should('include', `/application/${application.id}/device-groups`)
+
+            // the page should show a list of device groups and the rows should be clickable
+            // click on the first row
+            cy.get('[data-el="device-groups-table"] tbody').find('tr').eq(0).click()
+
+            // the url should match /application/${application.id}/device-group/<alphanumeric-id>/devices
+            cy.url().should('match', new RegExp(`/application/${application.id}/device-group/[a-zA-Z0-9]+/devices`))
+
+            // check the target snapshot is displayed upper right
+            cy.get('[data-el="device-group-target-snapshot"]').should('exist')
+            cy.get('[data-el="device-group-target-snapshot"] [data-el="snapshot-name"]').should('have.text', 'No Target Snapshot Set')
+            cy.get('[data-el="device-group-target-snapshot"] [data-el="snapshot-id"]').should('not.exist')
+
+            // check the table is displayed and contains 1 device and the columns are correct
+            // columns: Name, Type, Active Snapshot
+            cy.get('[data-el="device-group-members"] tbody').find('tr').should('have.length', 1)
+            cy.get('[data-el="device-group-members"] tbody').find('tr').eq(0).find('td').eq(0).should('have.text', 'application-device-b')
+            cy.get('[data-el="device-group-members"] tbody').find('tr').eq(0).find('td').eq(1).should('have.text', 'application-device-b')
+            // the next cell has the snapshot it contains spans with the name and the id
+            cy.get('[data-el="device-group-members"] tbody > tr:nth-child(1) > td [data-el="snapshot-name"]').should('have.text', 'none')
+            cy.get('[data-el="device-group-members"] tbody > tr:nth-child(1) > td [data-el="snapshot-id"]').should('not.exist')
+        })
+        it('snapshot info is displayed', () => {
+            // override the fixtures with the devices having snapshots
+            cy.intercept('GET', '/api/*/applications/*/device-groups/*', deviceGroup1).as('getDeviceGroup')
+            cy.intercept('GET', '/api/*/applications/*/devices', applicationDevices).as('getApplicationDevices')
+
+            // open the application page
+            cy.visit(`/application/${application.id}`)
+            // navigate to the device groups tab
+            cy.get('[data-nav="application-devices-groups-overview"]').should('exist').click()
+            // check the url is correct
+            cy.url().should('include', `/application/${application.id}/device-groups`)
+
+            // the page should show a list of device groups and the rows should be clickable
+            // click on the first row
+            cy.get('[data-el="device-groups-table"] tbody').find('tr').eq(0).click()
+
+            // the url should match /application/${application.id}/device-group/<alphanumeric-id>/devices
+            cy.url().should('match', new RegExp(`/application/${application.id}/device-group/[a-zA-Z0-9]+/devices`))
+
+            // check the target snapshot is displayed upper right
+            cy.get('[data-el="device-group-target-snapshot"]').should('exist')
+            cy.get('[data-el="device-group-target-snapshot"] [data-el="snapshot-name"]').should('have.text', 'V1')
+            cy.get('[data-el="device-group-target-snapshot"] [data-el="snapshot-id"]').should('have.text', 'snapv1')
+
+            // check the table is displayed and contains 2 devices and the columns are correct
+            // columns: Name, Type, Active Snapshot
+            cy.get('[data-el="device-group-members"] tbody').find('tr').should('have.length', 2)
+            // **Device 1**: has active snapshot V1
+            cy.get('[data-el="device-group-members"] tbody').find('tr').eq(0).find('td').eq(0).should('have.text', 'Device 1')
+            cy.get('[data-el="device-group-members"] tbody').find('tr').eq(0).find('td').eq(1).should('have.text', 'Device 1')
+            // the next cell has the snapshot it contains spans with the name and the id
+            cy.get('[data-el="device-group-members"] tbody > tr:nth-child(1) > td [data-el="snapshot-name"]').should('have.text', 'V1')
+            cy.get('[data-el="device-group-members"] tbody > tr:nth-child(1) > td [data-el="snapshot-id"]').should('have.text', 'snapv1')
+
+            // **Device 2**: has active snapshot V2
+            cy.get('[data-el="device-group-members"] tbody').find('tr').eq(1).find('td').eq(0).should('have.text', 'Device 2')
+            cy.get('[data-el="device-group-members"] tbody').find('tr').eq(1).find('td').eq(1).should('have.text', 'Device 2')
+            // the next cell has the snapshot it contains spans with the name and the id
+            cy.get('[data-el="device-group-members"] tbody > tr:nth-child(2) > td [data-el="snapshot-name"]').should('have.text', 'V2')
+            cy.get('[data-el="device-group-members"] tbody > tr:nth-child(2) > td [data-el="snapshot-id"]').should('have.text', 'snapv2')
+        })
+    })
+})

--- a/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
@@ -96,7 +96,7 @@ describe('FlowForge - Team Overview (Home) - With License', () => {
                         const text = labels.toArray().join(', ')
 
                         // Test should pass for single test of full suite (objects persist between tests)
-                        expect(text).to.match(/2 x Instances, 2 x Devices, 2 x Device Groups, 8 x Snapshots, 4 x Pipelines|2 x Instances, 2 x Devices, 1 x Device Group, 3 x Snapshots/)
+                        expect(text).to.match(/2 x Instances, 2 x Devices, 2 x Device Groups, 8 x Snapshots, 4 x Pipelines|2 x Instances, 2 x Devices, 1 x Device Group, 4 x Snapshots/)
                     })
 
                     cy.get('[data-el="application-instances"]').find('li').should('have.length', 2)

--- a/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
@@ -96,7 +96,7 @@ describe('FlowForge - Team Overview (Home) - With License', () => {
                         const text = labels.toArray().join(', ')
 
                         // Test should pass for single test of full suite (objects persist between tests)
-                        expect(text).to.match(/2 x Instances, 2 x Devices, 2 x Device Groups, 8 x Snapshots, 4 x Pipelines|2 x Instances, 2 x Devices, 1 x Device Group, 4 x Snapshots/)
+                        expect(text).to.match(/2 x Instances, 2 x Devices, 2 x Device Groups, 9 x Snapshots, 4 x Pipelines|2 x Instances, 2 x Devices, 1 x Device Group, 4 x Snapshots/)
                     })
 
                     cy.get('[data-el="application-instances"]').find('li').should('have.length', 2)

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -159,15 +159,16 @@ module.exports = async function (settings = {}, config = {}) {
     await factory.createSnapshot({ name: 'snapshot 3' }, instanceWithDevices, userBob)
 
     // create devices bound to application directly
-    await factory.createDevice({ name: 'application-device-a', type: 'type2' }, team2, null, application2)
+    const deviceA = await factory.createDevice({ name: 'application-device-a', type: 'type2' }, team2, null, application2)
     const deviceB = await factory.createDevice({ name: 'application-device-b', type: 'type2' }, team2, null, application2)
 
     // create a device group and add deviceB to it
-    const deviceGroup = await factory.createApplicationDeviceGroup({ name: 'application-device-group-a' }, application2)
-    await factory.addDeviceToGroup(deviceB, deviceGroup)
+    const deviceGroupA = await factory.createApplicationDeviceGroup({ name: 'application-device-group-a' }, application2)
+    await factory.addDeviceToGroup(deviceB, deviceGroupA)
 
     forge.teams = [team1, team2]
     forge.projectTypes = [projectType, spareProjectType]
-
+    forge.applicationDevices = [deviceA, deviceB]
+    forge.applicationDeviceGroups = [deviceGroupA]
     return forge
 }

--- a/test/e2e/frontend/test_environment_ee.js
+++ b/test/e2e/frontend/test_environment_ee.js
@@ -34,6 +34,10 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
         email: {
             enabled: true,
             debug: true
+        },
+        // configure a broker so that device app.comms is loaded and can be stubbed
+        broker: {
+            url: ':test:'
         }
     })
 
@@ -66,6 +70,10 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
         order: 2,
         properties: { instances: {}, devices: {}, users: {}, features: {} }
     })
+
+    // create a snapshot on DeviceB
+    const deviceB = flowforge.applicationDevices.find((device) => device.name === 'application-device-b')
+    await factory.createDeviceSnapshot({ name: 'application-device-b snapshot 1' }, deviceB, userTerry)
 
     flowforge.listen({ port: PORT }, function (err, address) {
         console.info(`EE Environment running at http://localhost:${PORT}`)

--- a/test/unit/forge/ee/routes/api/applicationDeviceGroups_spec.js
+++ b/test/unit/forge/ee/routes/api/applicationDeviceGroups_spec.js
@@ -185,6 +185,7 @@ describe('Application Device Groups API', function () {
             result.groups[0].should.have.property('id', deviceGroup.hashid)
             result.groups[0].should.have.property('name', deviceGroup.name)
             result.groups[0].should.have.property('description', deviceGroup.description)
+            result.groups[0].should.have.property('targetSnapshot')
         })
 
         it('Paginates device groups', async function () {


### PR DESCRIPTION
## Description

Add snapshot information to device groups as part of "Improve Snapshot lifecycle handling https://github.com/FlowFuse/flowfuse/issues/3622"

* Adds snapshot summary info to Device Group(s) API responses
* "Device Groups"
   * Adds per-row "Target Snapshot" on "Device Groups" page
   * ![image](https://github.com/FlowFuse/flowfuse/assets/44235289/52c8276c-d445-4eb4-8ab5-a3be5aea4f51)
* "Device Group"
   * Adds "Target Snapshot" info box in "Device Group" page
   * Adds per-row "Active Snapshot" info in "Device Group" page
   * ![image](https://github.com/FlowFuse/flowfuse/assets/44235289/6ea7117c-d698-4c44-afb7-09a2c423c74f)


### Tests

#### Unit

Updates "Application Device Groups API" to check for presence of `targetSnapshot` property
```
 Application Device Groups API
    Read Device Groups
      ✔ Owner can read device groups (124ms)
```

#### e2e

A new set of e2e tests for device-groups was required to be able to check the snapshot info was present on the Device Groups and Device Group pages

```
FlowForge - Application - Device Groups
  Device Groups Overview
    ✔ can navigate to the /device-groups page with EE license
  Device Group
    ✔ can navigate to the /device-group/xxxxxxxx/devices page with EE license
    ✔ snapshot info is displayed
```

## Related Issue(s)

Closes #3672

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

