### PR TITLE
4078 blank page after redirect

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -76,7 +76,7 @@ export default {
     mixins: [navigationMixin],
     computed: {
         ...mapState('account', ['user', 'team', 'teams']),
-        ...mapGetters('account', ['notifications', 'defaultUserTeam']),
+        ...mapGetters('account', ['notifications']),
         navigationOptions () {
             return [
                 {

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -60,6 +60,8 @@ import { AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIcon, QuestionMarkC
 import { ref } from 'vue'
 import { mapGetters, mapState } from 'vuex'
 
+import navigationMixin from '../mixins/Navigation.js'
+
 import NavItem from './NavItem.vue'
 import TeamSelection from './TeamSelection.vue'
 
@@ -71,9 +73,10 @@ export default {
         }
     },
     emits: ['menu-toggle'],
+    mixins: [navigationMixin],
     computed: {
         ...mapState('account', ['user', 'team', 'teams']),
-        ...mapGetters('account', ['notifications']),
+        ...mapGetters('account', ['notifications', 'defaultUserTeam']),
         navigationOptions () {
             return [
                 {
@@ -110,7 +113,7 @@ export default {
                     label: 'Sign Out',
                     icon: LogoutIcon,
                     tag: 'sign-out',
-                    onclick: this.signout
+                    onclick: this.signOut
                 }
             ].filter(option => option !== undefined)
         }
@@ -142,16 +145,8 @@ export default {
         }
     },
     methods: {
-        home () {
-            if (this.team?.slug) {
-                this.$router.push({ name: 'Team', params: { team_slug: this.team.slug } })
-            }
-        },
         to (route) {
             window.open(route.url, '_blank')
-        },
-        signout () {
-            this.$router.push({ name: 'Sign out' })
         }
     }
 }

--- a/frontend/src/mixins/Navigation.js
+++ b/frontend/src/mixins/Navigation.js
@@ -1,0 +1,21 @@
+import { mapState } from 'vuex'
+
+export default {
+    computed: {
+        ...mapState('account', ['team'])
+    },
+    methods: {
+        home () {
+            if (this.team?.slug) {
+                this.$router.push({ name: 'Team', params: { team_slug: this.team.slug } })
+            } else if (this.defaultUserTeam?.slug) {
+                this.$router.push({ name: 'Team', params: { team_slug: this.defaultUserTeam?.slug } })
+            } else {
+                this.$router.push({ name: 'Home' })
+            }
+        },
+        signOut () {
+            this.$router.push({ name: 'Sign out' })
+        }
+    }
+}

--- a/frontend/src/mixins/Navigation.js
+++ b/frontend/src/mixins/Navigation.js
@@ -2,7 +2,7 @@ import { mapState } from 'vuex'
 
 export default {
     computed: {
-        ...mapState('account', ['team'])
+        ...mapState('account', ['team', 'defaultUserTeam'])
     },
     methods: {
         home () {

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -13,7 +13,7 @@
 
 <script>
 
-import { mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 
 import FlowFuseLogo from '../components/Logo.vue'
 
@@ -31,7 +31,8 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['pending', 'user', 'team', 'teams', 'redirectUrlAfterLogin'])
+        ...mapState('account', ['pending', 'user', 'team', 'teams', 'redirectUrlAfterLogin']),
+        ...mapGetters('account', ['defaultUserTeam'])
     },
     watch: {
         team: 'redirectOnLoad',
@@ -47,12 +48,12 @@ export default {
             }
 
             // Only bounce to team view if there's no redirectUrlAfterLogin set
-            if (!this.redirectUrlAfterLogin && this.user.email_verified) {
-                if (this.team) {
+            if (this.user.email_verified) {
+                if (this.team || this.defaultUserTeam) {
                     this.$router.push({
                         name: 'Team',
                         params: {
-                            team_slug: this.team.slug
+                            team_slug: this.team?.slug || this.defaultUserTeam?.slug
                         }
                     })
                 }

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -42,6 +42,10 @@ export default {
     },
     methods: {
         redirectOnLoad () {
+            if (this.redirectUrlAfterLogin) {
+                return this.$router.push(this.redirectUrlAfterLogin)
+            }
+
             // Only bounce to team view if there's no redirectUrlAfterLogin set
             if (!this.redirectUrlAfterLogin && this.user.email_verified) {
                 if (this.team) {

--- a/frontend/src/pages/team/createInstance.vue
+++ b/frontend/src/pages/team/createInstance.vue
@@ -19,7 +19,7 @@
 
         <ff-loading v-if="loading" message="Creating instance..." />
         <InstanceForm
-            v-else
+            v-else-if="team"
             :instance="instanceDetails"
             :team="team"
             :applicationSelection="true"
@@ -118,15 +118,15 @@ export default {
             return this.blueprints.find(blueprint => blueprint.id === this.preDefinedInputs?.flowBlueprintId)
         }
     },
+    watch: {
+        async team () {
+            await this.getData()
+        }
+    },
     async created () {
-        const data = await teamApi.getTeamApplications(this.team.id)
-        this.applications = data.applications.map((a) => {
-            return {
-                label: a.name,
-                description: a.description,
-                value: a.id
-            }
-        })
+        if (this.team) {
+            await this.getData()
+        }
 
         if (!this.applications.length && !this.isLandingFromExternalLink) {
             // need to also create an Application
@@ -194,6 +194,16 @@ export default {
         createApplication (applicationDetails) {
             const createPayload = { ...applicationDetails, teamId: this.team.id }
             return ApplicationApi.createApplication(createPayload)
+        },
+        async getData () {
+            const data = await teamApi.getTeamApplications(this.team.id)
+            this.applications = data.applications.map((a) => {
+                return {
+                    label: a.name,
+                    description: a.description,
+                    value: a.id
+                }
+            })
         }
     }
 }

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,5 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
+import { useStore } from 'vuex'
+
 import Home from './pages/Home.vue'
 import PageNotFound from './pages/PageNotFound.vue'
 
@@ -43,6 +45,17 @@ const router = createRouter({
     routes
 })
 
+function clearRedirectUrl (to, from) {
+    const store = useStore()
+
+    if (
+        store.state?.account?.user &&
+        store.state?.account?.redirectUrlAfterLogin &&
+        from.fullPath === store.state?.account?.redirectUrlAfterLogin) {
+        store.dispatch('account/setRedirectUrl', null)
+    }
+}
+
 /*
     Set Page Title when switching views
 */
@@ -84,8 +97,11 @@ router.beforeEach((to, from, next) => {
     Array.from(document.querySelectorAll('[data-vue-router-controlled]')).map(el => el.parentNode.removeChild(el))
 
     // Skip rendering meta tags if there are none.
-    if (!nearestWithMeta) return next()
-
+    if (!nearestWithMeta) {
+        next()
+        clearRedirectUrl(to, from)
+        return
+    }
     // Turn the meta tag definitions into actual elements in the head.
     nearestWithMeta.meta.metaTags.map(tagDef => {
         const tag = document.createElement('meta')
@@ -103,6 +119,7 @@ router.beforeEach((to, from, next) => {
         .forEach(tag => document.head.appendChild(tag))
 
     next()
+    clearRedirectUrl(to, from)
 })
 
 export default router

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -51,7 +51,7 @@ function clearRedirectUrl (to, from) {
     if (
         store.state?.account?.user &&
         store.state?.account?.redirectUrlAfterLogin &&
-        from.fullPath === store.state?.account?.redirectUrlAfterLogin) {
+        store.state?.account?.redirectUrlAfterLogin.includes(from.fullPath)) {
         store.dispatch('account/setRedirectUrl', null)
     }
 }


### PR DESCRIPTION
## Description

The `redirectUrlAfterLogin` url is not cleared after the redirect occurred and that causes side effects in other locations in the app. This is now a problem because we're storing the `redirectUrlAfterLogin` in localStorage and it doesn't get cleared on page refresh

Three part fix:
- making sure that the `redirectUrlAfterLogin` is cleared after the route is hit for logged in users
- making sure that users that have the `redirectUrlAfterLogin` get redirected when they reach the home page
- fix the FF home logo not following any path when clicked in this state

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4078

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

