### PR TITLE
Backend API for Upload A Snapshot 

### DIFF
--- a/forge/auditLog/application.js
+++ b/forge/auditLog/application.js
@@ -32,6 +32,9 @@ module.exports = {
                     async exported (actionedBy, error, application, device, snapshot) {
                         await log('application.device.snapshot.exported', actionedBy, application?.id, generateBody({ error, device, snapshot }))
                     },
+                    async imported (actionedBy, error, application, device, sourceProject, sourceDevice, snapshot) {
+                        await log('application.device.snapshot.imported', actionedBy, application?.id, generateBody({ error, device, sourceProject, sourceDevice, snapshot }))
+                    },
                     async deviceTargetSet (actionedBy, error, application, device, snapshot) {
                         await log('application.device.snapshot.device-target-set', actionedBy, application?.id, generateBody({ error, device, snapshot }))
                     }

--- a/forge/db/controllers/Snapshot.js
+++ b/forge/db/controllers/Snapshot.js
@@ -167,7 +167,6 @@ module.exports = {
         })
         // store the snapshot
         const newSnapshot = await app.db.models.ProjectSnapshot.create(snapshotOptions)
-        await newSnapshot.save()
         return newSnapshot
     }
 }

--- a/forge/db/controllers/Snapshot.js
+++ b/forge/db/controllers/Snapshot.js
@@ -106,5 +106,68 @@ module.exports = {
 
         await snapshot.destroy()
         return true
+    },
+
+    /**
+     * Upload a snapshot
+     * @param {*} app - app instance
+     * @param {*} owner - project/device-originator of this snapshot
+     * @param {*} snapshotData - snapshot data
+     */
+    async uploadSnapshot (app, owner, snapshot, credentialSecret, user) {
+        // 1. If the snapshot includes credentials but no credentialSecret, we should reject it
+        // 2. if the snapshot includes credentials and a credentialSecret, we should validate the secret
+        if (snapshot.flows.credentials?.$) {
+            if (!credentialSecret) {
+                throw new Error('Missing credentialSecret')
+            }
+            // validate the secret by trying to decrypt and re-encrypt the credentials using the provided secret
+            // if the secret is invalid, this will throw an error
+            app.db.controllers.Project.exportCredentials(snapshot.flows.credentials, credentialSecret, credentialSecret)
+        }
+
+        // use the project/device's credentialSecret if none is provided
+        if (!credentialSecret) {
+            credentialSecret = owner.credentialSecret || (owner.getCredentialSecret && await owner.getCredentialSecret())
+        }
+
+        let ownerType
+        if (owner.constructor.name === 'Project') {
+            ownerType = 'instance'
+        } else if (owner.constructor.name === 'Device') {
+            ownerType = 'device'
+        } else {
+            throw new Error('Invalid owner type')
+        }
+        const ProjectId = ownerType === 'instance' ? owner.id : null
+        const DeviceId = ownerType === 'device' ? owner.id : null
+
+        const snapshotOptions = {
+            name: snapshot.name,
+            description: snapshot.description || '',
+            credentialSecret,
+            settings: {
+                settings: snapshot.settings || {},
+                env: snapshot.env || {},
+                modules: snapshot.modules || {}
+            },
+            flows: {
+                flows: snapshot.flows.flows || [],
+                credentials: snapshot.flows.credentials || { }
+            },
+            ProjectId,
+            DeviceId,
+            UserId: user.id
+        }
+        // remove an env vars that start with FF_ from the snapshot
+        Object.keys(snapshotOptions.settings.env).forEach((key) => {
+            if (key.startsWith('FF_')) {
+                delete snapshotOptions.settings.env[key]
+            }
+        })
+        // store the snapshot
+        const newSnapshot = await app.db.models.ProjectSnapshot.create(snapshotOptions)
+        await newSnapshot.save()
+        return newSnapshot
     }
 }

