### PR TITLE
Swap maps with arrays on the applications page

### DIFF
--- a/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
@@ -17,7 +17,7 @@
         </label>
         <div class="items-wrapper" :class="{one: singleDevice, two: twoDevices, three: threeDevices}">
             <div
-                v-for="device in Array.from(application.devices.values())"
+                v-for="device in devices"
                 :key="device.id"
                 class="item-wrapper"
                 @click.stop="openDevice(device)"
@@ -91,14 +91,14 @@ export default {
     emits: ['delete-device'],
     computed: {
         hasMoreDevices () {
-            return this.application.deviceCount > this.application.devices.size
+            return this.application.deviceCount > this.application.devices.length
         },
         hasNoDevices () {
-            return this.application.devices.size === 0
+            return this.application.devices.length === 0
         },
         remainingDevices () {
             if (this.hasNoDevices || this.hasMoreDevices) {
-                return this.application.deviceCount - this.application.devices.size
+                return this.application.deviceCount - this.application.devices.length
             } else return 0
         },
         singleDevice () {

--- a/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
@@ -57,17 +57,17 @@ export default {
     emits: ['delete-instance'],
     computed: {
         instances () {
-            return Array.from(this.application.instances.values())
+            return this.application.instances
         },
         hasMoreInstances () {
-            return this.application.instanceCount > this.application.instances.size
+            return this.application.instanceCount > this.application.instances.length
         },
         hasNoInstances () {
-            return this.application.instances.size === 0
+            return this.application.instances.length === 0
         },
         remainingInstances () {
             if (this.hasNoInstances || this.hasMoreInstances) {
-                return this.application.instanceCount - this.application.instances.size
+                return this.application.instanceCount - this.application.instances.length
             } else return 0
         },
         singleInstance () {

--- a/frontend/src/pages/team/Applications/index.vue
+++ b/frontend/src/pages/team/Applications/index.vue
@@ -235,6 +235,9 @@ export default {
                     })
                 })
 
+                application.instances = Array.from(application.instances.values())
+                application.devices = Array.from(application.devices.values())
+
                 this.applications.set(applicationData.id, {
                     ...application,
                     ...applicationProps

--- a/frontend/src/pages/team/Applications/index.vue
+++ b/frontend/src/pages/team/Applications/index.vue
@@ -129,7 +129,13 @@ export default {
     },
     computed: {
         applicationsList () {
-            return Array.from(this.applications.values())
+            return Array.from(this.applications.values()).map(app => {
+                return {
+                    ...app,
+                    instances: Array.from(app.instances.values()),
+                    devices: Array.from(app.devices.values())
+                }
+            })
         },
         filteredApplications () {
             if (this.filterTerm) {
@@ -234,9 +240,6 @@ export default {
                         ...deviceStatusData
                     })
                 })
-
-                application.instances = Array.from(application.instances.values())
-                application.devices = Array.from(application.devices.values())
 
                 this.applications.set(applicationData.id, {
                     ...application,


### PR DESCRIPTION
## Description

use arrays instead of maps for application devices and instances on the applications page

## Related Issue(s)
part of https://github.com/FlowFuse/flowfuse/issues/4014

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

