### PR TITLE
Adding e2e tests to confirm that admins can navigate cancelled teams

### DIFF
--- a/test/e2e/frontend/cypress/tests/team/billing.js
+++ b/test/e2e/frontend/cypress/tests/team/billing.js
@@ -107,11 +107,7 @@ describe('FlowForge - Team Billing', () => {
                     ...{
                         billing: {
                             active: false,
-                            canceled: true,
-                            customer: 'cus_Q7HgF3LrYhO3r2',
-                            pastDue: false,
-                            subscription: 'sub_1PH36qJ6VWAujNoL8DX1oE7V',
-                            unmanaged: false
+                            canceled: true
                         }
                     }
                 }

--- a/test/e2e/frontend/cypress/tests/team/billing.js
+++ b/test/e2e/frontend/cypress/tests/team/billing.js
@@ -51,4 +51,93 @@ describe('FlowForge - Team Billing', () => {
             })
         })
     })
+
+    describe('Cancelled subscriptions', () => {
+        it('redirects regular users to the billing page', () => {
+            cy.login('bob', 'bbPassword')
+
+            cy.intercept('GET', '/api/v1/teams/*', (req) => req.reply(res => {
+                res.body = {
+                    ...res.body,
+                    ...{
+                        billing: {
+                            active: false,
+                            canceled: true,
+                            customer: 'cus_Q7HgF3LrYhO3r2',
+                            pastDue: false,
+                            subscription: 'sub_1PH36qJ6VWAujNoL8DX1oE7V',
+                            unmanaged: false
+                        }
+                    }
+                }
+                return res
+            })).as('getTeams')
+
+            cy.visit('/')
+
+            cy.wait('@getTeams')
+
+            cy.url().should('include', '/team/ateam/billing')
+
+            cy.get('[data-nav="team-applications"').click()
+            cy.url().should('include', '/team/ateam/billing')
+            cy.get('[data-nav="team-instances"').click()
+            cy.url().should('include', '/team/ateam/billing')
+            cy.get('[data-nav="team-devices"').click()
+            cy.url().should('include', '/team/ateam/billing')
+            cy.get('[data-nav="shared-library"').click()
+            cy.url().should('include', '/team/ateam/billing')
+            cy.get('[data-nav="team-members"').click()
+            cy.url().should('include', '/team/ateam/billing')
+            cy.get('[data-nav="team-audit"').click()
+            cy.url().should('include', '/team/ateam/billing')
+            cy.get('[data-nav="team-billing"').click()
+            cy.url().should('include', '/team/ateam/billing')
+
+            cy.get('[data-nav="team-settings"').click()
+            cy.url().should('include', '/team/ateam/settings/general')
+        })
+
+        it('allows admins to navigate the team', () => {
+            cy.login('alice', 'aaPassword')
+
+            cy.intercept('GET', '/api/v1/teams/*', (req) => req.reply(res => {
+                res.body = {
+                    ...res.body,
+                    ...{
+                        billing: {
+                            active: false,
+                            canceled: true,
+                            customer: 'cus_Q7HgF3LrYhO3r2',
+                            pastDue: false,
+                            subscription: 'sub_1PH36qJ6VWAujNoL8DX1oE7V',
+                            unmanaged: false
+                        }
+                    }
+                }
+                return res
+            })).as('getTeams')
+
+            cy.visit('/')
+
+            cy.wait('@getTeams')
+
+            cy.get('[data-nav="team-applications"').click()
+            cy.url().should('include', '/team/ateam/applications')
+            cy.get('[data-nav="team-instances"').click()
+            cy.url().should('include', '/team/ateam/instances')
+            cy.get('[data-nav="team-devices"').click()
+            cy.url().should('include', '/team/ateam/devices')
+            cy.get('[data-nav="shared-library"').click()
+            cy.url().should('include', '/team/ateam/library/')
+            cy.get('[data-nav="team-members"').click()
+            cy.url().should('include', '/team/ateam/members/general')
+            cy.get('[data-nav="team-audit"').click()
+            cy.url().should('include', '/team/ateam/audit-log')
+            cy.get('[data-nav="team-billing"').click()
+            cy.url().should('include', '/team/ateam/billing')
+            cy.get('[data-nav="team-settings"').click()
+            cy.url().should('include', '/team/ateam/settings/general')
+        })
+    })
 })


### PR DESCRIPTION
## Description

adding e2e tests for #2528

## Related Issue(s)

#2528

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - ~~[ ] Documentation has been updated~~
    - ~~[ ] Upgrade instructions~~
    - ~~[ ] Configuration details~~
    - ~~[ ] Concepts~~
 - ~~[ ] Changes `flowforge.yml`?~~
    - ~~[ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template~~
    - ~~[ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production~~

## Labels

 - ~~[ ] Includes a DB migration? -> add the `area:migration` label~~

