### PR TITLE
Snapshot compare

### DIFF
--- a/frontend/src/components/dialogs/AssetDetailDialog.vue
+++ b/frontend/src/components/dialogs/AssetDetailDialog.vue
@@ -2,7 +2,7 @@
     <ff-dialog ref="dialog" :header="header" confirm-label="Close" :closeOnConfirm="true" data-el="flow-view-dialog" boxClass="!min-w-[80%] !min-h-[80%] !w-[80%] !h-[80%]" contentClass="overflow-hidden flex-grow" @confirm="confirm()">
         <template #default>
             <div v-if="mode==='compare'" class="w-full h-full">
-                <div class="flex gap-2">
+                <div class="flex gap-2" data-el="snapshot-compare-toolbar">
                     <ff-dropdown v-model="compareSnapshot" class="flex-grow">
                         <ff-dropdown-option v-for="option in compareSnapshotList" :key="option.value" :value="option.value" :label="option.label" :title="option.description" class="text-sm">
                             {{ option.label }}

--- a/frontend/src/components/dialogs/AssetDetailDialog.vue
+++ b/frontend/src/components/dialogs/AssetDetailDialog.vue
@@ -1,7 +1,39 @@
 <template>
-    <ff-dialog ref="dialog" :header="header" confirm-label="Close" :closeOnConfirm="true" data-el="flow-view-dialog" boxClass="!min-w-[80%] !min-h-[80%] !w-[80%] !h-[80%]" contentClass="overflow-hidden" @confirm="confirm()">
+    <ff-dialog ref="dialog" :header="header" confirm-label="Close" :closeOnConfirm="true" data-el="flow-view-dialog" boxClass="!min-w-[80%] !min-h-[80%] !w-[80%] !h-[80%]" contentClass="overflow-hidden flex-grow" @confirm="confirm()">
         <template #default>
-            <div ref="viewer" data-el="ff-flow-previewer" class="ff-flow-viewer" @click.stop.prevent>
+            <div v-if="mode==='compare'" class="w-full h-full">
+                <div class="flex gap-2">
+                    <ff-dropdown v-model="compareSnapshot" class="flex-grow">
+                        <ff-dropdown-option v-for="option in compareSnapshotList" :key="option.value" :value="option.value" :label="option.label" :title="option.description" class="text-sm">
+                            {{ option.label }}
+                        </ff-dropdown-option>
+                    </ff-dropdown>
+                    <ff-button
+                        v-if="true"
+                        :disabled="!compareSnapshot"
+                        data-action="compare-snapshots"
+                        kind="secondary"
+                        style="height: 30px; width: 106px"
+                        class="w-32"
+                        @click="renderComparison"
+                    >
+                        Compare
+                    </ff-button>
+                </div>
+                <div v-if="changes.length" class="flex justify-between items-center gap-2 mt-2 ml-2">
+                    <div class="whitespace-nowrap">Change {{ changeIndex + 1 }} of {{ changes.length }}:</div>
+                    <div class="text-sm text-gray-500 flex-grow truncate overflow-ellipsis">{{ changes[changeIndex].toString() }}</div>
+                    <ff-button kind="secondary" size="small" class="w-14" @click="gotoPreviousDifference">Prev</ff-button>
+                    <ff-button kind="secondary" size="small" class="w-14" @click="gotoNextDifference">Next</ff-button>
+                </div>
+                <div v-else class="mt-2">
+                    <div class="text-sm text-gray-500 flex-grow truncate overflow-ellipsis ml-2">No differences found</div>
+                </div>
+                <div ref="compareViewer" data-el="ff-flow-compare-view" class="ff-flow-compare-viewer pt-4" @click.stop.prevent>
+                    &nbsp;
+                </div>
+            </div>
+            <div v-else ref="viewer" data-el="ff-flow-previewer" class="ff-flow-viewer" @click.stop.prevent>
                 Loading...
             </div>
         </template>
@@ -16,6 +48,8 @@
 
 import FlowRenderer from '@flowfuse/flow-renderer'
 
