### PR TITLE
make the team instance creation page look more like a page

### DIFF
--- a/frontend/src/components/blueprints/BlueprintTile.vue
+++ b/frontend/src/components/blueprints/BlueprintTile.vue
@@ -112,6 +112,8 @@ export default {
 <style lang="scss">
 .ff-blueprint-tile {
   background-color: $ff-white;
+  width: 250px;
+
   .ff-dialog-container {
     .ff-dialog-box {
       max-width: 75rem;

--- a/frontend/src/pages/instance/Blueprints/BlueprintSelection.vue
+++ b/frontend/src/pages/instance/Blueprints/BlueprintSelection.vue
@@ -7,7 +7,7 @@
         <div>
             <h4>{{ group }}</h4>
         </div>
-        <div class="grid grid-cols-3 gap-3" data-form="blueprint-selection">
+        <div class="gap-3 blueprint-group" data-form="blueprint-selection">
             <BlueprintTile v-for="print in prints" :key="print.id" :blueprint="print" @selected="$emit('selected', print)" />
         </div>
     </div>
@@ -63,4 +63,8 @@ export default {
 
 <style lang="scss">
 @import '../../../stylesheets/components/blueprint-selection.scss';
+.blueprint-group {
+  display: flex;
+  flex-wrap: wrap;
+}
 </style>

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -5,12 +5,10 @@
         class="space-y-6"
         @submit.prevent="$emit('on-submit', input, copyParts)"
     >
-        <SectionTopMenu
-            :hero="creatingNew ? (creatingApplication ? 'Create a new Application' : 'Create Instance') : 'Update Instance'"
-        />
+        <SectionTopMenu v-if="hasHeader" :hero="heroTitle" />
 
         <!-- Form title -->
-        <div class="mb-8 text-sm text-gray-500">
+        <div v-if="hasHeader" class="mb-8 text-sm text-gray-500">
             <template v-if="creatingNew">
                 <template v-if="!creatingApplication || applicationSelection">
                     Let's get your new Node-RED instance setup in no time.
@@ -350,6 +348,10 @@ export default {
         preDefinedInputs: {
             default: null,
             type: Object
+        },
+        hasHeader: {
+            default: true,
+            type: Boolean
         }
     },
     emits: ['on-submit'],
@@ -483,6 +485,9 @@ export default {
         },
         blueprintSelectionVisible () {
             return this.creatingNew && this.showFlowBlueprintSelection && !this.input.flowBlueprintId
+        },
+        heroTitle () {
+            return this.creatingNew ? (this.creatingApplication ? 'Create a new Application' : 'Create Instance') : 'Update Instance'
         }
     },
     watch: {

--- a/frontend/src/pages/team/createInstance.vue
+++ b/frontend/src/pages/team/createInstance.vue
@@ -1,38 +1,36 @@
 <template>
-    <Teleport
-        v-if="mounted"
-        to="#platform-sidenav"
-    >
+    <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigation>
             <template #options>
                 <a @click="$router.back()">
-                    <nav-item
-                        :icon="icons.chevronLeft"
-                        label="Back"
-                    />
+                    <nav-item :icon="icons.chevronLeft" label="Back" />
                 </a>
             </template>
         </SideNavigation>
     </Teleport>
     <ff-page>
-        <div class="max-w-2xl m-auto">
-            <ff-loading
-                v-if="loading"
-                message="Creating instance..."
-            />
-            <InstanceForm
-                v-else
-                :instance="instanceDetails"
-                :team="team"
-                :applicationSelection="true"
-                :applications="applications"
-                :billing-enabled="!!features.billing"
-                :flow-blueprints-enabled="!!features.flowBlueprints"
-                :submit-errors="errors"
-                :pre-defined-inputs="preDefinedInputs"
-                @on-submit="handleFormSubmit"
-            />
-        </div>
+        <template #header>
+            <ff-page-header title="Instances">
+                <template #context>
+                    Let's get your new Node-RED instance setup in no time.
+                </template>
+            </ff-page-header>
+        </template>
+
+        <ff-loading v-if="loading" message="Creating instance..." />
+        <InstanceForm
+            v-else
+            :instance="instanceDetails"
+            :team="team"
+            :applicationSelection="true"
+            :applications="applications"
+            :billing-enabled="!!features.billing"
+            :flow-blueprints-enabled="!!features.flowBlueprints"
+            :submit-errors="errors"
+            :pre-defined-inputs="preDefinedInputs"
+            :has-header="false"
+            @on-submit="handleFormSubmit"
+        />
     </ff-page>
 </template>
 


### PR DESCRIPTION
## Description

Made the instance form more embed-able friendly by adding the ability to  hide it's title & heading.

Also removed center alignment of instance page and added a page header

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/3929

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

