### PR TITLE
Update FF Premium references to FF Enterprise

### DIFF
--- a/frontend/src/components/banners/FeatureUnavailable.vue
+++ b/frontend/src/components/banners/FeatureUnavailable.vue
@@ -22,7 +22,7 @@ export default {
     props: {
         message: {
             type: String,
-            default: 'This is a FlowFuse Premium feature'
+            default: 'This is a FlowFuse Enterprise feature'
         }
     }
 }

--- a/frontend/src/pages/device/Snapshots/index.vue
+++ b/frontend/src/pages/device/Snapshots/index.vue
@@ -31,7 +31,7 @@
             </ff-data-table>
         </template>
         <template v-else-if="!loading">
-            <EmptyState :feature-unavailable="!features.deviceEditor" :feature-unavailable-message="'This requires Developer Mode on Devices, which a FlowFuse Premium Feature'">
+            <EmptyState :feature-unavailable="!features.deviceEditor" :feature-unavailable-message="'This requires Developer Mode on Devices, which is a FlowFuse Enterprise Feature'">
                 <template #img>
                     <img src="../../../images/empty-states/instance-snapshots.png">
                 </template>

--- a/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
@@ -61,7 +61,7 @@ describe('FlowForge - Devices - With Billing', () => {
         cy.contains('A device must be in developer mode and online to create a snapshot.')
     })
 
-    it('doesn\'t show any "Premium Feature Only" guidance if billing is enabled', () => {
+    it('doesn\'t show any "Enterprise Feature Only" guidance if billing is enabled', () => {
         cy.contains('span', 'application-device-a').click()
         cy.get('[data-nav="device-snapshots"]').click()
         cy.get('[data-el="page-banner-feature-unavailable"]').should('not.exist')

--- a/test/e2e/frontend/cypress/tests/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/pipelines.spec.js
@@ -26,7 +26,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         cy.get('[data-nav="application-pipelines"]').get('[data-el="premium-feature"]').should('exist')
     })
 
-    it('is prompted that DevOps Pipelines are a premium feature', () => {
+    it('is prompted that DevOps Pipelines are an enterprise feature', () => {
         cy.visit(`/application/${application.id}/pipelines`)
         cy.url().should('include', `/application/${application.id}/pipelines`)
         cy.get('[data-el="page-banner-feature-unavailable"]').should('exist')

--- a/test/e2e/frontend/cypress/tests/blueprints/blueprints.spec.js
+++ b/test/e2e/frontend/cypress/tests/blueprints/blueprints.spec.js
@@ -4,7 +4,7 @@ describe('FlowForge - Blueprints', () => {
         cy.home()
     })
 
-    it('should flag it\'s a premium feature in the Admin navigation', () => {
+    it('should flag it\'s an enterprise feature in the Admin navigation', () => {
         cy.visit('/admin/overview')
         cy.get('[data-nav="admin-flow-blueprints"]').should('exist')
         cy.get('[data-nav="admin-flow-blueprints"] [data-el="premium-feature"]').should('exist')

--- a/test/e2e/frontend/cypress/tests/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/snapshots.spec.js
@@ -10,14 +10,14 @@ describe('FlowForge - Devices', () => {
         cy.get('[data-action=open-editor]').should('not.exist')
     })
 
-    it('exposes a "Snapshots" tab if assigned to an Application & informs users this is a Premium Feature', () => {
+    it('exposes a "Snapshots" tab if assigned to an Application & informs users this is a Enterprise Feature', () => {
         cy.contains('span', 'application-device-a').click()
         cy.get('[data-nav="device-snapshots"]').should('exist')
         cy.get('[data-nav="device-snapshots"]').click()
         cy.get('[data-el="page-banner-feature-unavailable"]').should('exist')
     })
 
-    it('exposes a "Snapshots" tab if not assigned to anything & informs users this is a Premium Feature', () => {
+    it('exposes a "Snapshots" tab if not assigned to anything & informs users this is a Enterprise Feature', () => {
         cy.contains('span', 'team2-unassigned-device').click()
         cy.get('[data-nav="device-snapshots"]').should('exist')
         cy.get('[data-nav="device-snapshots"]').click()

--- a/test/e2e/frontend/cypress/tests/team/library.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/library.spec.js
@@ -13,7 +13,7 @@ describe('FlowForge - Library', () => {
 
             cy.contains('Shared repository to store common flows and nodes.')
             cy.contains('No Blueprints Available')
-            cy.contains('This is a FlowFuse Premium feature. Please upgrade your instance of FlowFuse in order to use it.')
+            cy.contains('This is a FlowFuse Enterprise feature. Please upgrade your instance of FlowFuse in order to use it.')
         })
     })
     describe('Team Library', () => {
@@ -21,7 +21,7 @@ describe('FlowForge - Library', () => {
             cy.visit('team/ateam/library')
 
             cy.contains('Create your own Team Library')
-            cy.contains('This is a FlowFuse Premium feature. Please upgrade your instance of FlowFuse in order to use it.')
+            cy.contains('This is a FlowFuse Enterprise feature. Please upgrade your instance of FlowFuse in order to use it.')
         })
     })
 })


### PR DESCRIPTION
Updates the use of `FlowFuse Premium` term to the correct `FlowFuse Enterprise` label. 

This is only shown when the platform is not running with an Enterprise license; it is not related to team level permissions.