### PR TITLE
Add charges table to device create dialog

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -170,6 +170,7 @@
     <TeamDeviceCreateDialog
         ref="teamDeviceCreateDialog"
         :team="team"
+        :teamDeviceCount="teamDeviceCount"
         @device-created="deviceCreated"
         @device-updated="deviceUpdated"
     >

--- a/frontend/src/pages/instance/components/InstanceChargesTable.vue
+++ b/frontend/src/pages/instance/components/InstanceChargesTable.vue
@@ -54,9 +54,14 @@
         class="text-right ff-description mb-2 space-y-1"
         data-el="payable-now-summary"
     >
-        {{ formatCurrency(selectedCostAfterCredit) }} now
-        <span v-if="pricingDetails?.interval">
-            then {{ formatCurrency(pricingDetails.cost) }} /{{ pricingDetails.interval }}
+        <span v-if="prorationMode === 'create_prorations'">
+            This will be added to your next invoice
+        </span>
+        <span v-else>
+            You will be charged {{ formatCurrency(selectedCostAfterCredit) }} now
+            <span v-if="pricingDetails?.interval">
+                then {{ formatCurrency(pricingDetails.cost) }} /{{ pricingDetails.interval }}
+            </span>
         </span>
     </div>
 </template>
@@ -80,6 +85,10 @@ export default {
         trialMode: {
             type: Boolean,
             default: false
+        },
+        prorationMode: {
+            type: String,
+            default: 'always_invoice'
         }
     },
     computed: {

--- a/frontend/src/pages/instance/components/InstanceChargesTable.vue
+++ b/frontend/src/pages/instance/components/InstanceChargesTable.vue
@@ -1,69 +1,70 @@
 <template>
-    <div
-        v-if="projectType && (pricingDetails?.cost > 0 || subscription?.customer?.balance > 0)"
-        class="pb-4 mb-4 border-b border-gray-300"
-        data-el="charges-table"
-    >
-        <h1 class="text-lg font-medium mb-2 border-b border-gray-700">
-            Charges
-        </h1>
+    <template v-if="projectType && (pricingDetails?.cost > 0 || subscription?.customer?.balance > 0)">
         <div
-            class="grid grid gap-x-1 gap-y-4 text-sm text-sm mt-4 ml-4"
-            style="grid-template-columns: 1fr 200px auto"
+            class="pb-4 mb-4 border-b border-gray-300"
+            data-el="charges-table"
         >
-            <template v-if="pricingDetails?.cost">
-                <div data-el="selected-instance-type-name">
-                    1 x {{ pricingDetails.name }}
-                </div>
-                <div
-                    data-el="selected-instance-type-cost"
-                    class="text-right"
-                >
-                    <template v-if="trialMode">
-                        Free during the trial, then
-                    </template>
-                    {{ formatCurrency(pricingDetails.cost) }}
-                </div>
-                <div
-                    v-if="pricingDetails?.interval"
-                    data-el="selected-instance-type-interval"
-                    class="text-left"
-                >
-                    /{{ pricingDetails.interval }}
-                </div>
-                <div v-else />
-            </template>
-            <template v-if="subscription?.customer?.balance">
-                <div v-if="subscription.customer.balance < 0" data-el="credit-balance-row">
-                    Credit Balance
-                </div>
-                <div v-else data-el="credit-balance-row">
-                    Debit Balance
-                </div>
-                <div
-                    data-el="credit-balance-amount"
-                    class="text-right"
-                >
-                    {{ formatCurrency(subscription?.customer?.balance) }}
-                </div>
-            </template>
+            <h1 class="text-lg font-medium mb-2 border-b border-gray-700">
+                Charges
+            </h1>
+            <div
+                class="grid grid gap-x-1 gap-y-4 text-sm text-sm mt-4 ml-4"
+                style="grid-template-columns: 1fr 200px auto"
+            >
+                <template v-if="pricingDetails?.cost">
+                    <div data-el="selected-instance-type-name">
+                        1 x {{ pricingDetails.name }}
+                    </div>
+                    <div
+                        data-el="selected-instance-type-cost"
+                        class="text-right"
+                    >
+                        <template v-if="trialMode">
+                            Free during the trial, then
+                        </template>
+                        {{ formatCurrency(pricingDetails.cost) }}
+                    </div>
+                    <div
+                        v-if="pricingDetails?.interval"
+                        data-el="selected-instance-type-interval"
+                        class="text-left"
+                    >
+                        /{{ pricingDetails.interval }}
+                    </div>
+                    <div v-else />
+                </template>
+                <template v-if="subscription?.customer?.balance">
+                    <div v-if="subscription.customer.balance < 0" data-el="credit-balance-row">
+                        Credit Balance
+                    </div>
+                    <div v-else data-el="credit-balance-row">
+                        Debit Balance
+                    </div>
+                    <div
+                        data-el="credit-balance-amount"
+                        class="text-right"
+                    >
+                        {{ formatCurrency(subscription?.customer?.balance) }}
+                    </div>
+                </template>
+            </div>
         </div>
-    </div>
-    <div
-        v-if="!trialMode && selectedCostAfterCredit >= 0"
-        class="text-right ff-description mb-2 space-y-1"
-        data-el="payable-now-summary"
-    >
-        <span v-if="prorationMode === 'create_prorations'">
-            This will be added to your next invoice
-        </span>
-        <span v-else>
-            You will be charged {{ formatCurrency(selectedCostAfterCredit) }} now
-            <span v-if="pricingDetails?.interval">
-                then {{ formatCurrency(pricingDetails.cost) }} /{{ pricingDetails.interval }}
+        <div
+            v-if="!trialMode && selectedCostAfterCredit >= 0"
+            class="text-right ff-description mb-2 space-y-1"
+            data-el="payable-now-summary"
+        >
+            <span v-if="prorationMode === 'create_prorations'">
+                This will be added to your next invoice
             </span>
-        </span>
-    </div>
+            <span v-else>
+                You will be charged {{ formatCurrency(selectedCostAfterCredit) }} now
+                <span v-if="pricingDetails?.interval">
+                    then {{ formatCurrency(pricingDetails.cost) }} /{{ pricingDetails.interval }}
+                </span>
+            </span>
+        </div>
+    </template>
 </template>
 
 <script>
@@ -99,7 +100,6 @@ export default {
             if (!this.projectType) {
                 return {}
             }
-
             return {
                 name: this.projectType.name,
                 currency: this.projectType.currency,

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -227,6 +227,7 @@
                             :project-type="selectedProjectType"
                             :subscription="subscription"
                             :trialMode="isTrialProjectSelected"
+                            :prorationMode="team?.type?.properties?.billing?.proration"
                         />
                     </div>
                 </template>

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -27,8 +27,13 @@
                     <template #description>Assign the device to an application (optional).</template>
                     Application
                 </FormRow>
-                <div v-if="billingDescription">
-                    <b>Price: {{ billingDescription }}</b>
+                <div v-if="deviceIsBillable">
+                    <InstanceChargesTable
+                        :project-type="deviceBillingInformation"
+                        :subscription="subscription"
+                        :trialMode="false"
+                        prorationMode="team?.type?.properties?.billing?.proration"
+                    />
                 </div>
             </form>
         </template>
@@ -38,6 +43,7 @@
 <script>
 import { mapState } from 'vuex'
 
+import billingApi from '../../../../api/billing.js'
 import devicesApi from '../../../../api/devices.js'
 import teamApi from '../../../../api/team.js'
 
@@ -45,15 +51,22 @@ import FormRow from '../../../../components/FormRow.vue'
 import formatCurrency from '../../../../mixins/Currency.js'
 import alerts from '../../../../services/alerts.js'
 
+import InstanceChargesTable from '../../../instance/components/InstanceChargesTable.vue'
+
 export default {
     name: 'TeamDeviceCreateDialog',
     components: {
-        FormRow
+        FormRow,
+        InstanceChargesTable
     },
     mixins: [formatCurrency],
     props: {
         team: {
             type: Object,
+            required: true
+        },
+        teamDeviceCount: {
+            type: Number,
             required: true
         }
     },
@@ -84,7 +97,7 @@ export default {
             device: null,
             instance: null,
             application: null,
-            totalDeviceCount: 0,
+            subscription: null,
             input: {
                 name: '',
                 type: '',
@@ -103,14 +116,23 @@ export default {
         ...mapState('account', ['features']),
         deviceIsBillable () {
             return this.features.billing && // billing enabled
-                this.team.type.properties.billing?.deviceCost > 0 && // >0 per device cost
-                (this.team.type.properties.deviceFreeAllocation || 0) <= this.totalDeviceCount // no remaining free allocation
+                !this.team.billing?.unmanaged &&
+                this.team.type.properties.devices?.description && // >0 per device cost
+                (this.team.type.properties.devices.free || 0) <= this.teamDeviceCount // no remaining free allocation
         },
-        billingDescription () {
-            if (this.deviceIsBillable && this.team.type.properties.billing?.deviceCost > 0) {
-                return `${this.formatCurrency(this.team.type.properties.billing?.deviceCost * 100)} /month`
+        deviceBillingInformation () {
+            if (this.deviceIsBillable && this.team.type.properties.devices?.description) {
+                const [price, priceInterval] = this.team.type.properties.devices?.description.split('/')
+                const currency = price.replace(/[\d.]+/, '')
+                const cost = (Number(price.replace(/[^\d.]+/, '')) || 0) * 100
+                return {
+                    name: 'Device',
+                    currency,
+                    cost,
+                    priceInterval
+                }
             }
-            return ''
+            return null
         },
         formValid () {
             return !!this.input.name
@@ -126,15 +148,13 @@ export default {
         }
     },
     async mounted () {
-        if (this.features.billing && // billing enabled
-                this.team.type.properties.billing?.deviceCost > 0) {
-            // Get the total device count for the team so that we can check allocation
-            // By passing 0 in as the limit, it will just return the `count`
-            // and not retrieve any actual devices
-            const teamData = await teamApi.getTeamDevices(this.team.id, null, 0)
-            this.totalDeviceCount = teamData.count
-        }
         this.loadApplications()
+        if (this.features.billing && !this.team.billing?.unmanaged) {
+            try {
+                this.subscription = await billingApi.getSubscriptionInfo(this.team.id)
+            } catch (err) {
+            }
+        }
     },
     methods: {
         loadApplications () {

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -32,7 +32,7 @@
                         :project-type="deviceBillingInformation"
                         :subscription="subscription"
                         :trialMode="false"
-                        prorationMode="team?.type?.properties?.billing?.proration"
+                        :prorationMode="team?.type?.properties?.billing?.proration"
                     />
                 </div>
             </form>


### PR DESCRIPTION
Closes #3892 

This reuses the existing `InstanceChargesTable` component to provide a summary of charges that will incurred by creating a new device:

As part of this, I've updated the message in the charges table based on the team proration behaviour. For Team/Enterprise we have it set to add items to the next invoice. For that case the message has been updated to say so:

<img width="597" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/0ab82a92-09a9-4d14-8718-4ab741fe7a21">


The other behaviour we have is to trigger an invoice for each change made. For that case, the message remains as it was -indicating an immediate charge will be made:

<img width="556" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/0919ecb3-039c-4e38-bd2b-bc990bf85cd1">