+import Alerts from '../../services/alerts.js'
+
 export default {
     name: 'FlowViewerDialog',
     props: {
@@ -27,17 +61,41 @@ export default {
     setup () {
         return {
             show (payload) { // accepts blueprints, snapshots and libraries
+                this.mode = 'view'
                 this.$refs.dialog.show()
                 this.payload = payload
                 setTimeout(() => {
                     this.renderFlows()
                 }, 20)
+            },
+            /**
+             * Shows the compare flows dialog and presents the user with a list of snapshots to compare against
+             * @param {{flows: { flows :[]}}} v1Snapshot - A snapshot object as the base for comparison
+             * @param {[{label: String, value: String}]} snapshotList - A list of snapshots to compare against where label is the snapshot name and value is the snapshot id
+             * @param {(snapshotId)=>Promise<{flows: { flows :[]}}>} snapshotLoaderCallback - A callback function that accepts a snapshot id and returns the snapshot object
+             */
+            showCompareSnapshots (v1Snapshot, snapshotList, snapshotLoaderCallback) {
+                this.mode = 'compare'
+                this.payload = v1Snapshot
+                this.compareSnapshot = null
+                this.changes = []
+                this.changeIndex = 0
+                this.compareSnapshotList = snapshotList
+                this.getSnapshotCallback = snapshotLoaderCallback
+                this.$refs.dialog.show()
             }
         }
     },
     data () {
         return {
-            payload: []
+            payload: [],
+            snapshotList: [],
+            compareSnapshot: null,
+            compareSnapshotList: [],
+            mode: 'view', // view, compare
+            getSnapshotCallback: null,
+            changes: [],
+            changeIndex: 0
         }
     },
     computed: {
@@ -52,13 +110,45 @@ export default {
     },
     methods: {
         confirm () {
+            this.cleanup()
             this.$refs.dialog.close()
         },
         renderFlows () {
+            this.cleanup()
             const flowRenderer = new FlowRenderer()
             flowRenderer.renderFlows(this.flow, {
                 container: this.$refs.viewer
             })
+        },
+        async renderComparison (snapshotId) {
+            this.cleanup()
+            const compareSnapshot = await this.getSnapshotCallback(this.compareSnapshot)
+            if (!compareSnapshot?.flows?.flows) {
+                Alerts.emit('Flows not found in the selected snapshot', 'warning')
+                return
+            }
+            const flowRenderer = new FlowRenderer()
+            const flows = [this.flow, compareSnapshot?.flows?.flows]
+            const result = flowRenderer.compare(flows, {
+                container: this.$refs.compareViewer
+            })
+            this.changes = result?.changes || []
+        },
+        gotoNextDifference () {
+            this.changeIndex = (this.changeIndex + 1) % this.changes.length
+            this.changes[this.changeIndex].highlight()
+        },
+        gotoPreviousDifference () {
+            this.changeIndex = (this.changeIndex - 1 + this.changes.length) % this.changes.length
+            this.changes[this.changeIndex].highlight()
+        },
+        cleanup () {
+            while (this.$refs.compareViewer?.firstChild) {
+                this.$refs.compareViewer.removeChild(this.$refs.compareViewer.firstChild)
+            }
+            while (this.$refs.viewer?.firstChild) {
+                this.$refs.viewer.removeChild(this.$refs.viewer.firstChild)
+            }
         }
     }
 }
@@ -67,5 +157,8 @@ export default {
 <style scoped>
 .ff-flow-viewer {
     height: 100%;
+}
+.ff-flow-compare-viewer {
+    height: calc(100% - 4.5rem);
 }
 </style>

--- a/frontend/src/pages/application/Snapshots.vue
+++ b/frontend/src/pages/application/Snapshots.vue
@@ -14,6 +14,7 @@
             <ff-data-table data-el="snapshots" class="space-y-4" :columns="columns" :rows="snapshots" :show-search="true" search-placeholder="Search Snapshots...">
                 <template #context-menu="{row}">
                     <ff-list-item :disabled="!canViewSnapshot(row)" label="View Snapshot" @click="showViewSnapshotDialog(row)" />
+                    <ff-list-item :disabled="!canViewSnapshot(row)" label="Compare Snapshot..." @click="showCompareSnapshotDialog(row)" />
                     <ff-list-item :disabled="!canDownload(row)" label="Download Snapshot" @click="showDownloadSnapshotDialog(row)" />
                     <ff-list-item :disabled="!canDownloadPackage(row)" label="Download package.json" @click="downloadSnapshotPackage(row)" />
                     <ff-list-item :disabled="!canDelete(row)" label="Delete Snapshot" kind="danger" @click="showDeleteSnapshotDialog(row)" />
@@ -41,6 +42,7 @@
     </div>
     <SnapshotExportDialog ref="snapshotExportDialog" data-el="dialog-export-snapshot" />
     <AssetDetailDialog ref="snapshotViewerDialog" data-el="dialog-view-snapshot" />
+    <AssetDetailDialog ref="snapshotCompareDialog" data-el="dialog-compare-snapshot" />
 </template>
 
 <script>
@@ -140,6 +142,24 @@ export default {
         showViewSnapshotDialog (row) {
             SnapshotsApi.getFullSnapshot(row.id).then((data) => {
                 this.$refs.snapshotViewerDialog.show(data)
+            }).catch(err => {
+                console.error(err)
+                Alerts.emit('Failed to get snapshot.', 'warning')
+            })
+        },
+        showCompareSnapshotDialog (snapshot) {
+            SnapshotsApi.getFullSnapshot(snapshot.id).then((data) => {
+                const snapshotList = this.snapshots.map(s => {
+                    return {
+                        label: s.name,
+                        description: s.description || '',
+                        value: s.id
+                    }
+                })
+                const snapshotLoaderCallback = (snapshotId) => {
+                    return SnapshotsApi.getFullSnapshot(snapshotId)
+                }
+                this.$refs.snapshotCompareDialog.showCompareSnapshots(data, snapshotList, snapshotLoaderCallback)
             }).catch(err => {
                 console.error(err)
                 Alerts.emit('Failed to get snapshot.', 'warning')

--- a/frontend/src/pages/instance/Snapshots/index.vue
+++ b/frontend/src/pages/instance/Snapshots/index.vue
@@ -19,6 +19,7 @@
                 <template #context-menu="{row}">
                     <ff-list-item :disabled="!hasPermission('project:snapshot:rollback')" label="Deploy Snapshot" @click="showRollbackDialog(row)" />
                     <ff-list-item :disabled="!hasPermission('snapshot:full')" label="View Snapshot" @click="showViewSnapshotDialog(row)" />
+                    <ff-list-item :disabled="!hasPermission('snapshot:full')" label="Compare Snapshot..." @click="showCompareSnapshotDialog(row)" />
                     <ff-list-item :disabled="!hasPermission('project:snapshot:export')" label="Download Snapshot" @click="showDownloadSnapshotDialog(row)" />
                     <ff-list-item :disabled="!hasPermission('project:snapshot:read')" label="Download package.json" @click="downloadSnapshotPackage(row)" />
                     <ff-list-item :disabled="!hasPermission('project:snapshot:set-target')" label="Set as Device Target" @click="showDeviceTargetDialog(row)" />
@@ -57,6 +58,7 @@
         <SnapshotExportDialog ref="snapshotExportDialog" data-el="dialog-export-snapshot" :project="instance" />
         <SnapshotImportDialog ref="snapshotImportDialog" title="Upload Snapshot" data-el="dialog-import-snapshot" :owner="instance" owner-type="instance" @snapshot-import-success="onSnapshotImportSuccess" @snapshot-import-failed="onSnapshotImportFailed" @canceled="onSnapshotImportCancel" />
         <AssetDetailDialog ref="snapshotViewerDialog" data-el="dialog-view-snapshot" />
+        <AssetDetailDialog ref="snapshotCompareDialog" data-el="dialog-compare-snapshot" />
     </div>
 </template>
 
@@ -268,7 +270,24 @@ export default {
                 Alerts.emit('Failed to get snapshot.', 'warning')
             })
         },
-
+        showCompareSnapshotDialog (snapshot) {
+            SnapshotsApi.getFullSnapshot(snapshot.id).then((data) => {
+                const snapshotList = this.snapshots.map(s => {
+                    return {
+                        label: s.name,
+                        description: s.description || '',
+                        value: s.id
+                    }
+                })
+                const snapshotLoaderCallback = (snapshotId) => {
+                    return SnapshotsApi.getFullSnapshot(snapshotId)
+                }
+                this.$refs.snapshotCompareDialog.showCompareSnapshots(data, snapshotList, snapshotLoaderCallback)
+            }).catch(err => {
+                console.error(err)
+                Alerts.emit('Failed to get snapshot.', 'warning')
+            })
+        },
         // snapshot actions - import
         showImportSnapshotDialog () {
             this.busyImportingSnapshot = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,15 +125,6 @@
                 "node": ">=18.x"
             }
         },
-        "../../../flow-renderer": {
-            "name": "@flowfuse/flow-renderer",
-            "version": "0.4.0",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=16.x"
-            }
-        },
         "node_modules/@aashutoshrathi/word-wrap": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@fastify/swagger-ui": "^3.0.0",
                 "@fastify/websocket": "^8.1.0",
                 "@flowfuse/driver-localfs": "^2.4.0",
-                "@flowfuse/flow-renderer": "^0.3.1",
+                "@flowfuse/flow-renderer": "^0.4.0",
                 "@headlessui/vue": "1.7.19",
                 "@heroicons/vue": "1.0.6",
                 "@immobiliarelabs/fastify-sentry": "^8.0.0",
@@ -123,6 +123,15 @@
             },
             "engines": {
                 "node": ">=18.x"
+            }
+        },
+        "../../../flow-renderer": {
+            "name": "@flowfuse/flow-renderer",
+            "version": "0.4.0",
+            "extraneous": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.x"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -5076,9 +5085,9 @@
             }
         },
         "node_modules/@flowfuse/flow-renderer": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/flow-renderer/-/flow-renderer-0.3.1.tgz",
-            "integrity": "sha512-2adjaABR3UfLiCnav2mp8Wdcc1Nj+ttJ/2Jlw+MOL5snI+CQgP62PmI7kFS12bUWsX8IsCsOvYMxWCWqQqCo7w==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/flow-renderer/-/flow-renderer-0.4.0.tgz",
+            "integrity": "sha512-TDctQlCTUnqfBFE11YUbYo+3B2p7pEJT5y4exZSlkwLeOXN4HURQF6Vah3OGyA5Ryt66fRSBnRmjPZmQ7XYjMw==",
             "engines": {
                 "node": ">=16.x"
             }
@@ -27760,9 +27769,9 @@
             }
         },
         "@flowfuse/flow-renderer": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@flowfuse/flow-renderer/-/flow-renderer-0.3.1.tgz",
