### PR TITLE
Add smtp server for e2e testing

### DIFF
--- a/config/cypress-ee.config.js
+++ b/config/cypress-ee.config.js
@@ -10,5 +10,8 @@ module.exports = defineConfig({
             baseUrl: 'http://localhost:3002',
             specPattern: 'test/e2e/frontend/cypress/tests-ee'
         }
+    },
+    env: {
+        mailpitUrl: 'http://localhost:8026/'
     }
 })

--- a/config/cypress-os.config.js
+++ b/config/cypress-os.config.js
@@ -10,5 +10,8 @@ module.exports = defineConfig({
             baseUrl: 'http://localhost:3001',
             specPattern: 'test/e2e/frontend/cypress/tests'
         }
+    },
+    env: {
+        mailpitUrl: 'http://localhost:8026/'
     }
 })

--- a/config/cypress-shared.config.js
+++ b/config/cypress-shared.config.js
@@ -6,7 +6,6 @@ module.exports = {
     viewportWidth: 1024,
     viewportHeight: 768,
     e2e: {
-        experimentalSessionAndOrigin: true,
         downloadsFolder,
         fixturesFolder: 'test/e2e/frontend/cypress/fixtures',
         screenshotsFolder: 'test/e2e/frontend/cypress/screenshots',

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
                 "cross-env": "^7.0.3",
                 "css-loader": "^6.8.1",
                 "cypress": "^13.2.0",
+                "cypress-mailpit": "^0.0.4",
                 "dotenv-webpack": "^8.0.1",
                 "eslint": "^8.48.0",
                 "eslint-config-standard": "^17.1.0",
@@ -10496,6 +10497,12 @@
             "engines": {
                 "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
             }
+        },
+        "node_modules/cypress-mailpit": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/cypress-mailpit/-/cypress-mailpit-0.0.4.tgz",
+            "integrity": "sha512-RbE5nv6UsA3DW/CDl6+d0W6BZS1WlHrhE4NwCm/202D8qIIEhkrwp4oMCBNoPFbacS0dGu3ZTec58Z1oGFWmjg==",
+            "dev": true
         },
         "node_modules/cypress/node_modules/ansi-styles": {
             "version": "4.3.0",
@@ -31909,6 +31916,12 @@
                     }
                 }
             }
