### PR TITLE
Ensure node red version in app device snapshot

### DIFF
--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -114,20 +114,23 @@ module.exports = async function (app) {
                 obj.modules['node-red'] = editor?.nodeRedVersion
             }
         }
-
+        const getDefaultNodeRedVersion = (dev) => {
+            let nodeRedVersion = '3.0.2' // default to older Node-RED
+            if (SemVer.satisfies(SemVer.coerce(dev.agentVersion), '>=1.11.2')) {
+                // 1.11.2 includes fix for ESM loading of GOT, so lets use 'latest' as before
+                nodeRedVersion = 'latest'
+            }
+            if (SemVer.satisfies(SemVer.coerce(dev.agentVersion), '>=1.11.2')) {
+                // 1.11.2 includes fix for ESM loading of GOT, so lets use 'latest' as before
+                nodeRedVersion = 'latest'
+            }
+            return nodeRedVersion
+        }
         if (!device.targetSnapshot) {
             // device does not have a target snapshot
             // if this is an application owned device, return a starter snapshot
             if (device.isApplicationOwned) {
-                let nodeRedVersion = '3.0.2' // default to older Node-RED
-                if (SemVer.satisfies(SemVer.coerce(device.agentVersion), '>=1.11.2')) {
-                    // 1.11.2 includes fix for ESM loading of GOT, so lets use 'latest' as before
-                    nodeRedVersion = 'latest'
-                }
-                if (SemVer.satisfies(SemVer.coerce(device.agentVersion), '>=1.11.2')) {
-                    // 1.11.2 includes fix for ESM loading of GOT, so lets use 'latest' as before
-                    nodeRedVersion = 'latest'
-                }
+                const nodeRedVersion = getDefaultNodeRedVersion(device)
                 if (!device.agentVersion || SemVer.lt(device.agentVersion, '1.11.0')) {
                     reply.code(400).send({ code: 'invalid_agent_version', error: 'invalid agent version' })
                     return
@@ -145,7 +148,7 @@ module.exports = async function (app) {
                         { id: 'FFDBG00000000001', type: 'debug', z: 'FFF0000000000001', name: 'Info', active: true, tosidebar: true, console: true, tostatus: true, complete: 'payload', targetType: 'msg', statusVal: 'payload', statusType: 'auto', x: 490, y: 160 }
                     ],
                     modules: {
-                        'node-red': nodeRedVersion, // TODO: get this from the "somewhere!?!?" - this is where TAGs might work well.
+                        'node-red': nodeRedVersion,
                         // as of FF v1.14.0, we permit project nodes to work on application owned devices
                         // the support for this is in @flowfuse/nr-project-nodes > v0.5.0
                         '@flowfuse/nr-project-nodes': '>0.5.0' // TODO: get this from the "settings" (future)
@@ -187,6 +190,10 @@ module.exports = async function (app) {
                     // if the snapshot does not have the new module specified OR it is a version <= 0.5.0, update it
                     if (!settings.modules['@flowfuse/nr-project-nodes'] || SemVer.satisfies(SemVer.coerce(settings.modules['@flowfuse/nr-project-nodes']), '<=0.5.0')) {
                         settings.modules['@flowfuse/nr-project-nodes'] = '>0.5.0'
+                    }
+                    if (!settings.modules['node-red']) {
+                        // if the snapshot does not have the node-red module specified, ensure it is set to a valid version
+                        settings.modules['node-red'] = getDefaultNodeRedVersion(device)
                     }
                     // Belt and braces, remove old module! We don't want to be instructing the device to install the old version.
                     // (the old module can be present due to a snapshot applied from an instance or instance owned device)

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -790,10 +790,10 @@ describe('Device API', async function () {
 
                 // set this snapshot as the target snapshot for the device
                 await app.inject({
-                    method: 'POST',
-                    url: `/api/v1/devices/${device.id}/settings`,
+                    method: 'PUT',
+                    url: `/api/v1/devices/${device.id}`,
                     body: {
-                        targetSnapshot: snapshot.id
+                        targetSnapshot: snapshot.hashid
                     },
                     cookies: { sid: TestObjects.tokens.bob }
                 })

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -671,6 +671,62 @@ describe('Device API', async function () {
                 result.should.have.property('modules').and.be.an.Object()
                 result.modules.should.have.property('node-red', 'latest')
             })
+            it('snapshot uploaded without node-red dependency is always delivered to a device with the node-red:version', async function () {
+                const agentVersion = '1.11.2' // min agent version required for NR 3.1 (as this agent handles ESM issue)
+                const device = await createDevice({ name: 'Ad1a', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice, agentVersion })
+                // assign the new device to application
+                await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/devices/${device.id}`,
+                    body: {
+                        application: TestObjects.Application1.hashid
+                    },
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+
+                // upload a basic snapshot for this device
+                const simpleSnapshot = {
+                    name: 'uploaded snapshot',
+                    description: '',
+                    credentialSecret: '',
+                    settings: {
+                        settings: {},
+                        env: {},
+                        modules: {}
+                    },
+                    flows: {
+                        flows: [],
+                        credentials: null
+                    },
+                    DeviceId: device.id,
+                    UserId: TestObjects.bob.id
+                }
+                const dbDevice = await app.db.models.Device.byId(device.id)
+                // uploadSnapshot (app, owner, snapshot, credentialSecret, user)
+                const snapshot = await app.db.controllers.Snapshot.uploadSnapshot(dbDevice, simpleSnapshot, '', TestObjects.bob)
+
+                // set this snapshot as the target snapshot for the device
+                await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/devices/${device.id}`,
+                    body: {
+                        targetSnapshot: snapshot.hashid
+                    },
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                const response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/devices/${device.id}/live/snapshot`,
+                    headers: {
+                        authorization: `Bearer ${device.credentials.token}`
+                    }
+                })
+                const result = response.json()
+                result.should.have.property('id')
+                result.should.have.property('name', 'uploaded snapshot')
+                result.should.have.property('modules').and.be.an.Object()
+                result.modules.should.have.property('node-red', 'latest')
+            })
             it('`@flowfuse/nr-project-nodes` dependency is included in the starter snapshot', async function () {
                 const agentVersion = '1.11.0' // min agent version required for application assignment
                 const device = await createDevice({ name: 'Ad1a-dep-test', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice, agentVersion })


### PR DESCRIPTION
closes #3941

## Description

Ensures the snapshot delivered via device/live includes a node-red version in the modules list

Adds test
```
  Device API
    Edit device details
      assign to application
        ✔ snapshot uploaded without node-red dependency is always delivered to a device with the node-red:version
```

Updates test
```
Device API
    Edit device details
      assign to application
        ✔ old `@flowforge/nr-project-nodes` dependency is replaced with @flowfuse dependency in an existing snapshot
```


## Related Issue(s)

3941 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

