### PR TITLE
fix: Update forge domain to use HTTPS

### DIFF
--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -1,6 +1,6 @@
 forge:
   domain: flowfuse.dev
-  https: false
+  https: true
   localPostgresql: true
   broker:
     enabled: true


### PR DESCRIPTION
## Description

This PR changes the pre-staging configuration and enables https.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

