### PR TITLE
Fix flaky time test

### DIFF
--- a/test/unit/frontend/utils/elapsedTime.spec.js
+++ b/test/unit/frontend/utils/elapsedTime.spec.js
@@ -62,6 +62,9 @@ describe('elapsedTime', () => {
         const soon = new Date()
         soon.setMinutes(soon.getMinutes() + 30)
         soon.setSeconds(soon.getSeconds() + 15)
+        // This test would occasionally fail due to a combination of the random ms value in `soon`, the time taken to
+        // run the test and the fact that the elapsed time string is calculated using Math.floor
+        soon.setMilliseconds(soon.getMilliseconds() + 500) // Grace to prevent random test fails.
 
         expect(elapsedTime(soon)).toBe('30 minutes, 15 seconds')
     })


### PR DESCRIPTION
closes #3874

## Description

Add 500ms grace to the relative time test to avoid a rare (but frequent enough to waste our time) test bug.

## Related Issue(s)

#3874

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
