### PR TITLE
Adds creatable flag on TeamType/Instance settings

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       # Install NPM dependencies
       - name: Install Dependencies
         run: npm ci

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -376,6 +376,11 @@ module.exports = {
                     await this.ensureTeamTypeExists()
                     return this.TeamType.getInstanceTypeProperty(instanceType, 'active', false)
                 },
+                isInstanceTypeCreatable: async function (instanceType) {
+                    await this.ensureTeamTypeExists()
+                    // Defaults to true unless explicit disabled
+                    return this.TeamType.getInstanceTypeProperty(instanceType, 'creatable', true)
+                },
                 getInstanceTypeLimit: async function (instanceType) {
                     await this.ensureTeamTypeExists()
                     if (!await this.isInstanceTypeAvailable(instanceType)) {
@@ -398,6 +403,15 @@ module.exports = {
                  */
                 checkInstanceTypeCreateAllowed: async function (instanceType) {
                     await this.ensureTeamTypeExists()
+
+                    const typeAvailable = await this.isInstanceTypeAvailable(instanceType)
+                    const typeCreatable = await this.isInstanceTypeCreatable(instanceType)
+                    if (!typeAvailable || !typeCreatable) {
+                        const err = new Error()
+                        err.code = 'instance_not_available'
+                        err.error = `Instance type '${instanceType.name}' not available for this team`
+                        throw err
+                    }
 
                     const instanceTypeLimit = await this.getInstanceTypeLimit(instanceType)
                     // Note that if the instanceType is unavailable for this team type,

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -53,7 +53,10 @@
                 </div>
                 <div v-for="(instanceType, index) in instanceTypes" :key="index">
                     <FormHeading>Instance Type: {{ instanceType.name }}</FormHeading>
-                    <FormRow v-model="input.properties.instances[instanceType.id].active" type="checkbox" class="mb-4">Available</FormRow>
+                    <div class="grid gap-3 grid-cols-4">
+                        <FormRow v-model="input.properties.instances[instanceType.id].active" type="checkbox" class="mb-4">Available</FormRow>
+                        <FormRow v-if="input.properties.instances[instanceType.id].active" v-model="input.properties.instances[instanceType.id].creatable" type="checkbox" class="mb-4">Creatable</FormRow>
+                    </div>
                     <div v-if="input.properties.instances[instanceType.id].active" class="grid gap-3 grid-cols-4 pl-4">
                         <div class="grid gap-3 grid-cols-2">
                             <FormRow v-model="input.properties.instances[instanceType.id].limit"># Limit</FormRow>
@@ -213,10 +216,13 @@ export default {
                 // Need to ensure we have input.properties.instances entries
                 // for all known instance types
                 this.instanceTypes.forEach(instanceType => {
-                    if (!this.input.properties.instances[instanceType.id]) {
+                    const typeProperties = this.input.properties.instances[instanceType.id]
+                    if (!typeProperties) {
                         this.input.properties.instances[instanceType.id] = {
                             active: false
                         }
+                    } else if (typeProperties.active && typeProperties.creatable === undefined) {
+                        typeProperties.creatable = true
                     }
                 })
 

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -510,6 +510,35 @@ export default {
         this.templates = (await templateListPromise).templates.filter(template => template.active)
 
         this.activeProjectTypeCount = projectTypes.length
+
+        // Do a first pass of the instance types to disable any not allowed for this team
+        projectTypes.forEach(pt => {
+            // Need to combine the projectType billing info with any overrides
+            // from the current teamType
+            const teamTypeInstanceProperties = this.team.type.properties.instances[pt.id]
+            const existingInstanceCount = this.team.instanceCountByType?.[pt.id] || 0
+            if (this.teamRuntimeLimitReached) {
+                // The overall limit has been reached
+                pt.disabled = true
+            } else if (teamTypeInstanceProperties) {
+                if (!teamTypeInstanceProperties.active) {
+                    // This instanceType is disabled for this teamType
+                    pt.disabled = true
+                } else if (teamTypeInstanceProperties.creatable === false) {
+                    // Type is active (it can exist), but not creatable (not allowed to create more) for this team type.
+                    // This can happen follow a change of TeamType where different instance types are available.
+                    // This check treats undefined as true for backwards compatibility
+                    pt.disabled = true
+                } else if (teamTypeInstanceProperties.limit !== null && teamTypeInstanceProperties.limit <= existingInstanceCount) {
+                    // This team has reached the limit of this instance type
+                    pt.disabled = true
+                }
+            }
+            if (pt.disabled) {
+                this.activeProjectTypeCount--
+            }
+        })
+
         if (this.billingEnabled) {
             if (!this.team.billing?.unmanaged) {
                 try {
@@ -523,33 +552,17 @@ export default {
                     }
                 }
             }
+            // With billing enabled, do a second pass through the instance types
+            // to populate their billing info
             projectTypes.forEach(pt => {
                 // Need to combine the projectType billing info with any overrides
                 // from the current teamType
                 const teamTypeInstanceProperties = this.team.type.properties.instances[pt.id]
                 const existingInstanceCount = this.team.instanceCountByType?.[pt.id] || 0
-
                 pt.price = ''
                 pt.priceInterval = ''
                 pt.currency = ''
                 pt.cost = 0
-                if (this.teamRuntimeLimitReached) {
-                    // The overall limit has been reached
-                    pt.disabled = true
-                } else if (teamTypeInstanceProperties) {
-                    if (!teamTypeInstanceProperties.active) {
-                        // This instanceType is disabled for this teamType
-                        pt.disabled = true
-                    } else if (teamTypeInstanceProperties.creatable === false) {
-                        // Type is active (it can exist), but not creatable (not allowed to create more) for this team type.
-                        // This can happen follow a change of TeamType where different instance types are available.
-                        // This check treats undefined as true for backwards compatibility
-                        pt.disabled = true
-                    } else if (teamTypeInstanceProperties.limit !== null && teamTypeInstanceProperties.limit <= existingInstanceCount) {
-                        // This team has reached the limit of this instance type
-                        pt.disabled = true
-                    }
-                }
                 if (!pt.disabled && !this.team.billing?.unmanaged) {
                     let billingDescription
                     if (teamTypeInstanceProperties) {
@@ -579,6 +592,9 @@ export default {
                             if (!this.team.billing?.active) {
                                 // No active billing - only allow the trial instance type
                                 pt.disabled = !isTrialProjectType
+                                if (pt.disabled) {
+                                    this.activeProjectTypeCount--
+                                }
                             }
                             if (isTrialProjectType && this.team.billing?.trialProjectAllowed) {
                                 pt.price = 'Free Trial'
@@ -586,9 +602,6 @@ export default {
                             }
                         }
                     }
-                }
-                if (pt.disabled) {
-                    this.activeProjectTypeCount--
                 }
             })
         }

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -540,6 +540,11 @@ export default {
                     if (!teamTypeInstanceProperties.active) {
                         // This instanceType is disabled for this teamType
                         pt.disabled = true
+                    } else if (teamTypeInstanceProperties.creatable === false) {
+                        // Type is active (it can exist), but not creatable (not allowed to create more) for this team type.
+                        // This can happen follow a change of TeamType where different instance types are available.
+                        // This check treats undefined as true for backwards compatibility
+                        pt.disabled = true
                     } else if (teamTypeInstanceProperties.limit !== null && teamTypeInstanceProperties.limit <= existingInstanceCount) {
                         // This team has reached the limit of this instance type
                         pt.disabled = true


### PR DESCRIPTION
Fixes #3859 

The existing model for how we enable/disable instance types for a particular team type means its all or nothing; a team can either have instances of a particular type or not.

This poses a problem in FFC when a Starter Team with a Small instance wants to upgrade to Enterprise Team that does not have Small instance type enabled.

The linked issue lists a few ways to tackle the problem - this PR is the quickest way forward:

 - In the TeamType configuration for what instances are available (`active`), it now also has a `creatable` flag.
 - A Team Type can have an Instance Type marked as `active` but if `creatable` is not enabled, then the team will not be allowed to create *new* instances of that type.
 - This means a Starter Team with a Small Instance can upgrade to Enterprise, but Small Type will not be an option when creating new instances.

In discussion on #3859 there were ideas around auto-upgrading instances to an 'allowed' type. This gets quite complicated to configure as you have to tell the platform how to map between instance types when changing teams. In the interests of unblocking the core issue, I've gone for this more straight-forward approach.