### PR TITLE
Add a Blueprint selection dialog

### DIFF
--- a/frontend/src/components/blueprints/BlueprintTile.vue
+++ b/frontend/src/components/blueprints/BlueprintTile.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="ff-blueprint-tile" :class="'ff-blueprint-group--' + categoryClass" data-el="blueprint-tile">
+    <div class="ff-blueprint-tile" :class="{['ff-blueprint-group--' + categoryClass]: true, active}" data-el="blueprint-tile">
         <div class="ff-blueprint-tile--header">
             <component :is="getIcon(blueprint.icon)" class="ff-icon" />
         </div>
@@ -13,6 +13,7 @@
                 <label class="text-green-800">Default</label>
             </div>
             <ff-button
+                v-if="displayPreviewButton"
                 data-action="show-blueprint"
                 class="ff-btn--secondary"
                 @click="$refs['flow-renderer-dialog'].show(blueprint)"
@@ -58,6 +59,14 @@ export default {
             type: Object
         },
         editable: {
+            type: Boolean,
+            default: false
+        },
+        displayPreviewButton: {
+            type: Boolean,
+            default: true
+        },
+        active: {
             type: Boolean,
             default: false
         }
@@ -113,6 +122,11 @@ export default {
 .ff-blueprint-tile {
   background-color: $ff-white;
   width: 250px;
+
+  &.active {
+    border-color: $ff-blue-600;
+    transition: border-color .3s;
+  }
 
   .ff-dialog-container {
     .ff-dialog-box {

--- a/frontend/src/components/blueprints/BlueprintTile.vue
+++ b/frontend/src/components/blueprints/BlueprintTile.vue
@@ -29,7 +29,7 @@
                 Edit
             </ff-button>
         </div>
-        <AssetDetailDialog ref="flow-renderer-dialog" :title="blueprint.name" />
+        <AssetDetailDialog v-if="displayPreviewButton" ref="flow-renderer-dialog" :title="blueprint.name" />
     </div>
 </template>
 

--- a/frontend/src/components/blueprints/BlueprintTile.vue
+++ b/frontend/src/components/blueprints/BlueprintTile.vue
@@ -16,7 +16,7 @@
                 v-if="displayPreviewButton"
                 data-action="show-blueprint"
                 class="ff-btn--secondary"
-                @click="$refs['flow-renderer-dialog'].show(blueprint)"
+                @click="$refs.flowRendererDialog.show(blueprint)"
             >
                 <template #icon>
                     <ProjectIcon />
@@ -29,7 +29,7 @@
                 Edit
             </ff-button>
         </div>
-        <AssetDetailDialog v-if="displayPreviewButton" ref="flow-renderer-dialog" :title="blueprint.name" />
+        <AssetDetailDialog v-if="displayPreviewButton" ref="flowRendererDialog" :title="blueprint.name" />
     </div>
 </template>
 

--- a/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
+++ b/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
@@ -1,8 +1,8 @@
 <template>
     <ff-dialog ref="dialog" data-el="blueprint-selector-dialog" class="blueprints-selector-dialog" header="Select a Blueprint">
         <template #default>
-            <section class="blueprints-container">
-                <div class="header">
+            <section class="blueprints-container w-full md:w-full lg:w-2/5 xl:w-2/5 2xl:w-2/5">
+                <div class="header hidden 2xl:block xl:block lg:block">
                     <h3>Select Your Blueprint</h3>
                     <p>To get started, we have a collection of pre-built flow templates that you can use as a starting point for your Node-RED Instance.</p>
                 </div>
@@ -16,7 +16,7 @@
                     />
                 </div>
             </section>
-            <section class="flow-viewer-container">
+            <section class="flow-viewer-container hidden 2xl:block xl:block lg:block w-full md:w-full lg:w-3/5 xl:w-3/5 2xl:w-3/5">
                 <div ref="viewer" class="viewer" @click.stop.prevent />
             </section>
         </template>
@@ -118,17 +118,13 @@ export default {
 
       .ff-dialog-content {
         display: flex;
+        flex-direction: row;
         padding: 0;
         overflow: auto;
 
         .blueprints-container {
-          padding: 10px;
+          padding: 10px 10px 0;
           overflow: auto;
-          max-width: 40%;
-          min-width: 450px;
-          flex: 1;
-          display: flex;
-          flex-direction: column;
 
           .header {
             padding: 0 0 10px;
@@ -155,12 +151,22 @@ export default {
               line-height: 1.5;
               margin-top: 10px;
             }
-          }
 
+            .blueprint-group {
+              display: flex;
+              flex-direction: row;
+              flex-wrap: wrap;
+
+              .ff-blueprint-tile {
+                width: auto;
+                max-width: 250px;
+                flex: 1 1 200px;
+              }
+            }
+          }
         }
 
         .flow-viewer-container {
-          flex: 1;
           overflow: hidden;
 
           .viewer {

--- a/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
+++ b/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
@@ -1,9 +1,8 @@
 <template>
-    <ff-dialog ref="dialog" data-el="blueprint-selector-dialog" class="blueprints-selector-dialog" header="Select a Blueprint">
+    <ff-dialog ref="dialog" data-el="blueprint-selector-dialog" class="blueprints-selector-dialog" header="Choose a Blueprint">
         <template #default>
             <section class="blueprints-container w-full md:w-full lg:w-2/5 xl:w-2/5 2xl:w-2/5">
                 <div class="header hidden 2xl:block xl:block lg:block">
-                    <h3>Select Your Blueprint</h3>
                     <p>To get started, we have a collection of pre-built flow templates that you can use as a starting point for your Node-RED Instance.</p>
                 </div>
                 <div class="blueprint-selection-wrapper">

--- a/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
+++ b/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
@@ -22,7 +22,7 @@
         <template #actions>
             <div class="flex justify-end">
                 <ff-button kind="secondary" data-action="dialog-cancel" @click="closeDialog">Cancel</ff-button>
-                <ff-button data-action="dialog-confirm" @click="confirmSelection">Confirm Changes</ff-button>
+                <ff-button data-action="dialog-confirm" @click="confirmSelection">Confirm Choice</ff-button>
             </div>
         </template>
     </ff-dialog>

--- a/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
+++ b/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
@@ -1,0 +1,180 @@
+<template>
+    <ff-dialog ref="dialog" data-el="blueprint-selector-dialog" class="blueprints-selector-dialog">
+        <template #default>
+            <section class="blueprints-container">
+                <div class="header">
+                    <h3>Select Your Blueprint</h3>
+                    <p>To get started, we have a collection of pre-built flow templates that you can use as a starting point for your Node-RED Instance.</p>
+                </div>
+                <div class="blueprint-selection-wrapper">
+                    <BlueprintSelection
+                        :blueprints="blueprints"
+                        :with-header="false"
+                        :preview-tiles="false"
+                        :active-blueprint="currentBlueprint"
+                        @selected="onBlueprintSelected"
+                    />
+                </div>
+            </section>
+            <section class="flow-viewer-container">
+                <div ref="viewer" class="viewer" @click.stop.prevent />
+            </section>
+        </template>
+        <template #actions>
+            <div class="flex justify-end">
+                <ff-button kind="secondary" data-action="dialog-cancel" @click="closeDialog">Cancel</ff-button>
+                <ff-button data-action="dialog-confirm" @click="confirmSelection">Confirm Changes</ff-button>
+            </div>
+        </template>
+    </ff-dialog>
+</template>
+<script>
+import FlowRenderer from '@flowfuse/flow-renderer'
+
+import BlueprintSelection from '../../pages/instance/Blueprints/BlueprintSelection.vue'
+
+export default {
+    name: 'BlueprintSelectorDialog',
+    components: { BlueprintSelection },
+    props: {
+        blueprints: {
+            required: true,
+            type: Array
+        },
+        activeBlueprint: {
+            type: Object,
+            required: true
+        }
+    },
+    emits: ['blueprint-updated'],
+    setup () {
+        return {
+            show () {
+                this.renderFlows()
+                this.$refs.dialog.show()
+            }
+        }
+    },
+    data () {
+        return {
+            currentBlueprint: null,
+            renderer: null
+        }
+    },
+    watch: {
+        currentBlueprint (val) {
+            if (val) {
+                this.renderFlows()
+            }
+        }
+    },
+    mounted () {
+        this.mountRenderer()
+            .then(() => this.setCurrentBlueprint())
+            .catch((error) => {
+                console.error('Error mounting renderer', error)
+            })
+    },
+    methods: {
+        closeDialog () {
+            this.$refs.dialog.close()
+        },
+        onBlueprintSelected (blueprint) {
+            this.currentBlueprint = blueprint
+        },
+        renderFlows () {
+            const flows = this.currentBlueprint.flows.flows
+            setTimeout(() => {
+                this.renderer.renderFlows(flows, {
+                    container: this.$refs.viewer
+                })
+            }, 20)
+        },
+        mountRenderer () {
+            return new Promise((resolve) => {
+                this.renderer = new FlowRenderer()
+                resolve()
+            })
+        },
+        setCurrentBlueprint () {
+            this.currentBlueprint = this.activeBlueprint
+        },
+        confirmSelection () {
+            this.$emit('blueprint-updated', this.currentBlueprint)
+            this.closeDialog()
+        }
+    }
+}
+</script>
+
+<style lang="scss">
+.blueprints-selector-dialog {
+    margin: 0 !important;
+
+    .ff-dialog-box {
+      max-width: 90vw;
+      max-height: 80vh;
+      overflow: auto;
+
+      .ff-dialog-content {
+        display: flex;
+        padding: 0;
+        overflow: auto;
+
+        .blueprints-container {
+          padding: 10px;
+          overflow: auto;
+          max-width: 40%;
+          min-width: 450px;
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+
+          .header {
+            padding: 0 0 10px;
+
+            h3 {
+              font-size: 30px;
+            }
+
+            p {
+              line-height: 20px;
+              padding-top: 10px;
+              color : $ff-grey-500;
+            }
+          }
+
+          .blueprint-selection-wrapper {
+            overflow: auto;
+            padding: 10px 0;
+          }
+
+          .ff-blueprint-groups {
+            h4 {
+              font-size: 25px;
+              line-height: 1.5;
+              margin-top: 10px;
+            }
+          }
+
+        }
+
+        .flow-viewer-container {
+          flex: 1;
+          overflow: hidden;
+
+          .viewer {
+            height: 100%;
+            width: 100%;
+          }
+        }
+
+      }
+
+      .ff-dialog-actions {
+        border-top: 1px solid $ff-grey-400;
+      }
+    }
+}
+
+</style>

--- a/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
+++ b/frontend/src/components/dialogs/BlueprintSelectorDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog ref="dialog" data-el="blueprint-selector-dialog" class="blueprints-selector-dialog">
+    <ff-dialog ref="dialog" data-el="blueprint-selector-dialog" class="blueprints-selector-dialog" header="Select a Blueprint">
         <template #default>
             <section class="blueprints-container">
                 <div class="header">

--- a/frontend/src/pages/instance/Blueprints/BlueprintSelection.vue
+++ b/frontend/src/pages/instance/Blueprints/BlueprintSelection.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div v-if="withHeader">
         <h3>Select Your Blueprint</h3>
         <p>To get started, we have a collection of pre-built flow templates that you can use as a starting point for your Node-RED Instance.</p>
     </div>
@@ -8,7 +8,14 @@
             <h4>{{ group }}</h4>
         </div>
         <div class="gap-3 blueprint-group" data-form="blueprint-selection">
-            <BlueprintTile v-for="print in prints" :key="print.id" :blueprint="print" @selected="$emit('selected', print)" />
+            <BlueprintTile
+                v-for="print in prints"
+                :key="print.id"
+                :blueprint="print"
+                :display-preview-button="previewTiles"
+                :active="activeBlueprint && activeBlueprint.id === print.id"
+                @selected="$emit('selected', print)"
+            />
         </div>
     </div>
 </template>
@@ -26,6 +33,18 @@ export default {
     props: {
         blueprints: {
             type: Array,
+            default: null
+        },
+        withHeader: {
+            type: Boolean,
+            default: true
+        },
+        previewTiles: {
+            type: Boolean,
+            default: true
+        },
+        activeBlueprint: {
+            type: Object,
             default: null
         }
     },

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -221,7 +221,7 @@
                 No changes have been made
             </label>
         </div>
-        <AssetDetailDialog ref="flow-renderer-dialog" />
+        <AssetDetailDialog ref="flow-renderer-dialog" class="preview-main-blueprint" />
         <BlueprintSelectorDialog
             v-if="blueprints.length"
             ref="blueprint-selector-dialog"

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -221,10 +221,10 @@
                 No changes have been made
             </label>
         </div>
-        <AssetDetailDialog ref="flow-renderer-dialog" class="preview-main-blueprint" />
+        <AssetDetailDialog ref="flowRendererDialog" class="preview-main-blueprint" />
         <BlueprintSelectorDialog
             v-if="blueprints.length"
-            ref="blueprint-selector-dialog"
+            ref="blueprintSelectorDialog"
             :blueprints="blueprints"
             :active-blueprint="selectedBlueprint"
             @blueprint-updated="input.flowBlueprintId = $event.id"
@@ -720,10 +720,10 @@ export default {
             this.input.flowBlueprintId = blueprint.id
         },
         openBlueprintSelectorDialog () {
-            this.$refs['blueprint-selector-dialog'].show()
+            this.$refs.blueprintSelectorDialog.show()
         },
         previewBlueprint (blueprint) {
-            this.$refs['flow-renderer-dialog'].show(blueprint)
+            this.$refs.flowRendererDialog.show(blueprint)
         },
         onSubmit () {
             this.$emit(

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -86,7 +86,7 @@
                             </div>
                             <div
                                 class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-1 items-center"
-                                @click="input.flowBlueprintId = ''"
+                                @click="openBlueprintSelectorDialog"
                             >
                                 <FolderIcon class="ff-btn--icon" />
                                 <span>Choose a different Blueprint</span>
@@ -227,6 +227,13 @@
             </label>
         </div>
         <AssetDetailDialog ref="flow-renderer-dialog" />
+        <BlueprintSelectorDialog
+            v-if="blueprints.length"
+            ref="blueprint-selector-dialog"
+            :blueprints="blueprints"
+            :active-blueprint="selectedBlueprint"
+            @blueprint-updated="input.flowBlueprintId = $event.id"
+        />
     </form>
 </template>
 
@@ -244,6 +251,7 @@ import FormRow from '../../../components/FormRow.vue'
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
 import FeatureUnavailableToTeam from '../../../components/banners/FeatureUnavailableToTeam.vue'
 import AssetDetailDialog from '../../../components/dialogs/AssetDetailDialog.vue'
+import BlueprintSelectorDialog from '../../../components/dialogs/BlueprintSelectorDialog.vue'
 
 import ProjectIcon from '../../../components/icons/Projects.js'
 
@@ -260,6 +268,7 @@ export default {
     name: 'InstanceForm',
     components: {
         AssetDetailDialog,
+        BlueprintSelectorDialog,
         FolderIcon,
         ExportInstanceComponents,
         FeatureUnavailableToTeam,
@@ -719,6 +728,9 @@ export default {
         },
         selectBlueprint (blueprint) {
             this.input.flowBlueprintId = blueprint.id
+        },
+        openBlueprintSelectorDialog () {
+            this.$refs['blueprint-selector-dialog'].show()
         },
         previewBlueprint (blueprint) {
             this.$refs['flow-renderer-dialog'].show(blueprint)

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -67,144 +67,139 @@
         </FormRow>
 
         <div v-if="!creatingApplication || input.createInstance" :class="creatingApplication ? 'ml-6' : ''" class="space-y-6">
-            <template v-if="blueprintSelectionVisible">
-                <!-- Blueprints Selection First -->
-                <BlueprintSelection :blueprints="blueprints" @selected="selectBlueprint" />
-            </template>
-            <template v-else>
-                <div v-if="creatingNew && flowBlueprintsEnabled && atLeastOneFlowBlueprint && !isCopyProject">
-                    <div data-form="blueprint">
-                        <label class="block text-sm font-medium text-gray-800 mb-2">Blueprint:</label>
-                        <BlueprintTileSmall :blueprint="selectedBlueprint" @click="previewBlueprint" />
-                        <div v-if="showFlowBlueprintSelection" class="mt-2 flex gap-4" data-action="blueprint-actions">
-                            <div
-                                class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-1 items-center"
-                                @click="previewBlueprint(selectedBlueprint)"
-                            >
-                                <ProjectIcon class="ff-btn--icon" />
-                                <span>Preview Blueprint</span>
-                            </div>
-                            <div
-                                class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-1 items-center"
-                                @click="openBlueprintSelectorDialog"
-                            >
-                                <FolderIcon class="ff-btn--icon" />
-                                <span>Choose a different Blueprint</span>
-                            </div>
+            <!-- Instance Name -->
+            <div>
+                <FormRow
+                    v-model="input.name"
+                    :error="errors.name || submitErrors?.name"
+                    :disabled="!creatingNew"
+                    container-class="max-w-xl"
+                    data-form="project-name"
+                >
+                    <template #default>
+                        Instance Name
+                    </template>
+                    <template v-if="creatingNew" #appended-description>
+                        <p v-if="hasValidName" class="instance-name-confirmation">
+                            <CheckCircleIcon class="ff-btn--icon" />
+                            <span>Your instance will be created as "<i>{{ instanceName }}</i>".</span>
+                        </p>
+                        The instance name is used to access the editor, so it must be suitable for use in a URL. It is not currently possible to rename the instance after it has been created.
+                    </template>
+                    <template v-if="creatingNew" #append>
+                        <ff-button kind="secondary" @click="refreshName">
+                            <template #icon>
+                                <RefreshIcon />
+                            </template>
+                        </ff-button>
+                    </template>
+                </FormRow>
+            </div>
+
+            <div v-if="creatingNew && flowBlueprintsEnabled && atLeastOneFlowBlueprint && !isCopyProject">
+                <div data-form="blueprint">
+                    <label class="block text-sm font-medium text-gray-800 mb-2">Blueprint:</label>
+                    <BlueprintTileSmall :blueprint="selectedBlueprint" @click="previewBlueprint" />
+                    <div v-if="showFlowBlueprintSelection" class="mt-2 flex gap-4" data-action="blueprint-actions">
+                        <div
+                            class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-1 items-center"
+                            @click="previewBlueprint(selectedBlueprint)"
+                        >
+                            <ProjectIcon class="ff-btn--icon" />
+                            <span>Preview Blueprint</span>
+                        </div>
+                        <div
+                            class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline text-sm flex gap-1 items-center"
+                            @click="openBlueprintSelectorDialog"
+                        >
+                            <FolderIcon class="ff-btn--icon" />
+                            <span>Choose a different Blueprint</span>
                         </div>
                     </div>
                 </div>
-                <!-- Instance Name -->
-                <div>
-                    <FormRow
-                        v-model="input.name"
-                        :error="errors.name || submitErrors?.name"
-                        :disabled="!creatingNew"
-                        container-class="max-w-xl"
-                        data-form="project-name"
-                    >
-                        <template #default>
-                            Instance Name
-                        </template>
-                        <template v-if="creatingNew" #appended-description>
-                            <p v-if="hasValidName" class="instance-name-confirmation">
-                                <CheckCircleIcon class="ff-btn--icon" />
-                                <span>Your instance will be created as "<i>{{ instanceName }}</i>".</span>
-                            </p>
-                            The instance name is used to access the editor, so it must be suitable for use in a URL. It is not currently possible to rename the instance after it has been created.
-                        </template>
-                        <template v-if="creatingNew" #append>
-                            <ff-button kind="secondary" @click="refreshName">
-                                <template #icon>
-                                    <RefreshIcon />
-                                </template>
-                            </ff-button>
-                        </template>
-                    </FormRow>
-                </div>
+            </div>
 
-                <!-- Instance Type -->
-                <div v-if="errors.projectType" class="text-red-400 text-xs">
-                    {{ errors.projectType }}
-                </div>
-                <template v-else>
-                    <div v-if="projectTypes.length > 0" class="flex flex-wrap items-stretch">
-                        <label class="w-full block text-sm font-medium text-gray-700">Choose your Instance Type</label>
-                        <InstanceCreditBanner :subscription="subscription" />
-                        <ff-tile-selection v-model="input.projectType" class="mt-5" data-form="project-type">
-                            <ff-tile-selection-option
-                                v-for="(projType, index) in filteredProjectTypes"
-                                :key="index"
-                                :label="projType.name"
-                                :description="projType.description"
-                                :price="projType.price"
-                                :price-interval="projType.priceInterval"
-                                :value="projType.id"
-                                :disabled="projType.disabled"
-                            />
-                        </ff-tile-selection>
-                    </div>
-
-                    <!-- Stack -->
-                    <div class="flex flex-wrap gap-1 items-stretch">
-                        <label class="w-full block text-sm font-medium text-gray-700 mb-4">Choose your Node-RED Version</label>
-                        <label v-if="!input.projectType" class="text-sm text-gray-400">
-                            Please select a Instance Type first.
-                        </label>
-                        <label v-if="errors.stack" class="text-sm text-gray-400">
-                            {{ errors.stack }}
-                        </label>
-                        <ff-tile-selection v-if="input.projectType" v-model="input.stack" data-form="instance-stack">
-                            <ff-tile-selection-option
-                                v-for="(stack, index) in stacks"
-                                :key="index"
-                                :value="stack.id"
-                                :label="stack.label || stack.name"
-                            />
-                        </ff-tile-selection>
-                    </div>
-
-                    <!-- Template -->
-                    <div v-if="creatingNew && templates.length > 1 " class="flex flex-wrap gap-1 items-stretch">
-                        <label class="w-full block text-sm font-medium text-gray-700 mb-1">Template</label>
-                        <label v-if="!input.projectType || !input.stack" class="text-sm text-gray-400">
-                            Please select a Instance Type &amp; Node-RED Version first.
-                        </label>
-                        <label v-if="errors.template" class="text-sm text-gray-400">{{ errors.template }}</label>
-                        <ff-tile-selection v-if="input.projectType && input.stack" v-model="input.template" data-form="project-template">
-                            <ff-tile-selection-option
-                                v-for="(t, index) in templates"
-                                :key="index"
-                                :value="t.id"
-                                :disabled="isCopyProject"
-                                :label="t.name"
-                                :description="t.description"
-                            />
-                        </ff-tile-selection>
-                    </div>
-
-                    <!-- Copying a instance -->
-                    <template v-if="isCopyProject">
-                        <p class="text-gray-500">
-                            Select the components to copy from '{{ sourceInstance?.name }}'
-                        </p>
-                        <ExportInstanceComponents id="exportSettings" v-model="copyParts" />
-                    </template>
-
-                    <!-- Billing details -->
-                    <div v-if="showBilling">
-                        <InstanceChargesTable
-                            :project-type="selectedProjectType"
-                            :subscription="subscription"
-                            :trialMode="isTrialProjectSelected"
-                            :prorationMode="team?.type?.properties?.billing?.proration"
+            <!-- Instance Type -->
+            <div v-if="errors.projectType" class="text-red-400 text-xs">
+                {{ errors.projectType }}
+            </div>
+            <template v-else>
+                <div v-if="projectTypes.length > 0" class="flex flex-wrap items-stretch">
+                    <label class="w-full block text-sm font-medium text-gray-700">Choose your Instance Type</label>
+                    <InstanceCreditBanner :subscription="subscription" />
+                    <ff-tile-selection v-model="input.projectType" class="mt-5" data-form="project-type">
+                        <ff-tile-selection-option
+                            v-for="(projType, index) in filteredProjectTypes"
+                            :key="index"
+                            :label="projType.name"
+                            :description="projType.description"
+                            :price="projType.price"
+                            :price-interval="projType.priceInterval"
+                            :value="projType.id"
+                            :disabled="projType.disabled"
                         />
-                    </div>
+                    </ff-tile-selection>
+                </div>
+
+                <!-- Stack -->
+                <div class="flex flex-wrap gap-1 items-stretch">
+                    <label class="w-full block text-sm font-medium text-gray-700 mb-4">Choose your Node-RED Version</label>
+                    <label v-if="!input.projectType" class="text-sm text-gray-400">
+                        Please select a Instance Type first.
+                    </label>
+                    <label v-if="errors.stack" class="text-sm text-gray-400">
+                        {{ errors.stack }}
+                    </label>
+                    <ff-tile-selection v-if="input.projectType" v-model="input.stack" data-form="instance-stack">
+                        <ff-tile-selection-option
+                            v-for="(stack, index) in stacks"
+                            :key="index"
+                            :value="stack.id"
+                            :label="stack.label || stack.name"
+                        />
+                    </ff-tile-selection>
+                </div>
+
+                <!-- Template -->
+                <div v-if="creatingNew && templates.length > 1 " class="flex flex-wrap gap-1 items-stretch">
+                    <label class="w-full block text-sm font-medium text-gray-700 mb-1">Template</label>
+                    <label v-if="!input.projectType || !input.stack" class="text-sm text-gray-400">
+                        Please select a Instance Type &amp; Node-RED Version first.
+                    </label>
+                    <label v-if="errors.template" class="text-sm text-gray-400">{{ errors.template }}</label>
+                    <ff-tile-selection v-if="input.projectType && input.stack" v-model="input.template" data-form="project-template">
+                        <ff-tile-selection-option
+                            v-for="(t, index) in templates"
+                            :key="index"
+                            :value="t.id"
+                            :disabled="isCopyProject"
+                            :label="t.name"
+                            :description="t.description"
+                        />
+                    </ff-tile-selection>
+                </div>
+
+                <!-- Copying a instance -->
+                <template v-if="isCopyProject">
+                    <p class="text-gray-500">
+                        Select the components to copy from '{{ sourceInstance?.name }}'
+                    </p>
+                    <ExportInstanceComponents id="exportSettings" v-model="copyParts" />
                 </template>
+
+                <!-- Billing details -->
+                <div v-if="showBilling">
+                    <InstanceChargesTable
+                        :project-type="selectedProjectType"
+                        :subscription="subscription"
+                        :trialMode="isTrialProjectSelected"
+                        :prorationMode="team?.type?.properties?.billing?.proration"
+                    />
+                </div>
             </template>
         </div>
-        <!-- Submit -->
-        <div v-if="!blueprintSelectionVisible" class="flex flex-wrap gap-1 items-center">
+
+        <div class="flex flex-wrap gap-1 items-center">
             <ff-button v-if="!creatingNew" class="ff-btn--secondary" @click="$router.back()">
                 Cancel
             </ff-button>
@@ -257,7 +252,6 @@ import ProjectIcon from '../../../components/icons/Projects.js'
 
 import NameGenerator from '../../../utils/name-generator/index.js'
 
-import BlueprintSelection from '../Blueprints/BlueprintSelection.vue'
 import BlueprintTileSmall from '../Blueprints/BlueprintTileSmall.vue'
 
 import ExportInstanceComponents from './ExportInstanceComponents.vue'
@@ -277,7 +271,6 @@ export default {
         InstanceCreditBanner,
         RefreshIcon,
         SectionTopMenu,
-        BlueprintSelection,
         BlueprintTileSmall,
         CheckCircleIcon,
         ProjectIcon
@@ -465,9 +458,6 @@ export default {
         },
         selectedBlueprint () {
             return this.blueprints.find((blueprint) => blueprint.id === this.input.flowBlueprintId)
-        },
-        blueprintSelectionVisible () {
-            return this.creatingNew && this.showFlowBlueprintSelection && !this.input.flowBlueprintId
         },
         heroTitle () {
             return this.creatingNew ? (this.creatingApplication ? 'Create a new Application' : 'Create Instance') : 'Update Instance'

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -141,26 +141,26 @@
                     </ff-tile-selection>
                 </div>
 
-                    <!-- Stack -->
-                    <div class="flex flex-wrap gap-1 items-stretch">
-                        <label class="w-full block text-sm font-medium text-gray-700 mb-1">Choose your Node-RED Version</label>
-                        <FormRow
-                            v-model="input.stack"
-                            value="id" :options="stacks"
-                            :disabled="emptyStacks"
-                            data-el="stack-selector"
-                            container-class="max-w-sm w-full"
-                        >
-                            <template #description>
-                                <label v-if="!input.projectType" class="text-sm text-gray-400">
-                                    Please select a Instance Type first.
-                                </label>
-                                <label v-if="errors.stack" class="text-sm text-gray-400">
-                                    {{ errors.stack }}
-                                </label>
-                            </template>
-                        </FormRow>
-                    </div>
+                <!-- Stack -->
+                <div class="flex flex-wrap gap-1 items-stretch">
+                    <label class="w-full block text-sm font-medium text-gray-700 mb-1">Choose your Node-RED Version</label>
+                    <FormRow
+                        v-model="input.stack"
+                        value="id" :options="stacks"
+                        :disabled="emptyStacks"
+                        data-el="stack-selector"
+                        container-class="max-w-sm w-full"
+                    >
+                        <template #description>
+                            <label v-if="!input.projectType" class="text-sm text-gray-400">
+                                Please select a Instance Type first.
+                            </label>
+                            <label v-if="errors.stack" class="text-sm text-gray-400">
+                                {{ errors.stack }}
+                            </label>
+                        </template>
+                    </FormRow>
+                </div>
 
                 <!-- Template -->
                 <div v-if="creatingNew && templates.length > 1 " class="flex flex-wrap gap-1 items-stretch">

--- a/test/e2e/frontend/cypress/tests-ee/blueprints/blueprints.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/blueprints/blueprints.spec.js
@@ -2,21 +2,21 @@ import multipleBlueprints from '../../fixtures/blueprints/multiple-blueprints.js
 import singleBlueprint from '../../fixtures/blueprints/single-blueprint.json'
 
 const canPreviewBlueprintByClickingTheBlueprintTile = () => {
-    cy.get('[data-el="flow-view-dialog"]').should('not.be.visible')
+    cy.get('[data-el="flow-view-dialog"].preview-main-blueprint').should('not.be.visible')
     cy.get('[data-action="click-small-blueprint-tile"]').should('exist')
     cy.get('[data-action="click-small-blueprint-tile"]').click()
-    cy.get('[data-el="flow-view-dialog"]').should('be.visible')
-    cy.get('[data-el="flow-view-dialog"]').within(() => {
+    cy.get('[data-el="flow-view-dialog"].preview-main-blueprint').should('be.visible')
+    cy.get('[data-el="flow-view-dialog"].preview-main-blueprint').within(() => {
         cy.get('[data-action="dialog-confirm"]').click()
     })
 }
 
 const canPreviewBlueprintByClickingThePreviewBlueprintButton = () => {
-    cy.get('[data-el="flow-view-dialog"]').should('not.be.visible')
+    cy.get('[data-el="flow-view-dialog"].preview-main-blueprint').should('not.be.visible')
     cy.get('[data-action="blueprint-actions"]').should('exist')
     cy.get('[data-action="blueprint-actions"]').contains('Preview Blueprint').click()
-    cy.get('[data-el="flow-view-dialog"]').should('be.visible')
-    cy.get('[data-el="flow-view-dialog"]').within(() => {
+    cy.get('[data-el="flow-view-dialog"].preview-main-blueprint').should('be.visible')
+    cy.get('[data-el="flow-view-dialog"].preview-main-blueprint').within(() => {
         cy.get('[data-action="dialog-confirm"]').click()
     })
 }
@@ -95,7 +95,6 @@ describe('FlowForge - Blueprints', () => {
 
         cy.get('[data-action="blueprint-actions"]').should('not.exist')
 
-        cy.get('[data-form="blueprint-selection"]').should('not.exist')
         cy.get('[data-form="project-name"]').should('exist')
         cy.get('[data-form="project-type"]').should('exist')
     })
@@ -113,20 +112,35 @@ describe('FlowForge - Blueprints', () => {
         cy.get('[data-action="blueprint-actions"]').should('exist')
         cy.get('[data-action="blueprint-actions"]').contains('Choose a different Blueprint').click()
 
-        cy.get('[data-form="blueprint-selection"]').should('exist')
-        cy.get('[data-form="project-name"]').should('not.exist')
-        cy.get('[data-form="project-type"]').should('not.exist')
-
         // check we have two blueprint groups
-        cy.get('[data-form="blueprint-group"]').its('length').should('eq', 2)
+        cy.get('[data-form="blueprint-group"]')
+            .its('length')
+            .should('eq', 2)
         // and one blueprint in the first group, and 2 in the second
-        cy.get('[data-form="blueprint-group"]').first().find('[data-el="blueprint-tile"]').its('length').should('eq', 1)
-        cy.get('[data-form="blueprint-group"]').eq(1).find('[data-el="blueprint-tile"]').its('length').should('eq', 2)
+        cy.get('[data-form="blueprint-group"]')
+            .first()
+            .find('[data-el="blueprint-tile"]')
+            .its('length')
+            .should('eq', 1)
+
+        cy.get('[data-form="blueprint-group"]')
+            .eq(1)
+            .find('[data-el="blueprint-tile"]')
+            .its('length')
+            .should('eq', 2)
 
         // select the second blueprint
-        cy.get('[data-form="blueprint-group"]').eq(1).find('[data-el="blueprint-tile"] [data-action="select-blueprint"]').first().click()
+        cy.get('[data-form="blueprint-group"]')
+            .eq(1)
+            .find('[data-el="blueprint-tile"] [data-action="select-blueprint"]')
+            .first()
+            .click()
 
-        // chck our newly selected blueprint is now in the blueprint preview with the CreateInstance form
+        cy.get('[data-el=blueprint-selector-dialog]').within(() => {
+            cy.get('[data-action="dialog-confirm"]').click()
+        })
+
+        // check our newly selected blueprint is now in the blueprint preview with the CreateInstance form
         cy.get('[data-form="blueprint"]').contains(multipleBlueprints.blueprints[1].name)
     })
 


### PR DESCRIPTION
## Description

Replaces the existing instance form blueprint selection with a blueprint selection dialog.

## Related Issue(s)

closes #3944
part of #3884

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

