### PR TITLE
Allow admin to extend team trial

### DIFF
--- a/frontend/src/api/billing.js
+++ b/frontend/src/api/billing.js
@@ -31,9 +31,18 @@ const setupManualBilling = async (teamId, teamTypeId) => {
     })
 }
 
+const setTrialExpiry = async (teamId, trialEndsAt) => {
+    return client.post('/ee/billing/teams/' + teamId + '/trial', {
+        trialEndsAt
+    }).then(res => {
+        return res.data
+    })
+}
+
 export default {
     toCustomerPortal,
     getSubscriptionInfo,
     createSubscription,
-    setupManualBilling
+    setupManualBilling,
+    setTrialExpiry
 }

--- a/frontend/src/pages/team/dialogs/ExtendTeamTrialDialog.vue
+++ b/frontend/src/pages/team/dialogs/ExtendTeamTrialDialog.vue
@@ -1,0 +1,69 @@
+<template>
+    <ff-dialog ref="dialog" data-el="extend-trial-dialog" header="Extend Team Trial" kind="danger" confirm-label="Extend team trial" @confirm="confirm()">
+        <template #default>
+            <form v-if="team" class="space-y-6" @submit.prevent>
+                <p v-if="!trialHasEnded">This team's trial ends at <b>{{ trialEndDate }}</b>.</p>
+                <p v-else>This team's trial has ended.</p>
+                <p>
+                    Select a new end date for the team's trial:
+                </p>
+                <FormRow id="endDate" v-model="input.endDate" type="date" data-form="expiry-date" />
+            </form>
+        </template>
+    </ff-dialog>
+</template>
+
+<script>
+import FormRow from '../../../components/FormRow.vue'
+import formatDateMixin from '../../../mixins/DateTime.js'
+
+export default {
+    name: 'ExtendTeamTrialDialog',
+    components: {
+        FormRow
+    },
+    mixins: [formatDateMixin],
+    emits: ['extend-team-trial'],
+    setup () {
+        return {
+            show (team) {
+                this.team = team
+                if (this.team.billing.trialEndsAt) {
+                    this.originalEndDate = this.team.billing.trialEndsAt.substring(0, 10)
+                } else {
+                    this.originalEndDate = (new Date()).toISOString().split('T')[0]
+                }
+                this.input.endDate = this.originalEndDate
+                this.$refs.dialog.show()
+            }
+        }
+    },
+    data () {
+        return {
+            input: {
+                endDate: null
+            },
+            team: null
+        }
+    },
+    computed: {
+        billingSetUp () {
+            return this.team.billing?.active
+        },
+        trialMode () {
+            return this.team.billing?.trial
+        },
+        trialHasEnded () {
+            return this.team.billing?.trialEnded
+        },
+        trialEndDate () {
+            return this.formatDateTime(this.team.billing?.trialEndsAt)
+        }
+    },
+    methods: {
+        confirm () {
+            this.$emit('extend-team-trial', this.input.endDate)
+        }
+    }
+}
+</script>

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -1876,6 +1876,25 @@ describe('Billing routes', function () {
             })
             response.statusCode.should.equal(400)
         })
+        it('Prevents setting team trial end date for non trial team', async function () {
+            // Create trial team
+            const team = await app.factory.createTeam({ name: generateName('noBillingTeam') })
+            await team.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+            await app.factory.createSubscription(team)
+
+            const newEndDate = Date.now() + ONE_DAY * 370
+
+            // Set the end date for 10 days from now
+            const response = await app.inject({
+                method: 'POST',
+                url: `/ee/billing/teams/${team.hashid}/trial`,
+                payload: {
+                    trialEndsAt: newEndDate
+                },
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(400)
+        })
 
         it('Prevents non-admin from modifying team trial settings', async function () {
             const trialTeam = await app.factory.createTeam({ name: generateName('noBillingTeam'), TeamTypeId: trialTeamType.id })


### PR DESCRIPTION
Closes #4031 

Adds an 'Extend Trial' option under the Admin Tools section of Team Settings:

<img width="652" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/1b4e6f77-7da8-4f87-a3a7-8817b3064541">

Dialog lets you pick a new end date

<img width="605" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/d451d7fa-e67a-4ffc-b4cf-2d187c9ff47a">

The API prevents setting a date more than 1 year in the future. It can be set to a date in the past, in which case the next time the TrialTask runs (every 30mins) the trial will be ended.

Option only shows for a team in trial (or an expired trial). If they have setup stripe, the option is no longer available.