### PR TITLE
Hide disabled instance types from the instance creation form

### DIFF
--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -140,7 +140,7 @@
                             data-form="project-type"
                         >
                             <ff-tile-selection-option
-                                v-for="(projType, index) in projectTypes"
+                                v-for="(projType, index) in filteredProjectTypes"
                                 :key="index"
                                 :label="projType.name"
                                 :description="projType.description"
@@ -483,6 +483,12 @@ export default {
         },
         blueprintSelectionVisible () {
             return this.creatingNew && this.showFlowBlueprintSelection && !this.input.flowBlueprintId
+        },
+        heroTitle () {
+            return this.creatingNew ? (this.creatingApplication ? 'Create a new Application' : 'Create Instance') : 'Update Instance'
+        },
+        filteredProjectTypes () {
+            return this.projectTypes.filter(pt => !pt.disabled)
         }
     },
     watch: {

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -6,7 +6,7 @@
         @submit.prevent="$emit('on-submit', input, copyParts)"
     >
         <SectionTopMenu
-            :hero="creatingNew ? (creatingApplication ? 'Create a new Application' : 'Create Instance') : 'Update Instance'"
+            :hero="heroTitle"
         />
 
         <!-- Form title -->


### PR DESCRIPTION
## Description
Filtered disabled instance types from the instance creation form

## Related Issue(s)

closes #3896

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

