### PR TITLE
Remove licensing page and redirect to pricing page

### DIFF
--- a/docs/admin/licensing.md
+++ b/docs/admin/licensing.md
@@ -1,51 +1,6 @@
-# FlowFuse Licensing
-
-## Open-Source
-
-FlowFuse's open-source edition is free to use.
-It is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
-
-## Features
-
-The following features are available in the Open-Source version of FlowFuse:
-
-* Maximum Users: 150
-* Maximum Teams: 50
-* Maximum Projects: 50
-* Maximum Devices: 50
-
-Please note that the above limits are per instance of FlowFuse and are subject to change.
-Please refer to https://flowfuse.com/pricing/ for up-to-date information.
-
-## Premium
-
-With a FlowFuse Premium License, you get additional features and professional support.
-
-### Features
-
-The following features are available in FlowFuse Premium:
-
-* Unlimited Users[^User-Limit]
-* Unlimited Teams[^Team-Limit]
-* Unlimited Node-RED Instances[^Instance-Limit]
-* Unlimited Devices[^Device-Limit]
-* License Overage[^License-Overage]
-* Uninterrupted Service[^License-Expiry]
-* Single Sign-On (SSO)
-* Transparent Inter-instance Communication[^intercommunication]
-* Persistent Context Storage[^Context-Storage]
-* Shared Team Library
-* Ticket-Based Support[^Support]
-* Long-Term Support
-
-[^User-Limit]: The number of users is determined by the license purchased.
-[^Team-Limit]: The number of Teams is determined by the license purchased.
-[^Instance-Limit]: The number of Node-RED instances is determined by the license purchased.
-[^Device-Limit]: The number of devices is determined by the license purchased.
-[^License-Overage]: The Premium License permits the platform to continue to operate even if the license limits are exceeded. This is to allow for smooth and continuous operation. Overage will be logged and reported to the license holder and FlowForge Inc. The license holder will need to level up their license at the next available opportunity.
-[^License-Expiry]: The Premium License is valid for 12 months from the date of purchase. The FlowFuse Platform will not halt operation when the license expires, but will continue to operate to allow for smooth and continuous operation. Expiry will be logged and reported to the license holder and FlowForge Inc. The license holder will need to renew the license to continue using the platform or revert to the Open-Source version.
-[^intercommunication]: FlowFuse Project Nodes provide seamless passing of data and messages between your Node-RED instances.
-[^Context-Storage]: The Premium License permits the platform to store context data in a persistent database. This allows for the context data to be retained across Node-RED instance restarts.
-[^Support]: The Premium License provides ticketed support and long-term support. As part of this agreement, Telemetry for Premium Licensed instances is enabled by default and must remain enabled to satisfy the terms of the agreement.
-
-Please refer to https://flowfuse.com/pricing/ for up-to-date information.
+---
+navTitle: Licensing
+redirect:
+  to: /pricing/
+layout: redirect
+---


### PR DESCRIPTION
## Description

Removed the content from the licensing page and set up a redirect to the pricing page for users visiting the licensing page.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

