### PR TITLE
ci: Update deploy:pr configuration to exclude files in the 'docs' directory

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,3 @@
 deploy:pr:
-- all:
   - changed-files:
-    - any-glob-to-any-file: '*'
-    - all-globs-to-all-files: '!docs/*'
+    - any-glob-to-any-file: '!docs/**'


### PR DESCRIPTION
## Description

This pull request updates the labeler configuration to exclude files in the 'docs' directory from the list of changed files. This ensures that `deploy:pr` label will not be applied on pull requests which introduces changes made only to documentation files.

## Related Issue(s)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

