### PR TITLE
Fix the immersive editor dashboard button

### DIFF
--- a/frontend/src/pages/instance/Editor/index.vue
+++ b/frontend/src/pages/instance/Editor/index.vue
@@ -32,7 +32,7 @@
                 </div>
                 <ff-tabs :tabs="navigation" class="tabs" />
                 <div class="side-actions">
-                    <DashboardLink v-if="instance.settings?.dashboard2UI" :instance="instance" />
+                    <DashboardLink v-if="instance.settings?.dashboard2UI" :instance="instance" :disabled="!editorAvailable" />
                     <InstanceActionsButton :instance="instance" @instance-deleted="onInstanceDelete" />
                     <a :href="instance.url">
                         <ExternalLinkIcon class="ff-btn--icon" />
@@ -139,6 +139,9 @@ export default {
                     tag: 'instance-settings'
                 }
             ]
+        },
+        editorAvailable () {
+            return !this.isHA && this.instanceRunning
         }
     },
     mounted () {


### PR DESCRIPTION
## Description

Fixes the immersive editor's dashboard button by disabling it when the instance is not available/

## Related Issue(s)

closes #3789 

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] ~~Documentation has been updated~~
    - [ ] ~~Upgrade instructions~~
    - [ ] ~~Configuration details~~
    - [ ] ~~Concepts~~
 - [ ] ~~Changes `flowforge.yml`?~~
    - [ ] ~~Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template~~
    - [ ] ~~Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production~~

## Labels

 - [ ] ~~Includes a DB migration? -> add the `area:migration` label~~

