### PR TITLE
Ensure settings change toast informs user a restart is required.

### DIFF
--- a/frontend/src/pages/instance/Settings/Editor.vue
+++ b/frontend/src/pages/instance/Settings/Editor.vue
@@ -137,7 +137,7 @@ export default {
             })
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            alerts.emit('Instance settings successfully updated. NOTE: changes will be applied once the instance is restarted.', 'confirmation', 6000)
+            alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Editor.vue
+++ b/frontend/src/pages/instance/Settings/Editor.vue
@@ -137,7 +137,7 @@ export default {
             })
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            alerts.emit('Instance successfully updated.', 'confirmation')
+            alerts.emit('Instance settings successfully updated. NOTE: changes will be applied once the instance is restarted.', 'confirmation', 6000)
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -170,7 +170,7 @@ export default {
             })
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            alerts.emit('Instance settings successfully updated. NOTE: changes will be applied once the instance is restarted.', 'confirmation', 6000)
+            alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/LauncherSettings.vue
+++ b/frontend/src/pages/instance/Settings/LauncherSettings.vue
@@ -109,7 +109,7 @@ export default {
             }
             await InstanceApi.updateInstance(this.project.id, { launcherSettings })
             this.$emit('instance-updated')
-            alerts.emit('Instance settings successfully updated. NOTE: changes will be applied once the instance is restarted.', 'confirmation', 6000)
+            alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/LauncherSettings.vue
+++ b/frontend/src/pages/instance/Settings/LauncherSettings.vue
@@ -109,7 +109,7 @@ export default {
             }
             await InstanceApi.updateInstance(this.project.id, { launcherSettings })
             this.$emit('instance-updated')
-            alerts.emit('Instance successfully updated. Restart the instance to apply the changes.', 'confirmation')
+            alerts.emit('Instance settings successfully updated. NOTE: changes will be applied once the instance is restarted.', 'confirmation', 6000)
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -210,7 +210,7 @@ export default {
             }
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            alerts.emit('Instance successfully updated.', 'confirmation')
+            alerts.emit('Instance settings successfully updated. NOTE: changes will be applied once the instance is restarted.', 'confirmation', 6000)
         },
         async getTokens () {
             const response = await InstanceApi.getHTTPTokens(this.project.id)

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -210,7 +210,7 @@ export default {
             }
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            alerts.emit('Instance settings successfully updated. NOTE: changes will be applied once the instance is restarted.', 'confirmation', 6000)
+            alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
         },
         async getTokens () {
             const response = await InstanceApi.getHTTPTokens(this.project.id)


### PR DESCRIPTION
closes #2581

## Description

* Adds 'NOTE: changes will be applied once the instance is restarted.' to the toast message on Editor and Security tabs
* Tweaks the existing message on Launcher Settings (aligns with the Editor and Security tab) - to keep same messaging throughout.

## Related Issue(s)

Closes #2581

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

