### PR TITLE
ci: Update `publish_node_package` workflow to `v0.21.0`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ on:
       - 'Tests'
     branches: 
       - main
+      - ci-bump-publish-workflow
     types: 
       - completed
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,14 +23,14 @@ concurrency:
 
 jobs:
   publish:
-    if: |
-      ( github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' ) ||
-      ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
+    # if: |
+    #   ( github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' ) ||
+    #   ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.20.0'
     with:
       package_name: flowfuse
       build_package: true
-      publish_package: true
+      publish_package: false
       package_dependencies: |
         @flowfuse/driver-localfs
     secrets:
@@ -41,6 +41,7 @@ jobs:
 
   dispatch_container_build:
     needs: publish
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,6 @@ on:
       localfs_ref:
         description: 'localfs package ref'
         required: false
-  pull_request:
-    branches:
-      - main
   workflow_run:
     workflows: 
       - 'Tests'
@@ -26,14 +23,14 @@ concurrency:
 
 jobs:
   publish:
-    # if: |
-    #   ( github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' ) ||
-    #   ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
+    if: |
+      ( github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' ) ||
+      ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.20.0'
     with:
       package_name: flowfuse
       build_package: true
-      publish_package: false
+      publish_package: true
       package_dependencies: |
         @flowfuse/driver-localfs
     secrets:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     if: |
       ( github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' ) ||
       ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
-    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.10.0'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.20.0'
     with:
       package_name: flowfuse
       build_package: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,6 @@ jobs:
 
   dispatch_container_build:
     needs: publish
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,14 @@ on:
       localfs_ref:
         description: 'localfs package ref'
         required: false
+  pull_request:
+    branches:
+      - main
   workflow_run:
     workflows: 
       - 'Tests'
     branches: 
       - main
-      - ci-bump-publish-workflow
     types: 
       - completed
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     if: |
       ( github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' ) ||
       ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
-    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.20.0'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.21.0'
     with:
       package_name: flowfuse
       build_package: true

--- a/forge/app.js
+++ b/forge/app.js
@@ -67,6 +67,7 @@ const forge = require('./forge')
                 server.log.info('* FlowFuse is now running and can be accessed at: *')
                 server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
                 server.log.info('****************************************************')
+                server.log.info('****************************************************')
             }
             if (enableRepl) {
                 const repl = require('repl')

--- a/forge/app.js
+++ b/forge/app.js
@@ -67,7 +67,6 @@ const forge = require('./forge')
                 server.log.info('* FlowFuse is now running and can be accessed at: *')
                 server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
                 server.log.info('****************************************************')
-                server.log.info('****************************************************')
             }
             if (enableRepl) {
                 const repl = require('repl')


### PR DESCRIPTION
## Description

This pull request updates the `publish_node_package` workflow to version 0.20.0.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

