### PR TITLE
Fix semver checks to enable immersive editor

### DIFF
--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -46,8 +46,12 @@ export default {
     computed: {
         ...mapState('account', ['team', 'teamMembership']),
         isImmersiveEditor () {
-            return SemVer.satisfies(SemVer.coerce(this.instance?.meta?.versions?.launcher), '>=2.4.1') &&
-                SemVer.satisfies(SemVer.coerce(this.instance?.meta?.versions?.['node-red']), '>=4.0')
+            const nrSemver = SemVer.parse(this.instance?.meta?.versions?.['node-red'])
+            // Supported from 4.0.0-beta.4 and later. This requires a bit more effort to check
+            if (nrSemver && nrSemver.major >= 4 && (nrSemver.prerelease.length === 0 || nrSemver.prerelease[1] >= 4)) {
+                return SemVer.satisfies(SemVer.coerce(this.instance?.meta?.versions?.launcher), '>=2.5.0')
+            }
+            return false
         },
         url () {
             if (this.isImmersiveEditor) {


### PR DESCRIPTION
## Description

The immersive editor should only get enabled if NR 4.0.0-beta.4 or later is being used.

The semver check is a bit tricky for beta versions so has to be done more explicitly.