### PR TITLE
Add username to response logging

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -88,6 +88,7 @@ module.exports = async (options = {}) => {
                 return {
                     statusCode: reply.statusCode,
                     request: {
+                        user: reply.request?.session?.User?.username,
                         url: reply.request?.raw?.url,
                         method: reply.request?.method,
                         remoteAddress: reply.request?.ip,


### PR DESCRIPTION
Adds the session username (if available) to the http logging output:

```
{"reqId":"req-6","res":{"statusCode":200,"request":{"user":"nick","url":"/api/v1/user","method":"GET","remoteAddress":"127.0.0.1","remotePort":52061}},"responseTime":25.93}
```

Make it easier to filter logs to the actions of individual users.

Note this is only available on the response log line - not the initial request log, as we haven't looked up the user at the point fastify logs the info.