### PR TITLE
Fix tile-select option sizing

### DIFF
--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -15,7 +15,7 @@
         <ff-loading v-if="loading" message="Updating Team..." />
         <div v-else class="m-auto">
             <form class="space-y-6">
-                <div class="max-w-2xl m-auto">
+                <div>
                     <FormHeading>
                         <template v-if="isTypeChange">
                             Change your team type
@@ -34,7 +34,7 @@
                     </div>
                 </div>
                 <!-- TeamType Type -->
-                <div class="grid grid-1 justify-items-center">
+                <div class="grid grid-1">
                     <ff-tile-selection v-model="input.teamTypeId" data-form="team-type">
                         <ff-tile-selection-option
                             v-for="(teamType, index) in teamTypes" :key="index"
@@ -46,7 +46,7 @@
                         />
                     </ff-tile-selection>
                 </div>
-                <div class="max-w-2xl m-auto">
+                <div>
                     <template v-if="billingEnabled">
                         <div class="mb-8 text-sm text-gray-500 space-y-2">
                             <template v-if="trialMode && !trialHasEnded">

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -13,26 +13,28 @@
     </Teleport>
     <ff-page>
         <ff-loading v-if="loading" message="Updating Team..." />
-        <div v-else class="max-w-2xl m-auto">
+        <div v-else class="m-auto">
             <form class="space-y-6">
-                <FormHeading>
-                    <template v-if="isTypeChange">
-                        Change your team type
-                    </template>
-                    <template v-else>
-                        Select your team type
-                    </template>
-                </FormHeading>
-                <div v-if="isUnmanaged" class="space-y-2">
-                    <p>
-                        Your team type cannot currently be managed from the dashboard.
-                    </p>
-                    <p>
-                        Please contact <a href="https://flowfuse.com/support/" class="underline" target="_blank">Support</a> for help.
-                    </p>
+                <div class="max-w-2xl m-auto">
+                    <FormHeading>
+                        <template v-if="isTypeChange">
+                            Change your team type
+                        </template>
+                        <template v-else>
+                            Select your team type
+                        </template>
+                    </FormHeading>
+                    <div v-if="isUnmanaged" class="space-y-2">
+                        <p>
+                            Your team type cannot currently be managed from the dashboard.
+                        </p>
+                        <p>
+                            Please contact <a href="https://flowfuse.com/support/" class="underline" target="_blank">Support</a> for help.
+                        </p>
+                    </div>
                 </div>
                 <!-- TeamType Type -->
-                <div class="flex flex-wrap gap-1 items-stretch">
+                <div class="grid grid-1 justify-items-center">
                     <ff-tile-selection v-model="input.teamTypeId" data-form="team-type">
                         <ff-tile-selection-option
                             v-for="(teamType, index) in teamTypes" :key="index"
@@ -44,24 +46,26 @@
                         />
                     </ff-tile-selection>
                 </div>
-                <template v-if="billingEnabled">
-                    <div class="mb-8 text-sm text-gray-500 space-y-2">
-                        <template v-if="trialMode && !trialHasEnded">
-                            <p>Setting up billing will bring your free trial to an end</p>
-                        </template>
-                        <p v-if="isTypeChange">Your billing subscription will be updated to reflect the new costs</p>
+                <div class="max-w-2xl m-auto">
+                    <template v-if="billingEnabled">
+                        <div class="mb-8 text-sm text-gray-500 space-y-2">
+                            <template v-if="trialMode && !trialHasEnded">
+                                <p>Setting up billing will bring your free trial to an end</p>
+                            </template>
+                            <p v-if="isTypeChange">Your billing subscription will be updated to reflect the new costs</p>
+                        </div>
+                    </template>
+                    <div class="flex gap-x-4">
+                        <ff-button v-if="isTypeChange" :disabled="!formValid" data-action="change-team-type" @click="updateTeam()">
+                            Change team type
+                        </ff-button>
+                        <ff-button v-else :disabled="!formValid" data-action="setup-team-billing" @click="setupBilling()">
+                            Setup Payment Details
+                        </ff-button>
+                        <ff-button kind="secondary" data-action="cancel-change-team-type" @click="$router.back()">
+                            Cancel
+                        </ff-button>
                     </div>
