### PR TITLE
Generate snapshot-specific filename on download

### DIFF
--- a/config/cypress-shared.config.js
+++ b/config/cypress-shared.config.js
@@ -1,3 +1,5 @@
+const { readdir } = require('fs/promises')
+
 module.exports = {
     viewportWidth: 1024,
     viewportHeight: 768,
@@ -7,6 +9,35 @@ module.exports = {
         fixturesFolder: 'test/e2e/frontend/cypress/fixtures',
         screenshotsFolder: 'test/e2e/frontend/cypress/screenshots',
         supportFile: 'test/e2e/frontend/cypress/support/index.js',
-        videosFolder: 'test/e2e/frontend/cypress/videos'
+        videosFolder: 'test/e2e/frontend/cypress/videos',
+        setupNodeEvents (on, config) {
+            on('task', {
+                // Check if a file exists in a dir. Unlike cypress readFile,
+                // this can be used with a regex for 'fileName'
+                fileExists (options) {
+                    const baseDir = options.dir
+                    let fileName = options.file
+                    let debug = ''
+                    return readdir(baseDir).then(files => {
+                        if (options.file) {
+                            return files.includes(options.file)
+                        } else if (options.fileRE) {
+                            const re = new RegExp(options.fileRE)
+                            fileName = re.toString()
+                            // fileName looks like a regex
+                            debug = debug + JSON.stringify(files)
+                            const filteredList = files.filter(file => !!file.match(re))
+                            return filteredList.length === 1
+                        }
+                        return false
+                    }).then(result => {
+                        if (!result) {
+                            throw new Error(`${fileName} not found in ${baseDir} ${debug}`)
+                        }
+                        return true
+                    })
+                }
+            })
+        }
     }
 }

--- a/frontend/src/pages/instance/Snapshots/dialogs/SnapshotExportDialog.vue
+++ b/frontend/src/pages/instance/Snapshots/dialogs/SnapshotExportDialog.vue
@@ -104,7 +104,8 @@ export default {
                 snapshotApi.exportInstanceSnapshot(this.project.id, this.snapshot.id, opts).then((data) => {
                     return data
                 }).then(data => {
-                    this.download(data, 'snapshot.json')
+                    const snapshotDate = this.snapshot.updatedAt.replace(/[-:]/g, '').replace(/\..*$/, '').replace('T', '-')
+                    this.download(data, `snapshot-${this.snapshot.id}-${snapshotDate}.json`)
                     alerts.emit('Snapshot exported.', 'confirmation')
                     this.$refs.dialog.close()
                 }).catch(err => {
@@ -131,7 +132,7 @@ export default {
                 document.body.removeChild(element)
             }
         },
-        generateRandomKey (length = 32) {
+        generateRandomKey (length = 16) {
             const array = new Uint8Array(length)
             window.crypto.getRandomValues(array)
             return Array.from(array, byte => ('0' + (byte & 0xFF).toString(16)).slice(-2)).join('')


### PR DESCRIPTION
Closes #3813 

Generates a snapshot-specific filename rather than hardcoding to `snapshot.json`, in the format: `snapshot-<id>-<date>-<time>.json`. For example: `snapshot-WYNXyNORQK-20240122-175224.json`

Also reduced the generated cred secret length to be a bit more manageable.