### PR TITLE
Prevent password reuse

### DIFF
--- a/forge/db/controllers/User.js
+++ b/forge/db/controllers/User.js
@@ -34,6 +34,8 @@ module.exports = {
                 throw new Error('Password must not match username')
             } else if (newPassword === user.email) {
                 throw new Error('Password must not match email')
+            } else if (newPassword === oldPassword) {
+                throw new Error('Password must not match old password')
             }
             user.password = newPassword
             user.password_expired = false

--- a/frontend/src/pages/account/Security/ChangePassword.vue
+++ b/frontend/src/pages/account/Security/ChangePassword.vue
@@ -50,6 +50,7 @@ export default {
         formValid () {
             return this.input.old_password &&
                    this.input.password &&
+                   this.input.old_password !== this.input.password &&
                    this.input.password === this.input.password_confirm &&
                    !this.errors.password
         }
@@ -70,6 +71,10 @@ export default {
             }
             if (this.input.password === this.user.email) {
                 this.errors.password = 'Password must not match email'
+                return
+            }
+            if (this.input.password === this.input.old_password) {
+                this.errors.password = 'New password must not match old password'
                 return
             }
             const zxcvbnResult = zxcvbn(this.input.password)

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -379,6 +379,58 @@ describe('User API', async function () {
             // auditLogs.log[0].body.error.should.have.a.property('code', 'password_change_failed')
             // auditLogs.log[0].body.error.should.have.a.property('message')
         })
+        it('user can not change password to match username', async function () {
+            await login('elvis', 'eePassword')
+            TestObjects.elvis.username = 'elvisMoreComplicatedForWeaknessCheck'
+            await TestObjects.elvis.save()
+            const response = await app.inject({
+                method: 'PUT',
+                url: '/api/v1/user/change_password',
+                payload: {
+                    old_password: 'eePassword',
+                    password: 'elvisMoreComplicatedForWeaknessCheck'
+                },
+                cookies: { sid: TestObjects.tokens.elvis }
+            })
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('code', 'password_change_failed')
+        })
+        it('user can not change password to match email', async function () {
+            await login('elvis', 'eePassword')
+            TestObjects.elvis.email = 'elvisMoreComplicatedForWeaknessCheck@example.com'
+            await TestObjects.elvis.save()
+            const response = await app.inject({
+                method: 'PUT',
+                url: '/api/v1/user/change_password',
+                payload: {
+                    old_password: 'eePassword',
+                    password: 'elvisMoreComplicatedForWeaknessCheck@example.com'
+                },
+                cookies: { sid: TestObjects.tokens.elvis }
+            })
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('code', 'password_change_failed')
+        })
+        it('user can not change password to match old password', async function () {
+            await login('elvis', 'eePassword')
+            TestObjects.elvis.password = 'elvisMoreComplicatedForWeaknessCheck'
+            await TestObjects.elvis.save()
+            const response = await app.inject({
+                method: 'PUT',
+                url: '/api/v1/user/change_password',
+                payload: {
+                    old_password: 'elvisMoreComplicatedForWeaknessCheck',
+                    password: 'elvisMoreComplicatedForWeaknessCheck'
+                },
+                cookies: { sid: TestObjects.tokens.elvis }
+            })
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('code', 'password_change_failed')
+        })
+
         describe('Unverified Email', async function () {
             it('return user info for unverified_email user', async function () {
                 await login('chris', 'ccPassword')


### PR DESCRIPTION
Prevents password reuse at the api and UI level.

We get occasional security reports on this matter, so closing the door on them