### PR TITLE
update examples links

### DIFF
--- a/docs/install/first-run.md
+++ b/docs/install/first-run.md
@@ -11,10 +11,10 @@ through the initial setup.
 ## 1. Start setup
 
 ### - LocalFS
-Open FlowFuse in your browser [http://localhost:3000](http://localhost:3000){rel="nofollow"}.  
+Open FlowFuse in your browser `http://localhost:3000` 
 
 ### - Docker or Kubernetes
-Open FlowFuse in your browser [http://forge.example.com](http://forge.example.com){rel="nofollow"} (Change `.example.com` to match the domain you set up in DNS)
+Open FlowFuse in your browser `http://forge.example.com` (Change `.example.com` to match the domain you set up in DNS)
 
 
 Click the **START SETUP** button


### PR DESCRIPTION
Currently, the links given as examples are rendering as hyperlinks, which are causing SEO issues despite us using the 'rel="nofollow"' attribute, therefore i have updated them as blocks

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

https://github.com/FlowFuse/website/issues/2307

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

