### PR TITLE
Docs update for custom hostnames

### DIFF
--- a/docs/cloud/introduction.md
+++ b/docs/cloud/introduction.md
@@ -120,35 +120,32 @@ All incoming connections MUST use the hostname and not an IP address.
 
 ## Single-Sign On
 
-FlowFuse supports configuring SAML-based Single Sign-On for particular email domains.
+FlowFuse supports configuring both SAML and LDAP based Single Sign-On for particular email domains.
 
 This can be configured on request for FlowFuse Cloud by submitting a support request
 via our [Contact Us](https://flowfuse.com/contact-us/) page.
 
-You must have the ability to configure a SAML endpoint on your Identity Provider,
+For SAML providers, you must have the ability to configure a SAML endpoint on your Identity Provider,
 and have the authority to configure SSO for your email domain.
 
 We have currently validated our SSO support with the following Identity Providers:
 
+ - Microsoft Entra
  - Google Workspace
  - OneLogin
+ - Keycloak
 
 If you are using a different Identity Provider, please still get in touch, and we
 can evaluate what will be required to enable it.
 
 ## Custom Hostnames
 
-FlowFuse Cloud can support custom hostnames for instances.
+FlowFuse Cloud can support custom hostnames for instances in Enterprise teams.
 
-This feature allows a Team Admin to set an additional hostname for an instance.
-This hostname must be on a domain the Team Admin controls and can set up a DNS
-CNAME entry to point to the correct loadbalancer, for FlowFuse Cloud this should 
-be `custom-loadbalancer.flowfuse.com`
+This allows you to point your own subdomain, such as `dashboard.example.com` at
+one of your instances.
 
-If you also use CAA DNS entries to control which Certificate Authorities can issue
-certificates for your domains, you will need to add a record allowing LetsEncrypt
-to issue certificate. Please see details [here](https://letsencrypt.org/docs/caa/).
-The platform will issue certificates using the `http-01` validation method.
+See [Custom Hostnames](/docs/user/custom-hostnames.md) for more information.
 
 ## Removing your account
 

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -97,9 +97,9 @@ Option        | Description
 `driver.options.logPassthrough` | Prints the Node-RED logs in JSON format to stdout of the instance pods. This should be set with the `forge.logPassthrough=true` Helm chart value. Default: `false`
 `driver.options.privateCA` | The name of a ConfigMap containing a file called `certs.pem` which holds locally trusted CA cert chain. Default: not set
 `driver.options.customHostname.enabled` | Enables the custom hostname feature. Default: `false`
+`driver.options.customHostname.cnameTarget` | This is hostname that users should be the target of a CNAME DNS entry for the hostname. This value is required to enable this feature. Default: not set
 `driver.options.customHostname.ingressClass` | The name of the Ingress Class that should be used for the custom hostname. Default: not set
 `driver.options.customHostname.certManagerIssuer` | The name of the CertManager ClusterIssuer to provision HTTPS certificates for custom hostnames. Default: not set
-`driver.options.customHostname.cnameTarget` | This is hostname that users should be the target of a CNAME DNS entry for the hostname. Default: not set
 
 ## MQTT Broker configuration
 

--- a/docs/user/custom-hostnames.md
+++ b/docs/user/custom-hostnames.md
@@ -1,0 +1,35 @@
+---
+navTitle: Custom Hostnames
+---
+
+# Custom Hostnames
+
+FlowFuse allows you to point a custom subdomain at your instances, such as `dashboard.example.com`.
+
+This feature is available to:
+
+ - FlowFuse Cloud Enterprise teams
+ - Self-hosted FlowFuse Enterprise, running version 2.5 or later with the kubernetes driver
+
+## Configuring a custom hostname
+
+The Custom Hostname option is available under the General Settings tab of your Instance.
+
+Currently, FlowFuse only supports configuring a subdomain such as `dashboard.example.com`. Top level domains cannot be used.
+
+1. Enter your custom subdomain and click save.
+2. You will be shown a dialog to confirm the change, as this will require restarting your Instance to apply.
+   It also provides information on how to configure your DNS provider.
+3. Using your DNS provider, create a `CNAME` record for your chosen subdomain that points at the endpoint provided
+   in the dialog.
+
+**Note**: it is important to configure the Instance's Custom Hostname *before* you make the DNS changes. Making
+the DNS changes without configuring your Instance may allow someone else to configure their instance to use
+your subdomain.
+
+For FlowFuse Cloud, the `CNAME` should point to `custom-loadbalancer.flowfuse.com`. For self-hosted users,
+use the information provided in the dialog.
+
+If you also use CAA DNS entries to control which Certificate Authorities can issue certificates for your domains,
+you will need to add a record allowing LetsEncrypt to issue certificate. Please see details [here](https://letsencrypt.org/docs/caa/).
+The platform will issue certificates using the `http-01` validation method.

--- a/forge/ee/lib/customHostnames/index.js
+++ b/forge/ee/lib/customHostnames/index.js
@@ -1,11 +1,8 @@
 const { KEY_CUSTOM_HOSTNAME } = require('../../../db/models/ProjectSettings')
 
 module.exports.init = function (app) {
-    app.log.debug(`EE CustomHostname ${app.config.driver.type}\n ${JSON.stringify(app.config.driver.options)}`)
-    // TODO localfs should be removed before check in
     if (app.config.driver.type === 'kubernetes' || app.config.driver.type === 'stub') {
-        if (app.config.driver.options?.customHostname?.enabled) {
-            app.log.info('Enabling Custom Hostname Feature')
+        if (app.config.driver.options?.customHostname?.enabled && app.config.driver.options?.customHostname?.cnameTarget) {
             app.config.features.register('customHostnames', true, true)
             app.db.models.Project.prototype.getCustomHostname = async function () {
                 return this.getSetting(KEY_CUSTOM_HOSTNAME)

--- a/forge/ee/routes/customHostnames/index.js
+++ b/forge/ee/routes/customHostnames/index.js
@@ -3,7 +3,6 @@ const dns = require('dns/promises')
 const { KEY_CUSTOM_HOSTNAME } = require('../../../db/models/ProjectSettings')
 
 module.exports = async function (app) {
-    app.log.debug('registering custom hostname routes')
     app.addHook('preHandler', app.verifySession)
     app.addHook('preHandler', async (request, reply) => {
         if (!app.config.features.enabled('customHostnames')) {

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -44,6 +44,9 @@ module.exports = async function (app) {
                 base_url: app.config.base_url,
                 license: app.license.status()
             }
+            if (app.config.features.enabled('customHostnames')) {
+                response.cnameTarget = app.config.driver.options?.customHostname?.cnameTarget
+            }
 
             if (request.session.User.admin) {
                 response['platform:licensed'] = isLicensed

--- a/frontend/src/pages/instance/Settings/General.vue
+++ b/frontend/src/pages/instance/Settings/General.vue
@@ -44,9 +44,9 @@
                 Custom domain
                 <template #description>
                     <p>
-                        This allows you to access your instance from a custom domain or subdomain. This requires the DNS entry for the domain to
+                        This allows you to access your instance from a custom subdomain. This requires the DNS entry for the subdomain to
                         be updated to point at the FlowFuse platform.
-                        For more information, see the <a class="ff-link" target="_blank" href="https://flowfuse.com/docs/cloud/introduction/#custom-hostnames">documentation</a>.
+                        For more information, see the <a class="ff-link" target="_blank" href="https://flowfuse.com/docs/user/custom-hostnames">documentation</a>.
                     </p>
                 </template>
                 <template v-if="!customHostnameTeamAvailable" #input>
@@ -148,7 +148,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['features', 'team']),
+        ...mapState('account', ['features', 'team', 'settings']),
         isHA () {
             return !!this.instance?.ha
         },
@@ -179,7 +179,7 @@ export default {
         project: 'fetchData',
         'input.customHostname': function (v) {
             v = v || ''
-            const validChars = /^[a-zA-Z0-9-.]{1,253}\.?$/g
+            const validChars = /^[a-zA-Z0-9-.]{1,253}\.[a-zA-Z0-9-.]{1,253}\.[a-zA-Z0-9-.]{1,253}$/g
             let isValid = true
             const trimmedValue = v.trim()
             if (trimmedValue.length > 0) {
@@ -195,7 +195,7 @@ export default {
             if (isValid) {
                 this.errors.customHostname = ''
             } else {
-                this.errors.customHostname = 'Not a valid domain name'
+                this.errors.customHostname = 'Not a valid subdomain name'
             }
         }
     },
@@ -256,10 +256,19 @@ export default {
             // Validation of the value has already passed
             const domainName = this.input.customHostname.trim()
 
+            const message = []
+            if (domainName === '') {
+                message.push('Clearing the custom domain will cause the instance to be restarted to enable the change.')
+            } else {
+                message.push('Setting the custom domain will cause the instance to be restarted to enabled the change.')
+                message.push('The domain must have a <code>CNAME</code> record pointing at:')
+                message.push(`<code>${this.settings.cnameTarget}</code>`)
+            }
+
             Dialog.show({
                 header: 'Custom domain',
                 kind: 'primary',
-                html: 'Changing the custom domain for an instance will cause it to be restarted to enable the change.'
+                html: `<p>${message.join('</p><p>')}</p>`
             }, async () => {
                 if (domainName.length === 0) {
                     try {


### PR DESCRIPTION
Updates custom hostname docs - adds dedicated page and clarifies use of subdomain.

Frontend updated to point at new docs page

(also a drive-by update to the SSO docs as I noticed it needed updating)