### PR TITLE
Dashboard role uses should get team summary view on api

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -132,6 +132,11 @@ module.exports = async function (app) {
     })
 
     async function getTeamDetails (request, reply, team) {
+        if (!request.session.User?.admin && request.teamMembership.role < Roles.Viewer) {
+            // Return summary details for any role less than Viewer (eg dashboard)
+            reply.send(app.db.views.Team.teamSummary(team))
+            return
+        }
         const result = app.db.views.Team.team(team)
         result.instanceCountByType = await team.instanceCountByType()
         if (app.license.active() && app.billing) {


### PR DESCRIPTION
Part of https://github.com/FlowFuse/security/issues/89

A user with dashboard role doesn't need to see the full team api response. This PR resticts the response to the minimal summary needed for the UI to operate.
