### PR TITLE
Import ff-colors globally through webpack

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = function (env, argv) {
                         {
                             loader: 'sass-loader',
                             options: {
-                                additionalData: '@import "@/stylesheets/ff-colors.scss";'
+                                additionalData: '@import "@/ui-components/stylesheets/ff-colors.scss";'
                             }
                         }
 
@@ -165,7 +165,7 @@ module.exports = function (env, argv) {
                 // Use vue with the runtime compiler (needed for template strings)
                 // To-do: Remove use of template strings, https://github.com/FlowFuse/flowfuse/issues/3290
                 vue: 'vue/dist/vue.esm-bundler.js',
-                '@': path.resolve('frontend/src/ui-components')
+                '@': path.resolve('frontend/src')
             }
         }
     }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -82,7 +82,13 @@ module.exports = function (env, argv) {
                             loader: 'css-loader',
                             options: { import: true, url: true }
                         },
-                        'sass-loader'
+                        {
+                            loader: 'sass-loader',
+                            options: {
+                                additionalData: '@import "@/stylesheets/ff-colors.scss";'
+                            }
+                        }
+
                     ]
                 },
                 {
@@ -158,7 +164,8 @@ module.exports = function (env, argv) {
             alias: {
                 // Use vue with the runtime compiler (needed for template strings)
                 // To-do: Remove use of template strings, https://github.com/FlowFuse/flowfuse/issues/3290
-                vue: 'vue/dist/vue.esm-bundler.js'
+                vue: 'vue/dist/vue.esm-bundler.js',
+                '@': path.resolve('frontend/src/ui-components')
             }
         }
     }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = function (env, argv) {
                         {
                             loader: 'sass-loader',
                             options: {
-                                additionalData: '@import "@/ui-components/stylesheets/ff-colors.scss";'
+                                additionalData: '@import "@/ui-components/stylesheets/ff-colors.scss";@import "@/ui-components/stylesheets/ff-utility.scss";'
                             }
                         }
 

--- a/frontend/src/components/icons-animated/Installing.vue
+++ b/frontend/src/components/icons-animated/Installing.vue
@@ -18,7 +18,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '../../ui-components/stylesheets/ff-colors.scss';
 
 .ff-icon-anim {
     display: flex;

--- a/frontend/src/components/icons-animated/Restarting.vue
+++ b/frontend/src/components/icons-animated/Restarting.vue
@@ -18,7 +18,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '../../ui-components/stylesheets/ff-colors.scss';
 
 .ff-icon-restarting svg {
     --anim-time: 1s;

--- a/frontend/src/components/icons-animated/Starting.vue
+++ b/frontend/src/components/icons-animated/Starting.vue
@@ -11,8 +11,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-icon-anim {
     display: flex;
     justify-content: center;

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -267,7 +267,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-    @import '../../ui-components/stylesheets/ff-colors.scss';
 
     .error-banner {
         padding: 9px;

--- a/frontend/src/stylesheets/components/accordion.scss
+++ b/frontend/src/stylesheets/components/accordion.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-accordion {
     margin-bottom: 24px;
     &--button {

--- a/frontend/src/stylesheets/components/applications-list.scss
+++ b/frontend/src/stylesheets/components/applications-list.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-applications-list {
     display: flex;
     flex-direction: column;

--- a/frontend/src/stylesheets/components/audit-log.scss
+++ b/frontend/src/stylesheets/components/audit-log.scss
@@ -1,6 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-@import '../../ui-components/stylesheets/ff-utility.scss';
-
 .ff-audit-entry {
     display: grid;
     grid-template-areas:

--- a/frontend/src/stylesheets/components/blueprint-selection.scss
+++ b/frontend/src/stylesheets/components/blueprint-selection.scss
@@ -1,6 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-@import '../../ui-components/stylesheets/ff-utility.scss';
-
 .ff-blueprint-groups {
     h4 {
         border-bottom: 1px solid $ff-grey-200;

--- a/frontend/src/stylesheets/components/charts.scss
+++ b/frontend/src/stylesheets/components/charts.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-chart {
     padding: 12px 18px;
     border: 1px solid $ff-grey-300;

--- a/frontend/src/stylesheets/components/code-previewer.scss
+++ b/frontend/src/stylesheets/components/code-previewer.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-code-previewer {
     background-color: white;
     border: 1px solid $ff-grey-300;

--- a/frontend/src/stylesheets/components/empty-state.scss
+++ b/frontend/src/stylesheets/components/empty-state.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-empty-state {
     text-align: center;
     padding-top: 64px;

--- a/frontend/src/stylesheets/components/info-card.scss
+++ b/frontend/src/stylesheets/components/info-card.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-info-card h3 {
     display: flex;
     gap: 9px;

--- a/frontend/src/stylesheets/components/notifications.scss
+++ b/frontend/src/stylesheets/components/notifications.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-notification-interview {
     max-width: 450px;
     border: 1px solid $ff-grey-400;

--- a/frontend/src/stylesheets/components/pipelines.scss
+++ b/frontend/src/stylesheets/components/pipelines.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-pipeline {
     width: 100%;
     border: 1px solid $ff-grey-300;

--- a/frontend/src/stylesheets/components/team-list.scss
+++ b/frontend/src/stylesheets/components/team-list.scss
@@ -1,6 +1,4 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
- 
-.ff-dropdown-option-list {
+ .ff-dropdown-option-list {
   max-height: 200px;
   overflow-y: auto;
 }

--- a/frontend/src/stylesheets/pages/login.scss
+++ b/frontend/src/stylesheets/pages/login.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-login {
     .ff-layout--box--wrapper {
         width: 75%;

--- a/frontend/src/stylesheets/pages/project.scss
+++ b/frontend/src/stylesheets/pages/project.scss
@@ -1,5 +1,3 @@
-@import '../../ui-components/stylesheets/ff-colors.scss';
-
 .ff-project-overview {
     .ff-accordion--content {
         transition: none;


### PR DESCRIPTION
## Description

making ff-color variables globally available through webpack imports

## Related Issue(s)

#3731 closes
required in #3656 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] ~~Suitable unit/system level tests have been added and they pass~~ <!-- If not adding test coverage, please clarify why not? -->  app functionality not impacted
 - [ ] ~~Documentation has been updated~~
    - [ ] ~~Upgrade instructions~~
    - [ ] ~~Configuration details~~
    - [ ] ~~Concepts~~
 - [ ] ~~Changes `flowforge.yml`?~~
    - [ ] ~~Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template~~
    - [ ] ~~Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production~~

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

