### PR TITLE
ci: Add conditional check before removing pre-staging resources

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -270,6 +270,10 @@ jobs:
       
       - name: Remove resources
         run: |
-          helm uninstall --namespace "pr-${{ env.PR_NUMBER }}" flowfuse-pr-${{ env.PR_NUMBER }}
-          sleep 15
-          kubectl delete namespace "pr-${{ env.PR_NUMBER }}"
+          if helm list -n "pr-${{ env.PR_NUMBER }}" --filter "^flowfuse-pr-${{ env.PR_NUMBER }}$" | grep "flowfuse-pr-${{ env.PR_NUMBER }}"; then
+            helm uninstall --namespace "pr-${{ env.PR_NUMBER }}" flowfuse-pr-${{ env.PR_NUMBER }}
+            sleep 15
+            kubectl delete namespace "pr-${{ env.PR_NUMBER }}"
+          else
+            echo "Release flowfuse-pr-${{ env.PR_NUMBER }} does not exist"
+          fi


### PR DESCRIPTION
## Description

This pull request add a conditional check if pre-staging helm release for related PR exists befor removal attempt.
This is a temporary workaround for a problem when pre-staging environment was not created.
Long-term solution should be fixed as part of linked issue.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/4070

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