-            "integrity": "sha512-2adjaABR3UfLiCnav2mp8Wdcc1Nj+ttJ/2Jlw+MOL5snI+CQgP62PmI7kFS12bUWsX8IsCsOvYMxWCWqQqCo7w=="
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/flow-renderer/-/flow-renderer-0.4.0.tgz",
+            "integrity": "sha512-TDctQlCTUnqfBFE11YUbYo+3B2p7pEJT5y4exZSlkwLeOXN4HURQF6Vah3OGyA5Ryt66fRSBnRmjPZmQ7XYjMw=="
         },
         "@flowfuse/nr-file-nodes": {
             "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "@fastify/swagger-ui": "^3.0.0",
         "@fastify/websocket": "^8.1.0",
         "@flowfuse/driver-localfs": "^2.4.0",
-        "@flowfuse/flow-renderer": "^0.3.1",
+        "@flowfuse/flow-renderer": "^0.4.0",
         "@headlessui/vue": "1.7.19",
         "@heroicons/vue": "1.0.6",
         "@immobiliarelabs/fastify-sentry": "^8.0.0",

--- a/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
@@ -122,7 +122,7 @@ describe('FlowForge - Devices - With Billing', () => {
         // click kebab menu in row 1 - a device snapshot
         cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(0).click()
         // check the options are present
-        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 5)
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 6)
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DEPLOY_SNAPSHOT).contains('Deploy Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).contains('View Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).contains('Compare Snapshot...')
@@ -135,7 +135,7 @@ describe('FlowForge - Devices - With Billing', () => {
         // click kebab menu in row 2 - an instance snapshot
         cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(1).click()
         // click kebab menu in row 2 - an instance snapshot
-        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 5)
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 6)
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DEPLOY_SNAPSHOT).contains('Deploy Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).contains('View Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).contains('Compare Snapshot...')

