### PR TITLE
Fix instance creation form getting stuck without a team after refresh

### DIFF
--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -138,6 +138,9 @@ export default {
             delete createPayload.isHA
 
             return instanceApi.create(createPayload)
+        },
+        qwe () {
+
         }
     }
 }

--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -138,9 +138,6 @@ export default {
             delete createPayload.isHA
 
             return instanceApi.create(createPayload)
-        },
-        qwe () {
-
         }
     }
 }

--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -16,14 +16,8 @@
     </Teleport>
     <ff-page>
         <div class="max-w-2xl m-auto">
-            <ff-loading
-                v-if="loading"
-                message="Creating instance..."
-            />
-            <ff-loading
-                v-else-if="sourceInstanceId && !sourceInstance"
-                message="Loading instance to Copy From..."
-            />
+            <ff-loading v-if="isLoading" />
+            <ff-loading v-else-if="sourceInstanceId && !sourceInstance" message="Loading instance to Copy From..." />
             <InstanceForm
                 v-else
                 :instance="instanceDetails"
@@ -84,7 +78,10 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['features', 'team'])
+        ...mapState('account', ['features', 'team']),
+        isLoading () {
+            return this.loading || !this.team
+        }
     },
     created () {
         if (this.sourceInstanceId) {
@@ -107,7 +104,6 @@ export default {
 
             try {
                 await this.createInstance(instanceFields, copyParts)
-
                 await this.$store.dispatch('account/refreshTeam')
 
                 this.$emit('application-updated')


### PR DESCRIPTION
## Description

Extended the loading screen state to include the time it takes to load the teams.

The issue was caused by a combination of factors:
- we are passing the team from the createInstance.vue page down to the InstanceForm 
- there is no persistent state for teams in local storage and each full page refresh needs to call all API endpoints again
- creation form also loads teams

There is a short moment after the page re-loads and the team call is not finalized but the InstanceForm gets mounted with a null team prop and fails it's created method's api calls due to the team being null.

## Related Issue(s)
#3884 
#3934

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

