### PR TITLE
Fix displaying the nr editor while unavailable

### DIFF
--- a/frontend/src/pages/instance/Editor/components/EditorWrapper.vue
+++ b/frontend/src/pages/instance/Editor/components/EditorWrapper.vue
@@ -1,6 +1,6 @@
 <template>
     <section class="editor-wrapper">
-        <div v-if="isInstanceTransitioningStates" class="status-wrapper">
+        <div v-if="shouldDisplayLoadingScreen" class="status-wrapper">
             <InstanceStatusBadge
                 :status="instance.meta?.state"
                 :optimisticStateChange="instance.optimisticStateChange"
@@ -24,7 +24,16 @@
 
 <script>
 import InstanceStatusBadge from '../../components/InstanceStatusBadge.vue'
-
+const States = {
+    STOPPED: 'stopped',
+    LOADING: 'loading',
+    INSTALLING: 'installing',
+    STARTING: 'starting',
+    RUNNING: 'running',
+    SAFE: 'safe',
+    CRASHED: 'crashed',
+    STOPPING: 'stopping'
+}
 export default {
     name: 'EditorWrapper',
     components: { InstanceStatusBadge },
@@ -42,7 +51,16 @@ export default {
         isInstanceTransitioningStates () {
             const pendingState = (Object.hasOwnProperty.call(this.instance, 'pendingStateChange') && this.instance.pendingStateChange)
             const optimisticStateChange = (Object.hasOwnProperty.call(this.instance, 'optimisticStateChange') && this.instance.optimisticStateChange)
-            return pendingState || optimisticStateChange || ['starting', 'suspended', 'suspending'].includes(this.instance.meta?.state)
+
+            return pendingState || optimisticStateChange
+        },
+        shouldDisplayLoadingScreen () {
+            const unsafeStates = [
+                ...Object.values(States).filter(state => [States.RUNNING, state.SAFE].includes(state)),
+                ...['suspending', 'suspended']
+            ]
+
+            return this.isInstanceTransitioningStates || unsafeStates.includes(this.instance.meta?.state)
         }
     },
     mounted () {

--- a/frontend/src/pages/instance/Editor/components/EditorWrapper.vue
+++ b/frontend/src/pages/instance/Editor/components/EditorWrapper.vue
@@ -56,7 +56,7 @@ export default {
         },
         shouldDisplayLoadingScreen () {
             const unsafeStates = [
-                ...Object.values(States).filter(state => [States.RUNNING, state.SAFE].includes(state)),
+                ...Object.values(States).filter(state => ![States.RUNNING, States.SAFE].includes(state)),
                 ...['suspending', 'suspended']
             ]
 


### PR DESCRIPTION
## Description

Display the instance status badge instead of the actual editor when the editor is unavailable in the immersive editor page

## Related Issue(s)

closes #3787 

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] ~~Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->~~
  - no suitable way to e2e test this feature at the moment
 - [ ] ~~Documentation has been updated~~
    - [ ] ~~Upgrade instructions~~
    - [ ] ~~Configuration details~~
    - [ ] ~~Concepts~~
 - [ ] ~~Changes `flowforge.yml`?~~
    - [ ] ~~Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template~~
    - [ ] ~~Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production~~

## Labels

 - [ ] ~~Backport needed? -> add the `backport` label~~
 - [ ] ~~Includes a DB migration? -> add the `area:migration` label~~

