### PR TITLE
Sanitize content to avoid spurious links included in verification email

### DIFF
--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -143,7 +143,7 @@ module.exports = fp(async function (app, _opts) {
         const forgeURL = app.config.base_url
         const template = templates[templateName] || loadTemplate(templateName)
         const templateContext = { forgeURL, user, ...context }
-        templateContext.safeName = sanitizeText(user.name)
+        templateContext.safeName = sanitizeText(user.name || 'user')
         const mail = {
             to: user.email,
             subject: template.subject(templateContext, { allowProtoPropertiesByDefault: true, allowProtoMethodsByDefault: true }),

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -120,6 +120,19 @@ module.exports = fp(async function (app, _opts) {
     }
 
     /**
+     * Generates email-safe versions (both text and html) of a piece of text.
+     * This is intended to make user-provided strings (eg username) that may look
+     * like a URL to not looks like a URL to an email client
+     * @param {String} value
+     */
+    function sanitizeText (value) {
+        return {
+            text: value.replace(/\./g, ' '),
+            html: value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\./g, '<br style="display: none;"/>.')
+        }
+    }
+
+    /**
      * Send an email to a user
      *
      * @param user object - who to send the email to.
@@ -130,7 +143,7 @@ module.exports = fp(async function (app, _opts) {
         const forgeURL = app.config.base_url
         const template = templates[templateName] || loadTemplate(templateName)
         const templateContext = { forgeURL, user, ...context }
-
+        templateContext.safeName = sanitizeText(user.name)
         const mail = {
             to: user.email,
             subject: template.subject(templateContext, { allowProtoPropertiesByDefault: true, allowProtoMethodsByDefault: true }),

--- a/forge/postoffice/templates/VerifyEmail.js
+++ b/forge/postoffice/templates/VerifyEmail.js
@@ -1,14 +1,14 @@
 module.exports = {
     subject: 'Please verify your email address',
     text:
-`Hello, {{{user.name}}},
+`Hello, {{{safeName.text}}},
 
 Use the link below to verify your email address.
 
 {{{ confirmEmailLink }}}
 `,
     html:
-`<p>Hello, <b>{{user.name}}</b>,</p>
+`<p>Hello, <b>{{{safeName.html}}}</b>,</p>
 <p>Use the link below to verify your email address.</p>
 <p><a href="{{{ confirmEmailLink }}}">{{{ confirmEmailLink }}}</a></p>
 `


### PR DESCRIPTION
If a user provides a name that looks like a URL, some email clients will make it clickable. We have made previous attempts to sanitize the name field by explicitly disallowing `http`, but email clients will turn anything that smells like a URL into a clickable link.

This PR attempts to solve this by:

1. in plain text, strip out `.` from the name field
2. in html, breakup the name field with invisible markup that, appears to be the best solution in 2024 to work across lots of different email clients.
