### PR TITLE
Allow user/runtime limits to be applied during trial

### DIFF
--- a/forge/ee/db/controllers/Subscription.js
+++ b/forge/ee/db/controllers/Subscription.js
@@ -13,8 +13,8 @@ module.exports = {
             await existingSub.save()
 
             // This *could* be a trial team that has devices in it. In which case,
-            // we need to reconcile the subscription device count in case device billing
-            // is enabled.
+            // we need to reconcile the subscription device and instance count
+            await app.billing.updateTeamInstanceCount(team)
             await app.billing.updateTeamDeviceCount(team)
             return existingSub
         } else {

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -396,12 +396,14 @@ export default {
             return this.team.deviceCount + this.deviceCountDeltaSincePageLoad
         },
         teamRuntimeLimitReached () {
-            const teamTypeRuntimeLimit = this.team.type.properties?.runtimes?.limit
-            if (teamTypeRuntimeLimit > 0 && (this.teamDeviceCount + this.team.instanceCount) >= teamTypeRuntimeLimit) {
-                // Combined instance+device limit has been reached
-                return true
+            let teamTypeRuntimeLimit = this.team.type.properties?.runtimes?.limit
+            // Uses this.teamDeviceCount as that tracks live updates made in the page
+            // that may not have made it to this.team.deviceCount yet
+            const currentRuntimeCount = this.teamDeviceCount + this.team.instanceCount
+            if (this.team.billing?.trial && !this.team.billing?.active && this.team.type.properties?.trial?.runtimesLimit) {
+                teamTypeRuntimeLimit = this.team.type.properties?.trial?.runtimesLimit
             }
-            return false
+            return (teamTypeRuntimeLimit > 0 && currentRuntimeCount >= teamTypeRuntimeLimit)
         },
         teamDeviceLimitReached () {
             const teamTypeDeviceLimit = this.team.type.properties?.devices?.limit

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -37,6 +37,10 @@
                             </div>
                         </div>
                         <div v-if="input.properties.trial.active" class="grid gap-2 grid-cols-3 pl-4">
+                            <FormRow v-model="input.properties.trial.usersLimit" :type="editDisabled?'uneditable':''">Limit # Users</FormRow>
+                            <FormRow v-model="input.properties.trial.runtimesLimit" :type="editDisabled?'uneditable':''">Limit # Instances + Devices</FormRow>
+                        </div>
+                        <div v-if="input.properties.trial.active" class="grid gap-2 grid-cols-3 pl-4">
                             <FormRow v-model="input.properties.trial.productId" :type="editDisabled?'uneditable':''">Trial Product Id</FormRow>
                             <FormRow v-model="input.properties.trial.priceId" :type="editDisabled?'uneditable':''">Trial Price Id</FormRow>
                         </div>

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -459,8 +459,12 @@ export default {
             )
         },
         teamRuntimeLimitReached () {
-            const teamTypeRuntimeLimit = this.team.type.properties?.runtimes?.limit
-            return (teamTypeRuntimeLimit > 0 && (this.team.deviceCount + this.team.instanceCount) >= teamTypeRuntimeLimit)
+            let teamTypeRuntimeLimit = this.team.type.properties?.runtimes?.limit
+            const currentRuntimeCount = this.team.deviceCount + this.team.instanceCount
+            if (this.team.billing?.trial && !this.team.billing?.active && this.team.type.properties?.trial?.runtimesLimit) {
+                teamTypeRuntimeLimit = this.team.type.properties?.trial?.runtimesLimit
+            }
+            return (teamTypeRuntimeLimit > 0 && currentRuntimeCount >= teamTypeRuntimeLimit)
         },
         teamInstanceLimitReached () {
             return this.projectTypes.length > 0 && this.activeProjectTypeCount === 0

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -46,7 +46,10 @@ describe('Billing routes', function () {
         TestObjects.template1 = app.template
         TestObjects.stack1 = app.stack
 
+        TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+
         await login('alice', 'aaPassword')
+        await login('bob', 'bbPassword')
 
         await app.project.destroy() // clean up test project
     })
@@ -1655,8 +1658,7 @@ describe('Billing routes', function () {
                     response.statusCode.should.equal(200)
                 })
                 it('Applies user limit when in trial mode', async function () {
-                    // Create a couple more users to play with
-                    await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+                    // Create another user to play with
                     await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
 
                     // Create trial team
@@ -1767,18 +1769,10 @@ describe('Billing routes', function () {
             })
             it('Non-admin cannot make team unmanaged', async function () {
                 // Create non-admin user
-                const userBob = await app.factory.createUser({
-                    admin: false,
-                    username: 'bob',
-                    name: 'Bob Skywalker',
-                    email: 'bob@example.com',
-                    password: 'bbPassword'
-                })
-                await login('bob', 'bbPassword')
 
                 // Create trial team
                 const trialTeam = await app.factory.createTeam({ name: generateName('unmanagedSubTeam') })
-                await trialTeam.addUser(userBob, { through: { role: Roles.Owner } })
+                await trialTeam.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
                 await app.factory.createTrialSubscription(trialTeam, -1)
 
                 // Bob tries to make it unmanaged

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -984,6 +984,7 @@ describe('Billing routes', function () {
         describe('Trial Mode', function () {
             let legacyTrialTeamType
             let trialTeamType
+            let trialLimitedTeamType
             let projectType2
             before(async function () {
                 // Create a forbidden second projectType
@@ -1020,6 +1021,21 @@ describe('Billing routes', function () {
                         trial: {
                             active: true,
                             duration: 5
+                        }
+                    }
+                })
+                trialLimitedTeamType = await app.factory.createTeamType({
+                    name: 'trial-limited-type',
+                    properties: {
+                        instances: {
+                            [TestObjects.projectType1.hashid]: { active: true },
+                            [projectType2.hashid]: { active: true }
+                        },
+                        trial: {
+                            active: true,
+                            duration: 5,
+                            usersLimit: 2,
+                            runtimesLimit: 2
                         }
                     }
                 })
@@ -1517,6 +1533,165 @@ describe('Billing routes', function () {
                         cookies: { sid: TestObjects.tokens.alice }
                     })
                     unsuspendResponse.statusCode.should.equal(402)
+                })
+            })
+            describe('Full trial teams - with runtime/user limits', function () {
+                it('Applies runtime limit when creating instances/devices whilst in trial mode', async function () {
+                    // Create trial team
+                    const trialTeam = await app.factory.createTeam({ name: generateName('trialLimitTeam'), TeamTypeId: trialLimitedTeamType.id })
+                    await trialTeam.addUser(TestObjects.alice, { through: { role: Roles.Owner } })
+                    await app.factory.createTrialSubscription(trialTeam)
+
+                    const application = await app.factory.createApplication({ name: generateName('test-app') }, trialTeam)
+
+                    // Create two instances - both should be allowed
+                    let response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/projects',
+                        payload: {
+                            name: generateName('billing-project'),
+                            applicationId: application.hashid,
+                            projectType: TestObjects.projectType1.hashid,
+                            template: TestObjects.template1.hashid,
+                            stack: TestObjects.stack1.hashid
+                        },
+                        cookies: { sid: TestObjects.tokens.alice }
+                    })
+                    response.statusCode.should.equal(200)
+                    const instance1 = response.json()
+
+                    response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/projects',
+                        payload: {
+                            name: generateName('billing-project'),
+                            applicationId: application.hashid,
+                            projectType: TestObjects.projectType1.hashid,
+                            template: TestObjects.template1.hashid,
+                            stack: TestObjects.stack1.hashid
+                        },
+                        cookies: { sid: TestObjects.tokens.alice }
+                    })
+                    response.statusCode.should.equal(200)
+                    const instance2 = response.json()
+
+                    // 3rd instance should be rejected due to trial limit
+                    response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/projects',
+                        payload: {
+                            name: generateName('billing-project'),
+                            applicationId: application.hashid,
+                            projectType: TestObjects.projectType1.hashid,
+                            template: TestObjects.template1.hashid,
+                            stack: TestObjects.stack1.hashid
+                        },
+                        cookies: { sid: TestObjects.tokens.alice }
+                    })
+                    const instance3 = response.json()
+                    response.statusCode.should.equal(400)
+                    instance3.should.have.property('code', 'instance_limit_reached')
+                    // Check we didn't try to update stripe
+                    stripe.subscriptions.update.called.should.be.false()
+
+                    // Given the stub driver a chance to sort itself out
+                    await sleep(250)
+
+                    // delete instance1
+                    await app.inject({
+                        method: 'DELETE',
+                        url: '/api/v1/projects/' + instance1.id,
+                        cookies: { sid: TestObjects.tokens.alice }
+                    })
+
+                    // create instance should now succeed
+                    response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/projects',
+                        payload: {
+                            name: generateName('billing-project'),
+                            applicationId: application.hashid,
+                            projectType: TestObjects.projectType1.hashid,
+                            template: TestObjects.template1.hashid,
+                            stack: TestObjects.stack1.hashid
+                        },
+                        cookies: { sid: TestObjects.tokens.alice }
+                    })
+                    response.statusCode.should.equal(200)
+
+                    // create device should fail
+                    response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/devices',
+                        payload: {
+                            name: generateName('billing-project'),
+                            type: 'test-device',
+                            team: trialTeam.hashid
+                        },
+                        cookies: { sid: TestObjects.tokens.alice }
+                    })
+                    response.statusCode.should.equal(400)
+                    const device1 = response.json()
+                    device1.should.have.property('code', 'device_limit_reached')
+
+                    // Delete instance2
+                    await app.inject({
+                        method: 'DELETE',
+                        url: '/api/v1/projects/' + instance2.id,
+                        cookies: { sid: TestObjects.tokens.alice }
+                    })
+
+                    // create device should succeed
+                    response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/devices',
+                        payload: {
+                            name: generateName('billing-project'),
+                            type: 'test-device',
+                            team: trialTeam.hashid
+                        },
+                        cookies: { sid: TestObjects.tokens.alice }
+                    })
+                    response.statusCode.should.equal(200)
+                })
+                it('Applies user limit when in trial mode', async function () {
+                    // Create a couple more users to play with
+                    await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+                    await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+
+                    // Create trial team
+                    const trialTeam = await app.factory.createTeam({ name: generateName('trialLimitTeam'), TeamTypeId: trialLimitedTeamType.id })
+                    await trialTeam.addUser(TestObjects.alice, { through: { role: Roles.Owner } })
+                    await app.factory.createTrialSubscription(trialTeam)
+
+                    // Alice invite Bob
+                    let response = await app.inject({
+                        method: 'POST',
+                        url: `/api/v1/teams/${trialTeam.hashid}/invitations`,
+                        cookies: { sid: TestObjects.tokens.alice },
+                        payload: {
+                            user: 'bob',
+                            role: Roles.Viewer
+                        }
+                    })
+                    let result = response.json()
+                    result.should.have.property('status', 'okay')
+
+                    ;(await app.db.models.Invitation.findAll()).should.have.lengthOf(1)
+
+                    // Alice invite Chris
+                    response = await app.inject({
+                        method: 'POST',
+                        url: `/api/v1/teams/${trialTeam.hashid}/invitations`,
+                        cookies: { sid: TestObjects.tokens.alice },
+                        payload: {
+                            user: 'chris',
+                            role: Roles.Viewer
+                        }
+                    })
+                    response.statusCode.should.equal(400)
+                    result = response.json()
+                    result.should.have.property('code', 'invitation_failed')
                 })
             })
         })


### PR DESCRIPTION
Closes #3610 

## Description

This allows a TeamType to impose limits on users/runtimes that only apply during the trial phase.

We didn't need this previously as the Trial mode was applied to the Starter team and we applied the same limits to both trial and normal mode.

We want to enable Team tier trial mode, but with a runtime/user limit applied during the trial - which this PR achieves.

 - [x] Update `Team.getRuntimeLimit()` to return the trial period limit if it applies
 - [x] Update `Team.getUserLimit()` to return the trial period limit if it applies
 - [x] Update subscription handling to ensure proper runtime counts are applied when user exits trial mode
 - [x] Update unit tests to ensure limits apply property during trial mode at API level
 - [x] Update UX to block creation of device/instance/invitation if trial limit reached

