### PR TITLE
Add permission checks on app edit and instance add

### DIFF
--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -11,6 +11,7 @@
             </template>
             <template #tools>
                 <ff-button
+                    v-if="hasPermission('project:create')"
                     data-action="create-instance"
                     :to="{ name: 'ApplicationCreateInstance' }"
                 >
@@ -30,7 +31,7 @@
                 @row-selected="selectedCloudRow"
             >
                 <template
-                    v-if="hasPermission('device:edit')"
+                    v-if="hasPermission('project:change-status')"
                     #context-menu="{row}"
                 >
                     <ff-list-item
@@ -72,6 +73,7 @@
                 </template>
                 <template #actions>
                     <ff-button
+                        v-if="hasPermission('project:create')"
                         :to="{ name: 'ApplicationCreateInstance' }"
                     >
                         <template #icon-left><PlusSmIcon /></template>

--- a/frontend/src/pages/application/Settings.vue
+++ b/frontend/src/pages/application/Settings.vue
@@ -16,36 +16,41 @@
                     Description
                 </FormRow>
             </div>
-            <div class="space-x-4 whitespace-nowrap">
-                <template v-if="!editing">
-                    <ff-button kind="primary" data-action="application-edit" @click="editName">Edit</ff-button>
-                </template>
-                <template v-else>
-                    <div class="flex gap-x-3">
-                        <ff-button kind="secondary" @click="cancelEditName">Cancel</ff-button>
-                        <ff-button kind="primary" :disabled="!formValid" data-form="submit" @click="saveApplication">Save</ff-button>
+            <template v-if="hasPermission('project:edit')">
+                <div class="space-x-4 whitespace-nowrap">
+                    <template v-if="!editing">
+                        <ff-button kind="primary" data-action="application-edit" @click="editName">Edit</ff-button>
+                    </template>
+                    <template v-else>
+                        <div class="flex gap-x-3">
+                            <ff-button kind="secondary" @click="cancelEditName">Cancel</ff-button>
+                            <ff-button kind="primary" :disabled="!formValid" data-form="submit" @click="saveApplication">Save</ff-button>
+                        </div>
+                    </template>
+                </div>
+            </template>
+            <template v-if="hasPermission('project:delete')">
+                <FormHeading class="text-red-700">Delete Application</FormHeading>
+                <div class="flex flex-col space-y-4 max-w-2xl">
+                    <div class="flex-grow">
+                        <div class="max-w-sm">
+                            {{ getDeleteApplicationText }}
+                        </div>
                     </div>
-                </template>
-            </div>
-
-            <FormHeading class="text-red-700">Delete Application</FormHeading>
-            <div class="flex flex-col space-y-4 max-w-2xl">
-                <div class="flex-grow">
-                    <div class="max-w-sm">
-                        {{ getDeleteApplicationText }}
+                    <div class="min-w-fit flex-shrink-0">
+                        <ff-button data-action="delete-application" kind="danger" :disabled="options.instances > 0" @click="$emit('application-delete')">
+                            Delete Application
+                        </ff-button>
                     </div>
                 </div>
-                <div class="min-w-fit flex-shrink-0">
-                    <ff-button data-action="delete-application" kind="danger" :disabled="options.instances > 0" @click="$emit('application-delete')">
-                        Delete Application
-                    </ff-button>
-                </div>
-            </div>
+            </template>
         </div>
     </div>
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import ApplicationAPI from '../../api/application.js'
 
 import FormHeading from '../../components/FormHeading.vue'
@@ -93,6 +98,7 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['teamMembership']),
         formValid () {
             return this.input.projectName
         },


### PR DESCRIPTION
Fixes #3949 

## Description

Adds appropriate `needsPermission` checks on the following pieces of UI to hide them from users who don't have permission to do these actions:

- Application Instances - 'add instance' button visibility
- Edit Application details
- Delete Application

A couple other cases were identified in 3949 - in particular around Device Groups. However, Device Groups are an EE only feature - and the way our front-end permission checks currently work means we cannot use the existing `needsPermission` mixin as-is. I'll raise a separate issue with details, but no need to block making these quick improvements.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

