### PR TITLE
Replace stack tile selector with regular select on instance creation forms

### DIFF
--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -148,20 +148,16 @@
                     <!-- Stack -->
                     <div class="flex flex-wrap gap-1 items-stretch">
                         <label class="w-full block text-sm font-medium text-gray-700 mb-4">Choose your Node-RED Version</label>
-                        <label v-if="!input.projectType" class="text-sm text-gray-400">
-                            Please select a Instance Type first.
-                        </label>
-                        <label v-if="errors.stack" class="text-sm text-gray-400">
-                            {{ errors.stack }}
-                        </label>
-                        <ff-tile-selection v-if="input.projectType" v-model="input.stack" data-form="instance-stack">
-                            <ff-tile-selection-option
-                                v-for="(stack, index) in stacks"
-                                :key="index"
-                                :value="stack.id"
-                                :label="stack.label || stack.name"
-                            />
-                        </ff-tile-selection>
+                        <FormRow :model-value="input.stack" :options="stacks" :disabled="emptyStacks" data-form="stack">
+                            <template #description>
+                                <label v-if="!input.projectType" class="text-sm text-gray-400">
+                                    Please select a Instance Type first.
+                                </label>
+                                <label v-if="errors.stack" class="text-sm text-gray-400">
+                                    {{ errors.stack }}
+                                </label>
+                            </template>
+                        </FormRow>
                     </div>
 
                     <!-- Template -->
@@ -471,6 +467,9 @@ export default {
         },
         hasValidName () {
             return this.validateName(this.input.name)
+        },
+        emptyStacks () {
+            return this.stacks.length === 0
         }
     },
     watch: {
@@ -676,7 +675,9 @@ export default {
             this.errors.stack = ''
 
             const stackList = await stacksApi.getStacks(null, null, null, projectType.id)
-            this.stacks = stackList.stacks.filter(stack => stack.active)
+            this.stacks = stackList.stacks
+                .filter(stack => stack.active)
+                .map(stack => { return { ...stack, value: stack.id } })
 
             if (this.stacks.length === 0) {
                 this.input.stack = null

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -148,7 +148,13 @@
                     <!-- Stack -->
                     <div class="flex flex-wrap gap-1 items-stretch">
                         <label class="w-full block text-sm font-medium text-gray-700 mb-1">Choose your Node-RED Version</label>
-                        <FormRow v-model="input.stack" value="id" :options="stacks" :disabled="emptyStacks" data-el="stack-selector">
+                        <FormRow
+                            v-model="input.stack"
+                            value="id" :options="stacks"
+                            :disabled="emptyStacks"
+                            data-el="stack-selector"
+                            container-class="max-w-sm w-full"
+                        >
                             <template #description>
                                 <label v-if="!input.projectType" class="text-sm text-gray-400">
                                     Please select a Instance Type first.

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -148,7 +148,7 @@
                     <!-- Stack -->
                     <div class="flex flex-wrap gap-1 items-stretch">
                         <label class="w-full block text-sm font-medium text-gray-700 mb-4">Choose your Node-RED Version</label>
-                        <FormRow :model-value="input.stack" :options="stacks" :disabled="emptyStacks" data-form="stack">
+                        <FormRow v-model="input.stack" value="id" :options="stacks" :disabled="emptyStacks" data-el="stack-selector">
                             <template #description>
                                 <label v-if="!input.projectType" class="text-sm text-gray-400">
                                     Please select a Instance Type first.

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -147,7 +147,7 @@
 
                     <!-- Stack -->
                     <div class="flex flex-wrap gap-1 items-stretch">
-                        <label class="w-full block text-sm font-medium text-gray-700 mb-4">Choose your Node-RED Version</label>
+                        <label class="w-full block text-sm font-medium text-gray-700 mb-1">Choose your Node-RED Version</label>
                         <FormRow v-model="input.stack" value="id" :options="stacks" :disabled="emptyStacks" data-el="stack-selector">
                             <template #description>
                                 <label v-if="!input.projectType" class="text-sm text-gray-400">

--- a/test/e2e/frontend/cypress/tests/instances.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances.spec.js
@@ -148,10 +148,13 @@ describe('FlowForge - Instances', () => {
                 expect(projectName).to.equal('instance-1-1')
             })
 
-            cy.get('[data-form="instance-stack"]').contains('stack2').click()
+            // can't use .select('value') because we're not dealing with a select input
+            cy.get('[data-el="stack-selector"]').click()
+            cy.get('[data-el="stack-selector"]').contains('stack 2').click()
             cy.get('[data-action="update-project"]').should('not.be.disabled') // changes _have_ now been made
 
-            cy.get('[data-form="instance-stack"]').contains('stack1').click() // re-select
+            cy.get('[data-el="stack-selector"]').click()
+            cy.get('[data-el="stack-selector"]').contains('stack 1').click() // re-select
             cy.get('[data-action="update-project"]').should('be.disabled')
 
             cy.get('[data-form="project-type"]').contains('type2').click()
@@ -165,7 +168,7 @@ describe('FlowForge - Instances', () => {
         cy.wait('@getInstance')
 
         cy.contains('instance-1-1')
-        cy.contains('type2 / stack1-for-type2')
+        cy.contains('type2 / stack 1 for type2')
 
         // Put it back how it was
         cy.get('[data-nav="instance-settings"]').click()
@@ -181,7 +184,7 @@ describe('FlowForge - Instances', () => {
         cy.wait('@getInstance')
 
         cy.contains('instance-1-1')
-        cy.contains('type1 / stack1')
+        cy.contains('type1 / stack 1')
     })
 
     it('can be copied', () => {

--- a/test/e2e/frontend/cypress/tests/instances.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances.spec.js
@@ -218,7 +218,7 @@ describe('FlowForge - Instances', () => {
 
         cy.wait('@getInstance')
 
-        cy.contains('type1 / stack1')
+        cy.contains('type1 / stack 1')
     })
 
     it('can be created', () => {

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -72,13 +72,13 @@ module.exports = async function (settings = {}, config = {}) {
 
     // Platform Setup
     const template = await factory.createProjectTemplate({ name: 'template1' }, userAlice)
-    const stack = await factory.createStack({ name: 'stack1' }, projectType)
-    await factory.createStack({ name: 'stack2' }, projectType)
+    const stack = await factory.createStack({ name: 'stack1', label: 'stack 1' }, projectType)
+    await factory.createStack({ name: 'stack2', label: 'stack 2' }, projectType)
 
     // Unused templates and project types
     await factory.createProjectTemplate({ name: 'template2' }, userAlice)
     const spareProjectType = await factory.createProjectType({ name: 'type2' })
-    await factory.createStack({ name: 'stack1-for-type2' }, spareProjectType)
+    await factory.createStack({ name: 'stack1-for-type2', label: 'stack 1 for type2' }, spareProjectType)
 
     // Ensure projectTypes are allowed to be used by the default team type
     const teamType = await forge.db.models.TeamType.findOne({ where: { id: 1 } })


### PR DESCRIPTION
## Description

Replaced the tile selector with a regular select input on instance creation forms

## Related Issue(s)

closes #3895
part of #3884

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

