### PR TITLE
Update docs for device agent behind http proxy

### DIFF
--- a/docs/device-agent/running.md
+++ b/docs/device-agent/running.md
@@ -79,6 +79,39 @@ _Start the agent with a different working directory and the Web UI enabled_
 flowfuse-device-agent -d /path/to/working/directory -w --ui-user admin --ui-pass password --ui-port 8081
 ```
 
+## Running behind a HTTP Proxy
+
+If the device is behind a HTTP proxy, the agent can be configured to use the proxy by setting the `http_proxy`, `https_proxy` or `all_proxy` environment variables.
+
+If necessary, the `no_proxy` environment variable can be used to specify a list of hosts that should not be accessed via the proxy.
+
+For connecting to FlowFuse Cloud, the `https_proxy` variable should be set to your proxy URL. This environment variable will be used by the agent for both the HTTP
+and MQTT connections.
+
+### Example setting the proxy environment variables on Linux
+```bash
+# Set the https_proxy environment variable
+export https_proxy=http://my-proxy:3128
+# Set the no_proxy environment variable to exclude local addresses and all hosts in the .mydomain.com domain
+export no_proxy=localhost,127.0.0.1,.mydomain.com
+# Start the agent
+flowfuse-device-agent
+```
+
+_To make these settings permanent, see the documentation for your Linux distribution._
+
+### Example setting the proxy environment variables on Windows
+```bash
+# Set the https_proxy environment variable
+set https_proxy=http://my-proxy:3128
+# Set the no_proxy environment variable to exclude local addresses and all hosts in the .mydomain.com domain
+set no_proxy=localhost,127.0.0.1,.mydomain.com
+# Start the agent
+flowfuse-device-agent
+```
+
+_To make these settings permanent, see the documentation for your version of Windows._
+
 ## Running with no access to npmjs.org
 
 By default the Device Agent will try and download the correct version of Node-RED and 


### PR DESCRIPTION
closes #4023

## Description

Update docs for device agent behind http proxy

## Related Issue(s)

 #4023

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

