### PR TITLE
Relabel stack to node red version

### DIFF
--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -309,18 +309,18 @@
     </template>
     <template v-else-if="entry.event === 'platform.stack.created'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.stack">Stack '{{ entry.body.stack.name }}' has been created.</span>
-        <span v-else-if="!error">Stack data not found in audit entry.</span>
+        <span v-if="!error && entry.body?.stack">Node-RED Version '{{ entry.body.stack.name }}' has been created.</span>
+        <span v-else-if="!error">Node-RED Version data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'platform.stack.deleted'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.stack">Stack '{{ entry.body.stack.name }}' has been deleted.</span>
-        <span v-else-if="!error">Stack data not found in audit entry.</span>
+        <span v-if="!error && entry.body?.stack">Node-RED Version '{{ entry.body.stack.name }}' has been deleted.</span>
+        <span v-else-if="!error">Node-RED Version data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'platform.stack.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.stack">Stack '{{ entry.body.stack.name }}' has been updated with the following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
-        <span v-else-if="!error">Stack data not found in audit entry.</span>
+        <span v-if="!error && entry.body?.stack">Node-RED Version '{{ entry.body.stack.name }}' has been updated with the following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
+        <span v-else-if="!error">Node-RED Version data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'platform.settings.updated' || entry.event === 'platform.settings.update'">
         <label>{{ AuditEvents[entry.event] }}</label>
@@ -518,12 +518,12 @@
     </template>
     <template v-else-if="entry.event === 'project.stack.changed'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.project">The stack for Instance '{{ entry.body.project?.name }}' has been changed to Stack '{{ entry.body.stack?.name }}'</span>
+        <span v-if="!error && entry.body?.project">The Node-RED Version for Instance '{{ entry.body.project?.name }}' has been changed to Node-RED Version '{{ entry.body.stack?.name }}'</span>
         <span v-else-if="!error">Instance data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'project.stack.restart'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.project">The stack for Instance '{{ entry.body.project?.name }}' has been restarted</span>
+        <span v-if="!error && entry.body?.project">The Node-RED Version for Instance '{{ entry.body.project?.name }}' has been restarted</span>
         <span v-else-if="!error">Instance data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'project.settings.updated'">

--- a/frontend/src/pages/instance/Settings/Danger.vue
+++ b/frontend/src/pages/instance/Settings/Danger.vue
@@ -22,7 +22,7 @@
             <div class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
                 <div class="flex-grow">
                     <div class="max-w-sm">
-                        Changing the Instance Node-RED Version requires the instance to be restarted.
+                        Changing the Instances Node-RED Version requires the instance to be restarted.
                         The flows will not be running while this happens.
                     </div>
                 </div>

--- a/frontend/src/pages/instance/Settings/Danger.vue
+++ b/frontend/src/pages/instance/Settings/Danger.vue
@@ -1,33 +1,33 @@
 <template>
     <ff-loading v-if="loading.deleting" message="Deleting Instance..." />
     <ff-loading v-if="loading.duplicating" message="Copying Instance..." />
-    <ff-loading v-if="loading.changingStack" message="Changing Stack..." />
+    <ff-loading v-if="loading.changingStack" message="Changing Node-RED Version..." />
     <ff-loading v-if="loading.settingType" message="Setting Type..." />
     <ff-loading v-if="loading.suspend" message="Suspending Instance..." />
     <ff-loading v-if="loading.importing" message="Importing Instance..." />
     <form v-if="!isLoading" class="space-y-6">
         <template v-if="hasPermission('project:edit')">
-            <FormHeading>Change Instance Stack</FormHeading>
+            <FormHeading>Change Instance Node-RED Version</FormHeading>
             <div v-if="instance.stack && instance.stack.replacedBy" class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
                 <div class="flex-grow">
                     <div class="max-w-sm">
-                        There is a new version of the current stack available.
-                        Updating the stack will restart the instance.
+                        There is a new version of the current Node-RED Version available.
+                        Updating the Node-RED Version will restart the instance.
                     </div>
                 </div>
                 <div class="min-w-fit flex-shrink-0">
-                    <ff-button data-action="update-stack" :disabled="!instance.projectType" kind="secondary" @click="upgradeStack()">Update Stack</ff-button>
+                    <ff-button data-action="update-stack" :disabled="!instance.projectType" kind="secondary" @click="upgradeStack()">Update Node-RED Version</ff-button>
                 </div>
             </div>
             <div class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
                 <div class="flex-grow">
                     <div class="max-w-sm">
