### PR TITLE
fix: Do not send a slack notification on pre-staging termination

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -63,6 +63,9 @@ jobs:
       IMAGE_NAME: 'forge-k8s'
       PR_NUMBER: ${{ github.event.number }}
     steps:
+      - name: Simulate job failure
+        run: exit 1
+    
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -170,7 +173,7 @@ jobs:
   notify-slack:
     name: Notify about pre-staging deployment
     needs: [deploy]
-    # if: ${{ needs.deploy.result != 'skipped' }}
+    if: ${{ needs.deploy.result != 'skipped' }}
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build and contenerize
     if: |
       github.event_name == 'pull_request' && 
-      github.event.action != 'closed' &&
+      github.event.action == 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'deploy:pr')
     runs-on: ubuntu-latest
     env:
@@ -55,7 +55,7 @@ jobs:
     needs: build
     if: |
       github.event_name == 'pull_request' && 
-      github.event.action != 'closed' &&
+      github.event.action == 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'deploy:pr')
     runs-on: ubuntu-latest
     environment: staging

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build and contenerize
     if: |
       github.event_name == 'pull_request' && 
-      github.event.action == 'closed' &&
+      github.event.action != 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'deploy:pr')
     runs-on: ubuntu-latest
     env:
@@ -55,7 +55,7 @@ jobs:
     needs: build
     if: |
       github.event_name == 'pull_request' && 
-      github.event.action == 'closed' &&
+      github.event.action != 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'deploy:pr')
     runs-on: ubuntu-latest
     environment: staging

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -207,7 +207,7 @@ jobs:
                 "fields": [
                   {
                     "type": "mrkdwn",
-                    "text": "*Status:*\n${{ job.status == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
+                    "text": "*Status:*\n${{ needs.deploy.result == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
                   },
                   {
                     "type": "mrkdwn",

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build and contenerize
     if: |
       github.event_name == 'pull_request' && 
-      github.event.action != 'closed' &&
+      github.event.action == 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'deploy:pr')
     runs-on: ubuntu-latest
     env:
@@ -55,7 +55,7 @@ jobs:
     needs: build
     if: |
       github.event_name == 'pull_request' && 
-      github.event.action != 'closed' &&
+      github.event.action == 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'deploy:pr')
     runs-on: ubuntu-latest
     environment: staging
@@ -170,7 +170,7 @@ jobs:
   notify-slack:
     name: Notify about pre-staging deployment
     needs: [deploy]
-    if: ${{ needs.deploy.result != 'skipped' }}
+    # if: ${{ needs.deploy.result != 'skipped' }}
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -170,7 +170,7 @@ jobs:
   notify-slack:
     name: Notify about pre-staging deployment
     needs: [deploy]
-    if: always()
+    if: ${{ needs.deploy.result != 'skipped' }}
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build and contenerize
     if: |
       github.event_name == 'pull_request' && 
-      github.event.action == 'closed' &&
+      github.event.action != 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'deploy:pr')
     runs-on: ubuntu-latest
     env:
@@ -55,7 +55,7 @@ jobs:
     needs: build
     if: |
       github.event_name == 'pull_request' && 
-      github.event.action == 'closed' &&
+      github.event.action != 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'deploy:pr')
     runs-on: ubuntu-latest
     environment: staging
@@ -63,9 +63,6 @@ jobs:
       IMAGE_NAME: 'forge-k8s'
       PR_NUMBER: ${{ github.event.number }}
     steps:
-      - name: Simulate job failure
-        run: exit 1
-    
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -173,7 +173,7 @@ jobs:
   notify-slack:
     name: Notify about pre-staging deployment
     needs: [deploy]
-    if: ${{ needs.deploy.result != 'skipped' }}
+    if: success() || failure()
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
## Description

This pull request fixes a problem when Slack notification about pre-staging environment spin-up is sent on the environment termination run. 
Additionally, it fixes the job status icon in the message.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/3998

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

