### PR TITLE
Enable immersive editor for Node-RED 4.0.2+ and Launcher 2.6.0+

### DIFF
--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -17,7 +17,7 @@
 
 <script>
 import { ExternalLinkIcon } from '@heroicons/vue/solid'
-// import SemVer from 'semver'
+import SemVer from 'semver'
 
 import { mapState } from 'vuex'
 
@@ -46,14 +46,12 @@ export default {
     computed: {
         ...mapState('account', ['team', 'teamMembership']),
         isImmersiveEditor () {
-            return false
-
-            // const nrSemver = SemVer.parse(this.instance?.meta?.versions?.['node-red'])
-            // // Supported from 4.0.0-beta.4 and later. This requires a bit more effort to check
-            // if (nrSemver && nrSemver.major >= 4 && (nrSemver.prerelease.length === 0 || nrSemver.prerelease[1] >= 4)) {
-            //     return SemVer.satisfies(SemVer.coerce(this.instance?.meta?.versions?.launcher), '>=2.5.0')
-            // }
-            // return false
+            // Immersive Editor only available for:
+            // - Node-RED 4.0.2+
+            // - Launcher 2.6.0+
+            const validNR = SemVer.satisfies(this.instance?.meta?.versions?.['node-red'], '>=4.0.2', { includePrerelease: true })
+            const validLauncher = SemVer.satisfies(SemVer.coerce(this.instance?.meta?.versions?.launcher), '>=2.6.0')
+            return validNR && validLauncher
         },
         url () {
             if (this.isImmersiveEditor) {


### PR DESCRIPTION
Part of #3800 

Having verified the immersive editor is now working in production for the about-to-ship launcher version and Node-RED 4.0.2, this is the final step to update the editor button to direct to the right place if the conditions are met.

Technically, it will work with nr-launcher `2.5.2-2f3c495-202407020855.0` or later, but to keep things clean, am pinning it to tomorrow's release version.