### PR TITLE
Enable clicking on the Blueprint tile in Instance creation form

### DIFF
--- a/frontend/src/pages/instance/Blueprints/BlueprintTileSmall.vue
+++ b/frontend/src/pages/instance/Blueprints/BlueprintTileSmall.vue
@@ -1,5 +1,10 @@
 <template>
-    <div v-ff-tooltip="blueprint.description" class="ff-blueprint-tile-sm cursor-pointer" :class="'ff-blueprint-group--' + categoryClass" @click="onClick">
+    <div
+        v-ff-tooltip="blueprint.description"
+        class="ff-blueprint-tile-sm cursor-pointer" :class="'ff-blueprint-group--' + categoryClass"
+        data-action="click-small-blueprint-tile"
+        @click="onClick"
+    >
         <div class="ff-blueprint-tile--header">
             <component :is="getIcon(blueprint.icon)" class="ff-icon" />
         </div>

--- a/frontend/src/pages/instance/Blueprints/BlueprintTileSmall.vue
+++ b/frontend/src/pages/instance/Blueprints/BlueprintTileSmall.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-ff-tooltip="blueprint.description" class="ff-blueprint-tile-sm" :class="'ff-blueprint-group--' + categoryClass">
+    <div v-ff-tooltip="blueprint.description" class="ff-blueprint-tile-sm cursor-pointer" :class="'ff-blueprint-group--' + categoryClass" @click="onClick">
         <div class="ff-blueprint-tile--header">
             <component :is="getIcon(blueprint.icon)" class="ff-icon" />
         </div>
@@ -21,6 +21,7 @@ export default {
             type: Object
         }
     },
+    emits: ['click'],
     computed: {
         categoryClass () {
             // to lower case and strip spaces
@@ -48,6 +49,9 @@ export default {
                 }
                 return icon
             })
+        },
+        onClick () {
+            this.$emit('click', this.blueprint)
         }
     }
 }

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -82,16 +82,16 @@
                     <div data-form="blueprint">
                         <label class="block text-sm font-medium text-gray-800 mb-2">Blueprint:</label>
                         <BlueprintTileSmall :blueprint="selectedBlueprint" @click="previewBlueprint" />
-                        <div v-if="showFlowBlueprintSelection" class="mt-1 flex gap-3" data-action="blueprint-actions">
+                        <div v-if="showFlowBlueprintSelection" class="mt-2 flex gap-4" data-action="blueprint-actions">
                             <div
-                                class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-0.5 items-center"
+                                class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-1 items-center"
                                 @click="previewBlueprint(selectedBlueprint)"
                             >
                                 <ProjectIcon class="ff-btn--icon" />
                                 <span>Preview Blueprint</span>
                             </div>
                             <div
-                                class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-0.5 items-center"
+                                class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-1 items-center"
                                 @click="input.flowBlueprintId = ''"
                             >
                                 <FolderIcon class="ff-btn--icon" />

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -79,11 +79,24 @@
             </template>
             <template v-else>
                 <div v-if="creatingNew && flowBlueprintsEnabled && atLeastOneFlowBlueprint && !isCopyProject">
-                    <div class="max-w-sm" data-form="blueprint">
+                    <div data-form="blueprint">
                         <label class="block text-sm font-medium text-gray-800 mb-2">Blueprint:</label>
-                        <BlueprintTileSmall :blueprint="selectedBlueprint" />
-                        <div v-if="showFlowBlueprintSelection" class="mt-1" data-action="choose-blueprint">
-                            <span class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline inline items-center text-sm" @click="input.flowBlueprintId = ''">Choose a different Blueprint</span>
+                        <BlueprintTileSmall :blueprint="selectedBlueprint" @click="previewBlueprint" />
+                        <div v-if="showFlowBlueprintSelection" class="mt-1 flex gap-3" data-action="blueprint-actions">
+                            <div
+                                class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-0.5 items-center"
+                                @click="previewBlueprint(selectedBlueprint)"
+                            >
+                                <ProjectIcon class="ff-btn--icon" />
+                                <span>Preview Blueprint</span>
+                            </div>
+                            <div
+                                class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-0.5 items-center"
+                                @click="input.flowBlueprintId = ''"
+                            >
+                                <FolderIcon class="ff-btn--icon" />
+                                <span>Choose a different Blueprint</span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -262,11 +275,12 @@
                 No changes have been made
             </label>
         </div>
+        <AssetDetailDialog ref="flow-renderer-dialog" />
     </form>
 </template>
 
 <script>
-import { RefreshIcon } from '@heroicons/vue/outline'
+import { FolderIcon, RefreshIcon } from '@heroicons/vue/outline'
 import { mapState } from 'vuex'
 
 import billingApi from '../../../api/billing.js'
@@ -278,6 +292,9 @@ import templatesApi from '../../../api/templates.js'
 import FormRow from '../../../components/FormRow.vue'
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
 import FeatureUnavailableToTeam from '../../../components/banners/FeatureUnavailableToTeam.vue'
