### PR TITLE
Ensure user PATs are deleted when user is deleted

### DIFF
--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -122,6 +122,12 @@ module.exports = {
                         [Op.or]: [{ invitorId: user.id }, { inviteeId: user.id }]
                     }
                 })
+                await M.AccessToken.destroy({
+                    where: {
+                        ownerType: 'user',
+                        ownerId: '' + user.id
+                    }
+                })
             }
         }
     },


### PR DESCRIPTION
Closes #2569 

Having re-reviewed the list identified in 2569, this was the only item that needed action taking.

Given the way `AccessToken` can be owned by many different things, we don't have an explicit primary key relationship that allows us to rely on cascade deletes.

I think this was the only place we were missing an explicit removal of the tokens when a user is deleted. There is no issue having the orphaned items as the tokens are useless without the owner being resolvable. But that doesn't mean we don't need to delete them.