### PR TITLE
Add css & js webpack cache bust

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -25,7 +25,8 @@ module.exports = function (env, argv) {
             path: getPath('frontend/dist/app'),
             publicPath: '/app/',
             assetModuleFilename: './assets/[hash][ext][query]',
-            filename: '[name].js'
+            filename: '[name].[contenthash].js',
+            clean: true
         },
         module: {
             rules: [
@@ -121,7 +122,9 @@ module.exports = function (env, argv) {
                 filename: getPath('frontend/dist-setup/setup.html'),
                 chunks: ['setup']
             }),
-            new MiniCssExtractPlugin(),
+            new MiniCssExtractPlugin({
+                filename: '[name].[contenthash].css'
+            }),
             new CopyPlugin({
                 patterns: [
                     { from: getPath('frontend/public'), to: '..' }


### PR DESCRIPTION
## Description

Add webpack cache bust capability for front end assets (css/js)

docs: https://webpack.js.org/guides/caching/

## Related Issue(s)
closes https://github.com/FlowFuse/flowfuse/issues/4098


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

