### PR TITLE
ci: Replace `github.token` with one from secrets

### DIFF
--- a/.github/workflows/update-issue-status.yml
+++ b/.github/workflows/update-issue-status.yml
@@ -11,4 +11,4 @@ jobs:
   update_issue_status:
     uses: flowfuse/.github/.github/workflows/record-in-review.yml@main
     secrets:
-      PROJECT_ACCESS_TOKEN: ${{ github.token }}
+      PROJECT_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This pull request replaces `github.token` in a favor of `secrets.GITHUB_TOKEN` while calling `recors-in-review` reusable workflow.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

