### PR TITLE
Remove 'other' option from sign-up form

### DIFF
--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -114,8 +114,7 @@ export default {
             reasons: [
                 { label: 'Business Needs', value: 'business' },
                 { label: 'Personal Use', value: 'personal' },
-                { label: 'Educational Use', value: 'education' },
-                { label: 'Other', value: 'other' }
+                { label: 'Educational Use', value: 'education' }
             ]
         }
     },


### PR DESCRIPTION
Following strategy review, agreed to removed the 'other' option from the sign-up form.