### PR TITLE
Hide deprecated env vars in the UI

### DIFF
--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -149,11 +149,11 @@ export default {
         },
         filteredRows: function () {
             if (this.search === '') {
-                return this.editable.settings.env
+                return this.editable.settings.env.filter(row => !row.deprecated)
             }
             const search = this.search.toLowerCase()
             return this.editable.settings.env.filter(row => {
-                return row.name.toLowerCase().includes(search) || row.value.toLowerCase().includes(search)
+                return !row.deprecated && (row.name.toLowerCase().includes(search) || row.value.toLowerCase().includes(search))
             })
         },
         noDataMessage: function () {


### PR DESCRIPTION
## Description

This hides the long-deprecated env vars in the UI as they should not be used today and we should not publicise them.

The way the `FF_` env vars are injected, we have no way to selectively stop injecting them for new instances. We could just remove them (they have been marked deprecated for a long time) - but always nervous of breaking user's flows that have been happily running without needing to change.

Removing them in the UI removes the noise and will prevent further accidental adoption.



