### PR TITLE
PostHog - Add .group call to automatically map all events to the relevant team

### DIFF
--- a/frontend/src/services/product.js
+++ b/frontend/src/services/product.js
@@ -52,8 +52,33 @@ function groupUpdate (type, id, properties) {
     })
 }
 
+function setTeam (team) {
+    const props = {
+        'team-name': team.name,
+        'created-at': team.createdAt,
+        'count-instances': team.instanceCount,
+        'count-devices': team.deviceCount,
+        'count-members': team.memberCount,
+        'team-type-id': team.type.id,
+        'team-type-name': team.type.name
+    }
+    if ('billing' in team) {
+        props['billing-active'] = team.billing.active
+        props['billing-canceled'] = team.billing.canceled
+        props['billing-unmanaged'] = team.billing.unmanaged
+
+        if ('trial' in team.billing) {
+            props['billing-trial'] = team.billing.trial
+            props['billing-trial-ended'] = team.billing.trialEnded
+            props['billing-trial-ends-at'] = team.billing.trialEndsAt
+        }
+    }
+    window.posthog?.group('team', team.id, props)
+}
+
 export default {
     identify,
     capture,
-    groupUpdate
+    groupUpdate,
+    setTeam
 }

--- a/frontend/src/services/product.js
+++ b/frontend/src/services/product.js
@@ -53,27 +53,31 @@ function groupUpdate (type, id, properties) {
 }
 
 function setTeam (team) {
-    const props = {
-        'team-name': team.name,
-        'created-at': team.createdAt,
-        'count-instances': team.instanceCount,
-        'count-devices': team.deviceCount,
-        'count-members': team.memberCount,
-        'team-type-id': team.type.id,
-        'team-type-name': team.type.name
-    }
-    if ('billing' in team) {
-        props['billing-active'] = team.billing.active
-        props['billing-canceled'] = team.billing.canceled
-        props['billing-unmanaged'] = team.billing.unmanaged
-
-        if ('trial' in team.billing) {
-            props['billing-trial'] = team.billing.trial
-            props['billing-trial-ended'] = team.billing.trialEnded
-            props['billing-trial-ends-at'] = team.billing.trialEndsAt
+    if (team) {
+        const props = {
+            'team-name': team.name,
+            'created-at': team.createdAt,
+            'count-instances': team.instanceCount,
+            'count-devices': team.deviceCount,
+            'count-members': team.memberCount,
+            'team-type-id': team.type.id,
+            'team-type-name': team.type.name
         }
+        if ('billing' in team) {
+            props['billing-active'] = team.billing.active
+            props['billing-canceled'] = team.billing.canceled
+            props['billing-unmanaged'] = team.billing.unmanaged
+
+            if ('trial' in team.billing) {
+                props['billing-trial'] = team.billing.trial
+                props['billing-trial-ended'] = team.billing.trialEnded
+                props['billing-trial-ends-at'] = team.billing.trialEndsAt
+            }
+        }
+        window.posthog?.group('team', team.id, props)
+    } else {
+        window.posthog?.group('team', null)
     }
-    window.posthog?.group('team', team.id, props)
 }
 
 export default {

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -6,6 +6,7 @@ import settingsApi from '../api/settings.js'
 import teamApi from '../api/team.js'
 import userApi from '../api/user.js'
 import router from '../routes.js'
+import product from '../services/product.js'
 
 // initial state
 const state = () => ({
@@ -115,6 +116,8 @@ const mutations = {
         state.user = user
     },
     setTeam (state, team) {
+        // update the product session "team" to record all future events against them
+        product.setTeam(team)
         state.team = team
     },
     setTeamMembership (state, membership) {


### PR DESCRIPTION
## Description

Following chat with Greg this week, want to be more team-centric in our analysis on PostHog. These changes enable that.

- Adds in tier data for each team
- centralises the team assignment
- Calls `.group` within a wrapped `setTeam` function. This runs every time user logs in, or switches team, all events in that session _after_ this are then automatically mapped to the relevant team.
- This will mean we can do team-centric analysis on all insights in PostHog

Team is attached to _every_ event after as the property "Group 1" (it's just how PostHog tracks the concept of "groups")

Context: [PostHog Docs](https://posthog.com/docs/product-analytics/group-analytics)