-                        Changing the Instance Stack requires the instance to be restarted.
+                        Changing the Instance Node-RED Version requires the instance to be restarted.
                         The flows will not be running while this happens.
                     </div>
                 </div>
                 <div class="min-w-fit flex-shrink-0">
-                    <ff-button data-action="change-stack" :disabled="!instance.projectType" kind="secondary" @click="showChangeStackDialog()">Change Stack</ff-button>
+                    <ff-button data-action="change-stack" :disabled="!instance.projectType" kind="secondary" @click="showChangeStackDialog()">Change Node-RED Version</ff-button>
                     <ChangeStackDialog ref="changeStackDialog" @confirm="changeStack" />
                 </div>
             </div>
@@ -220,10 +220,10 @@ export default {
                 InstanceApi.changeStack(this.instance.id, selectedStack).then(() => {
                     this.$router.push({ name: 'Instance', params: { id: this.instance.id } })
                     this.$emit('instance-updated')
-                    alerts.emit('Instance stack successfully updated.', 'confirmation')
+                    alerts.emit('Instance Node-RED Version successfully updated.', 'confirmation')
                 }).catch(err => {
                     console.warn(err)
-                    alerts.emit('Instance stack was not updated due to an error.', 'warning')
+                    alerts.emit('Instance Node-RED Version was not updated due to an error.', 'warning')
                 }).finally(() => {
                     this.loading.changingStack = false
                 })

--- a/frontend/src/pages/instance/Settings/Danger.vue
+++ b/frontend/src/pages/instance/Settings/Danger.vue
@@ -11,7 +11,7 @@
             <div v-if="instance.stack && instance.stack.replacedBy" class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
                 <div class="flex-grow">
                     <div class="max-w-sm">
-                        There is a new version of the current Node-RED Version available.
+                        There is a new version of Node-RED available.
                         Updating the Node-RED Version will restart the instance.
                     </div>
                 </div>

--- a/frontend/src/pages/instance/Settings/General.vue
+++ b/frontend/src/pages/instance/Settings/General.vue
@@ -30,7 +30,7 @@
             </template>
         </FormRow>
         <FormRow v-model="input.stackDescription" type="uneditable">
-            Stack
+            Node-RED Version
         </FormRow>
         <FormRow v-model="input.templateName" type="uneditable">
             Template

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -29,7 +29,7 @@
                 </ff-data-table>
             </div>
             <div v-else>
-                Upgrade your stack to enable this feature
+                Upgrade your Node-RED Version to enable this feature
             </div>
         </div>
         <div class="space-x-4 whitespace-nowrap">

--- a/frontend/src/pages/instance/Settings/dialogs/ChangeStackDialog.vue
+++ b/frontend/src/pages/instance/Settings/dialogs/ChangeStackDialog.vue
@@ -1,8 +1,8 @@
 <template>
     <ff-dialog
         ref="dialog"
-        header="Change Instance Stack"
-        confirm-label="Change Stack"
+        header="Change Instance Node-RED Version"
+        confirm-label="Change Node-RED Version"
         class="ff-dialog-fixed-height"
         data-el="change-stack-dialog"
         @confirm="confirm()"
@@ -10,7 +10,7 @@
         <template #default>
             <form class="space-y-6" @submit.prevent>
                 <p>
-                    Select the new stack you want to use for this instance:
+                    Select the new Node-RED Version you want to use for this instance:
                 </p>
                 <FormRow
                     v-model="input.stack"
@@ -18,7 +18,7 @@
                     data-form="snapshot"
                     containerClass="w-full"
                 >
-                    Stack
+                    Node-RED Version
                 </FormRow>
             </form>
         </template>

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -165,7 +165,7 @@
 
                     <!-- Stack -->
                     <div class="flex flex-wrap gap-1 items-stretch">
-                        <label class="w-full block text-sm font-medium text-gray-700 mb-4">Choose your Stack</label>
+                        <label class="w-full block text-sm font-medium text-gray-700 mb-4">Choose your Node-RED Version</label>
                         <label
                             v-if="!input.projectType"
                             class="text-sm text-gray-400"
@@ -200,7 +200,7 @@
                         <label
                             v-if="!input.projectType || !input.stack"
                             class="text-sm text-gray-400"
-                        >Please select a Instance Type &amp; Stack first.</label>
+                        >Please select a Instance Type &amp; Node-RED Version first.</label>
                         <label
                             v-if="errors.template"
                             class="text-sm text-gray-400"
@@ -718,7 +718,7 @@ export default {
 
             if (this.stacks.length === 0) {
                 this.input.stack = null
-                this.errors.stack = 'No stacks available for this instance type. Ask an Administrator to create a new stack definition'
+                this.errors.stack = 'No Node-RED Versions available for this instance type. Ask an Administrator to create a Node-RED Version stack definition'
                 return
             }
 

--- a/frontend/src/pages/team/createApplication.vue
+++ b/frontend/src/pages/team/createApplication.vue
@@ -12,28 +12,25 @@
         <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
     </Teleport>
     <ff-page>
-        <template #header>
-            <ff-page-header title="Applications">
-                <template #context>
-                    Let's get your new Node-RED application setup in no time.
-                </template>
-            </ff-page-header>
-        </template>
-        <ff-loading v-if="loading" message="Creating Application..." />
-        <InstanceForm
-            v-else
-            :instance="projectDetails"
-            :has-header="false"
-            :applications="applications"
-            :applicationSelection="applicationCreated"
-            :team="team"
-            :applicationFieldsLocked="applicationCreated"
-            :applicationFieldsVisible="true"
-            :billing-enabled="!!features.billing"
-            :flow-blueprints-enabled="!!features.flowBlueprints"
-            :submit-errors="errors"
-            @on-submit="handleFormSubmit"
-        />
+        <div class="max-w-2xl m-auto">
+            <ff-loading
+                v-if="loading"
+                message="Creating Application..."
+            />
+            <InstanceForm
+                v-else
+                :instance="projectDetails"
+                :applications="applications"
+                :applicationSelection="applicationCreated"
+                :team="team"
+                :applicationFieldsLocked="applicationCreated"
+                :applicationFieldsVisible="true"
+                :billing-enabled="!!features.billing"
+                :flow-blueprints-enabled="!!features.flowBlueprints"
+                :submit-errors="errors"
+                @on-submit="handleFormSubmit"
+            />
+        </div>
     </ff-page>
 </template>
 

--- a/frontend/src/pages/team/createApplication.vue
+++ b/frontend/src/pages/team/createApplication.vue
@@ -1,15 +1,9 @@
 <template>
-    <Teleport
-        v-if="mounted"
-        to="#platform-sidenav"
-    >
+    <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigation>
             <template #options>
                 <a @click="$router.back()">
-                    <nav-item
-                        :icon="icons.chevronLeft"
-                        label="Back"
-                    />
+                    <nav-item :icon="icons.chevronLeft" label="Back" />
                 </a>
             </template>
         </SideNavigation>
@@ -18,25 +12,28 @@
         <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
     </Teleport>
     <ff-page>
-        <div class="max-w-2xl m-auto">
-            <ff-loading
-                v-if="loading"
-                message="Creating Application..."
-            />
-            <InstanceForm
-                v-else
-                :instance="projectDetails"
-                :applications="applications"
-                :applicationSelection="applicationCreated"
-                :team="team"
-                :applicationFieldsLocked="applicationCreated"
-                :applicationFieldsVisible="true"
-                :billing-enabled="!!features.billing"
-                :flow-blueprints-enabled="!!features.flowBlueprints"
-                :submit-errors="errors"
-                @on-submit="handleFormSubmit"
-            />
-        </div>
+        <template #header>
+            <ff-page-header title="Applications">
+                <template #context>
+                    Let's get your new Node-RED application setup in no time.
+                </template>
+            </ff-page-header>
+        </template>
+        <ff-loading v-if="loading" message="Creating Application..." />
+        <InstanceForm
+            v-else
+            :instance="projectDetails"
+            :has-header="false"
+            :applications="applications"
+            :applicationSelection="applicationCreated"
+            :team="team"
+            :applicationFieldsLocked="applicationCreated"
+            :applicationFieldsVisible="true"
+            :billing-enabled="!!features.billing"
+            :flow-blueprints-enabled="!!features.flowBlueprints"
+            :submit-errors="errors"
+            @on-submit="handleFormSubmit"
+        />
     </ff-page>
 </template>
 


### PR DESCRIPTION
## Description

Updated ui to reflect new nomenclature for stacks for non-admin users.

## Related Issue(s)

closes #3914
part of #3884

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

