### PR TITLE
Handle sessionless requests in deviceEditor routes

### DIFF
--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -37,7 +37,7 @@ module.exports = async function (app) {
                         reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
-                    if (request.session.User) {
+                    if (request.session?.User) {
                         request.teamMembership = await request.session.User.getTeamMembership(request.device.Team.id)
                         // If the user isn't in the team, only give 404 error if this
                         // is not a 'allowAnonymous' route. This allows the proxy routes


### PR DESCRIPTION
A customer was getting 404 errors on the Device Agent editor websocket connection. This was due to an error being thrown in the preHandler for the route that assumed `request.session` would be defined.

When running with an `enterprise` tier license, we have code in the SSO routes that adds `request.session` if it is not otherwise set (as this is rquired by the inner workings of the SSO auth routes)

This particular customer has a `teams` tier license, so the SSO routes were not enabled. This meant `request.session` was undefined. For most routes, this is guarded via `verifySession` preHandler. However this route in particular has the `allowAnonymous` flag set - as the route deals with the authentication itself.

I have searched through all EE-related routes for any with the `allowAnonymous` flag set and that have unguarded access to `request.session`. The only place that happens is in the `deviceEditor` routes - which is fixed via this PR.