### PR TITLE
Alter instance editor links pointing to the immersive editor to point to the default editor

### DIFF
--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -43,10 +43,15 @@ export default {
             required: true
         }
     },
+    data () {
+        return {
+            canUseImmersiveEditor: false
+        }
+    },
     computed: {
         ...mapState('account', ['team', 'teamMembership']),
         isImmersiveEditor () {
-            return SemVer.satisfies(SemVer.coerce(this.instance?.meta?.versions?.launcher), '>=2.3.1')
+            return this.canUseImmersiveEditor && SemVer.satisfies(SemVer.coerce(this.instance?.meta?.versions?.launcher), '>=2.3.1')
         },
         url () {
             if (this.isImmersiveEditor) {

--- a/test/e2e/frontend/cypress/tests/instances/editor.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances/editor.spec.js
@@ -54,12 +54,12 @@ describe('FlowForge - Instance editor', () => {
 
         cy.get('[data-action="open-editor"]')
             .children()
-            .should('not.exist')
+            .should('exist') // todo revert when the editor is ready
 
-        cy.get('[data-action="open-editor"]').click()
-
-        cy.get('[data-el="editor-iframe"]').should('exist')
-        cy.get('[data-el="tabs-drawer"]').should('exist')
+        // cy.get('[data-action="open-editor"]').click()
+        //
+        // cy.get('[data-el="editor-iframe"]').should('exist')
+        // cy.get('[data-el="tabs-drawer"]').should('exist')
     })
 
     it('has working drawer navigation tabs', () => {


### PR DESCRIPTION
## Description

Force instance editor links to point to the standard node-red editor instead of the immersive version until we can configure node-red instances to include CSP headers

## Related Issue(s)

closes #3786 

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] ~~Documentation has been updated~~
    - [ ] ~~Upgrade instructions~~
    - [ ] ~~Configuration details~~
    - [ ] ~~Concepts~~
 - [ ] ~~Changes `flowforge.yml`?~~
    - [ ] ~~Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template~~
    - [ ] ~~Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production~~

## Labels

 - [ ] ~~Backport needed? -> add the `backport` label~~
 - [ ] ~~Includes a DB migration? -> add the `area:migration` label~~

