### PR TITLE
Remove trickle down router props

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -7,7 +7,7 @@
             v-if="loadingStatuses || loadingDevices"
             message="Loading Devices..."
         />
-        <template v-else>
+        <template v-else-if="team">
             <FeatureUnavailableToTeam v-if="teamDeviceLimitReached" fullMessage="You have reached the device limit for this team." :class="{'mt-0': displayingTeam }" />
             <FeatureUnavailableToTeam v-if="teamRuntimeLimitReached" fullMessage="You have reached the runtime limit for this team." :class="{'mt-0': displayingTeam }" />
             <DevicesStatusBar v-if="allDeviceStatuses.size > 0" data-el="devicestatus-lastseen" label="Last Seen" :devices="Array.from(allDeviceStatuses.values())" property="lastseen" :filter="filter" @filter-selected="applyFilter" />
@@ -168,6 +168,7 @@
     </div>
 
     <TeamDeviceCreateDialog
+        v-if="team"
         ref="teamDeviceCreateDialog"
         :team="team"
         :teamDeviceCount="teamDeviceCount"
@@ -221,6 +222,7 @@ import { ClockIcon } from '@heroicons/vue/outline'
 import { PlusSmIcon } from '@heroicons/vue/solid'
 
 import { markRaw } from 'vue'
+import { mapState } from 'vuex'
 
 import ApplicationApi from '../api/application.js'
 import deviceApi from '../api/devices.js'
@@ -280,15 +282,6 @@ export default {
             type: Object,
             required: false,
             default: null
-        },
-        team: {
-            type: Object,
-            required: true
-        },
-        // Used for hasPermission
-        teamMembership: {
-            type: Object,
-            required: true
         }
     },
     emits: ['instance-updated'],
