### PR TITLE
Remove use of html option in Dialog when only used for newlines

### DIFF
--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -237,7 +237,7 @@ export default {
                 header: 'Delete Pipeline',
                 kind: 'danger',
                 confirmLabel: 'Delete',
-                html: `<p>Are you sure you want to delete the pipeline "${this.pipeline.name}"?</p>`
+                text: `Are you sure you want to delete the pipeline "${this.pipeline.name}"?`
             }
             Dialog.show(msg, async () => {
                 await ApplicationAPI.deletePipeline(

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -315,7 +315,7 @@ export default {
                 header: 'Delete Pipeline Stage',
                 kind: 'danger',
                 confirmLabel: 'Delete',
-                html: `<p>Are you sure you want to delete the pipeline stage "${this.stage.name}"?</p>`
+                text: `Are you sure you want to delete the pipeline stage "${this.stage.name}"?`
             }
             Dialog.show(msg, async () => {
                 await PipelineAPI.deletePipelineStage(

--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -17,10 +17,15 @@
                 />
             </TransitionGroup>
             <interview-popup v-if="interview?.enabled" :flag="interview.flag" :payload="interview.payload" />
-            <ff-dialog ref="dialog" data-el="platform-dialog" :header="dialog.header" :kind="dialog.kind" :disable-primary="dialog.disablePrimary" :confirm-label="dialog.confirmLabel" @cancel="clearDialog(true)" @confirm="dialog.onConfirm">
-                <p v-if="dialog.text">{{ dialog.text }}</p>
+            <ff-dialog ref="dialog" data-el="platform-dialog" :header="dialog.header" :kind="dialog.kind" :disable-primary="dialog.disablePrimary" :confirm-label="dialog.confirmLabel" :canBeCanceled="dialog.canBeCanceled" @cancel="clearDialog(true)" @confirm="dialog.onConfirm">
+                <template v-if="dialog.textLines">
+                    <div class="space-y-2">
+                        <p v-for="(text, $index) in dialog.textLines" :key="$index">{{ text }}</p>
+                    </div>
+                </template>
+                <p v-else-if="dialog.text">{{ dialog.text }}</p>
                 <!-- eslint-disable-next-line vue/no-v-html -->
-                <div class="space-y-2" v-html="dialog.html" />
+                <div v-else class="space-y-2" v-html="dialog.html" />
             </ff-dialog>
         </div>
     </div>

--- a/frontend/src/mixins/Dialog.js
+++ b/frontend/src/mixins/Dialog.js
@@ -6,9 +6,11 @@ export default {
             dialog: {
                 header: null,
                 text: null,
+                textLines: null,
                 html: null,
                 confirmLabel: null,
                 kind: null,
+                canBeCanceled: true,
                 onConfirm: null,
                 onCancel: null
             }
@@ -22,9 +24,11 @@ export default {
             this.dialog = {
                 header: null,
                 text: null,
+                textLines: null,
                 html: null,
                 confirmLabel: null,
                 kind: null,
+                canBeCanceled: true,
                 onConfirm: null,
                 onCancel: null
             }
@@ -36,10 +40,14 @@ export default {
                 // msg is an object, let's break it apart
                 this.dialog.header = msg.header
                 this.dialog.text = msg.text
+                this.dialog.textLines = msg.text?.split('\n')
                 this.dialog.html = msg.html
                 this.dialog.confirmLabel = msg.confirmLabel
                 this.dialog.kind = msg.kind
                 this.dialog.disablePrimary = msg.disablePrimary
+                if (Object.hasOwn(msg, 'canBeCanceled')) {
+                    this.dialog.canBeCanceled = msg.canBeCanceled
+                }
             }
             this.dialog.onConfirm = onConfirm
             this.dialog.onCancel = onCancel

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -208,8 +208,8 @@ export default {
             dialog.show({
                 header: 'Delete Account',
                 kind: 'danger',
-                html: `<p>Are you sure you want to delete your account?</p>
-                       <p>This action cannot be undone.</p>`,
+                text: `Are you sure you want to delete your account?
+                       This action cannot be undone.`,
                 confirmLabel: 'Delete'
             }, async () => {
                 userApi.deleteUser()

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -423,7 +423,8 @@ export default {
             Dialog.show({
                 header: 'Update Terms and Conditions',
                 kind: 'danger',
-                html: '<p>This action will require all existing users to reaccept the Terms and Conditions the next time they access the platform.</p><p>Are you sure?</p>',
+                text: `This action will require all existing users to reaccept the Terms and Conditions the next time they access the platform.
+                       Are you sure?`,
                 confirmLabel: 'Continue'
             }, async () => {
                 this.loading = true

--- a/frontend/src/pages/admin/Template/index.vue
+++ b/frontend/src/pages/admin/Template/index.vue
@@ -262,7 +262,7 @@ export default {
                 html += '<p>Application instances using this template will need to be manually restarted to pick up the changes.</p>'
             }
             if (this.modulesChanged) {
-                html += '<p>NOTE: Exiting instances will not inherit the modules in this list.  They must be added manually in the instance settings.</p>'
+                html += '<p>NOTE: Existing instances will not inherit the modules in this list.  They must be added manually in the instance settings.</p>'
             }
             Dialog.show({
                 header: 'Update Template',

--- a/frontend/src/pages/admin/Template/index.vue
+++ b/frontend/src/pages/admin/Template/index.vue
@@ -257,16 +257,16 @@ export default {
             this.editable.errors = {}
         },
         showSaveTemplateDialog () {
-            let html = '<p>Are you sure you want to save this template?</p>'
+            const lines = ['Are you sure you want to save this template?']
             if (this.needsRestart) {
-                html += '<p>Application instances using this template will need to be manually restarted to pick up the changes.</p>'
+                lines.push('Application instances using this template will need to be manually restarted to pick up the changes.')
             }
             if (this.modulesChanged) {
-                html += '<p>NOTE: Existing instances will not inherit the modules in this list.  They must be added manually in the instance settings.</p>'
+                lines.push('NOTE: Existing instances will not inherit the modules in this list.  They must be added manually in the instance settings.')
             }
             Dialog.show({
                 header: 'Update Template',
-                html,
+                text: lines.join('\n'),
                 confirmLabel: 'Save Template'
             }, this.saveTemplate)
         },

--- a/frontend/src/pages/application/DeviceGroup/devices.vue
+++ b/frontend/src/pages/application/DeviceGroup/devices.vue
@@ -320,11 +320,11 @@ export default {
             }
             warning.push('Do you want to continue?')
 
-            const warningMessage = `<p>${warning.join('<br>')}</p>`
+            const warningMessage = warning.join('\n')
             Dialog.show({
                 header: 'Update device group members',
                 kind: 'danger',
-                html: warningMessage,
+                text: warningMessage,
                 confirmLabel: 'Confirm',
                 cancelLabel: 'No'
             }, async () => {

--- a/frontend/src/pages/application/DeviceGroup/settings.vue
+++ b/frontend/src/pages/application/DeviceGroup/settings.vue
@@ -103,8 +103,8 @@ export default {
             Dialog.show({
                 header: 'Delete Account',
                 kind: 'danger',
-                html: `<p>Are you sure you want to delete this device group?</p>
-                       <p>This action cannot be undone.</p>`,
+                text: `Are you sure you want to delete this device group?
+                       This action cannot be undone.`,
                 confirmLabel: 'Delete'
             }, async () => {
                 try {

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -26,7 +26,7 @@ export default {
             const dialogOpts = {
                 header: 'Unsaved changes',
                 kind: 'danger',
-                html: '<p>You have unsaved changes. Are you sure you want to leave?</p>',
+                text: 'You have unsaved changes. Are you sure you want to leave?',
                 confirmLabel: 'Yes, lose changes'
             }
             const answer = await dialog.showAsync(dialogOpts)

--- a/frontend/src/pages/device/components/DeveloperModeToggle.vue
+++ b/frontend/src/pages/device/components/DeveloperModeToggle.vue
@@ -70,17 +70,9 @@ export default {
                     header: 'Disable Developer Mode',
                     kind: 'danger',
                     confirmLabel: 'Confirm',
-                    html: `<p>
-                        Disabling developer mode will turn off access to the editor and
-                        may redeploy the current target snapshot to the device.
-                    </p>
-                    <p>
-                        Any changes made to the device whilst in developer mode will be lost.
-                    </p>
-                    <p>
-                        To avoid losses, you can cancel this operation and create a snapshot
-                        in the developer mode tab.
-                    </p>`
+                    text: `Disabling developer mode will turn off access to the editor and may redeploy the current target snapshot to the device.
+                           Any changes made to the device whilst in developer mode will be lost.
+                           To avoid losses, you can cancel this operation and create a snapshot in the developer mode tab.`
                 }
                 const dialogResult = await Dialog.showAsync(msg)
                 if (dialogResult === 'confirm') {

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -30,7 +30,7 @@ export default {
             const dialogOpts = {
                 header: 'Unsaved changes',
                 kind: 'danger',
-                html: '<p>You have unsaved changes. Are you sure you want to leave?</p>',
+                text: 'You have unsaved changes. Are you sure you want to leave?',
                 confirmLabel: 'Yes, lose changes'
             }
             const answer = await dialog.showAsync(dialogOpts)

--- a/frontend/src/pages/instance/Settings/HighAvailability.vue
+++ b/frontend/src/pages/instance/Settings/HighAvailability.vue
@@ -83,10 +83,8 @@ export default {
         async enableHA () {
             const msg = {
                 header: 'Enable High Availability mode',
-                html: `<p>Enabling HA mode will require a restart of the instance.</p>
-                       <p>Once enabled, the editor will be disabled. The flows can only
-                          be updated by using a DevOps Pipeline to deploy to this instance
-                          from another one, or by disabling HA mode first.</p>`
+                text: `Enabling HA mode will require a restart of the instance.
+                       Once enabled, the editor will be disabled. The flows can only be updated by using a DevOps Pipeline to deploy to this instance from another one, or by disabling HA mode first.`
             }
             Dialog.show(msg, async () => {
                 this.updating = true
@@ -103,7 +101,7 @@ export default {
         async disableHA () {
             const msg = {
                 header: 'Disable High Availability mode',
-                html: '<p>Disabling HA mode will require a restart of the instance.</p>'
+                text: 'Disabling HA mode will require a restart of the instance.'
             }
             Dialog.show(msg, async () => {
                 this.updating = true

--- a/frontend/src/pages/instance/Snapshots/index.vue
+++ b/frontend/src/pages/instance/Snapshots/index.vue
@@ -211,10 +211,9 @@ export default {
         showRollbackDialog (snapshot) {
             Dialog.show({
                 header: 'Deploy Snapshot',
-                html: `<p>This will overwrite the current instance.</p>
-            <p>All changes to the flows, settings and environment variables made since
-                the last snapshot will be lost.</p>
-            <p>Are you sure you want to deploy to this snapshot?</p>`,
+                text: `This will overwrite the current instance.
+                       All changes to the flows, settings and environment variables made since the last snapshot will be lost.
+                       Are you sure you want to deploy to this snapshot?`,
                 confirmLabel: 'Confirm'
             }, async () => {
                 await SnapshotApi.rollbackSnapshot(this.instance.id, snapshot.id)
@@ -225,8 +224,8 @@ export default {
         showDeviceTargetDialog (snapshot) {
             Dialog.show({
                 header: 'Set Device Target Snapshot',
-                html: `<p>Are you sure you want to set this snapshot as the device target?</p>
-            <p>All devices assigned to this instance will be restarted on this snapshot.</p>`,
+                text: `Are you sure you want to set this snapshot as the device target?
+                       All devices assigned to this instance will be restarted on this snapshot.`,
                 confirmLabel: 'Set Target'
             }, async () => {
                 await InstanceApi.updateInstanceDeviceSettings(this.instance.id, {

--- a/frontend/src/services/dialog.js
+++ b/frontend/src/services/dialog.js
@@ -5,8 +5,8 @@ const subscriptions = []
  * @typedef {Object} DialogOptions
  * @param {string} header The dialog title
  * @param {string} kind The dialog kind (optional)
- * @param {string} text The dialog text
- * @param {string} html The dialog html (instead of text)
+ * @param {string} text The dialog text - can include newlines (\n) and they will be formatted properly
+ * @param {string} html The dialog html (instead of text - use with caution to avoid XSS)
  * @param {string} confirmLabel The dialog confirm button label
  */
 


### PR DESCRIPTION
## Description

The `Dialog` service allows content to be provided as either `text` or `html`. Use of the `html` option brings additional risk when including component names as that can lead to XSS vulnerabilities.

This PR does three things:

1. Allows the `text` content to include newlines - which are then automatically rendered properly in the dialog
2. Moves all uses of the `html` option over to `text` where that were purely done to have newlines in the content
3. Ensures the recently added `canBeCanceled` option is also available when using the dialog service rather than via the component directly

