### PR TITLE
Fix migations for non-ee installs

### DIFF
--- a/forge/db/migrations/20231207-01-EE-add-to-flow-template-table.js
+++ b/forge/db/migrations/20231207-01-EE-add-to-flow-template-table.js
@@ -10,7 +10,7 @@ module.exports = {
     up: async (context) => {
         const tableExists = await context.tableExists('FlowTemplates')
         if (!tableExists) {
-            return context.sequelize.log('Skipping Subscription migration as table does not exist')
+            return context.sequelize.log('Skipping FlowTemplates migration as table does not exist')
         }
 
         await context.addColumn('FlowTemplates', 'icon', {

--- a/forge/db/migrations/20240325-01-add-teamTypeScope-to-FlowTemplates.js
+++ b/forge/db/migrations/20240325-01-add-teamTypeScope-to-FlowTemplates.js
@@ -11,11 +11,14 @@ module.exports = {
      * @param {QueryInterface} context Sequelize.QueryInterface
      */
     up: async (context) => {
-        await context.addColumn('FlowTemplates', 'teamTypeScope', {
-            type: DataTypes.TEXT,
-            allowNull: true,
-            defaultValue: null
-        })
+        const tableExists = await context.tableExists('FlowTemplates')
+        if (tableExists) {
+            await context.addColumn('FlowTemplates', 'teamTypeScope', {
+                type: DataTypes.TEXT,
+                allowNull: true,
+                defaultValue: null
+            })
+        }
     },
     down: async (context) => {
     }


### PR DESCRIPTION
Fixes #3811 

PR https://github.com/FlowFuse/flowfuse/pull/3645 introduced a migration on an EE-only model without a check the DB table exists.

For clean installs of 2.1 or later, this wouldn't be a problem because of the baseline migration we added in 2.1.0 that initialises all expected tables for an empty database. The idea was to remove the need to have lots of guards in future migrations. However that baseline wasn't intended to also help upgrade an existing database. And that's what this PR addresses.

For someone who installed pre 2.1.0, without an EE license, they won't have some of the EE tables. This PR does two things:

1. adds a table guard in the existing migration
2. adds a new migration that checks the existence of each EE table and creates it if needed

The net result will be the db structure *should* be identical for OSS and EE installs so future migrations don't have to worry about that.