@@ -321,6 +314,7 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['team', 'teamMembership']),
         columns () {
             const columns = [
                 { label: 'Device', key: 'name', class: ['w-64'], sortable: !this.moreThanOnePage, component: { is: markRaw(DeviceLink) } },

--- a/frontend/src/components/banners/SubscriptionExpired.vue
+++ b/frontend/src/components/banners/SubscriptionExpired.vue
@@ -29,8 +29,6 @@
 <script>
 import { ChevronRightIcon, ExclamationCircleIcon } from '@heroicons/vue/outline'
 
-import { mapState } from 'vuex'
-
 import permissionsMixin from '../../mixins/Permissions.js'
 
 export default {
@@ -40,14 +38,7 @@ export default {
         ChevronRightIcon
     },
     mixins: [permissionsMixin],
-    props: {
-        team: {
-            type: Object,
-            required: true
-        }
-    },
     computed: {
-        ...mapState('account', ['teamMembership']),
         billingPath () {
             return '/team/' + this.team.slug + '/billing'
         },

--- a/frontend/src/mixins/Application.js
+++ b/frontend/src/mixins/Application.js
@@ -1,4 +1,3 @@
-import { Roles } from '../../../forge/lib/roles.js'
 import ApplicationApi from '../api/application.js'
 import alerts from '../services/alerts.js'
 
@@ -16,9 +15,6 @@ export default {
         }
     },
     computed: {
-        isVisitingAdmin () {
-            return this.teamMembership?.role === Roles.Admin
-        },
         isLoading () {
             return this.loading.deleting || this.loading.suspend
         },

--- a/frontend/src/mixins/Permissions.js
+++ b/frontend/src/mixins/Permissions.js
@@ -1,6 +1,15 @@
+import { mapState } from 'vuex'
+
 import { Permissions } from '../../../forge/lib/permissions.js'
+import { Roles } from '../../../forge/lib/roles.js'
 
 export default {
+    computed: {
+        ...mapState('account', ['team', 'teamMembership']),
+        isVisitingAdmin () {
+            return this.teamMembership?.role === Roles.Admin
+        }
+    },
     methods: {
         hasPermission (scope) {
             if (!Permissions[scope]) {

--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -56,7 +56,6 @@
                 :applicationDevices="devicesArray"
                 :is-visiting-admin="isVisitingAdmin"
                 :team="team"
-                :team-membership="teamMembership"
                 @device-group-updated="load"
                 @device-group-members-updated="load"
             />
@@ -68,8 +67,6 @@
 import { CheckCircleIcon, CogIcon, ExclamationIcon } from '@heroicons/vue/outline'
 
 import { mapState } from 'vuex'
-
-import { Roles } from '../../../../../forge/lib/roles.js'
 
 import ApplicationApi from '../../../api/application.js'
 
@@ -103,10 +100,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership', 'team']),
-        isVisitingAdmin () {
-            return this.teamMembership?.role === Roles.Admin
-        },
+        ...mapState('account', ['team']),
         navigation () {
             const routes = [
                 {

--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -55,7 +55,6 @@
                 :deviceGroup="deviceGroup"
                 :applicationDevices="devicesArray"
                 :is-visiting-admin="isVisitingAdmin"
-                :team="team"
                 @device-group-updated="load"
                 @device-group-members-updated="load"
             />

--- a/frontend/src/pages/application/Devices.vue
+++ b/frontend/src/pages/application/Devices.vue
@@ -11,11 +11,7 @@
             </template>
         </SectionTopMenu>
 
-        <DevicesBrowser
-            :application="application"
-            :team="team"
-            :teamMembership="teamMembership"
-        />
+        <DevicesBrowser :application="application" />
     </div>
 </template>
 
@@ -33,14 +29,6 @@ export default {
     mixins: [permissionsMixin],
     props: {
         application: {
-            type: Object,
-            required: true
-        },
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
             type: Object,
             required: true
         }

--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -58,7 +58,6 @@ import instanceApi from '../../api/instances.js'
 import NavItem from '../../components/NavItem.vue'
 import SideNavigation from '../../components/SideNavigation.vue'
 import applicationMixin from '../../mixins/Application.js'
-import permissionMixin from '../../mixins/Permissions.js'
 import Alerts from '../../services/alerts.js'
 import InstanceForm from '../instance/components/InstanceForm.vue'
 
@@ -69,7 +68,7 @@ export default {
         NavItem,
         SideNavigation
     },
-    mixins: [applicationMixin, permissionMixin],
+    mixins: [applicationMixin],
     inheritAttrs: false,
     props: {
         sourceInstanceId: {

--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -58,6 +58,7 @@ import instanceApi from '../../api/instances.js'
 import NavItem from '../../components/NavItem.vue'
 import SideNavigation from '../../components/SideNavigation.vue'
 import applicationMixin from '../../mixins/Application.js'
+import permissionMixin from '../../mixins/Permissions.js'
 import Alerts from '../../services/alerts.js'
 import InstanceForm from '../instance/components/InstanceForm.vue'
 
@@ -68,7 +69,7 @@ export default {
         NavItem,
         SideNavigation
     },
-    mixins: [applicationMixin],
+    mixins: [applicationMixin, permissionMixin],
     inheritAttrs: false,
     props: {
         sourceInstanceId: {

--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -147,10 +147,6 @@ export default {
         instance: {
             required: true,
             type: Object
-        },
-        isVisitingAdmin: {
-            required: true,
-            type: Boolean
         }
     },
     data () {

--- a/frontend/src/pages/team/Applications/index.vue
+++ b/frontend/src/pages/team/Applications/index.vue
@@ -101,16 +101,6 @@ export default {
         PlusSmIcon
     },
     mixins: [permissionsMixin],
-    props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        }
-    },
     data () {
         return {
             loading: false,

--- a/frontend/src/pages/team/AuditLog.vue
+++ b/frontend/src/pages/team/AuditLog.vue
@@ -29,16 +29,6 @@ export default {
         AuditLogBrowser
     },
     mixins: [permissionsMixin],
-    props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        }
-    },
     data () {
         return {
             logEntries: [],

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -140,16 +140,6 @@ export default {
         EmptyState
     },
     mixins: [formatDateMixin, formatCurrency, permissionsMixin],
-    props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        }
-    },
     data () {
         return {
             loading: false,

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -61,10 +61,6 @@ export default {
     },
     mixins: [formatCurrency],
     props: {
-        team: {
-            type: Object,
-            required: true
-        },
         teamDeviceCount: {
             type: Number,
             required: true
@@ -113,7 +109,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['features']),
+        ...mapState('account', ['features', 'team']),
         deviceIsBillable () {
             return this.features.billing && // billing enabled
                 !this.team.billing?.unmanaged &&

--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -16,33 +16,17 @@
                 </template>
             </ff-page-header>
         </template>
-        <DevicesBrowser
-            :team="team"
-            :teamMembership="teamMembership"
-        />
+        <DevicesBrowser />
     </ff-page>
 </template>
 
 <script>
 import DevicesBrowser from '../../../components/DevicesBrowser.vue'
 
-import permissionsMixin from '../../../mixins/Permissions.js'
-
 export default {
     name: 'TeamDevices',
     components: {
         DevicesBrowser
-    },
-    mixins: [permissionsMixin],
-    props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        }
     }
 }
 </script>

--- a/frontend/src/pages/team/Instances.vue
+++ b/frontend/src/pages/team/Instances.vue
@@ -100,16 +100,6 @@ export default {
         EmptyState
     },
     mixins: [permissionsMixin],
-    props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        }
-    },
     data () {
         return {
             loading: false,

--- a/frontend/src/pages/team/Library/TeamLibrary.vue
+++ b/frontend/src/pages/team/Library/TeamLibrary.vue
@@ -106,7 +106,6 @@ export default {
     },
     computed: {
         ...mapState('account', ['team', 'teamMembership'])
-
     },
     created () {
         this.$watch(

--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -48,14 +48,6 @@ export default {
     },
     mixins: [permissionsMixin],
     props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        },
         inviteCount: {
             type: Number,
             required: true

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -26,14 +26,6 @@ export default {
     name: 'MemberInviteTable',
     mixins: [permissionsMixin],
     props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        },
         inviteCount: {
             type: Number,
             required: true

--- a/frontend/src/pages/team/Members/index.vue
+++ b/frontend/src/pages/team/Members/index.vue
@@ -8,7 +8,7 @@
             </ff-page-header>
         </template>
         <div class="flex-grow">
-            <router-view :team="team" :teamMembership="teamMembership" :inviteCount="inviteCount" @invites-updated="checkAccess()" />
+            <router-view :inviteCount="inviteCount" @invites-updated="checkAccess()" />
         </div>
     </ff-page>
 </template>
@@ -23,16 +23,6 @@ import permissionsMixin from '../../../mixins/Permissions.js'
 export default {
     name: 'TeamUsers',
     mixins: [permissionsMixin],
-    props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        }
-    },
     data: function () {
         return {
             navigation: [],

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -46,12 +46,6 @@ export default {
         ConfirmTeamDeleteDialog,
         TeamAdminTools
     },
-    props: {
-        team: {
-            type: Object,
-            required: true
-        }
-    },
     data () {
         return {
             applicationCount: -1,
@@ -60,7 +54,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['user', 'features']),
+        ...mapState('account', ['user', 'features', 'team']),
         isAdmin: function () {
             return this.user.admin
         }

--- a/frontend/src/pages/team/Settings/Devices.vue
+++ b/frontend/src/pages/team/Settings/Devices.vue
@@ -88,16 +88,6 @@ export default {
         PlusSmIcon
     },
     mixins: [permissionsMixin],
-    props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        }
-    },
     data () {
         return {
             loading: true,

--- a/frontend/src/pages/team/Settings/General.vue
+++ b/frontend/src/pages/team/Settings/General.vue
@@ -87,12 +87,6 @@ export default {
         SparklesIcon,
         TemplateIcon
     },
-    props: {
-        team: {
-            type: Object,
-            required: true
-        }
-    },
     data () {
         return {
             errors: {
@@ -109,7 +103,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['user', 'features']),
+        ...mapState('account', ['user', 'features', 'team']),
         formValid () {
             return this.input.teamName && !this.pendingSlugCheck && !this.errors.slug && !this.errors.teamName
         },

--- a/frontend/src/pages/team/Settings/Permissions.vue
+++ b/frontend/src/pages/team/Settings/Permissions.vue
@@ -18,12 +18,6 @@ export default {
         FormRow,
         FormHeading
     },
-    props: {
-        team: {
-            type: Object,
-            required: true
-        }
-    },
     data () {
         return {
             input: {

--- a/frontend/src/pages/team/Settings/index.vue
+++ b/frontend/src/pages/team/Settings/index.vue
@@ -9,7 +9,7 @@
         </template>
         <div class="flex flex-col sm:flex-row">
             <div class="flex-grow pt-4">
-                <router-view :team="team" :teamMembership="teamMembership" />
+                <router-view />
             </div>
         </div>
     </ff-page>
@@ -24,16 +24,6 @@ import permissionsMixin from '../../../mixins/Permissions.js'
 export default {
     name: 'TeamSettings',
     mixins: [permissionsMixin],
-    props: {
-        team: {
-            type: Object,
-            required: true
-        },
-        teamMembership: {
-            type: Object,
-            required: true
-        }
-    },
     data: function () {
         return {
             sideOptions: [

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -12,7 +12,7 @@
                 <SubscriptionExpiredBanner :team="team" />
                 <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
             </Teleport>
-            <router-view :team="team" :teamMembership="teamMembership" />
+            <router-view />
         </div>
         <div v-else-if="!canAccessTeam">
             <EmptyState>

--- a/test/e2e/frontend/cypress/tests/team/team.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/team.spec.js
@@ -94,3 +94,60 @@ describe('FlowForge - Team', () => {
         })
     })
 })
+
+describe('Navigation', () => {
+    it('correctly changes the team when navigating via url between teams', () => {
+        cy.login('bob', 'bbPassword')
+        cy.home()
+
+        cy.get('[data-action="team-selection"].ff-dropdown.ff-dropdown--closed.ff-team-selection')
+            .within(() => {
+                cy.contains('ATeam')
+            })
+        cy.contains('application-1')
+
+        cy.get('[data-nav="team-instances"]').click()
+        cy.contains('instance-1-1')
+        cy.contains('instance-1-2')
+
+        cy.visit('/team/bteam/applications')
+
+        cy.get('[data-action="team-selection"].ff-dropdown.ff-dropdown--closed.ff-team-selection')
+            .within(() => {
+                cy.contains('BTeam')
+            })
+        cy.contains('application-2')
+
+        cy.get('[data-nav="team-instances"]').click()
+        cy.contains('instance-2-1')
+        cy.contains('instance-2-with-devices')
+    })
+
+    it.only('correctly changes the team when manually selecting a different team', () => {
+        cy.login('bob', 'bbPassword')
+        cy.home()
+
+        cy.get('[data-action="team-selection"].ff-dropdown.ff-dropdown--closed.ff-team-selection')
+            .within(() => {
+                cy.contains('ATeam')
+            })
+        cy.contains('application-1')
+
+        cy.get('[data-nav="team-instances"]').click()
+        cy.contains('instance-1-1')
+        cy.contains('instance-1-2')
+
+        cy.get('[data-action="team-selection"].ff-dropdown.ff-dropdown--closed.ff-team-selection').click()
+        cy.get('[data-action="switch-team"]').contains('BTeam').parent().click()
+
+        cy.get('[data-action="team-selection"].ff-dropdown.ff-dropdown--closed.ff-team-selection')
+            .within(() => {
+                cy.contains('BTeam')
+            })
+        cy.contains('application-2')
+
+        cy.get('[data-nav="team-instances"]').click()
+        cy.contains('instance-2-1')
+        cy.contains('instance-2-with-devices')
+    })
+})

--- a/test/e2e/frontend/cypress/tests/team/team.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/team.spec.js
@@ -123,7 +123,7 @@ describe('Navigation', () => {
         cy.contains('instance-2-with-devices')
     })
 
-    it.only('correctly changes the team when manually selecting a different team', () => {
+    it('correctly changes the team when manually selecting a different team', () => {
         cy.login('bob', 'bbPassword')
         cy.home()
 


### PR DESCRIPTION
Remove trickle down router props and cohesive way of using team, teamMembership and isVisitingAdmin

## Description

Focusing mainly on teamMembership & team props which can be used directly from the permissionsMixin, or using accessing the account store directly where the permission mixin is not used. 

The isVisitingAdmin computed prop has also been moved in the permissionsMixin

## Related Issue(s)
none

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

