### PR TITLE
Hide environment variable add/import buttons in read-only mode

### DIFF
--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -17,15 +17,17 @@
                 :noDataMessage="noDataMessage"
             >
                 <template #actions>
-                    <input id="fileUpload" ref="fileUpload" type="file" accept=".env, text/plain, *" class="hidden" hidden>
-                    <ff-button kind="secondary" @click="importEnv">
-                        <template #icon><DocumentDownloadIcon /></template>
-                        <span class="hidden sm:flex pl-1">Import .env</span>
-                    </ff-button>
-                    <ff-button kind="primary" accesskey="a" @click="addVarHandler">
-                        <template #icon><PlusSmIcon /></template>
-                        <span class="hidden sm:flex pl-1">Add variable</span>
-                    </ff-button>
+                    <template v-if="!readOnly">
+                        <input id="fileUpload" ref="fileUpload" type="file" accept=".env, text/plain, *" class="hidden" hidden>
+                        <ff-button kind="secondary" @click="importEnv">
+                            <template #icon><DocumentDownloadIcon /></template>
+                            <span class="hidden sm:flex pl-1">Import .env</span>
+                        </ff-button>
+                        <ff-button kind="primary" accesskey="a" @click="addVarHandler">
+                            <template #icon><PlusSmIcon /></template>
+                            <span class="hidden sm:flex pl-1">Add variable</span>
+                        </ff-button>
+                    </template>
                 </template>
                 <template #header>
                     <ff-data-table-row class="font-medium">


### PR DESCRIPTION
When logged in as a Viewer role user, the instance env var table still has the add/import buttons which are semi-functional. But as the Viewer role cannot save any chances, they should not see these buttons at all.

This PR hides those actions if the table is in read-only mode.