+        },
+        "cypress-mailpit": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/cypress-mailpit/-/cypress-mailpit-0.0.4.tgz",
+            "integrity": "sha512-RbE5nv6UsA3DW/CDl6+d0W6BZS1WlHrhE4NwCm/202D8qIIEhkrwp4oMCBNoPFbacS0dGu3ZTec58Z1oGFWmjg==",
+            "dev": true
         },
         "dashdash": {
             "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
         "cross-env": "^7.0.3",
         "css-loader": "^6.8.1",
         "cypress": "^13.2.0",
+        "cypress-mailpit": "^0.0.4",
         "dotenv-webpack": "^8.0.1",
         "eslint": "^8.48.0",
         "eslint-config-standard": "^17.1.0",

--- a/test/e2e/frontend/cypress/support/commands.js
+++ b/test/e2e/frontend/cypress/support/commands.js
@@ -1,3 +1,5 @@
+import 'cypress-mailpit'
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/test/e2e/frontend/environments/smtp.js
+++ b/test/e2e/frontend/environments/smtp.js
@@ -1,0 +1,49 @@
+const childProcess = require('child_process')
+
+const mailpitLogger = (data) => {
+    console.info(`Mailpit: ${data}`)
+}
+
+module.exports = async function (config = {}) {
+    let { webPort, smtpPort } = config
+
+    webPort = webPort || 8025
+    smtpPort = smtpPort || 1025
+
+    mailpitLogger('Starting e-mail server...')
+
+    const dockerCommand = 'docker'
+    const args = [
+        'run',
+        '--rm',
+        `-p=${webPort}:8025`,
+        `-p=${smtpPort}:1025`,
+        '-e=MP_MAX_MESSAGES=5000',
+        '-e=MP_SMTP_AUTH_ACCEPT_ANY=1',
+        '-e=MP_SMTP_AUTH_ALLOW_INSECURE=1',
+        'axllent/mailpit'
+    ]
+
+    const dockerProcess = childProcess.spawn(dockerCommand, args)
+
+    dockerProcess.on('spawn', () => {
+        mailpitLogger(`Web UI available at http://localhost:${webPort}/ with SMTP listening on port ${smtpPort}`)
+    })
+
+    // dockerProcess.stdout.on('data', mailpitLogger)
+    dockerProcess.stderr.on('data', mailpitLogger)
+
+    dockerProcess.on('close', (code) => {
+        console.error(`Child process exited with code ${code}`)
+    })
+
+    // Handle process exit to clean up the Docker container
+    // const cleanup = () => {
+    // ... clean up code here
+    //     process.exit(0)
+    // }
+
+    // process.on('exit', cleanup)
+    // process.on('SIGINT', cleanup)
+    // process.on('SIGTERM', cleanup)
+}

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -6,7 +6,6 @@ const multipleBlueprints = require('../cypress/fixtures/blueprints/multiple-blue
 const FF_UTIL = require('flowforge-test-utils')
 const Forge = FF_UTIL.require('forge/forge.js')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
-const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 
 module.exports = async function (settings = {}, config = {}) {
     process.env.FF_TELEMETRY_DISABLED = true
@@ -21,11 +20,14 @@ module.exports = async function (settings = {}, config = {}) {
             storage: ':memory:'
         },
         email: {
-            enabled: true,
-            transport: new LocalTransport()
+            enabled: true
         },
         driver: {
             type: 'stub'
+        },
+        // configure a broker so that device app.comms is loaded and can be stubbed
+        broker: {
+            url: ':test:'
         }
     }
 

--- a/test/e2e/frontend/test_environment_ee.js
+++ b/test/e2e/frontend/test_environment_ee.js
@@ -3,6 +3,7 @@
 
 const TestModelFactory = require('../../lib/TestModelFactory')
 
+const smtp = require('./environments/smtp')
 const app = require('./environments/standard')
 
 const FF_UTIL = require('flowforge-test-utils')
@@ -10,6 +11,12 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
 
 ;(async function () {
     const PORT = 3002
+    const smtpConfig = {
+        smtpPort: 1026,
+        webPort: 8026
+    }
+
+    await smtp({ smtpPort: smtpConfig.smtpPort, webPort: smtpConfig.webPort })
 
     const flowforge = await app({
         trialMode: true
@@ -31,13 +38,11 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
                 }
             }
         },
-        email: {
-            enabled: true,
+        smtp: {
+            host: 'localhost',
+            port: smtpConfig.smtpPort,
+            secure: false,
             debug: true
-        },
-        // configure a broker so that device app.comms is loaded and can be stubbed
-        broker: {
-            url: ':test:'
         }
     })
 

--- a/test/e2e/frontend/test_environment_os.js
+++ b/test/e2e/frontend/test_environment_os.js
@@ -1,14 +1,27 @@
 /* eslint-disable n/no-process-exit */
 'use strict'
 
-const app = require('./environments/standard')
+const smtp = require('./environments/smtp.js')
+const app = require('./environments/standard.js')
 
 ;(async function () {
     const PORT = 3001
+    const smtpConfig = {
+        smtpPort: 1025,
+        webPort: 8025
+    }
+
+    await smtp({ smtpPort: smtpConfig.smtpPort, webPort: smtpConfig.webPort })
 
     const flowforge = await app({}, {
         host: 'localhost',
-        port: PORT
+        port: PORT,
+        smtp: {
+            host: 'localhost',
+            port: smtpConfig.smtpPort,
+            secure: false,
+            debug: true
+        }
     })
 
     flowforge.listen({ port: PORT }, function (err, address) {


### PR DESCRIPTION
## Description

Adds a simple smtp server for e2e tests that cypress can interact with to grab email confirmation links/password change, etc

## Related Issue(s)

Pre-requisite for https://github.com/FlowFuse/flowfuse/issues/3999
part of https://github.com/FlowFuse/flowfuse/issues/3946
part of https://github.com/FlowFuse/flowfuse/issues/3917

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

