### PR TITLE
Update frameguard to sameorigin

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -410,7 +410,7 @@ module.exports = async (options = {}) => {
             hidePoweredBy: true,
             strictTransportSecurity,
             frameguard: {
-                action: 'deny'
+                action: 'sameorigin'
             },
             referrerPolicy: {
                 policy: 'origin-when-cross-origin'


### PR DESCRIPTION
Current helmet/frameguard policy is set to `deny` - which prevents the app being embedded in an iframe.

This *might* be causing issues with the immersive editor in production - yet it works on staging. Raising PR to get this change (from `deny` to `sameorigin`) and test in a dev env.