-                </template>
-                <div class="flex gap-x-4">
-                    <ff-button v-if="isTypeChange" :disabled="!formValid" data-action="change-team-type" @click="updateTeam()">
-                        Change team type
-                    </ff-button>
-                    <ff-button v-else :disabled="!formValid" data-action="setup-team-billing" @click="setupBilling()">
-                        Setup Payment Details
-                    </ff-button>
-                    <ff-button kind="secondary" data-action="cancel-change-team-type" @click="$router.back()">
-                        Cancel
-                    </ff-button>
                 </div>
             </form>
         </div>

--- a/frontend/src/ui-components/components/form/TileSelectionOption.vue
+++ b/frontend/src/ui-components/components/form/TileSelectionOption.vue
@@ -1,35 +1,32 @@
 <template>
-    <div
-        v-ff-tooltip="disabled ? disabledTooltip : undefined"
+    <div ref="input"
+         v-ff-tooltip="disabled ? disabledTooltip : undefined"
+         :class="{'editable': editable, 'disabled': disabled, 'active': selected}"
+         class="ff-tile-selection-option"
+         :style="{'--ff-tile-selection-color': color || null}"
+         tabindex="0"
+         :data-form="`tile-selection-option-${value}`"
+         @click="select(false)"
+         @keydown.space.prevent="select(true)"
     >
-        <div ref="input"
-             :class="{'editable': editable, 'disabled': disabled, 'active': selected}"
-             class="ff-tile-selection-option"
-             :style="{'--ff-tile-selection-color': color || null}"
-             tabindex="0"
-             :data-form="`tile-selection-option-${value}`"
-             @click="select(false)"
-             @keydown.space.prevent="select(true)"
-        >
-            <div class="ff-tile-selection-option--header">
-                <h2>
-                    <PencilAltIcon v-if="editable" class="ff-tile-selection-option--edit" @click="select(true)" />
-                    <slot v-else name="icon"><CheckCircleIcon /></slot>
-                    {{ label }}
-                </h2>
-                <div class="ff-tile-selection-option--price">
-                    <h2>{{ price }}</h2>
-                    <label>{{ priceInterval }}</label>
-                </div>
+        <div class="ff-tile-selection-option--header">
+            <h2>
+                <PencilAltIcon v-if="editable" class="ff-tile-selection-option--edit" @click="select(true)" />
+                <slot v-else name="icon"><CheckCircleIcon /></slot>
+                {{ label }}
+            </h2>
+            <div class="ff-tile-selection-option--price">
+                <h2>{{ price }}</h2>
+                <label>{{ priceInterval }}</label>
             </div>
-            <div v-if="description" class="ff-tile-selection-option--description">
-                <ff-markdown-viewer :content="description" />
-            </div>
-            <div v-if="meta" class="ff-tile-selection-option--meta">
-                <div v-for="(row, $index) in meta" :key="$index">
-                    <span>{{ row.key }}</span>
-                    <span>{{ row.value }}</span>
-                </div>
+        </div>
+        <div v-if="description" class="ff-tile-selection-option--description">
+            <ff-markdown-viewer :content="description" />
+        </div>
+        <div v-if="meta" class="ff-tile-selection-option--meta">
+            <div v-for="(row, $index) in meta" :key="$index">
+                <span>{{ row.key }}</span>
+                <span>{{ row.value }}</span>
             </div>
         </div>
     </div>

--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -650,7 +650,7 @@ li.ff-list-item {
         }
       }
     }
-    &:not(.editable):hover {
+    &:not(.editable):not(.disabled):hover {
       cursor: pointer;
       border: 2px solid var(--ff-tile-selection-color);
     }
@@ -661,7 +661,6 @@ li.ff-list-item {
       }
     }
     &.disabled {
-      pointer-events: none;
       opacity: 0.5;
     }
   }


### PR DESCRIPTION
Whilst working on some improvements around changing team type, I notice the layout of the tile-selection-options was not aligning the vertical sizes.

<img width="300" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/72804d7e-813f-49f3-bbb6-db9db9ff8e19">

On investigation, I found #3249 had wrapped the `tile-selection-option` in a div in order to get `ff-tooltip` working on the option. The wrapping div is then getting the right vertical size, but the option doesn't grow to fill it.

On further digging into *why* the div was added, it was done to get the tooltip working. The reason it wasn't working was a disabled tile-selection-option sets `pointer-events:none`, so the hover state is never triggered to show the tooltip.

This PR removes the wrapping div and modifies the css to remove the need to use `pointer-events: none` in the disabled state.

End result:

<img width="300" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/eb22b807-b585-4041-bd36-0cb51d989297">
