### PR TITLE
Set secure flag on session cookie when running on https

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -172,6 +172,11 @@ async function init (app, opts) {
         if (session) {
             const cookieOptions = { ...SESSION_COOKIE_OPTIONS }
             cookieOptions.maxAge = SESSION_MAX_AGE
+            if (/^https:/.test(app.config.base_url)) {
+                // If base_url starts https then we can safely set the secure flag
+                // on the cookie
+                cookieOptions.secure = true
+            }
             return {
                 session,
                 cookieOptions


### PR DESCRIPTION
Part of https://github.com/FlowFuse/security/issues/88

## Description

If we know we're running with https configured, we should set the secure flag on the session cookie. We cannot set it always on as that will break localfs installs without https configured.

I believe the test on `base_url` is the right one to do here. I've checked our helm chart sets that with a `https` prefix if the `https` flag is set.