### PR TITLE
4004 enable blueprints for all team types

### DIFF
--- a/frontend/src/pages/team/Library/Blueprints.vue
+++ b/frontend/src/pages/team/Library/Blueprints.vue
@@ -14,7 +14,7 @@
             </div>
         </li>
     </ul>
-    <EmptyState v-else :featureUnavailable="!isSharedLibraryFeatureEnabledForPlatform" :featureUnavailableToTeam="!isSharedLibraryFeatureEnabledForTeam">
+    <EmptyState v-else>
         <template #img>
             <img src="../../../images/empty-states/team-library.png" alt="team-logo">
         </template>
@@ -81,10 +81,6 @@ export default {
     },
     methods: {
         async loadBlueprints () {
-            if (!this.isSharedLibraryFeatureEnabled) {
-                return
-            }
-
             const res = await flowBlueprintsApi.getFlowBlueprintsForTeam(this.team.id)
             if (Object.hasOwnProperty.call(res, 'blueprints')) {
                 this.blueprints = res.blueprints

--- a/test/e2e/frontend/cypress/tests/team/library.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/library.spec.js
@@ -1,3 +1,12 @@
+import multipleBlueprints from '../../fixtures/blueprints/multiple-blueprints.json'
+
+function interceptBlueprints (blueprints = []) {
+    cy.intercept('/api/*/flow-blueprints?*', {
+        meta: {},
+        ...blueprints
+    }).as('getBlueprints')
+}
+
 describe('FlowForge - Library', () => {
     beforeEach(() => {
         cy.login('alice', 'aaPassword')
@@ -5,15 +14,39 @@ describe('FlowForge - Library', () => {
     })
 
     describe('Blueprints', () => {
-        it('should load the Library page and display the unavailable feature banner for the Blueprints tab', () => {
+        it.only('should load the Library page and display the unavailable feature banner for the Blueprints tab', () => {
+            interceptBlueprints(multipleBlueprints)
+
             cy.visit('team/ateam/library')
 
             cy.get('[data-el="page-name"]').contains('Library')
             cy.get('[data-el="ff-tab"]').contains('Blueprints').click()
 
-            cy.contains('Shared repository to store common flows and nodes.')
-            cy.contains('No Blueprints Available')
-            cy.contains('This is a FlowFuse Enterprise feature. Please upgrade your instance of FlowFuse in order to use it.')
+            cy.get('[data-el="category"]')
+                .contains('Category A')
+                .parent()
+                .within(() => {
+                    cy.get('[data-el="tiles-wrapper"]')
+                        .children()
+                        .should('have.length', 1)
+
+                    cy.contains('Blueprint 1')
+                    cy.contains('This is a blueprint')
+                })
+
+            cy.get('[data-el="category"]')
+                .contains('Category B')
+                .parent()
+                .within(() => {
+                    cy.get('[data-el="tiles-wrapper"]')
+                        .children()
+                        .should('have.length', 2)
+
+                    cy.contains('Blueprint 2')
+                    cy.contains('Blueprint 3')
+                    cy.contains('This is another blueprint')
+                    cy.contains('This is yet another blueprint')
+                })
         })
     })
     describe('Team Library', () => {

--- a/test/e2e/frontend/cypress/tests/team/library.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/library.spec.js
@@ -14,7 +14,7 @@ describe('FlowForge - Library', () => {
     })
 
     describe('Blueprints', () => {
-        it.only('should load the Library page and display the unavailable feature banner for the Blueprints tab', () => {
+        it('should load the Library page and display the unavailable feature banner for the Blueprints tab', () => {
             interceptBlueprints(multipleBlueprints)
 
             cy.visit('team/ateam/library')


### PR DESCRIPTION
## Description

Enable Library blueprints for all team types.

## Related Issue(s)

closes #4004

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