--- a/forge/db/controllers/Snapshot.js
+++ b/forge/db/controllers/Snapshot.js
@@ -109,10 +109,12 @@ module.exports = {
     },
 
     /**
-     * Upload a snapshot
+     * Upload a snapshot.
      * @param {*} app - app instance
      * @param {*} owner - project/device-originator of this snapshot
-     * @param {*} snapshotData - snapshot data
+     * @param {*} snapshot - snapshot data
+     * @param {String} credentialSecret - secret to encrypt credentials with. Can be null if the snapshot does not contain credentials.
+     * @param {*} user - user who uploaded the snapshot
      */
     async uploadSnapshot (app, owner, snapshot, credentialSecret, user) {
         // 1. If the snapshot includes credentials but no credentialSecret, we should reject it

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -84,6 +84,7 @@ const Permissions = {
     'snapshot:full': { description: 'View full snapshot details excluding credentials', role: Roles.Member },
     'snapshot:export': { description: 'Export a snapshot including credentials', role: Roles.Member },
     'snapshot:delete': { description: 'Delete a Snapshot', role: Roles.Owner },
+    'snapshot:import': { description: 'Import a Snapshot', role: Roles.Owner },
 
     // Project Types
     'project-type:create': { description: 'Create a ProjectType', role: Roles.Admin },

--- a/forge/routes/api/snapshot.js
+++ b/forge/routes/api/snapshot.js
@@ -19,19 +19,8 @@ module.exports = async function (app) {
         try {
             request.ownerType = null
             request.owner = null
-            if (request.body.ownerId && request.body.ownerType && request.body.snapshot) {
-                // upload route:- /import
-                if (request.body.ownerType === 'device') {
-                    request.owner = await app.db.models.Device.byId(request.body.ownerId)
-                    request.ownerType = 'device'
-                } else if (request.body.ownerType === 'instance') {
-                    request.owner = await app.db.models.Project.byId(request.body.ownerId)
-                    request.ownerType = 'instance'
-                } else {
-                    return reply.code(400).send({ code: 'bad_request', error: 'Invalid ownerType' })
-                }
-            } else if (request.params.id) {
-                // All other routes
+            if (request.params.id) {
+                // non upload route
                 request.snapshot = await app.db.models.ProjectSnapshot.byId(request.params.id)
                 if (!request.snapshot) {
                     return reply.code(404).send({ code: 'not_found', error: 'Not Found' })
@@ -50,9 +39,17 @@ module.exports = async function (app) {
                 } else {
                     return reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                 }
-            } else {
-                // invalid request
-                return reply.code(400).send({ code: 'bad_request', error: 'Invalid request' })
+            } else if (request.body.ownerId && request.body.ownerType && request.body.snapshot) {
+                // upload route
+                if (request.body.ownerType === 'device') {
+                    request.owner = await app.db.models.Device.byId(request.body.ownerId)
+                    request.ownerType = 'device'
+                } else if (request.body.ownerType === 'instance') {
+                    request.owner = await app.db.models.Project.byId(request.body.ownerId)
+                    request.ownerType = 'instance'
+                } else {
+                    return reply.code(400).send({ code: 'bad_request', error: 'Invalid ownerType' })
+                }
             }
             if (request.session.User) {
                 request.teamMembership = await request.session.User.getTeamMembership(request.owner.TeamId)

--- a/forge/routes/api/snapshot.js
+++ b/forge/routes/api/snapshot.js
@@ -19,7 +19,19 @@ module.exports = async function (app) {
         try {
             request.ownerType = null
             request.owner = null
-            if (request.params.id) {
+            if (request.body.ownerId && request.body.ownerType && request.body.snapshot) {
+                // upload route:- /import
+                if (request.body.ownerType === 'device') {
+                    request.owner = await app.db.models.Device.byId(request.body.ownerId)
+                    request.ownerType = 'device'
+                } else if (request.body.ownerType === 'instance') {
+                    request.owner = await app.db.models.Project.byId(request.body.ownerId)
+                    request.ownerType = 'instance'
+                } else {
+                    return reply.code(400).send({ code: 'bad_request', error: 'Invalid ownerType' })
+                }
+            } else if (request.params.id) {
+                // All other routes
                 request.snapshot = await app.db.models.ProjectSnapshot.byId(request.params.id)
                 if (!request.snapshot) {
                     return reply.code(404).send({ code: 'not_found', error: 'Not Found' })
@@ -38,6 +50,9 @@ module.exports = async function (app) {
                 } else {
                     return reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                 }
+            } else {
+                // invalid request
+                return reply.code(400).send({ code: 'bad_request', error: 'Invalid request' })
             }
             if (request.session.User) {
                 request.teamMembership = await request.session.User.getTeamMembership(request.owner.TeamId)
@@ -196,6 +211,90 @@ module.exports = async function (app) {
             reply.send(snapshotExport)
         } else {
             reply.send({})
+        }
+    })
+
+    /**
+     * Import a snapshot
+     */
+    app.post('/import', {
+        preHandler: app.needsPermission('snapshot:import'),
+        schema: {
+            summary: 'Upload a snapshot',
+            tags: ['Snapshots'],
+            body: {
+                type: 'object',
+                properties: {
+                    ownerId: { type: 'string' },
+                    ownerType: { type: 'string' },
+                    snapshot: {
+                        type: 'object',
+                        properties: {
+                            name: { type: 'string' },
+                            description: { type: 'string' },
+                            flows: {
+                                type: 'object',
+                                properties: {
+                                    flows: { type: 'array', items: {}, minItems: 0 },
+                                    credentials: { type: 'object' }
+                                },
+                                required: ['flows']
+                            },
+                            settings: {
+                                type: 'object',
+                                properties: {
+                                    settings: { type: 'object' },
+                                    env: { type: 'object' },
+                                    modules: { type: 'object' }
+                                },
+                                required: []
+                            }
+                        },
+                        required: ['name', 'flows', 'settings']
+                    },
+                    credentialSecret: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'Snapshot'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        const owner = request.owner
+        const snapshot = request.body.snapshot
+        if (!owner || !snapshot) {
+            reply.code(400).send({ code: 'bad_request', error: 'owner and snapshot are mandatory in the body' })
+            return
+        }
+        if (snapshot.flows.credentials?.$ && !request.body.credentialSecret) {
+            reply.code(400).send({ code: 'bad_request', error: 'Credential secret is required when importing a snapshot with credentials' })
+            return
+        }
+        try {
+            const newSnapshot = await snapshotController.uploadSnapshot(owner, snapshot, request.body.credentialSecret, request.session.User)
+            if (!newSnapshot) {
+                throw new Error('Failed to upload snapshot')
+            }
+            // reload the snapshot to get the full details, including the User & Device/Project
+            await newSnapshot.reload({ include: ['User', 'Device', 'Project'] })
+            if (request.ownerType === 'device') {
+                const application = await owner.getApplication()
+                await applicationLogger.application.device.snapshot.imported(request.session.User, null, application, owner, null, null, newSnapshot)
+            } else if (request.ownerType === 'instance') {
+                await projectLogger.project.snapshot.imported(request.session.User, null, owner, null, null, newSnapshot)
+            }
+            reply.send(projectSnapshotView.snapshot(newSnapshot))
+        } catch (err) {
+            // if err message is a JSON.parse failure in decryptCreds, it's a bad secret
+            if (/JSON\.parse.*decryptCreds/si.test(err.stack)) {
+                return reply.code(400).send({ code: 'bad_request', error: 'Invalid credential secret' })
+            }
+            throw err // handled by global error handler
         }
     })
 }

--- a/test/unit/forge/auditLog/application_spec.js
+++ b/test/unit/forge/auditLog/application_spec.js
@@ -181,6 +181,21 @@ describe('Audit Log > Application', async function () {
         logEntry.body.snapshot.id.should.equal(SNAPSHOT.hashid)
     })
 
+    it('Provides a logger for application device snapshot imported', async function () {
+        await logger.application.device.snapshot.imported(ACTIONED_BY, null, APPLICATION, DEVICE, null, null, SNAPSHOT)
+        // check log stored
+        const logEntry = await getLog()
+        logEntry.should.have.property('event', 'application.device.snapshot.imported')
+        logEntry.should.have.property('scope', { id: APPLICATION.hashid, type: 'application' })
+        logEntry.should.have.property('trigger', { id: ACTIONED_BY.hashid, type: 'user', name: ACTIONED_BY.username })
+        logEntry.should.have.property('body')
+        logEntry.body.should.only.have.keys('device', 'snapshot')
+        logEntry.body.device.should.only.have.keys('id', 'name')
+        logEntry.body.device.id.should.equal(DEVICE.hashid)
+        logEntry.body.snapshot.should.only.have.keys('id', 'name')
+        logEntry.body.snapshot.id.should.equal(SNAPSHOT.hashid)
+    })
+
     it('Provides a logger for creating a device group', async function () {
         await logger.application.deviceGroup.created(ACTIONED_BY, null, APPLICATION, DEVICEGROUP)
         // check log stored

--- a/test/unit/forge/routes/api/snapshots_spec.js
+++ b/test/unit/forge/routes/api/snapshots_spec.js
@@ -18,15 +18,26 @@ function decryptCredentials (key, cipher) {
     return JSON.parse(decrypted)
 }
 
+function encryptCredentials (secret, plain) {
+    const key = crypto.createHash('sha256').update(secret).digest()
+    const initVector = crypto.randomBytes(16)
+    const cipher = crypto.createCipheriv('aes-256-ctr', key, initVector)
+    return { $: initVector.toString('hex') + cipher.update(JSON.stringify(plain), 'utf8', 'base64') + cipher.final('base64') }
+}
+
 describe('Snapshots API', function () {
     let app
     /** @type {TestModelFactory} */ let factory = null
 
     const TestObjects = {
         application1: null,
+        application2: null,
         project1: null,
         device1: null,
+        project2: null,
+        device2: null,
         /** ATeam Owner & Admin */ alice: null,
+        /** ATeam Owner */ dave: null,
         /** ATeam Member */ bob: null,
         /** ATeam Viewer */ verity: null,
         /** BTeam Owner */ chris: null,
@@ -34,14 +45,17 @@ describe('Snapshots API', function () {
         BTeam: null,
         tokens: {
             project1: null,
+            project2: null,
             device1: null,
+            device2: null,
             /** ATeam Owner */ alice: null,
             /** ATeam Member */ bob: null,
             /** ATeam Viewer */ verity: null,
             /** BTeam Owner */ chris: null
         },
         template1: null,
-        stack1: null
+        stack1: null,
+        projectType1: null
     }
     before(async function () {
         app = await setup()
@@ -51,17 +65,20 @@ describe('Snapshots API', function () {
         TestObjects.template1 = app.template
         TestObjects.stack1 = app.stack
         TestObjects.project1 = app.project
+        TestObjects.projectType1 = app.projectType
 
         // Alice create in setup()
         TestObjects.alice = await app.db.models.User.byUsername('alice')
         TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
         TestObjects.verity = await app.db.models.User.create({ username: 'verity', name: 'Verity Viewer', email: 'verity@example.com', email_verified: true, password: 'vvPassword' })
         TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
+        TestObjects.dave = await app.db.models.User.create({ username: 'dave', name: 'Dave Skywalker', email: 'dave@example.com', email_verified: true, password: 'ddPassword' })
 
         // Add Bob and Verity to ATeam
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
         await TestObjects.ATeam.addUser(TestObjects.bob, { through: { role: Roles.Member } })
         await TestObjects.ATeam.addUser(TestObjects.verity, { through: { role: Roles.Viewer } })
+        await TestObjects.ATeam.addUser(TestObjects.dave, { through: { role: Roles.Owner } })
 
         // Add BTeam and add Chris as owner
         TestObjects.BTeam = await factory.createTeam({ name: 'BTeam' })
@@ -70,15 +87,25 @@ describe('Snapshots API', function () {
         // create a device
         TestObjects.device1 = await factory.createDevice({ name: 'device-1' }, TestObjects.ATeam, null, TestObjects.application1)
 
+        // Create an application for BTeam
+        TestObjects.application2 = await factory.createApplication({ name: 'application-2' }, TestObjects.BTeam)
+
+        // Create a project for BTeam
+        TestObjects.project2 = await factory.createInstance({ name: 'project-2' }, TestObjects.application2, TestObjects.stack1, TestObjects.template1, TestObjects.projectType1)
+
+        // Create a device for BTeam, application2
+        TestObjects.device2 = await factory.createDevice({ name: 'device-2' }, TestObjects.BTeam, null, TestObjects.application2)
+
         TestObjects.tokens = {}
         await login('alice', 'aaPassword')
         await login('bob', 'bbPassword')
         await login('chris', 'ccPassword')
         await login('verity', 'vvPassword')
+        await login('dave', 'ddPassword')
 
         // TestObjects.tokens.alice = (await app.db.controllers.AccessToken.createTokenForPasswordReset(TestObjects.alice)).token
         TestObjects.tokens.project1 = (await TestObjects.project1.refreshAuthTokens()).token
-        // TestObjects.tokens.project2 = (await TestObjects.project2.refreshAuthTokens()).token
+        TestObjects.tokens.project2 = (await TestObjects.project2.refreshAuthTokens()).token
 
         TestObjects.template1 = app.template
         TestObjects.stack1 = app.stack
@@ -183,6 +210,23 @@ describe('Snapshots API', function () {
                 credentialSecret,
                 ...(credentials ? { credentials } : {})
             }
+        })
+    }
+
+    async function importSnapshot (ownerId, ownerType, snapshot, credentialSecret, token) {
+        const payload = {
+            ownerId,
+            ownerType,
+            snapshot
+        }
+        if (credentialSecret) {
+            payload.credentialSecret = credentialSecret
+        }
+        return await app.inject({
+            method: 'POST',
+            url: '/api/v1/snapshots/import',
+            cookies: { sid: token },
+            payload
         })
     }
 
@@ -497,6 +541,162 @@ describe('Snapshots API', function () {
                 const keyHash = crypto.createHash('sha256').update('test-secret').digest()
                 const decrypted = decryptCredentials(keyHash, exportResult.flows.credentials)
                 JSON.stringify(decrypted).should.equal(JSON.stringify({ testCreds: 'abc' }))
+            })
+        }
+        describe('instance', function () {
+            tests('instance')
+        })
+        describe('device', function () {
+            tests('device')
+        })
+    })
+
+    // Tests for POST /api/v1/snapshots/{snapshotId}/import
+    // * Imports a project or device snapshot into a project or device
+
+    describe('Import snapshot', function () {
+        const dummySnapshot = (name, flows = [], settings = {}, env = {}, modules = {}, credentials = null) => {
+            const _name = name === undefined ? nameGenerator('snapshot') : name
+            const _settings = (settings || env || modules) ? {} : undefined
+            if (settings !== null) {
+                _settings.settings = settings
+            }
+            if (env !== null) {
+                _settings.env = env
+            }
+            if (modules !== null) {
+                _settings.modules = modules
+            }
+            const snapshot = {
+                name: _name,
+                description: 'dummy description',
+                flows: {
+                    flows
+                },
+                settings: _settings
+            }
+            if (credentials) {
+                snapshot.flows.credentials = credentials
+            }
+            return snapshot
+        }
+
+        afterEach(async function () {
+            await app.db.models.ProjectSnapshot.destroy({ where: {} })
+        })
+
+        /**
+         * post import snapshot tests
+         * @param {'instance' | 'device'} kind - 'instance' or 'device'
+         */
+        function tests (kind) {
+            const modelType = kind === 'instance' ? 'project' : 'device'
+            const getOwnerId = () => kind === 'instance' ? TestObjects.project1.id : TestObjects.device1.hashid
+            const getTeamBOwnerId = () => kind === 'instance' ? TestObjects.project2.id : TestObjects.device2.hashid
+
+            it('Owner can import snapshot with credentials', async function () {
+                const ownerId = getOwnerId()
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, encryptCredentials('test-secret', { testCreds: 'abc' }))
+                const response = await importSnapshot(ownerId, kind, ss, 'test-secret', TestObjects.tokens.alice)
+
+                response.statusCode.should.equal(200)
+
+                // check the result
+                const result = response.json()
+                result.should.have.property(modelType).and.be.an.Object() // should contain the project/device - for updating the snapshot table client-side without refreshing/reloading from the server
+                result[modelType].should.have.property('id', ownerId) // id of owner should be the hash string
+                result.should.have.property('user').and.be.an.Object() // should contain the user - for updating the snapshot table client-side without refreshing/reloading from the server
+                result.should.have.property('id').and.be.a.String()
+                result.should.have.property('name', 'dummy')
+            })
+
+            it('Owner can import snapshot without credentials', async function () {
+                const ownerId = getOwnerId()
+                const ss = dummySnapshot('dummy-no-creds', [], {}, {}, {}, null)
+                const response = await importSnapshot(ownerId, kind, ss, null, TestObjects.tokens.alice)
+
+                response.statusCode.should.equal(200)
+
+                const result = response.json()
+                result.should.have.property(modelType).and.be.an.Object() // should contain the project/device - for updating the snapshot table client-side without refreshing/reloading from the server
+                result[modelType].should.have.property('id', ownerId) // id of owner should be the hash string
+                result.should.have.property('user').and.be.an.Object() // should contain the user - for updating the snapshot table client-side without refreshing/reloading from the server
+                result.should.have.property('id').and.be.a.String()
+                result.should.have.property('name', 'dummy-no-creds')
+            })
+
+            it('Returns 400 for missing snapshot', async function () {
+                const response = await importSnapshot(getOwnerId(), kind, null, 'test-secret', TestObjects.tokens.alice)
+                response.statusCode.should.equal(400)
+                const result = response.json()
+                result.should.have.property('code', 'FST_ERR_VALIDATION')
+            })
+
+            it(`Returns 404 for non-existant ${kind}`, async function () {
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, encryptCredentials('test-secret', { testCreds: 'abc' }))
+                const response = await importSnapshot('non_existant-owner', kind, ss, 'test-secret', TestObjects.tokens.alice)
+                response.statusCode.should.equal(404)
+            })
+
+            it('Returns 400 for missing credentialSecret', async function () {
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, encryptCredentials('test-secret', { testCreds: 'abc' }))
+                const response = await importSnapshot(getOwnerId(), kind, ss, '', TestObjects.tokens.alice)
+                response.statusCode.should.equal(400)
+                const result = response.json()
+                result.should.have.property('code', 'bad_request')
+            })
+
+            it('Returns 400 for bad/invalid snapshot (missing flows)', async function () {
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, encryptCredentials('test-secret', { testCreds: 'abc' }))
+                delete ss.flows
+                const response = await importSnapshot(getOwnerId(), kind, ss, '', TestObjects.tokens.alice)
+                response.statusCode.should.equal(400)
+                response.json().should.have.property('code', 'FST_ERR_VALIDATION')
+            })
+
+            it('Returns 400 for bad/invalid snapshot (missing settings)', async function () {
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, encryptCredentials('test-secret', { testCreds: 'abc' }))
+                delete ss.settings
+                const response = await importSnapshot(getOwnerId(), kind, ss, '', TestObjects.tokens.alice)
+                response.statusCode.should.equal(400)
+                response.json().should.have.property('code', 'FST_ERR_VALIDATION')
+            })
+
+            it('Returns 400 for incorrect credentialSecret', async function () {
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, encryptCredentials('test-secret', { testCreds: 'abc' }))
+                const response = await importSnapshot(getOwnerId(), kind, ss, 'wrong-secret', TestObjects.tokens.alice)
+                response.statusCode.should.equal(400)
+                response.json().should.have.property('code', 'bad_request')
+            })
+
+            it(`TeamB member cannot import snapshot for ${kind} belonging to TeamA - 404`, async function () {
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, null)
+                // chris (TeamB member, non admin) will attempt to import a snapshot into a project/device belonging to TeamA
+                const response = await importSnapshot(getOwnerId(), kind, ss, null, TestObjects.tokens.chris) // chris is not a member of TeamA where the project/device is
+                // 404 as a non member should not know the resource exists
+                response.statusCode.should.equal(404)
+                response.json().should.have.property('code', 'not_found')
+            })
+
+            it(`TeamA Owner cannot import snapshot for ${kind} belonging to TeamB - 404`, async function () {
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, encryptCredentials('test-secret', { testCreds: 'abc' }))
+                // dave (TeamA owner, non admin) will attempt to import a snapshot into a project/device belonging to TeamB
+                const response = await importSnapshot(getTeamBOwnerId(), kind, ss, 'test-secret', TestObjects.tokens.dave) // dave is the owner of Team B where the project/device is
+                response.statusCode.should.equal(404)
+            })
+
+            it('Member cannot import snapshot - 403', async function () {
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, null)
+                const response = await importSnapshot(getOwnerId(), kind, ss, null, TestObjects.tokens.bob)
+                response.statusCode.should.equal(403)
+                response.json().should.have.property('code', 'unauthorized')
+            })
+
+            it('Viewer cannot import snapshot - 403', async function () {
+                const ss = dummySnapshot('dummy', [], {}, {}, {}, null)
+                const response = await importSnapshot(getOwnerId(), kind, ss, null, TestObjects.tokens.verity)
+                response.statusCode.should.equal(403)
+                response.json().should.have.property('code', 'unauthorized')
             })
         }
         describe('instance', function () {


### PR DESCRIPTION
Task 1 of 3 (part of #3628)

## Description

Adds backend parts for Uploading A Snapshot

### Details
- All FE and BE API parts refer to the action as "import" (not "upload") as a counterpart to the "export" API actions whereas the FE buttons will be labelled "Upload Snapshot" to align with the existing "Download Snapshot" actions in the UI
- Adds the endpoint `POST` `api/v1/snapshots/import` in the Snapshots API
  - The schema for the POST body is fairly strict to ensure that the snapshot is valid and can be imported
    - It could be made further strict by validating the `flows` array and `settings.xxx` objects, but this is not done in this PR
- Adds RBAC role `snapshots:import` for which only the `owner` of the instance or device can import snapshots
  - This may be a bit restrictive, since `member` is permitted to create snapshots? 
- credentialSecret is NOT rehashed and is stored in the DB as provided

 
### NOTE 
- Frontend and Docs will be issued in separate PRs (see parent story #3628)

### Unit tests added
```
  Snapshots API
    Import snapshot
      instance
        ✔ Owner can import snapshot with credentials
        ✔ Owner can import snapshot without credentials
        ✔ Returns 400 for missing snapshot
        ✔ Returns 404 for non-existant instance
        ✔ Returns 400 for missing credentialSecret
        ✔ Returns 400 for bad/invalid snapshot (missing flows)
        ✔ Returns 400 for bad/invalid snapshot (missing settings)
        ✔ Returns 400 for incorrect credentialSecret
        ✔ TeamB member cannot import snapshot for instance belonging to TeamA - 404
        ✔ TeamA Owner cannot import snapshot for instance belonging to TeamB - 404
        ✔ Member cannot import snapshot - 403
        ✔ Viewer cannot import snapshot - 403
      device
        ✔ Owner can import snapshot with credentials
        ✔ Owner can import snapshot without credentials
        ✔ Returns 400 for missing snapshot
        ✔ Returns 404 for non-existant device
        ✔ Returns 400 for missing credentialSecret
        ✔ Returns 400 for bad/invalid snapshot (missing flows)
        ✔ Returns 400 for bad/invalid snapshot (missing settings)
        ✔ Returns 400 for incorrect credentialSecret
        ✔ TeamB member cannot import snapshot for device belonging to TeamA - 404
        ✔ TeamA Owner cannot import snapshot for device belonging to TeamB - 404
        ✔ Member cannot import snapshot - 403
        ✔ Viewer cannot import snapshot - 403


  24 passing (4s)
```

## Related Issue(s)

Issue: #3865
Story: #3628 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

