### PR TITLE
Guard to ensure 501 is returned when config has no `service` object in `assistant` settings

### DIFF
--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -48,7 +48,7 @@ module.exports = async function (app) {
         // const method = request.params.method // FUTURE: allow for different methods
         const method = 'function' // for now, only function node/code generation is supported
 
-        const serviceUrl = app.config.assistant?.service.url
+        const serviceUrl = app.config.assistant?.service?.url
         const serviceToken = app.config.assistant?.service?.token
         const enabled = app.config.assistant?.enabled !== false && serviceUrl
         const requestTimeout = app.config.assistant?.service?.requestTimeout || 60000


### PR DESCRIPTION
## Description

Additional guard to ensure the `return 501` is actually reached in cases where `service` is not configured.


