### PR TITLE
Reset posthog localStorage if found not to be logged in

### DIFF
--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -230,6 +230,8 @@ const actions = {
         } catch (err) {
             // Not logged in
             state.commit('clearPending')
+            window.posthog?.reset()
+
             if (router.currentRoute.value.meta.requiresLogin !== false) {
                 if (router.currentRoute.value.path !== '/') {
                     // Only remember the url if it isn't the default / path

--- a/test/e2e/frontend/cypress/tests/registration.spec.js
+++ b/test/e2e/frontend/cypress/tests/registration.spec.js
@@ -261,7 +261,8 @@ describe('FlowForge - Sign Up Page', () => {
             win.posthog = {
                 onFeatureFlags: () => {},
                 capture: () => {},
-                identify: () => {}
+                identify: () => {},
+                reset: () => {}
             }
         })
 


### PR DESCRIPTION
When a user logs out we correctly reset posthog state to clear any user-identifying information.

If however the user's session has naturally expired, we need a mechanism to clear the state.

This is a quick fix that resets the posthog state if we find the user is not currently logged in. This doesn't reset the device-id so should not interrupt the intended tracking.