### PR TITLE
Allow Create Team view to go full width

### DIFF
--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -34,7 +34,7 @@
                     </div>
                 </div>
                 <!-- TeamType Type -->
-                <div class="grid grid-1">
+                <div class="grid">
                     <ff-tile-selection v-model="input.teamTypeId" data-form="team-type">
                         <ff-tile-selection-option
                             v-for="(teamType, index) in teamTypes" :key="index"

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -11,12 +11,12 @@
     <ff-page>
         <ff-loading v-if="redirecting" message="Redirecting to Stripe..." />
         <ff-loading v-else-if="loading" message="Creating Team..." />
-        <div v-else class="max-w-2xl m-auto">
+        <div v-else class="m-auto">
             <form class="space-y-6">
                 <FormHeading>Create a new team</FormHeading>
                 <div class="mb-8 text-sm text-gray-500">Teams are how you organize who collaborates on your projects.</div>
                 <!-- TeamType Type -->
-                <div class="flex flex-wrap gap-1 items-stretch">
+                <div class="grid grid-1">
                     <ff-tile-selection v-model="input.teamTypeId">
                         <ff-tile-selection-option
                             v-for="(teamType, index) in teamTypes" :key="index"

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -16,7 +16,7 @@
                 <FormHeading>Create a new team</FormHeading>
                 <div class="mb-8 text-sm text-gray-500">Teams are how you organize who collaborates on your projects.</div>
                 <!-- TeamType Type -->
-                <div class="grid grid-1">
+                <div class="grid">
                     <ff-tile-selection v-model="input.teamTypeId">
                         <ff-tile-selection-option
                             v-for="(teamType, index) in teamTypes" :key="index"


### PR DESCRIPTION
This copies the changes made for the Upgrade Team Type view in [3861](https://github.com/FlowFuse/flowfuse/pull/3861) to the Create Team view for consistency.

<img width="882" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/ee2bdcf8-8188-4785-83fb-ca6d31913e27">