--- a/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
@@ -9,10 +9,11 @@ const snapshots = {
 }
 
 const IDX_DEPLOY_SNAPSHOT = 0
-const IDX_VIEW_SNAPSHOT = 1
-const IDX_DOWNLOAD_SNAPSHOT = 2
-const IDX_DOWNLOAD_PACKAGE = 3
-const IDX_DELETE_SNAPSHOT = 4
+const IDX_COMPARE_SNAPSHOT = 1
+const IDX_VIEW_SNAPSHOT = 2
+const IDX_DOWNLOAD_SNAPSHOT = 3
+const IDX_DOWNLOAD_PACKAGE = 4
+const IDX_DELETE_SNAPSHOT = 5
 
 describe('FlowForge - Devices - With Billing', () => {
     beforeEach(() => {
@@ -124,6 +125,7 @@ describe('FlowForge - Devices - With Billing', () => {
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 5)
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DEPLOY_SNAPSHOT).contains('Deploy Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).contains('View Snapshot')
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).contains('Compare Snapshot...')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_SNAPSHOT).contains('Download Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_PACKAGE).contains('Download package.json')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DELETE_SNAPSHOT).contains('Delete Snapshot').and('not.have.class', 'disabled')
@@ -136,6 +138,7 @@ describe('FlowForge - Devices - With Billing', () => {
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 5)
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DEPLOY_SNAPSHOT).contains('Deploy Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).contains('View Snapshot')
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).contains('Compare Snapshot...')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_SNAPSHOT).contains('Download Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_PACKAGE).contains('Download package.json')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DELETE_SNAPSHOT).contains('Delete Snapshot')
@@ -161,6 +164,34 @@ describe('FlowForge - Devices - With Billing', () => {
         cy.get('[data-el="dialog-view-snapshot"] .ff-dialog-header').contains(deviceFullSnapshot.name)
         // check an SVG in present the content section
         cy.get('[data-el="dialog-view-snapshot"] .ff-dialog-content svg').should('exist')
+    })
+
+    it('provides functionality to compare snapshots', () => {
+        cy.intercept('GET', '/api/*/applications/*/snapshots*', deviceSnapshots).as('getSnapshots')
+        cy.intercept('GET', '/api/*/snapshots/*/full', deviceFullSnapshot).as('fullSnapshot')
+
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-nav="device-snapshots"]').click()
+
+        // click kebab menu in row 1
+        cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(0).click()
+        // click the View Snapshot option
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).click()
+
+        cy.wait('@fullSnapshot')
+
+        // initially, the compare button should be disabled
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] [data-action="compare-snapshots"]').should('be.disabled')
+
+        // select the snapshot to compare with
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] .ff-dropdown[disabled=false]').click()
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+        // click compare button
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] [data-action="compare-snapshots"]').click()
+        cy.wait('@fullSnapshot')
+
+        // check the flow renders an SVG in the content section
+        cy.get('[data-el="dialog-compare-snapshot"] .ff-dialog-content svg').should('exist')
     })
 
     it('upload snapshot with credentials', () => {

--- a/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
@@ -9,8 +9,8 @@ const snapshots = {
 }
 
 const IDX_DEPLOY_SNAPSHOT = 0
-const IDX_COMPARE_SNAPSHOT = 1
-const IDX_VIEW_SNAPSHOT = 2
+const IDX_VIEW_SNAPSHOT = 1
+const IDX_COMPARE_SNAPSHOT = 2
 const IDX_DOWNLOAD_SNAPSHOT = 3
 const IDX_DOWNLOAD_PACKAGE = 4
 const IDX_DELETE_SNAPSHOT = 5
@@ -176,7 +176,7 @@ describe('FlowForge - Devices - With Billing', () => {
         // click kebab menu in row 1
         cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(0).click()
         // click the View Snapshot option
-        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).click()
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).click()
 
         cy.wait('@fullSnapshot')
 

--- a/test/e2e/frontend/cypress/tests/applications/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/snapshots.spec.js
@@ -14,9 +14,10 @@ const emptySnapshots = {
 }
 
 const IDX_VIEW_SNAPSHOT = 0
-const IDX_DOWNLOAD_SNAPSHOT = 1
-const IDX_DOWNLOAD_PACKAGE = 2
-const IDX_DELETE_SNAPSHOT = 3
+const IDX_COMPARE_SNAPSHOT = 1
+const IDX_DOWNLOAD_SNAPSHOT = 2
+const IDX_DOWNLOAD_PACKAGE = 3
+const IDX_DELETE_SNAPSHOT = 4
 
 describe('FlowForge - Application - Snapshots', () => {
     let application
@@ -71,6 +72,7 @@ describe('FlowForge - Application - Snapshots', () => {
         // check the options are present
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 4)
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).contains('View Snapshot')
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).contains('Compare Snapshot...')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_SNAPSHOT).contains('Download Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_PACKAGE).contains('Download package.json')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DELETE_SNAPSHOT).contains('Delete Snapshot')
@@ -80,6 +82,7 @@ describe('FlowForge - Application - Snapshots', () => {
         // click kebab menu in row 2 - a instance snapshot
         cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(1).click()
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).contains('View Snapshot')
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).contains('Compare Snapshot...')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_SNAPSHOT).contains('Download Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_PACKAGE).contains('Download package.json')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DELETE_SNAPSHOT).contains('Delete Snapshot')
@@ -123,5 +126,36 @@ describe('FlowForge - Application - Snapshots', () => {
         cy.get('[data-el="dialog-view-snapshot"] .ff-dialog-header').contains(instanceFullSnapshot.name)
         // check an SVG in present the content section
         cy.get('[data-el="dialog-view-snapshot"] .ff-dialog-content svg').should('exist')
+    })
+
+    it('provides functionality to compare snapshots', () => {
+        cy.intercept('GET', '/api/*/applications/*/snapshots*', snapshots).as('getSnapshots')
+        cy.intercept('GET', '/api/*/snapshots/*/full', instanceFullSnapshot).as('fullSnapshot')
+
+        cy.get('[data-nav="application-snapshots"]').click()
+
+        // click kebab menu in row 2
+        cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(1).click()
+        // click the View Snapshot option
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).click()
+
+        cy.wait('@fullSnapshot')
+
+        // check the snapshot dialog is visible and contains the snapshot name
+        cy.get('[data-el="dialog-compare-snapshot"]').should('be.visible')
+        cy.get('[data-el="dialog-compare-snapshot"] .ff-dialog-header').contains(instanceFullSnapshot.name)
+
+        // initially, the compare button should be disabled
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] [data-action="compare-snapshots"]').should('be.disabled')
+
+        // select a comparison snapshot
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] .ff-dropdown[disabled=false]').click()
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+        // click compare button
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] [data-action="compare-snapshots"]').click()
+        cy.wait('@fullSnapshot')
+
+        // check an SVG in present the content section
+        cy.get('[data-el="dialog-compare-snapshot"] .ff-dialog-content svg').should('exist')
     })
 })

