### PR TITLE
Remove coverage reporting of frontend tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Run Linting Tests
         run: npm run lint
       - name: Run UI Unit Tests
-        run: npm run cover:unit:frontend
+        run: npm run test:unit:frontend
       - name: Run UI E2E (Cypress) Tests - OS
         uses: cypress-io/github-action@v4
         with:
@@ -169,11 +169,11 @@ jobs:
           path: |
             test/e2e/frontend/cypress/screenshots
             test/e2e/frontend/cypress/videos
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: frontend
+      # - name: Upload coverage reports to Codecov
+      #   uses: codecov/codecov-action@v3
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     flags: frontend
 
   notify-slack:
     name: Notify on failure


### PR DESCRIPTION
As discussed in Eng Team, removing coverage reporting of frontend code given the lack of capability to do so with cypress. So rather than having lots of false-flag coverage failures, this should keep the focus on our coverage we are able to progress.