### PR TITLE
CI: Add  Serban to the list of slack-github users mapping

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,7 +192,8 @@ jobs:
           "knolleary":"U02248XSR32",
           "joepavitt":"U031G1H5QPR",
           "Pezmc":"U0465FK1ULR",
-          "Steve-Mcl":"U02UQG3RYQ5"
+          "Steve-Mcl":"U02UQG3RYQ5",
+          "sherbastian":"U06SB5MSS3B"
           }'
         default-mapping: C067BD0377F
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,7 +191,6 @@ jobs:
           "hardillb":"U021T9TT2SV",
           "knolleary":"U02248XSR32",
           "joepavitt":"U031G1H5QPR",
-          "Pezmc":"U0465FK1ULR",
           "Steve-Mcl":"U02UQG3RYQ5",
           "sherbastian":"U06SB5MSS3B"
           }'


### PR DESCRIPTION
## Description

This PR adds "sherbastian" GitHub account to the list of slack-github mappings.. This change ensures that "sherbastian" will be correctly mapped to the corresponding Slack user ID and notified on the tests pipeline failure via Slack within FlowFuse workspace. 
Additionally, mapping for Pez has been removed.

## Related Issue(s)


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

