### PR TITLE
Add 'app' to list of banned instance names

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -20,6 +20,7 @@ const Controllers = require('../controllers')
 const { KEY_HOSTNAME, KEY_SETTINGS, KEY_HA, KEY_PROTECTED, KEY_HEALTH_CHECK_INTERVAL } = require('./ProjectSettings')
 
 const BANNED_NAME_LIST = [
+    'app',
     'www',
     'node-red',
     'nodered',


### PR DESCRIPTION
In anticipation of FFDedicated, adding `app` to the list of banned instance names to prevent clasjes.