### PR TITLE
ci: Add additional stacks to pre-staging configuration script

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -125,14 +125,30 @@ curl -ks -XPOST \
   -d '{"name":"Default", "description":"DefaultInstanceType","active": true}' \
   https://$FLOWFUSE_URL/api/v1/project-types/
 
-### Create stack
-echo "Creating stack"
-projectTypeId=$(curl -ks -XGET -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" https://$FLOWFUSE_URL/api/v1/project-types/ | jq -r '.types[].id')
-curl -ks -XPOST \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" \
-  -d '{"name":"Default","label":"Default", "projectType":"'"$projectTypeId"'","properties":{ "cpu":10,"memory":256,"container":"flowfuse/node-red"}}' \
-  https://$FLOWFUSE_URL/api/v1/stacks/
+# ### Create default stack
+# echo "Creating default stack"
+# projectTypeId=$(curl -ks -XGET -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" https://$FLOWFUSE_URL/api/v1/project-types/ | jq -r '.types[].id')
+# curl -ks -XPOST \
+#   -H "Content-Type: application/json" \
+#   -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" \
+#   -d '{"name":"Default","label":"Default", "projectType":"'"$projectTypeId"'","properties":{ "cpu":10,"memory":256,"container":"flowfuse/node-red"}}' \
+#   https://$FLOWFUSE_URL/api/v1/stacks/
+
+create_stack() {
+  local STACK_NAME=$1
+  local STACK_CPU=$2
+  local STACK_MEMORY=$3
+  local STACK_CONTAINER=$4
+  echo "Creating $STACK_NAME stack"
+  projectTypeId=$(curl -ks -XGET -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" https://$FLOWFUSE_URL/api/v1/project-types/ | jq -r '.types[].id')
+  curl -ks -XPOST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" \
+    -d '{"name":"'"$STACK_NAME"'","label":"'"$STACK_NAME"'", "projectType":"'"$projectTypeId"'","properties":{ "cpu":'"$STACK_CPU"',"memory":'"$STACK_MEMORY"',"container":"'"$STACK_CONTAINER"'"}}' \
+    https://$FLOWFUSE_URL/api/v1/stacks/
+}
+
+create_stack "Default" 100 256 "flowfuse/node-red"
 
 ### Link stack to project type
 echo "Linking stack to project type"

--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -123,6 +123,7 @@ kubectl run flowfuse-setup-0 \
   -- psql -h flowfuse-pr-$PR_NUMBER-postgresql -U forge -d flowforge -c \
   "INSERT INTO public.\"Users\" (username,name,email,email_verified,sso_enabled,mfa_enabled,\"password\",password_expired,\"admin\",avatar,tcs_accepted,suspended,\"createdAt\",\"updatedAt\",\"defaultTeamId\") \
     VALUES ('flowfusedeveloper','flowfusedeveloper','noreply@flowfuse.dev',true,false,false,'$INIT_CONFIG_PASSWORD_HASH',false,true,'/avatar/Zmxvd2Z1c2VkZXZlbG9wZXI',NULL,false,'2024-03-15 19:51:49.449+01','2024-03-15 19:51:49.449+01',NULL);"
+
 ### Mark platform as configured
 kubectl run flowfuse-setup-1 \
   --namespace "pr-$PR_NUMBER" \

--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -112,7 +112,7 @@ create_stack() {
     https://$FLOWFUSE_URL/api/v1/stacks/
 }
 
-
+### Create first user
 DBPASSWORD=$(kubectl --namespace "pr-$PR_NUMBER" get secret flowfuse-pr-$PR_NUMBER-postgresql -o jsonpath='{.data.password}' | base64 -d)
 kubectl run flowfuse-setup-0 \
   --namespace "pr-$PR_NUMBER" \
@@ -123,6 +123,7 @@ kubectl run flowfuse-setup-0 \
   -- psql -h flowfuse-pr-$PR_NUMBER-postgresql -U forge -d flowforge -c \
   "INSERT INTO public.\"Users\" (username,name,email,email_verified,sso_enabled,mfa_enabled,\"password\",password_expired,\"admin\",avatar,tcs_accepted,suspended,\"createdAt\",\"updatedAt\",\"defaultTeamId\") \
     VALUES ('flowfusedeveloper','flowfusedeveloper','noreply@flowfuse.dev',true,false,false,'$INIT_CONFIG_PASSWORD_HASH',false,true,'/avatar/Zmxvd2Z1c2VkZXZlbG9wZXI',NULL,false,'2024-03-15 19:51:49.449+01','2024-03-15 19:51:49.449+01',NULL);"
+### Mark platform as configured
 kubectl run flowfuse-setup-1 \
   --namespace "pr-$PR_NUMBER" \
   -it --rm \
@@ -132,6 +133,7 @@ kubectl run flowfuse-setup-1 \
   -- psql -h flowfuse-pr-$PR_NUMBER-postgresql -U forge -d flowforge -c \
   "INSERT INTO public.\"PlatformSettings\" (\"key\",value,\"valueType\",\"createdAt\",\"updatedAt\")\
     VALUES ('setup:initialised','true',1,'2024-03-15 19:51:52.287','2024-03-15 19:51:52.287')"
+### Configure access token
 kubectl run flowfuse-setup-2 \
   --namespace "pr-$PR_NUMBER" \
   -it --rm \

--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -16,7 +16,7 @@ create_user() {
   local PASSWORD="${INIT_CONFIG_PASSWORD}"
 
   echo "Creating $USERNAME user"
-  curl -ks -XPOST \
+  curl -ks -w "\n" -XPOST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" \
     -d '{
@@ -35,7 +35,7 @@ create_team() {
   local TEAM_TYPE_ID
   TEAM_TYPE_ID=$(curl -ks -XGET -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" https://$FLOWFUSE_URL/api/v1/team-types/ | jq -r --arg TYPE "$TEAM_TYPE_SELECTOR" '.types[] | select(.name==$TYPE) | .id')
   echo "Creating $TEAM_NAME team"
-  curl -ks -XPOST \
+  curl -ks -w "\n" -XPOST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" \
     -d '{
@@ -155,7 +155,7 @@ get_latest_image_tag() {
   local TOKEN
   local TAG
   TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${IMAGE}:pull" | jq -r '.token')
-  TAG=$(curl -s -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/${image}/tags/list | jq -r '.tags[]' | grep -vE '^v' | grep "${NR_VERSION}" | sort -rV | head -n 1)
+  TAG=$(curl -s -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/${IMAGE}/tags/list | jq -r '.tags[]' | grep -vE '^v' | grep "${NR_VERSION}" | sort -rV | head -n 1)
   echo "$TAG"
 }
 

--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -87,7 +87,7 @@ create_device() {
   local TEAM_NAME=$3
   TEAM_ID=$(get_team_id "${TEAM_NAME}")
   echo "Creating $DEVICE_NAME@$TEAM_ID device"
-  curl -ks -w "\n" -XPOST \
+  curl -ks -w "\n" -XPOST -o /dev/null \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" \
     -d '{


### PR DESCRIPTION
## Description

This PR extends the existing pre-staging environment setup script by adding additional stacks next to the default one. Additional stacks are providing the possibility to run instances on NodeRED 3.1.x and 4.0.x versions.
Additionally, this PR introduces:
* new line at the end of each API response
* hides the API response on the device creation step

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/3762

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

