### PR TITLE
Security Settings - Improve language & hide user/pw fields when not used

### DIFF
--- a/frontend/src/pages/admin/Template/sections/Security.vue
+++ b/frontend/src/pages/admin/Template/sections/Security.vue
@@ -11,24 +11,26 @@
             <LockSetting v-model="editable.policy.httpNodeAuth_type" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.httpNodeAuth_type" />
         </div>
         <ff-radio-group v-model="editable.settings.httpNodeAuth_type" orientation="vertical" :options="authOptions1" />
-        <div class="flex flex-col sm:flex-row sm:ml-4">
-            <div class="space-y-4 w-full max-w-md sm:mr-8">
-                <FormRow v-model="editable.settings.httpNodeAuth_user" :disabled="editable.settings.httpNodeAuth_type !=='basic' || !editTemplate && !editable.policy.httpNodeAuth_user" :type="(editTemplate||editable.policy.httpNodeAuth_user)?'text':'uneditable'">
-                    HTTP Auth Username
-                    <template #append><ChangeIndicator :value="editable.changed.settings.httpNodeAuth_user" /></template>
-                </FormRow>
+        <template v-if="editable.settings?.httpNodeAuth_type === 'basic'">
+            <div class="flex flex-col sm:flex-row sm:ml-4">
+                <div class="space-y-4 w-full max-w-md sm:mr-8">
+                    <FormRow v-model="editable.settings.httpNodeAuth_user" :disabled="editable.settings.httpNodeAuth_type !=='basic' || !editTemplate && !editable.policy.httpNodeAuth_user" :type="(editTemplate||editable.policy.httpNodeAuth_user)?'text':'uneditable'">
+                        HTTP Auth Username
+                        <template #append><ChangeIndicator :value="editable.changed.settings.httpNodeAuth_user" /></template>
+                    </FormRow>
+                </div>
+                <LockSetting v-model="editable.policy.httpNodeAuth_user" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.httpNodeAuth_user" />
             </div>
-            <LockSetting v-model="editable.policy.httpNodeAuth_user" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.httpNodeAuth_user" />
-        </div>
-        <div class="flex flex-col sm:flex-row sm:ml-4">
-            <div class="space-y-4 w-full max-w-md sm:mr-8">
-                <FormRow v-model="editable.settings.httpNodeAuth_pass" :disabled="editable.settings.httpNodeAuth_type !=='basic' || !editTemplate && !editable.policy.httpNodeAuth_pass" :type="(editTemplate||editable.policy.httpNodeAuth_pass)?'password':'uneditable'">
-                    HTTP Auth Password
-                    <template #append><ChangeIndicator :value="editable.changed.settings.httpNodeAuth_pass" /></template>
-                </FormRow>
+            <div class="flex flex-col sm:flex-row sm:ml-4">
+                <div class="space-y-4 w-full max-w-md sm:mr-8">
+                    <FormRow v-model="editable.settings.httpNodeAuth_pass" :disabled="editable.settings.httpNodeAuth_type !=='basic' || !editTemplate && !editable.policy.httpNodeAuth_pass" :type="(editTemplate||editable.policy.httpNodeAuth_pass)?'password':'uneditable'">
+                        HTTP Auth Password
+                        <template #append><ChangeIndicator :value="editable.changed.settings.httpNodeAuth_pass" /></template>
+                    </FormRow>
+                </div>
+                <LockSetting v-model="editable.policy.httpNodeAuth_pass" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.httpNodeAuth_pass" />
             </div>
-            <LockSetting v-model="editable.policy.httpNodeAuth_pass" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.httpNodeAuth_pass" />
-        </div>
+        </template>
         <FeatureUnavailableToTeam v-if="!ffAuthFeatureAvailable" featureName="FlowFuse User Authentication" />
         <ff-radio-group v-model="editable.settings.httpNodeAuth_type" orientation="vertical" :options="authOptions2" />
     </form>
@@ -104,7 +106,7 @@ export default {
                     label: 'FlowFuse User Authentication',
                     value: 'flowforge-user',
                     disabled: !this.ffAuthFeatureAvailable || (!this.editTemplate && !this.editable.policy.httpNodeAuth_type),
-                    description: 'Only members of the application instance\'s team will be able to access the routes'
+                    description: 'Only members of the instance\'s team will be able to access the routes'
                 }
             ]
         }

--- a/frontend/src/pages/admin/Template/sections/Security.vue
+++ b/frontend/src/pages/admin/Template/sections/Security.vue
@@ -32,7 +32,7 @@
             </div>
         </template>
         <FeatureUnavailableToTeam v-if="!ffAuthFeatureAvailable" featureName="FlowFuse User Authentication" />
-        <ff-radio-group v-model="editable.settings.httpNodeAuth_type" orientation="vertical" :options="authOptions2" />
+        <ff-radio-group v-model="editable.settings.httpNodeAuth_type" data-el="http-auth-option-ff" orientation="vertical" :options="authOptions2" />
     </form>
 </template>
 

--- a/test/e2e/frontend/cypress/tests-ee/instances/httpTokens.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/instances/httpTokens.spec.js
@@ -30,7 +30,7 @@ describe('FlowFuse EE - HTTP Auth tokens', () => {
         navigateToInstanceSettings('BTeam', 'instance-2-1')
 
         cy.get('[data-nav="security"').click()
-        cy.get('[data-el="http-auth"] div:nth-child(6)').click()
+        cy.get('[data-el="http-auth-option-ff"]').click()
 
         cy.get('[data-action="new-token"]').should('exist')
         cy.get('[data-action="new-token"] span:first').click()


### PR DESCRIPTION
## Description

- Was taking a screenshot for an article of the security settings, and the "username"/"password" fields are distracting when they're not in use. This changes it so that they only show when you have "Basic Auth" option selected.
- Also changes the language for the FF User Auth option to be a little clearer

## Related Issue(s)

No linked issue, small PR