### PR TITLE
Add headers identifying the owner in requests to assistant service

### DIFF
--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -63,6 +63,22 @@ module.exports = async function (app) {
 
         // post to the assistant service
         const headers = {}
+        if (request.session?.ownerType) {
+            switch (request.session.ownerType) {
+            case 'team':
+                headers['ff-owner-type'] = 'team'
+                headers['ff-owner-id'] = app.db.models.Team.encodeHashid(request.session.ownerId)
+                break
+            case 'device':
+                headers['ff-owner-type'] = 'device'
+                headers['ff-owner-id'] = app.db.models.Device.encodeHashid(request.session.ownerId)
+                break
+            case 'project':
+            case 'instance':
+                headers['ff-owner-type'] = request.session.ownerType
+                headers['ff-owner-id'] = request.session.ownerId
+            }
+        }
         if (serviceToken) {
             headers.Authorization = `Bearer ${serviceToken}`
         }

--- a/test/unit/forge/routes/api/assistant_spec.js
+++ b/test/unit/forge/routes/api/assistant_spec.js
@@ -192,6 +192,34 @@ describe('Assistant API', async function () {
                 })
                 response.statusCode.should.equal(400)
             })
+            it('contains owner info in headers for an instance', async function () {
+                sinon.stub(axios, 'post').resolves({ data: { status: 'ok' } })
+                await app.inject({
+                    method: 'POST',
+                    url: `/api/v1/assistant/${serviceName}`,
+                    headers: { authorization: 'Bearer ' + TestObjects.tokens.instance },
+                    payload: { prompt: 'multiply by 5', transactionId: '1234' }
+                })
+                axios.post.calledOnce.should.be.true()
+                axios.post.args[0][2].headers.should.have.properties({
+                    'ff-owner-type': 'project',
+                    'ff-owner-id': TestObjects.instance.id
+                })
+            })
+            it('contains owner info in headers for a device', async function () {
+                sinon.stub(axios, 'post').resolves({ data: { status: 'ok' } })
+                await app.inject({
+                    method: 'POST',
+                    url: `/api/v1/assistant/${serviceName}`,
+                    headers: { authorization: 'Bearer ' + TestObjects.tokens.device },
+                    payload: { prompt: 'multiply by 5', transactionId: '1234' }
+                })
+                axios.post.calledOnce.should.be.true()
+                axios.post.args[0][2].headers.should.have.properties({
+                    'ff-owner-type': 'device',
+                    'ff-owner-id': TestObjects.device.hashid
+                })
+            })
         }
         describe('function service', async function () {
             serviceTests('function')


### PR DESCRIPTION
closes #4160

## Description

Adds vendor specific headers to identify the owner type and id making a request to the assistant service.

## Related Issue(s)

#4160 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

