### PR TITLE
Revert billing_cycle_anchor change to fix coupons

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -35,24 +35,6 @@ module.exports.init = async function (app) {
         return null
     }
 
-    /**
-     * @returns {Date} The next month start date in UTC
-     */
-    function getNextMonthStartUTC () {
-        const now = new Date()
-        let year = now.getUTCFullYear()
-        let month = now.getUTCMonth() + 1
-
-        // If this is December, increment year and set month to January (0)
-        if (month === 12) {
-            year++
-            month = 0
-        }
-
-        // Create a new Date object for the first day of the next month in UTC
-        return new Date(Date.UTC(year, month, 1))
-    }
-
     return {
         createSubscriptionSession: async (team, user = null, teamTypeId = null) => {
             // When setting up the initial subscription we'll default to the billing
@@ -82,8 +64,7 @@ module.exports.init = async function (app) {
                 subscription_data: {
                     metadata: {
                         team: team.hashid
-                    },
-                    billing_cycle_anchor: getNextMonthStartUTC()
+                    }
                 },
                 tax_id_collection: {
                     enabled: true


### PR DESCRIPTION
Fixes #3950 - reverting the billing_cycle_anchor change as I don't see any other practical way to support both that and coupons.