### PR TITLE
Alter application instance creation page to resemble a standalone page

### DIFF
--- a/frontend/src/components/SectionNavigationHeader.vue
+++ b/frontend/src/components/SectionNavigationHeader.vue
@@ -5,10 +5,13 @@
                 <slot name="hero">
                     <div class="flex-grow items-center grid gap-1">
                         <div class="inline-flex flex-wrap gap-1">
-                            <div class="flex items-center mr-6">
+                            <div v-if="!hasCustomBreadcrumbs" class="flex items-center mr-6">
                                 <slot name="breadcrumbs" />
                                 <ff-nav-breadcrumb data-el="page-name" data-cy="page-name">{{ title }}</ff-nav-breadcrumb>
                                 <InformationCircleIcon v-if="hasInfoDialog" class="ml-3 min-w-[20px] ff-icon text-gray-800 cursor-pointer hover:text-blue-700" @click="openInfoDialog()" />
+                            </div>
+                            <div v-else class="flex items-center mr-6">
+                                <slot name="custom-breadcrumbs" />
                             </div>
                             <slot name="status" />
                         </div>
@@ -66,6 +69,9 @@ export default {
     computed: {
         hasInfoDialog () {
             return !!this.$slots.helptext
+        },
+        hasCustomBreadcrumbs () {
+            return !!this.$slots['custom-breadcrumbs']
         }
     },
     methods: {

--- a/frontend/src/mixins/Application.js
+++ b/frontend/src/mixins/Application.js
@@ -1,0 +1,120 @@
+import { Roles } from '../../../forge/lib/roles.js'
+import ApplicationApi from '../api/application.js'
+import alerts from '../services/alerts.js'
+
+export default {
+    data () {
+        return {
+            application: {},
+            applicationDevices: [],
+            deviceGroups: [],
+            applicationInstances: new Map(),
+            loading: {
+                deleting: false,
+                suspend: false
+            }
+        }
+    },
+    computed: {
+        isVisitingAdmin () {
+            return this.teamMembership?.role === Roles.Admin
+        },
+        isLoading () {
+            return this.loading.deleting || this.loading.suspend
+        },
+        instancesArray () {
+            if (this.applicationInstances.size === 0) {
+                return []
+            }
+            return Array.from(this.applicationInstances.values()).filter(el => el)
+        },
+        devicesArray () {
+            return this.applicationDevices
+        },
+        deviceGroupsArray () {
+            return this.deviceGroups || []
+        }
+    },
+    watch: {
+    },
+    methods: {
+        async updateApplication () {
+            const applicationId = this.$route.params.id
+
+            // See https://github.com/FlowFuse/flowfuse/issues/2929
+            if (!applicationId) {
+                return
+            }
+
+            try {
+                this.applicationInstances = []
+                this.application = await ApplicationApi.getApplication(applicationId)
+                // Check to see if we have the right team loaded
+                if (this.team?.slug !== this.application.team.slug) {
+                    // Load the team for this application
+                    await this.$store.dispatch('account/setTeam', this.application.team.slug)
+                }
+                const instancesPromise = ApplicationApi.getApplicationInstances(applicationId) // To-do needs to be enriched with instance state
+                const devicesPromise = ApplicationApi.getApplicationDevices(applicationId)
+                const deviceData = await devicesPromise
+                this.applicationDevices = deviceData?.devices
+                const applicationInstances = await instancesPromise
+                if (this.features?.deviceGroups && this.team.type.properties.features?.deviceGroups) {
+                    const deviceGroupsData = await ApplicationApi.getDeviceGroups(applicationId)
+                    this.deviceGroups = deviceGroupsData?.groups || []
+                } else {
+                    this.deviceGroups = []
+                }
+
+                this.applicationInstances = new Map()
+                applicationInstances.forEach(instance => {
+                    this.applicationInstances.set(instance.id, instance)
+                })
+
+                // Not waited for, as loading status is slightly slower
+                ApplicationApi
+                    .getApplicationInstancesStatuses(applicationId)
+                    .then((instanceStatuses) => {
+                        instanceStatuses.forEach((instanceStatus) => {
+                            this.applicationInstances.set(instanceStatus.id, {
+                                ...this.applicationInstances.get(instanceStatus.id),
+                                ...instanceStatus
+                            })
+                        })
+                    })
+                    .catch((err) => {
+                        console.error(err)
+                    })
+            } catch (err) {
+                this.$router.push({
+                    name: 'PageNotFound',
+                    params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
+                    // preserve existing query and hash if any
+                    query: this.$router.currentRoute.value.query,
+                    hash: this.$router.currentRoute.value.hash
+                })
+            }
+        },
+        async deleteApplication () {
+            this.loading.deleting = true
+
+            try {
+                await ApplicationApi.deleteApplication(this.application.id, this.team.id)
+                await this.$store.dispatch('account/refreshTeam')
+                this.$router.push({ name: 'Home' })
+                alerts.emit('Application successfully deleted.', 'confirmation')
+            } catch (err) {
+                if (err.response.data.error) {
+                    alerts.emit(`Application failed to delete: ${err.response.data.error}`, 'warning', 10000)
+                } else {
+                    alerts.emit('Application failed to delete', 'warning')
+                }
+            }
+
+            this.loading.deleting = false
+        }
+    },
+    async created () {
+
+    }
+}

--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -15,21 +15,37 @@
         </SideNavigation>
     </Teleport>
     <ff-page>
-        <div class="max-w-2xl m-auto">
-            <ff-loading v-if="isLoading" />
-            <ff-loading v-else-if="sourceInstanceId && !sourceInstance" message="Loading instance to Copy From..." />
-            <InstanceForm
-                v-else
-                :instance="instanceDetails"
-                :source-instance="sourceInstance"
-                :team="team"
-                :applicationFieldsLocked="!!application?.id"
-                :billing-enabled="!!features.billing"
-                :flow-blueprints-enabled="!!features.flowBlueprints"
-                :submit-errors="errors"
-                @on-submit="handleFormSubmit"
-            />
-        </div>
+        <template #header>
+            <ff-page-header title="Instances">
+                <template #custom-breadcrumbs>
+                    <ff-nav-breadcrumb v-if="team" :to="{name: 'Applications', params: {team_slug: team.slug}}">Applications</ff-nav-breadcrumb>
+                    <ff-nav-breadcrumb v-if="team" :to="{name: 'Application', params: {id: application.id}}">
+                        {{ application.name }}
+                    </ff-nav-breadcrumb>
+                    <ff-nav-breadcrumb>
+                        Create Instance
+                    </ff-nav-breadcrumb>
+                </template>
+                <template #context>
+                    Let's get your new Node-RED instance setup in no time.
+                </template>
+            </ff-page-header>
+        </template>
+
+        <ff-loading v-if="isLoading" />
+        <ff-loading v-else-if="sourceInstanceId && !sourceInstance" message="Loading instance to Copy From..." />
+        <InstanceForm
+            v-else
+            :has-header="false"
+            :instance="instanceDetails"
+            :source-instance="sourceInstance"
+            :team="team"
+            :applicationFieldsLocked="!!application?.id"
+            :billing-enabled="!!features.billing"
+            :flow-blueprints-enabled="!!features.flowBlueprints"
+            :submit-errors="errors"
+            @on-submit="handleFormSubmit"
+        />
     </ff-page>
 </template>
 
@@ -41,6 +57,7 @@ import instanceApi from '../../api/instances.js'
 
 import NavItem from '../../components/NavItem.vue'
 import SideNavigation from '../../components/SideNavigation.vue'
+import applicationMixin from '../../mixins/Application.js'
 import Alerts from '../../services/alerts.js'
 import InstanceForm from '../instance/components/InstanceForm.vue'
 
@@ -51,16 +68,10 @@ export default {
         NavItem,
         SideNavigation
     },
+    mixins: [applicationMixin],
     inheritAttrs: false,
     props: {
-        application: {
-            required: true,
-            type: Object
-        },
-        sourceInstanceId: {
-            default: null,
-            type: String
-        }
+
     },
     emits: ['application-updated'],
     data () {
@@ -83,7 +94,9 @@ export default {
             return this.loading || !this.team
         }
     },
-    created () {
+    async created () {
+        await this.updateApplication()
+
         if (this.sourceInstanceId) {
             instanceApi.getInstance(this.sourceInstanceId).then(instance => {
                 this.sourceInstance = instance

--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -71,7 +71,10 @@ export default {
     mixins: [applicationMixin],
     inheritAttrs: false,
     props: {
-
+        sourceInstanceId: {
+            default: null,
+            type: String
+        }
     },
     emits: ['application-updated'],
     data () {

--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -143,6 +143,8 @@ export default {
 
             return instanceApi.create(createPayload)
         }
+
     }
+
 }
 </script>

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -52,9 +52,6 @@ import { ChipIcon, ClockIcon, CogIcon, TerminalIcon, ViewListIcon } from '@heroi
 
 import { mapState } from 'vuex'
 
-import { Roles } from '../../../../forge/lib/roles.js'
-
-import ApplicationApi from '../../api/application.js'
 import InstanceApi from '../../api/instances.js'
 
 import InstanceStatusPolling from '../../components/InstanceStatusPolling.vue'
@@ -64,6 +61,7 @@ import TeamTrialBanner from '../../components/banners/TeamTrial.vue'
 import PipelinesIcon from '../../components/icons/Pipelines.js'
 import ProjectsIcon from '../../components/icons/Projects.js'
 
+import applicationMixin from '../../mixins/Application.js'
 import permissionsMixin from '../../mixins/Permissions.js'
 
 import alerts from '../../services/alerts.js'
@@ -85,28 +83,14 @@ export default {
         SubscriptionExpiredBanner,
         TeamTrialBanner
     },
-    mixins: [permissionsMixin],
+    mixins: [permissionsMixin, applicationMixin],
     data: function () {
         return {
-            mounted: false,
-            application: {},
-            applicationDevices: [],
-            deviceGroups: [],
-            applicationInstances: new Map(),
-            loading: {
-                deleting: false,
-                suspend: false
-            }
+            mounted: false
         }
     },
     computed: {
         ...mapState('account', ['teamMembership', 'team', 'features']),
-        isVisitingAdmin () {
-            return this.teamMembership?.role === Roles.Admin
-        },
-        isLoading () {
-            return this.loading.deleting || this.loading.suspend
-        },
         navigation () {
             const routes = [
                 { label: 'Instances', to: `/application/${this.application.id}/instances`, tag: 'application-overview', icon: ProjectsIcon },
@@ -132,18 +116,6 @@ export default {
             ]
 
             return routes
-        },
-        instancesArray () {
-            if (this.applicationInstances.size === 0) {
-                return []
-            }
-            return Array.from(this.applicationInstances.values()).filter(el => el)
-        },
-        devicesArray () {
-            return this.applicationDevices
-        },
-        deviceGroupsArray () {
-            return this.deviceGroups || []
         }
     },
     async created () {
@@ -160,64 +132,6 @@ export default {
         this.mounted = true
     },
     methods: {
-        async updateApplication () {
-            const applicationId = this.$route.params.id
-
-            // See https://github.com/FlowFuse/flowfuse/issues/2929
-            if (!applicationId) {
-                return
-            }
-
-            try {
-                this.applicationInstances = []
-                this.application = await ApplicationApi.getApplication(applicationId)
-                // Check to see if we have the right team loaded
-                if (this.team?.slug !== this.application.team.slug) {
-                    // Load the team for this application
-                    await this.$store.dispatch('account/setTeam', this.application.team.slug)
-                }
-                const instancesPromise = ApplicationApi.getApplicationInstances(applicationId) // To-do needs to be enriched with instance state
-                const devicesPromise = ApplicationApi.getApplicationDevices(applicationId)
-                const deviceData = await devicesPromise
-                this.applicationDevices = deviceData?.devices
-                const applicationInstances = await instancesPromise
-                if (this.features?.deviceGroups && this.team.type.properties.features?.deviceGroups) {
-                    const deviceGroupsData = await ApplicationApi.getDeviceGroups(applicationId)
-                    this.deviceGroups = deviceGroupsData?.groups || []
-                } else {
-                    this.deviceGroups = []
-                }
-
-                this.applicationInstances = new Map()
-                applicationInstances.forEach(instance => {
-                    this.applicationInstances.set(instance.id, instance)
-                })
-
-                // Not waited for, as loading status is slightly slower
-                ApplicationApi
-                    .getApplicationInstancesStatuses(applicationId)
-                    .then((instanceStatuses) => {
-                        instanceStatuses.forEach((instanceStatus) => {
-                            this.applicationInstances.set(instanceStatus.id, {
-                                ...this.applicationInstances.get(instanceStatus.id),
-                                ...instanceStatus
-                            })
-                        })
-                    })
-                    .catch((err) => {
-                        console.error(err)
-                    })
-            } catch (err) {
-                this.$router.push({
-                    name: 'PageNotFound',
-                    params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
-                    // preserve existing query and hash if any
-                    query: this.$router.currentRoute.value.query,
-                    hash: this.$router.currentRoute.value.hash
-                })
-            }
-        },
-
         instanceUpdated: function (newData) {
             const mutator = new InstanceStateMutator(newData)
             mutator.clearState()
@@ -227,30 +141,9 @@ export default {
                 ...newData
             })
         },
-
         showConfirmDeleteApplicationDialog () {
             this.$refs.confirmApplicationDeleteDialog.show(this.application)
         },
-
-        async deleteApplication () {
-            this.loading.deleting = true
-
-            try {
-                await ApplicationApi.deleteApplication(this.application.id, this.team.id)
-                await this.$store.dispatch('account/refreshTeam')
-                this.$router.push({ name: 'Home' })
-                alerts.emit('Application successfully deleted.', 'confirmation')
-            } catch (err) {
-                if (err.response.data.error) {
-                    alerts.emit(`Application failed to delete: ${err.response.data.error}`, 'warning', 10000)
-                } else {
-                    alerts.emit('Application failed to delete', 'warning')
-                }
-            }
-
-            this.loading.deleting = false
-        },
-
         async instanceStart (instance) {
             const mutator = new InstanceStateMutator(instance)
             mutator.setStateOptimistically('starting')
@@ -264,7 +157,6 @@ export default {
                 mutator.restoreState()
             }
         },
-
         async instanceRestart (instance) {
             const mutator = new InstanceStateMutator(instance)
             mutator.setStateOptimistically('restarting')
@@ -278,7 +170,6 @@ export default {
                 mutator.restoreState()
             }
         },
-
         instanceShowConfirmSuspend (instance) {
             Dialog.show({
                 header: 'Suspend Instance',
@@ -301,7 +192,6 @@ export default {
                 })
             })
         },
-
         instanceShowConfirmDelete (instance) {
             this.$refs.confirmInstanceDeleteDialog.show(instance)
         },

--- a/frontend/src/pages/application/routes.js
+++ b/frontend/src/pages/application/routes.js
@@ -67,17 +67,6 @@ export default [
                 }
             },
             {
-                path: 'instances/create',
-                name: 'ApplicationCreateInstance',
-                component: ApplicationCreateInstance,
-                props: route => ({
-                    sourceInstanceId: route.query.sourceInstanceId
-                }),
-                meta: {
-                    title: 'Application - Instances - Create'
-                }
-            },
-            {
                 path: 'pipelines',
                 name: 'ApplicationPipelines',
                 component: ApplicationPipelines,
@@ -150,6 +139,17 @@ export default [
         ]
     },
     {
+        path: '/application/:id/instances/create',
+        name: 'ApplicationCreateInstance',
+        component: ApplicationCreateInstance,
+        props: route => ({
+            sourceInstanceId: route.query.sourceInstanceId
+        }),
+        meta: {
+            title: 'Application - Instances - Create'
+        }
+    },
+    {
         path: '/application/:applicationId/device-group/:deviceGroupId',
         name: 'ApplicationDeviceGroupIndex',
         component: ApplicationDeviceGroupIndex,
@@ -178,5 +178,4 @@ export default [
             }
         ]
     }
-
 ]


### PR DESCRIPTION
## Description

- General styling made to the Application instance creation page.
- Extracted common application instance non-representational functionality into separate mixin which will also allow to move entire state in the vuex store later on.
- added an additional slot to the SectionNavigationHeader which allows replacing the existing breadcrumbs, required because of the custom format of the breadcrumbs of the create instance page


## Related Issue(s)

closes #3933 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

