### PR TITLE
ci: Skip labeler action on release pull requests

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   labeler:
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && !startsWith(github.event.pull_request.title, 'Release')
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Description

This pull request adds a condition to the `Pull Request Labeler` workflow to skip executing it if PR starts with string `Release` . In result, `deploy:pr` label will not be applied on release PRs and pre-staging environment will not be created.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/3845

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

