### PR TITLE
Validate pipeline stage ownership on update

### DIFF
--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -23,14 +23,13 @@ module.exports = {
      * @param {String} [options.deviceGroupId] The ID of the device group to deploy to
      * @param {Boolean} [options.deployToDevices] Whether to deploy to devices of the source stage
      */
-    updatePipelineStage: async function (app, stageId, options) {
+    updatePipelineStage: async function (app, pipeline, stageId, options) {
         const stage = await app.db.models.PipelineStage.byId(stageId)
         if (!stage) {
             throw new PipelineControllerError('not_found', 'Pipeline stage not found', 404)
         }
-        const pipeline = await app.db.models.Pipeline.byId(stage.PipelineId)
-        if (!pipeline) {
-            throw new PipelineControllerError('not_found', 'Pipeline not found', 404)
+        if (stage.PipelineId !== pipeline.id) {
+            throw new PipelineControllerError('not_found', 'Pipeline stage not found', 404)
         }
 
         if (options.name) {

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -369,6 +369,7 @@ module.exports = async function (app) {
             }
 
             const stage = await app.db.controllers.Pipeline.updatePipelineStage(
+                request.pipeline,
                 request.params.stageId,
                 options
             )

--- a/test/unit/forge/ee/routes/api/pipeline_spec.js
+++ b/test/unit/forge/ee/routes/api/pipeline_spec.js
@@ -681,6 +681,24 @@ describe('Pipelines API', function () {
 
                 response.statusCode.should.equal(200)
             })
+            it('Should fail if the pipeline does not contain the request stage', async function () {
+                const pipelineId = TestObjects.pipelineDevices.hashid
+                const stageId = TestObjects.stageOne.hashid
+
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/pipelines/${pipelineId}/stages/${stageId}`,
+                    payload: {
+                        name: 'New Name'
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+
+                })
+
+                const body = await response.json()
+                body.should.have.property('code', 'not_found')
+                response.statusCode.should.equal(404)
+            })
         })
 
         describe('With a new instance', function () {


### PR DESCRIPTION
Ensures the pipeline stage belongs to the pipeline in the update api.

Adds unit test for same.