--- a/test/e2e/frontend/cypress/tests/applications/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/snapshots.spec.js
@@ -70,7 +70,7 @@ describe('FlowForge - Application - Snapshots', () => {
         cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(0).click()
 
         // check the options are present
-        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 4)
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 5)
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).contains('View Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).contains('Compare Snapshot...')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_SNAPSHOT).contains('Download Snapshot')

--- a/test/e2e/frontend/cypress/tests/instances/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances/snapshots.spec.js
@@ -69,7 +69,7 @@ describe('FlowForge - Instance Snapshots', () => {
         cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(0).click()
 
         // check the options are present
-        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 6)
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 7)
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DEPLOY_SNAPSHOT).contains('Deploy Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).contains('View Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).contains('Compare Snapshot...')

--- a/test/e2e/frontend/cypress/tests/instances/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances/snapshots.spec.js
@@ -4,10 +4,11 @@ import instanceFullSnapshot from '../../fixtures/snapshots/instance2-full-snapsh
 import instanceSnapshot from '../../fixtures/snapshots/instance2-snapshot2.json'
 const IDX_DEPLOY_SNAPSHOT = 0
 const IDX_VIEW_SNAPSHOT = 1
-const IDX_DOWNLOAD_SNAPSHOT = 2
-const IDX_DOWNLOAD_PACKAGE = 3
-const IDX_SET_TARGET = 4
-const IDX_DELETE_SNAPSHOT = 5
+const IDX_COMPARE_SNAPSHOT = 2
+const IDX_DOWNLOAD_SNAPSHOT = 3
+const IDX_DOWNLOAD_PACKAGE = 4
+const IDX_SET_TARGET = 5
+const IDX_DELETE_SNAPSHOT = 6
 
 describe('FlowForge - Instance Snapshots', () => {
     let projectId
@@ -71,6 +72,7 @@ describe('FlowForge - Instance Snapshots', () => {
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').should('have.length', 6)
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DEPLOY_SNAPSHOT).contains('Deploy Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_VIEW_SNAPSHOT).contains('View Snapshot')
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).contains('Compare Snapshot...')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_SNAPSHOT).contains('Download Snapshot')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_DOWNLOAD_PACKAGE).contains('Download package.json')
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_SET_TARGET).contains('Set as Device Target')
@@ -93,6 +95,34 @@ describe('FlowForge - Instance Snapshots', () => {
 
         // check the flow renders an SVG in the content section
         cy.get('[data-el="dialog-view-snapshot"] .ff-dialog-content svg').should('exist')
+    })
+
+    it('provides functionality to compare snapshots', () => {
+        cy.intercept('GET', '/api/*/snapshots/*/full', instanceFullSnapshot).as('fullSnapshot')
+        // click kebab menu in row 1
+        cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(0).click()
+        // click the View Snapshot option
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(IDX_COMPARE_SNAPSHOT).click()
+
+        cy.wait('@fullSnapshot')
+
+        cy.get('[data-el="dialog-compare-snapshot"]').should('be.visible')
+
+        // check the snapshot name in the dialog header
+        cy.get('[data-el="dialog-compare-snapshot"] .ff-dialog-header').contains('instance-2 snapshot-2')
+
+        // initially, the compare button should be disabled
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] [data-action="compare-snapshots"]').should('be.disabled')
+
+        // select the snapshot to compare with
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] .ff-dropdown[disabled=false]').click()
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+        // click compare button
+        cy.get('[data-el="dialog-compare-snapshot"] [data-el="snapshot-compare-toolbar"] [data-action="compare-snapshots"]').click()
+        cy.wait('@fullSnapshot')
+
+        // check the flow renders an SVG in the content section
+        cy.get('[data-el="dialog-compare-snapshot"] .ff-dialog-content svg').should('exist')
     })
 
     it('download snapshot', () => {


### PR DESCRIPTION
closes #3977 

## Description

- updates `frontend/src/components/dialogs/AssetDetailDialog.vue` to support snapshot comparison
- updates flow-renderer dep to 0.4.0
- updates/adds e2e tests


### TODO
- [ ] check and update docs if appropriate

## Related Issue(s)

#3977 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

