### PR TITLE
Add Blueprints preview

### DIFF
--- a/forge/ee/db/views/FlowTemplate.js
+++ b/forge/ee/db/views/FlowTemplate.js
@@ -11,12 +11,13 @@ module.exports = function (app) {
             icon: { type: 'string' },
             order: { type: 'number' },
             default: { type: 'boolean' },
+            flows: { type: 'array' },
             createdAt: { type: 'string' },
             updatedAt: { type: 'string' }
         }
     })
     function flowBlueprintSummary (blueprint) {
-        return {
+        const newVar = {
             id: blueprint.hashid,
             active: blueprint.active,
             name: blueprint.name,
@@ -25,9 +26,11 @@ module.exports = function (app) {
             icon: blueprint.icon,
             order: blueprint.order,
             default: blueprint.default,
+            flows: blueprint.flows.flows,
             createdAt: blueprint.createdAt,
             updatedAt: blueprint.updatedAt
         }
+        return newVar
     }
 
     app.addSchema({

--- a/frontend/src/components/blueprints/BlueprintTile.vue
+++ b/frontend/src/components/blueprints/BlueprintTile.vue
@@ -12,6 +12,16 @@
                 <CheckCircleIcon class="ff-icon-lg" />
                 <label class="text-green-800">Default</label>
             </div>
+            <ff-button
+                v-if="!editable"
+                data-action="show-blueprint"
+                class="ff-btn--secondary"
+                @click="$refs['dialog'].show()"
+            >
+                <template #icon>
+                    <ProjectIcon />
+                </template>
+            </ff-button>
             <ff-button v-if="!editable" data-action="select-blueprint" @click="choose(blueprint)">
                 Select
             </ff-button>
@@ -19,6 +29,18 @@
                 Edit
             </ff-button>
         </div>
+        <ff-dialog
+            ref="dialog"
+            data-el="preview-blueprint-dialog"
+            :header="`Flow Preview: ${blueprint.name}`"
+            :closeOnConfirm="true"
+            confirmLabel="Close"
+            :canBeCanceled="false"
+        >
+            <template #default>
+                <ff-flow-viewer :flow="blueprint.flows" />
+            </template>
+        </ff-dialog>
     </div>
 </template>
 
@@ -27,12 +49,20 @@ import { CheckCircleIcon, QuestionMarkCircleIcon } from '@heroicons/vue/outline'
 import { defineAsyncComponent } from 'vue'
 import { mapState } from 'vuex'
 
+import ProjectIcon from '../../components/icons/Projects.js'
 import product from '../../services/product.js'
+import FfDialog from '../../ui-components/components/DialogBox.vue'
+import FormRow from '../FormRow.vue'
+import FlowViewer from '../flow-viewer/FlowViewer.vue'
 
 export default {
     name: 'BlueprintTile',
     components: {
-        CheckCircleIcon
+        FfDialog,
+        FormRow,
+        'ff-flow-viewer': FlowViewer,
+        CheckCircleIcon,
+        ProjectIcon
     },
     props: {
         blueprint: {
@@ -90,3 +120,19 @@ export default {
     }
 }
 </script>
+
+<style lang="scss">
+.ff-dialog-container {
+  .ff-dialog-box {
+    max-width: 75rem;
+
+    .ff-dialog-content {
+      padding: 0;
+    }
+
+    .ff-dialog-actions {
+      padding: 5px 15px;
+    }
+  }
+}
+</style>

--- a/frontend/src/stylesheets/components/blueprint-selection.scss
+++ b/frontend/src/stylesheets/components/blueprint-selection.scss
@@ -77,6 +77,7 @@
 .ff-blueprint-tile--actions {
     width: 100%;
     display: flex;
+    gap: 5px;
     padding: 0 $ff-unit-sm $ff-unit-md;
     align-items: center;
 }

--- a/frontend/src/ui-components/components/DialogBox.vue
+++ b/frontend/src/ui-components/components/DialogBox.vue
@@ -1,13 +1,13 @@
 <template>
     <div ref="container" class="ff-dialog-container" :class="'ff-dialog-container--' + (open ? 'open' : 'closed')">
-        <div class="ff-dialog-box" :class="boxClass">
+        <div v-click-outside="close" class="ff-dialog-box" :class="boxClass">
             <div class="ff-dialog-header" data-sentry-unmask>{{ header }}</div>
             <div ref="content" class="ff-dialog-content" :class="contentClass">
                 <slot></slot>
             </div>
             <div class="ff-dialog-actions">
                 <slot name="actions">
-                    <ff-button kind="secondary" data-action="dialog-cancel" @click="cancel()">Cancel</ff-button>
+                    <ff-button v-if="canBeCanceled" kind="secondary" data-action="dialog-cancel" @click="cancel()">Cancel</ff-button>
                     <ff-button :kind="kind" data-action="dialog-confirm" :disabled="disablePrimary" @click="confirm()">{{ confirmLabel }}</ff-button>
                 </slot>
             </div>
@@ -46,6 +46,10 @@ export default {
         contentClass: {
             type: String,
             default: ''
+        },
+        canBeCanceled: {
+            type: Boolean,
+            default: true
         }
     },
     emits: ['cancel', 'confirm'],


### PR DESCRIPTION
## Description

Adding support to preview blueprints using the flow-renderer across blueprint tiles

## Related Issue(s)

closes #3838

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] ~~Documentation has been updated~~
    - [ ] ~~Upgrade instructions~~
    - [ ] ~~Configuration details~~
    - [ ] ~~Concepts~~
 - [ ] ~~Changes `flowforge.yml`?~~
    - [ ] ~~Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template~~
    - [ ] ~~Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production~~

## Labels

 - [ ] ~~Includes a DB migration? -> add the `area:migration` label~~

