### PR TITLE
nr-assistant integration

### DIFF
--- a/etc/flowforge.yml
+++ b/etc/flowforge.yml
@@ -68,6 +68,17 @@ driver:
 
 
 #################################################
+# Assistant Configuration                       #
+#################################################
+
+# assistant:
+#   enabled: true
+#   service:
+#     url: https://assistant.service
+#     token: token_for_service
+#     requestTimeout: 60000
+
+#################################################
 # File Server config                            #
 #################################################
 

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -109,7 +109,10 @@ const Permissions = {
     'platform:debug': { description: 'View platform debug information', role: Roles.Admin },
     'platform:stats': { description: 'View platform stats information', role: Roles.Admin },
     'platform:stats:token': { description: 'Create/Delete platform stats token', role: Roles.Admin },
-    'platform:audit-log': { description: 'View platform audit log', role: Roles.Admin }
+    'platform:audit-log': { description: 'View platform audit log', role: Roles.Admin },
+
+    // assistant
+    'assistant:function': { description: 'Access the assistant function endpoint', role: Roles.Member }
 }
 
 module.exports = {

--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -18,7 +18,31 @@ module.exports = async function (app) {
      * use an alternative means of accessing it.
     */
     app.post('/function', {
-        preHandler: app.needsPermission('assistant:function')
+        preHandler: app.needsPermission('assistant:function'),
+        schema: {
+            hide: true, // dont show in swagger
+            body: {
+                type: 'object',
+                properties: {
+                    // The prompt to send to the assistant (required)
+                    prompt: { type: 'string' },
+                    // A correlation id for the transaction (required)
+                    transactionId: { type: 'string' },
+                    // Additional context for the function (optional)
+                    context: { type: 'object', additionalProperties: true }
+                },
+                required: ['prompt', 'transactionId']
+            },
+            response: {
+                200: {
+                    type: 'object',
+                    additionalProperties: true
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     },
     async (request, reply) => {
         // const method = request.params.method // FUTURE: allow for different methods

--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -1,0 +1,52 @@
+const { default: axios } = require('axios')
+
+/**
+ * Assistant api routes
+ *
+ * - /api/v1/assistant
+ *
+ * @namespace assistant
+ * @memberof forge.routes.api
+ */
+module.exports = async function (app) {
+    app.addHook('preHandler', app.verifySession)
+
+    /**
+     * Endpoint for assistant functions
+     * For now, this is simply a relay to an external assistant service
+     * In the future, we may decide to bring that service inside the core or
+     * use an alternative means of accessing it.
+    */
+    app.post('/function', {
+        preHandler: app.needsPermission('assistant:function')
+    },
+    async (request, reply) => {
+        // const method = request.params.method // FUTURE: allow for different methods
+        const method = 'function' // for now, only function node/code generation is supported
+
+        const serviceUrl = app.config.assistant?.service.url
+        const serviceToken = app.config.assistant?.service?.token
+        const enabled = app.config.assistant?.enabled !== false && serviceUrl
+        const requestTimeout = app.config.assistant?.service?.requestTimeout || 60000
+
+        if (!enabled) {
+            return reply.code(501).send({ code: 'service_disabled', error: 'Assistant service is not enabled' })
+        }
+
+        const url = `${serviceUrl.replace(/\/+$/, '')}/${method.replace(/^\/+/, '')}`
+
+        // post to the assistant service
+        const headers = {}
+        if (serviceToken) {
+            headers.Authorization = `Bearer ${serviceToken}`
+        }
+        const response = await axios.post(url, {
+            ...request.body
+        }, {
+            headers,
+            timeout: requestTimeout
+        })
+
+        reply.send(response.data)
+    })
+}

--- a/forge/routes/api/index.js
+++ b/forge/routes/api/index.js
@@ -7,6 +7,7 @@
  */
 const Admin = require('./admin.js')
 const Application = require('./application.js')
+const Assistant = require('./assistant.js')
 const Device = require('./device.js')
 const Project = require('./project.js')
 const ProjectType = require('./projectType.js')
@@ -34,6 +35,7 @@ module.exports = async function (app) {
     app.register(Device, { prefix: '/devices' })
     app.register(ProjectType, { prefix: '/project-types' })
     app.register(Snapshot, { prefix: '/snapshots' })
+    app.register(Assistant, { prefix: '/assistant' })
     app.get('*', function (request, reply) {
         reply.code(404).send({ code: 'not_found', error: 'Not Found' })
     })

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -822,6 +822,10 @@ module.exports = async function (app) {
         settings.baseURL = request.project.url
         settings.forgeURL = app.config.base_url
         settings.fileStore = app.config.fileStore ? { ...app.config.fileStore } : null
+        settings.assistant = {
+            enabled: app.config.assistant?.enabled || false,
+            requestTimeout: app.config.assistant?.requestTimeout
+        }
         settings.teamID = request.project.Team.hashid
         settings.storageURL = request.project.storageURL
         settings.auditURL = request.project.auditURL

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -9,7 +9,8 @@ const IMPLICIT_TOKEN_SCOPES = {
     device: [
         'team:projects:list', // permit a device being edited via a tunnel in developer mode to list projects
         'library:entry:create', // permit a device being edited via a tunnel in developer mode to create library entries
-        'library:entry:list' // permit a device being edited via a tunnel in developer mode to list library entries
+        'library:entry:list', // permit a device being edited via a tunnel in developer mode to list library entries
+        'assistant:function' // permit calls to the assistant endpoint for function node/code creation
     ],
     project: [
         'user:read',
@@ -17,7 +18,8 @@ const IMPLICIT_TOKEN_SCOPES = {
         'project:flows:edit',
         'team:projects:list',
         'library:entry:create',
-        'library:entry:list'
+        'library:entry:list',
+        'assistant:function'
     ]
 }
 

--- a/test/unit/forge/routes/api/assistant_spec.js
+++ b/test/unit/forge/routes/api/assistant_spec.js
@@ -1,0 +1,164 @@
+const { default: axios } = require('axios')
+const should = require('should') // eslint-disable-line
+const sinon = require('sinon')
+
+const setup = require('../setup')
+
+describe('Assistant API', async function () {
+    let app
+    const TestObjects = {
+        /** admin - owns ATeam */
+        alice: {},
+        ATeam: {},
+        /** ATeam Application */
+        Application1: {},
+        /** ATeam Instance */
+        instance: {},
+        device: {},
+        tokens: {}
+    }
+    /** @type {import('../../../../lib/TestModelFactory')} */
+    let factory = null
+
+    async function setupApp (license) {
+        const setupConfig = {
+            features: { devices: true },
+            assistant: {
+                enabled: true,
+                service: {
+                    url: 'http://localhost:9876',
+                    token: 'blah'
+                }
+            }
+        }
+        if (license) {
+            setupConfig.license = license
+        }
+        app = await setup(setupConfig)
+        factory = app.factory
+
+        await login('alice', 'aaPassword')
+
+        // ATeam create in setup()
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+        TestObjects.instance = app.project
+        TestObjects.Application1 = app.application
+        TestObjects.tokens.instance = (await TestObjects.instance.refreshAuthTokens()).token
+        TestObjects.device = await factory.createDevice({ name: 'device1' }, TestObjects.ATeam, null, TestObjects.Application1)
+        app.comms = null // skip all the broker stuff
+        TestObjects.tokens.device = (await TestObjects.device.refreshAuthTokens()).token
+    }
+
+    before(async function () {
+        return setupApp()
+    })
+    after(async function () {
+        await app.close()
+    })
+    afterEach(async function () {
+        sinon.restore()
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    describe('service disabled', async function () {
+        it('should return 501 if assistant service is disabled', async function () {
+            sinon.stub(app.config.assistant, 'enabled').get(() => false)
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/assistant/function',
+                headers: { authorization: 'Bearer ' + TestObjects.tokens.instance },
+                payload: { prompt: 'multiply by 5', transactionId: '1234' }
+            })
+            response.statusCode.should.equal(501)
+        })
+        it('should return 501 if assistant service url is not set', async function () {
+            sinon.stub(app.config.assistant.service, 'url').get(() => null)
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/assistant/function',
+                headers: { authorization: 'Bearer ' + TestObjects.tokens.instance },
+                payload: { prompt: 'multiply by 5', transactionId: '1234' }
+            })
+            response.statusCode.should.equal(501)
+        })
+    })
+    describe('function service', async function () {
+        it('anonymous cannot access /function', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/assistant/function'
+            })
+            response.statusCode.should.equal(401)
+        })
+        it('random token cannot access /function', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/assistant/function',
+                headers: { authorization: 'Bearer blah-blah' }
+            })
+            response.statusCode.should.equal(401)
+        })
+        it('device token can access /function', async function () {
+            // const device = await createDevice({ name: 'Ad1', type: 'Ad1_type', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
+            const deviceCreateResponse = await app.inject({
+                method: 'POST',
+                url: '/api/v1/devices',
+                body: {
+                    name: 'Ad1',
+                    type: 'Ad1_type',
+                    team: TestObjects.ATeam.hashid
+                },
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            const device = deviceCreateResponse.json()
+            sinon.stub(axios, 'post').resolves({ data: { status: 'ok' } })
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/assistant/function',
+                headers: { authorization: 'Bearer ' + device.credentials.token },
+                payload: { prompt: 'multiply by 5', transactionId: '1234' }
+            })
+            axios.post.calledOnce.should.be.true()
+            response.statusCode.should.equal(200)
+        })
+        it('instance token can access /function', async function () {
+            sinon.stub(axios, 'post').resolves({ data: { status: 'ok' } })
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/assistant/function',
+                headers: { authorization: 'Bearer ' + TestObjects.tokens.instance },
+                payload: { prompt: 'multiply by 5', transactionId: '1234' }
+            })
+            axios.post.calledOnce.should.be.true()
+            response.statusCode.should.equal(200)
+        })
+        it('fails when prompt is not supplied', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/assistant/function',
+                headers: { authorization: 'Bearer ' + TestObjects.tokens.instance },
+                payload: { transactionId: '1234' }
+            })
+            response.statusCode.should.equal(400)
+        })
+        it('fails when transactionId is not supplied', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/assistant/function',
+                headers: { authorization: 'Bearer ' + TestObjects.tokens.instance },
+                payload: { prompt: 'multiply by 5' }
+            })
+            response.statusCode.should.equal(400)
+        })
+    })
+})


### PR DESCRIPTION
closes #4083

## Description

* Adds commented section to yaml config
* Adds permission `'assistant:function'`
  * the function part is for permitting node-red function code generation
* adds api `assistant` with a single POST route `/api/v1/assistant/function`
  * This route expects a device/project token only since it would be tiggered from the nr-assistant plugin loaded into Node-RED
  * In this first implementation, the route is a simple relay to the real assistant (which behind the scenes talks to an LLM)

### TODO:
- [x] tests
- [ ] ~~docs~~ docs to be addressed separately.

## Related Issue(s)

#4083

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