+import AssetDetailDialog from '../../../components/dialogs/AssetDetailDialog.vue'
+
+import ProjectIcon from '../../../components/icons/Projects.js'
 
 import NameGenerator from '../../../utils/name-generator/index.js'
 
@@ -291,6 +308,8 @@ import InstanceCreditBanner from './InstanceCreditBanner.vue'
 export default {
     name: 'InstanceForm',
     components: {
+        AssetDetailDialog,
+        FolderIcon,
         ExportInstanceComponents,
         FeatureUnavailableToTeam,
         FormRow,
@@ -299,7 +318,8 @@ export default {
         RefreshIcon,
         SectionTopMenu,
         BlueprintSelection,
-        BlueprintTileSmall
+        BlueprintTileSmall,
+        ProjectIcon
     },
     props: {
         team: {
@@ -728,6 +748,9 @@ export default {
         },
         selectBlueprint (blueprint) {
             this.input.flowBlueprintId = blueprint.id
+        },
+        previewBlueprint (blueprint) {
+            this.$refs['flow-renderer-dialog'].show(blueprint)
         }
     }
 }

--- a/test/e2e/frontend/cypress/tests-ee/blueprints/blueprints.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/blueprints/blueprints.spec.js
@@ -1,6 +1,26 @@
 import multipleBlueprints from '../../fixtures/blueprints/multiple-blueprints.json'
 import singleBlueprint from '../../fixtures/blueprints/single-blueprint.json'
 
+const canPreviewBlueprintByClickingTheBlueprintTile = () => {
+    cy.get('[data-el="flow-view-dialog"]').should('not.be.visible')
+    cy.get('[data-action="click-small-blueprint-tile"]').should('exist')
+    cy.get('[data-action="click-small-blueprint-tile"]').click()
+    cy.get('[data-el="flow-view-dialog"]').should('be.visible')
+    cy.get('[data-el="flow-view-dialog"]').within(() => {
+        cy.get('[data-action="dialog-confirm"]').click()
+    })
+}
+
+const canPreviewBlueprintByClickingThePreviewBlueprintButton = () => {
+    cy.get('[data-el="flow-view-dialog"]').should('not.be.visible')
+    cy.get('[data-action="blueprint-actions"]').should('exist')
+    cy.get('[data-action="blueprint-actions"]').contains('Preview Blueprint').click()
+    cy.get('[data-el="flow-view-dialog"]').should('be.visible')
+    cy.get('[data-el="flow-view-dialog"]').within(() => {
+        cy.get('[data-action="dialog-confirm"]').click()
+    })
+}
+
 describe('FlowForge - Blueprints', () => {
     // Blueprint Details
     const NAME = 'Test Blueprint'
@@ -71,7 +91,9 @@ describe('FlowForge - Blueprints', () => {
         cy.get('[data-form="blueprint"]').should('exist')
         cy.get('[data-form="blueprint"]').contains(singleBlueprint.blueprints[0].name)
 
-        cy.get('[data-action="choose-blueprint"]').should('not.exist')
+        canPreviewBlueprintByClickingTheBlueprintTile()
+
+        cy.get('[data-action="blueprint-actions"]').should('not.exist')
 
         cy.get('[data-form="blueprint-selection"]').should('not.exist')
         cy.get('[data-form="project-name"]').should('exist')
@@ -85,8 +107,11 @@ describe('FlowForge - Blueprints', () => {
         cy.get('[data-form="blueprint"]').should('exist')
         cy.get('[data-form="blueprint"]').contains(multipleBlueprints.blueprints[0].name)
 
-        cy.get('[data-action="choose-blueprint"]').should('exist')
-        cy.get('[data-action="choose-blueprint"] span').click()
+        canPreviewBlueprintByClickingTheBlueprintTile()
+        canPreviewBlueprintByClickingThePreviewBlueprintButton()
+
+        cy.get('[data-action="blueprint-actions"]').should('exist')
+        cy.get('[data-action="blueprint-actions"]').contains('Choose a different Blueprint').click()
 
         cy.get('[data-form="blueprint-selection"]').should('exist')
         cy.get('[data-form="project-name"]').should('not.exist')
@@ -121,6 +146,8 @@ describe('FlowForge - Blueprints', () => {
 
                 cy.get('[data-form="blueprint"]').should('exist')
                 cy.get('[data-form="blueprint"]').contains(defaultBlueprint.name)
+
+                canPreviewBlueprintByClickingTheBlueprintTile()
 
                 // fill out form
 


### PR DESCRIPTION
## Description

Make the Blueprint Small Tile reactive to clicks.
Added a preview blueprint button under the small blueprint tile that opens the asset detail dialog.
Clicking the Blueprint small tile also opens the asset detail dialog dialog

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/3918

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

