### PR TITLE
ci: Update `update-issue-status` workflow to use github token

### DIFF
--- a/.github/workflows/update-issue-status.yml
+++ b/.github/workflows/update-issue-status.yml
@@ -10,4 +10,5 @@ on:
 jobs:
   update_issue_status:
     uses: flowfuse/.github/.github/workflows/record-in-review.yml@main
-    secrets: inherit
+    secrets:
+      PROJECT_ACCESS_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Description

Update the `update_issue_status` job within `update-issue-status` workflow to pass `github.token` to the reusable workflow.

Is dependent on https://github.com/FlowFuse/.github/pull/52

## Related Issue(s)

https://github.com/FlowFuse/.github/pull/52

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

