### PR TITLE
Add flowfuse.com to the list of places allowed to load images from

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -239,7 +239,7 @@ module.exports = async (options = {}) => {
                         'script-src': ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
                         'worker-src': ["'self'", 'blob:'],
                         'connect-src': ["'self'"],
-                        'img-src': ["'self'", 'data:', 'www.gravatar.com'],
+                        'img-src': ["'self'", 'data:', 'flowfuse.com', 'www.gravatar.com'],
                         'font-src': ["'self'"],
                         'style-src': ["'self'", 'https:', "'unsafe-inline'"],
                         'upgrade-insecure-requests': null


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This is CSP update to remove one more warning and get closer to enforcing, not just reporting.

The sign-up page on FF Cloud loads image from the website.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

