### PR TITLE
Only permit instance/device token to call upon assistant endpoint

### DIFF
--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -109,10 +109,7 @@ const Permissions = {
     'platform:debug': { description: 'View platform debug information', role: Roles.Admin },
     'platform:stats': { description: 'View platform stats information', role: Roles.Admin },
     'platform:stats:token': { description: 'Create/Delete platform stats token', role: Roles.Admin },
-    'platform:audit-log': { description: 'View platform audit log', role: Roles.Admin },
-
-    // assistant
-    'assistant:method': { description: 'Access the assistant method endpoint', role: null }
+    'platform:audit-log': { description: 'View platform audit log', role: Roles.Admin }
 }
 
 module.exports = {

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -112,7 +112,7 @@ const Permissions = {
     'platform:audit-log': { description: 'View platform audit log', role: Roles.Admin },
 
     // assistant
-    'assistant:method': { description: 'Access the assistant method endpoint', role: Roles.Member }
+    'assistant:method': { description: 'Access the assistant method endpoint', role: null }
 }
 
 module.exports = {

--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -11,8 +11,10 @@ const { default: axios } = require('axios')
 module.exports = async function (app) {
     app.addHook('preHandler', app.verifySession)
     app.addHook('preHandler', (request, reply, done) => {
-        // Only permit requests made by a device or instance
-        if (request.session?.ownerType !== 'device' && request.session?.ownerType !== 'project') {
+        // Only permit requests made by a valid device or instance token
+        if (!request.session || request.session.provisioning) {
+            reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+        } else if (request.session.ownerType !== 'device' && request.session.ownerType !== 'project') {
             reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
         } else {
             done()
@@ -26,7 +28,6 @@ module.exports = async function (app) {
      * use an alternative means of accessing it.
     */
     app.post('/:method', {
-        preHandler: app.needsPermission('assistant:method'),
         schema: {
             hide: true, // dont show in swagger
             body: {

--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -10,6 +10,14 @@ const { default: axios } = require('axios')
  */
 module.exports = async function (app) {
     app.addHook('preHandler', app.verifySession)
+    app.addHook('preHandler', (request, reply, done) => {
+        // Only permit requests made by a device or instance
+        if (request.session?.ownerType !== 'device' && request.session?.ownerType !== 'project') {
+            reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+        } else {
+            done()
+        }
+    })
 
     /**
      * Endpoint for assistant methods

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -9,8 +9,7 @@ const IMPLICIT_TOKEN_SCOPES = {
     device: [
         'team:projects:list', // permit a device being edited via a tunnel in developer mode to list projects
         'library:entry:create', // permit a device being edited via a tunnel in developer mode to create library entries
-        'library:entry:list', // permit a device being edited via a tunnel in developer mode to list library entries
-        'assistant:method' // permit calls to the assistant endpoint for method node/code/json/etc creation
+        'library:entry:list' // permit a device being edited via a tunnel in developer mode to list library entries
     ],
     project: [
         'user:read',
@@ -18,8 +17,7 @@ const IMPLICIT_TOKEN_SCOPES = {
         'project:flows:edit',
         'team:projects:list',
         'library:entry:create',
-        'library:entry:list',
-        'assistant:method'
+        'library:entry:list'
     ]
 }
 

--- a/test/unit/forge/routes/api/assistant_spec.js
+++ b/test/unit/forge/routes/api/assistant_spec.js
@@ -140,6 +140,18 @@ describe('Assistant API', async function () {
                 })
                 response.statusCode.should.equal(401)
             })
+            it('user token can not access', async function () {
+                sinon.stub(axios, 'post').resolves({ data: { status: 'ok' } })
+                const response = await app.inject({
+                    method: 'POST',
+                    url: `/api/v1/assistant/${serviceName}`,
+                    // headers: { authorization: 'Bearer ' + TestObjects.tokens.alice },
+                    cookies: { sid: TestObjects.tokens.alice },
+                    payload: { prompt: 'multiply by 5', transactionId: '1234' }
+                })
+                response.statusCode.should.equal(401)
+                axios.post.calledOnce.should.be.false()
+            })
             it('device token can access', async function () {
                 // const device = await createDevice({ name: 'Ad1', type: 'Ad1_type', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
                 const deviceCreateResponse = await app.inject({

--- a/test/unit/forge/routes/api/assistant_spec.js
+++ b/test/unit/forge/routes/api/assistant_spec.js
@@ -145,7 +145,6 @@ describe('Assistant API', async function () {
                 const response = await app.inject({
                     method: 'POST',
                     url: `/api/v1/assistant/${serviceName}`,
-                    // headers: { authorization: 'Bearer ' + TestObjects.tokens.alice },
                     cookies: { sid: TestObjects.tokens.alice },
                     payload: { prompt: 'multiply by 5', transactionId: '1234' }
                 })
@@ -153,7 +152,6 @@ describe('Assistant API', async function () {
                 axios.post.calledOnce.should.be.false()
             })
             it('device token can access', async function () {
-                // const device = await createDevice({ name: 'Ad1', type: 'Ad1_type', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
                 const deviceCreateResponse = await app.inject({
                     method: 'POST',
                     url: '/api/v1/devices',


### PR DESCRIPTION
## Description

* Ensures assistant endpoint requests are made by a device or instance token only
* Removes unnecessary permission `"assistant:method"` now that we limit to devices/instances via `preHandler` 
* Adds test to ensure user tokens are rejected (401)

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

