### PR TITLE
Remove project nodes from built-in list so they can be upgraded

### DIFF
--- a/forge/lib/builtInModules.js
+++ b/forge/lib/builtInModules.js
@@ -1,9 +1,7 @@
 // These are the modules we preinstall that Node-RED will report back in its
-// runtime settings.
+// runtime settings that we don't want to appear in snapshots/settings
 
 const BUILT_IN_MODULES = [
-    '@flowforge/nr-project-nodes',
-    '@flowfuse/nr-project-nodes',
     '@flowforge/nr-file-nodes',
     '@flowfuse/nr-file-nodes'
 ]


### PR DESCRIPTION
Part of #3816

## Description

This removes project-nodes from our list of built-in modules. This list was used to filter what modules we'd present in the settings/palette view. However, by doing that, we made it hard for the user to update the nodes.

On reflection, there is nothing wrong with the user being able to see and edit the project nodes version. As a consequence of this change:

1. A user will be able to upgrade the project nodes in their instance (without needing a stack update)
2. If the user updates, the settings/palette view will list what they have installed.
3. If a user *deletes* project nodes from the settings/palette view and restarts, it will revert to the version of the nodes baked into the stack.

