### PR TITLE
Add redirect for /project/xyz to /instance/xyz

### DIFF
--- a/frontend/src/pages/instance/routes.js
+++ b/frontend/src/pages/instance/routes.js
@@ -68,6 +68,12 @@ export { children }
 
 export default [
     {
+        path: '/project/:id/:remaining*',
+        redirect: to => {
+            return { name: 'Instance', params: to.params }
+        }
+    },
+    {
         path: '/instance/:id/:remaining*',
         redirect: to => {
             return { name: 'instance-overview', params: { id: to.params.id } }


### PR DESCRIPTION
Fixes #3799 

The `nr-launcher` includes a link to the FF application in the format `/project/:id`. At some point, that has started to 404. This adds a redirect in place so it gets to the right place.

~I'll raise a separate PR on `nr-launcher` to use the right url to start with.~ already done via https://github.com/FlowFuse/nr-launcher/pull/229