### PR TITLE
ci: Do not apply automatic labels on dependabot pull requests

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   labeler:
+    if: github.actor == 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   labeler:
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Description

This pull request updates the labeler workflow to stop it from running on pull requests made by dependabot.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

