### PR TITLE
Ensure proration_behaviour set when adding first device

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -378,14 +378,15 @@ module.exports.init = async function (app) {
                     }
                 } else if (billableCount > 0) {
                     // Need to add the device item to the subscription
+                    app.log.info(`Updating team ${team.hashid} subscription device count to ${billableCount}`)
                     const update = {
+                        proration_behavior: prorationBehavior,
                         items: [{
                             price: deviceBillingIds.price,
                             quantity: billableCount
                         }]
                     }
                     try {
-                        app.log.info(update)
                         await stripe.subscriptions.update(subscription.subscription, update)
                     } catch (error) {
                         console.error(error)


### PR DESCRIPTION
Fixes #3890 

Adds the missing `proration_behaviour` option to the code path when adding a teams first device.

This is outside the scope of our unit tests, and I don't believe the pre-staging setup has billing configured. I have verified this locally with the test stripe account - and the change is bringing this one call inline with all of the other calls to modify a users subscription.