### PR TITLE
Apply maximum password length

### DIFF
--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -193,6 +193,8 @@ export default {
                 this.errors.password = 'Password is required'
             } else if (this.input.password.length < 8) {
                 this.errors.password = 'Password needs to be longer than 8 chars'
+            } else if (this.input.password.length > 128) {
+                this.errors.password = 'Password too long'
             } else if (this.input.password === this.input.username.trim()) {
                 this.errors.password = 'Password must not match username'
             } else if (this.input.password === this.input.email.trim()) {

--- a/frontend/src/pages/account/PasswordReset.vue
+++ b/frontend/src/pages/account/PasswordReset.vue
@@ -60,7 +60,7 @@ export default {
                 this.errors.password = 'Password must be at least 8 characters'
                 return
             }
-            if (this.input.password.length > 1024) {
+            if (this.input.password.length > 128) {
                 this.errors.password = 'Password too long'
                 return
             }

--- a/frontend/src/pages/account/Security/ChangePassword.vue
+++ b/frontend/src/pages/account/Security/ChangePassword.vue
@@ -61,7 +61,7 @@ export default {
                 this.errors.password = 'Password must be at least 8 characters'
                 return
             }
-            if (this.input.password.length > 1024) {
+            if (this.input.password.length > 128) {
                 this.errors.password = 'Password too long'
                 return
             }

--- a/frontend/src/pages/admin/Users/createUser.vue
+++ b/frontend/src/pages/admin/Users/createUser.vue
@@ -101,7 +101,7 @@ export default {
                 this.errors.password = 'Password must be at least 8 characters'
                 return
             }
-            if (this.input.password.length > 1024) {
+            if (this.input.password.length > 128) {
                 this.errors.password = 'Password too long'
                 return
             }

--- a/frontend/src/pages/setup/CreateAdminUser.vue
+++ b/frontend/src/pages/setup/CreateAdminUser.vue
@@ -120,7 +120,7 @@ export default {
             } else {
                 this.errors.password = ''
             }
-            if (this.input.password && this.input.password.length > 1024) {
+            if (this.input.password && this.input.password.length > 128) {
                 this.errors.password = 'Password too long'
                 return
             } else {

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -655,6 +655,22 @@ describe('User API', async function () {
                 result.code.should.equal('password_change_failed_too_weak')
             })
 
+            it('user can not set too long password', async function () {
+                await login('dave', 'ddPassword')
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: '/api/v1/user/change_password',
+                    payload: {
+                        old_password: 'ddPassword',
+                        password: 'a'.padStart(129, 'iusegkfsafjsbegouasf')
+                    },
+                    cookies: { sid: TestObjects.tokens.dave }
+                })
+                response.statusCode.should.equal(400)
+                const result = response.json()
+                result.code.should.equal('password_change_failed')
+            })
+
             it('cannot access other parts of api', async function () {
                 // Not an exhaustive check by any means, but a simple check the
                 // basic blocking is working


### PR DESCRIPTION
Fixes https://github.com/FlowFuse/security/issues/91

## Description

Applies a maximum password length of 128 chars.

We already had a soft-limit in place of 1024 in some places, but this adds it consistently across all the relevant places at 128 chars. Most crucially, it then applies that limit when do the password auth check so that we don't pass arbitrarily long strings to the hash function.