### PR TITLE
Add option to show mfa code instead of qrcode

### DIFF
--- a/frontend/src/pages/account/Security/dialogs/MFASetupDialog.vue
+++ b/frontend/src/pages/account/Security/dialogs/MFASetupDialog.vue
@@ -3,12 +3,30 @@
         <template #default>
             <div class="space-y-4">
                 <template v-if="step === 0">
-                    <p>
-                        To get started, scan the following QR code into your Authenticator app, then click next to continue.
-                    </p>
-                    <div class="text-center mt-4">
-                        <img v-if="!!qrcode" :src="qrcode" class="m-auto border rounded">
-                    </div>
+                    <template v-if="showQRCode">
+                        <p>
+                            To get started, scan the following QR code into your Authenticator app, then click next to continue.
+                        </p>
+                        <div class="text-center mt-4">
+                            <template v-if="!!qrcode">
+                                <img v-if="!!qrcode" :src="qrcode" class="m-auto border rounded">
+                                <p>
+                                    <a class="cursor-pointer" @click="showSecret()">Can't scan QR code?</a>
+                                </p>
+                            </template>
+                        </div>
+                    </template>
+                    <template v-else>
+                        <p>
+                            To get started, enter the following code into your Authenticator app, then click next to continue.
+                        </p>
+                        <div class="text-center mt-4">
+                            <p class="text-2xl w-64 text-wrap font-mono break-all tracking-wider mx-auto my-2">{{ secretCode }}</p>
+                            <p>
+                                <a class="cursor-pointer" @click="hideSecret()">Show QR code</a>
+                            </p>
+                        </div>
+                    </template>
                 </template>
                 <template v-if="step === 1">
                     <p>
@@ -57,12 +75,15 @@ export default {
             async show () {
                 this.step = 0
                 this.qrcode = ''
+                this.showQRCode = true
+                this.secretCode = ''
                 this.verifyToken = ''
                 this.verifyError = ''
                 this.$refs.dialog.show()
                 try {
                     const mfaDetails = await userApi.enableMFA()
                     this.qrcode = mfaDetails.qrcode
+                    this.secretCode = mfaDetails.url.split('=')[1]
                 } catch (err) {
 
                 }
@@ -72,6 +93,7 @@ export default {
     data () {
         return {
             step: 0,
+            showQRCode: true,
             qrcode: '',
             verifyToken: ''
         }
@@ -85,6 +107,12 @@ export default {
     methods: {
         close () {
             this.$refs.dialog.close()
+        },
+        showSecret () {
+            this.showQRCode = false
+        },
+        hideSecret () {
+            this.showQRCode = true
         },
         complete () {
             this.$emit('user-updated')

--- a/frontend/src/pages/account/Security/dialogs/MFASetupDialog.vue
+++ b/frontend/src/pages/account/Security/dialogs/MFASetupDialog.vue
@@ -21,7 +21,11 @@
                             To get started, enter the following code into your Authenticator app, then click next to continue.
                         </p>
                         <div class="text-center mt-4">
-                            <p class="text-2xl w-64 text-wrap font-mono break-all tracking-wider mx-auto my-2">{{ secretCode }}</p>
+                            <p class="text-2xl w-72 text-wrap font-mono tracking-wider mx-auto my-2">
+                                <template v-for="i in secretCode" :key="i">
+                                    <span class="mx-1">{{ i }}</span><wbr>
+                                </template>
+                            </p>
                             <p>
                                 <a class="cursor-pointer" @click="hideSecret()">Show QR code</a>
                             </p>
@@ -76,14 +80,14 @@ export default {
                 this.step = 0
                 this.qrcode = ''
                 this.showQRCode = true
-                this.secretCode = ''
+                this.secretCode = []
                 this.verifyToken = ''
                 this.verifyError = ''
                 this.$refs.dialog.show()
                 try {
                     const mfaDetails = await userApi.enableMFA()
                     this.qrcode = mfaDetails.qrcode
-                    this.secretCode = mfaDetails.url.split('=')[1]
+                    this.secretCode = mfaDetails.url.split('=')[1].match(/.{1,4}/g)
                 } catch (err) {
 
                 }
@@ -95,7 +99,8 @@ export default {
             step: 0,
             showQRCode: true,
             qrcode: '',
-            verifyToken: ''
+            verifyToken: '',
+            secretCode: []
         }
     },
     computed: {


### PR DESCRIPTION
Fixes #4118 

## Description

Adds option to show mfa secret for manual setup of authenticator app.

Link added below qrcode:

<img width="583" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/c9d803f4-7689-4ada-b66b-c1aa55c52535">

Clicking it toggles the view to:

<img width="596" alt="image" src="https://github.com/FlowFuse/flowfuse/assets/51083/d9e74892-e363-41eb-9906-9a64d7b787bf">

with an option to toggle back.