### PR TITLE
Use stack name if label not set

### DIFF
--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -682,7 +682,7 @@ export default {
             const stackList = await stacksApi.getStacks(null, null, null, projectType.id)
             this.stacks = stackList.stacks
                 .filter(stack => stack.active)
-                .map(stack => { return { ...stack, value: stack.id } })
+                .map(stack => { return { ...stack, value: stack.id, label: stack.label || stack.name } })
 
             if (this.stacks.length === 0) {
                 this.input.stack = null


### PR DESCRIPTION
Fixes #4032

## Description

Ensures the `label` value passed to the `<FormRow> options has a non-blank value - using the `stack.name` if `stack.label` hasn't been set.
