### PR TITLE
Remove stray : in instance form

### DIFF
--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -98,7 +98,7 @@
 
             <div v-if="creatingNew && flowBlueprintsEnabled && atLeastOneFlowBlueprint && !isCopyProject">
                 <div data-form="blueprint">
-                    <label class="block text-sm font-medium text-gray-800 mb-2">Blueprint:</label>
+                    <label class="block text-sm font-medium text-gray-800 mb-2">Blueprint</label>
                     <BlueprintTileSmall :blueprint="selectedBlueprint" @click="previewBlueprint" />
                     <div v-if="showFlowBlueprintSelection" class="mt-2 flex gap-4" data-action="blueprint-actions">
                         <div


### PR DESCRIPTION
Noticed the Blueprint header in the instance form has a trailing `:` - but none of the other fields does.

<img width="298" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/c6a8720b-e8f3-4cf5-8954-ffcd068950a6">

