### PR TITLE
PostHog - Better capturing of Snapshot-based activity

### DIFF
--- a/frontend/src/api/projectSnapshots.js
+++ b/frontend/src/api/projectSnapshots.js
@@ -26,6 +26,11 @@ const create = async (projectId, options) => {
 }
 
 const rollbackSnapshot = async (instanceId, snapshotId) => {
+    product.capture('ff-snapshot-rollback', {
+        'snapshot-id': snapshotId
+    }, {
+        instance: instanceId
+    })
     return instanceApi.rollbackInstance(instanceId, snapshotId)
 }
 

--- a/frontend/src/pages/instance/Snapshots/index.vue
+++ b/frontend/src/pages/instance/Snapshots/index.vue
@@ -81,6 +81,7 @@ import { downloadData } from '../../../composables/Download.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
 import Alerts from '../../../services/alerts.js'
 import Dialog from '../../../services/dialog.js'
+import Product from '../../../services/product.js'
 import { applySystemUserDetails } from '../../../transformers/snapshots.transformer.js'
 import DaysSince from '../../application/Snapshots/components/cells/DaysSince.vue'
 import DeviceCount from '../../application/Snapshots/components/cells/DeviceCount.vue'
@@ -257,6 +258,11 @@ export default {
             this.$emit('instance-updated')
         },
         async downloadSnapshotPackage (snapshot) {
+            Product.capture('ff-snapshot-download', {
+                'snapshot-id': snapshot.id
+            }, {
+                instance: this.instance?.id
+            })
             const ss = await SnapshotsApi.getSummary(snapshot.id)
             const owner = ss.device || ss.project
             const ownerType = ss.device ? 'device' : 'instance'
@@ -273,6 +279,11 @@ export default {
             this.$refs.snapshotExportDialog.show(snapshot)
         },
         showViewSnapshotDialog (snapshot) {
+            Product.capture('ff-snapshot-view', {
+                'snapshot-id': snapshot.id
+            }, {
+                instance: this.instance?.id
+            })
             SnapshotsApi.getFullSnapshot(snapshot.id).then((data) => {
                 this.$refs.snapshotViewerDialog.show(data)
             }).catch(err => {
@@ -281,6 +292,11 @@ export default {
             })
         },
         showCompareSnapshotDialog (snapshot) {
+            Product.capture('ff-snapshot-compare', {
+                'snapshot-id': snapshot.id
+            }, {
+                instance: this.instance?.id
+            })
             SnapshotsApi.getFullSnapshot(snapshot.id)
                 .then((data) => this.$refs.snapshotCompareDialog.show(data, this.snapshotList))
                 .catch(err => {


### PR DESCRIPTION
## Description

Went to do some analysis on recent features we introduced for Snapshots (Comparing, Previewing, Rollback) and the autocapture events for this in PostHog aren't good because the list is populated after first page render (so PH doesn't append the autocapture handler)

This adds explicit posthog events so that we can better identify user behaviour and uptake of Snapshot features here