### PR TITLE
Fix posthog csp header

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -277,23 +277,17 @@ module.exports = async (options = {}) => {
                 }
             }
             if (runtimeConfig.telemetry?.frontend?.posthog?.apikey) {
-                let posthogHost = 'app.posthog.com'
-                if (runtimeConfig.telemetry.frontend.posthog.apiurl) {
-                    posthogHost = new URL(runtimeConfig.telemetry.frontend.posthog.apiurl).host
-                }
+                // ref: https://posthog.com/docs/advanced/content-security-policy
+                const posthogHost = '*.posthog.com'
                 if (contentSecurityPolicy.directives['script-src'] && Array.isArray(contentSecurityPolicy.directives['script-src'])) {
                     contentSecurityPolicy.directives['script-src'].push(posthogHost)
                 } else {
                     contentSecurityPolicy.directives['script-src'] = [posthogHost]
                 }
-                const posthogConnect = [
-                    posthogHost,
-                    'eu.i.posthog.com'
-                ]
                 if (contentSecurityPolicy.directives['connect-src'] && Array.isArray(contentSecurityPolicy.directives['connect-src'])) {
-                    contentSecurityPolicy.directives['connect-src'].push(...posthogConnect)
+                    contentSecurityPolicy.directives['connect-src'].push(posthogHost)
                 } else {
-                    contentSecurityPolicy.directives['connect-src'] = posthogConnect
+                    contentSecurityPolicy.directives['connect-src'] = posthogHost
                 }
             }
             if (runtimeConfig.telemetry?.frontend?.sentry) {

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -287,7 +287,7 @@ module.exports = async (options = {}) => {
                 if (contentSecurityPolicy.directives['connect-src'] && Array.isArray(contentSecurityPolicy.directives['connect-src'])) {
                     contentSecurityPolicy.directives['connect-src'].push(posthogHost)
                 } else {
-                    contentSecurityPolicy.directives['connect-src'] = posthogHost
+                    contentSecurityPolicy.directives['connect-src'] = [posthogHost]
                 }
             }
             if (runtimeConfig.telemetry?.frontend?.sentry) {


### PR DESCRIPTION
The [posthog docs ](https://posthog.com/docs/advanced/content-security-policy)recommend setting `*.posthog.com` in the CSP header rather than particular subdomains - so that is what we should do.