### PR TITLE
carry on application search params to followup pages

### DIFF
--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -28,6 +28,7 @@
                 :columns="cloudColumns"
                 :rows="filteredRows"
                 :show-search="true"
+                :search="searchTerm"
                 search-placeholder="Search Instances"
                 :rows-selectable="true"
                 @update:search="updateSearch"
@@ -172,6 +173,11 @@ export default {
         },
         isVisitingAdmin () {
             return this.teamMembership.role === Roles.Admin
+        }
+    },
+    mounted () {
+        if (this.$route?.query?.searchQuery) {
+            this.searchTerm = this.$route.query.searchQuery
         }
     },
     methods: {

--- a/frontend/src/pages/team/Applications/components/Application.vue
+++ b/frontend/src/pages/team/Applications/components/Application.vue
@@ -1,9 +1,9 @@
 <template>
     <ApplicationHeader :application="localApplication" />
 
-    <InstancesWrapper :application="localApplication" :is-searching="isSearching" @delete-instance="onInstanceDelete" />
+    <InstancesWrapper :application="localApplication" :search-query="searchQuery" @delete-instance="onInstanceDelete" />
 
-    <DevicesWrapper :application="localApplication" :is-searching="isSearching" @delete-device="$emit('device-deleted')" />
+    <DevicesWrapper :application="localApplication" :search-query="searchQuery" @delete-device="$emit('device-deleted')" />
 
     <ConfirmInstanceDeleteDialog ref="confirmInstanceDeleteDialog" @confirm="onInstanceDeleted" />
 </template>
@@ -29,10 +29,10 @@ export default {
             type: Object,
             required: true
         },
-        isSearching: {
-            type: Boolean,
+        searchQuery: {
+            type: String,
             required: false,
-            default: false
+            default: ''
         }
     },
     emits: ['instance-deleted', 'device-deleted'],

--- a/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
@@ -27,15 +27,13 @@
             >
                 <DeviceTile :device="device" :application="application" @device-action="onDeviceAction" />
             </div>
-            <div v-if="hasMoreDevices" class="has-more item-wrapper">
-                <router-link :to="{name: 'ApplicationDevices', params: {id: application.id}}">
-                    <span>
-                        {{ remainingDevices }}
-                        More...
-                    </span>
-                    <ChevronRightIcon class="ff-icon" />
-                </router-link>
-            </div>
+            <HasMoreTile
+                v-if="hasMoreDevices"
+                link-to="ApplicationDevices"
+                :remaining="remainingDevices"
+                :application="application"
+                :search-query="searchQuery"
+            />
         </div>
 
         <TeamDeviceCreateDialog
@@ -71,18 +69,17 @@
 </template>
 
 <script>
-import { ChevronRightIcon } from '@heroicons/vue/solid'
-
 import IconDeviceSolid from '../../../../../components/icons/DeviceSolid.js'
 import deviceActionsMixin from '../../../../../mixins/DeviceActions.js'
 import DeviceCredentialsDialog from '../../../Devices/dialogs/DeviceCredentialsDialog.vue'
 import TeamDeviceCreateDialog from '../../../Devices/dialogs/TeamDeviceCreateDialog.vue'
 
 import DeviceTile from './DeviceTile.vue'
+import HasMoreTile from './HasMoreTile.vue'
 
 export default {
     name: 'DevicesWrapper',
-    components: { TeamDeviceCreateDialog, DeviceCredentialsDialog, ChevronRightIcon, IconDeviceSolid, DeviceTile },
+    components: { HasMoreTile, TeamDeviceCreateDialog, DeviceCredentialsDialog, IconDeviceSolid, DeviceTile },
     mixins: [deviceActionsMixin],
     props: {
         application: {
@@ -90,10 +87,10 @@ export default {
             required: true,
             default: null
         },
-        isSearching: {
-            type: Boolean,
+        searchQuery: {
+            type: String,
             required: false,
-            default: false
+            default: ''
         }
     },
     emits: ['delete-device'],
@@ -120,6 +117,9 @@ export default {
         },
         devices () {
             return this.application.devices.slice(0, 3)
+        },
+        isSearching () {
+            return this.searchQuery.length > 0
         }
     },
     mounted () {

--- a/frontend/src/pages/team/Applications/components/compact/HasMoreTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/HasMoreTile.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="has-more item-wrapper">
-        <router-link :to="{name: linkTo, params: {id: application.id, searchQuery: searchQuery}}">
+        <router-link :to="{name: linkTo, params: {id: application.id}, query: {searchQuery}}">
             <span>
                 {{ remaining }}
                 More...

--- a/frontend/src/pages/team/Applications/components/compact/HasMoreTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/HasMoreTile.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="has-more item-wrapper">
+    <div class="has-more item-wrapper" data-el="has-more-tile">
         <router-link :to="{name: linkTo, params: {id: application.id}, query: {searchQuery}}">
             <span>
                 {{ remaining }}

--- a/frontend/src/pages/team/Applications/components/compact/HasMoreTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/HasMoreTile.vue
@@ -1,0 +1,43 @@
+<template>
+    <div class="has-more item-wrapper">
+        <router-link :to="{name: linkTo, params: {id: application.id, searchQuery: searchQuery}}">
+            <span>
+                {{ remaining }}
+                More...
+            </span>
+            <ChevronRightIcon class="ff-icon" />
+        </router-link>
+    </div>
+</template>
+
+<script>
+import { ChevronRightIcon } from '@heroicons/vue/solid'
+
+export default {
+    name: 'HasMoreTile',
+    components: { ChevronRightIcon },
+    props: {
+        application: {
+            type: Object,
+            required: true
+        },
+        remaining: {
+            type: Number,
+            required: true
+        },
+        linkTo: {
+            type: String,
+            required: true
+        },
+        searchQuery: {
+            type: String,
+            required: false,
+            default: ''
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+
+</style>

--- a/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
@@ -27,39 +27,37 @@
             >
                 <InstanceTile :instance="instance" @delete-instance="$emit('delete-instance', $event)" />
             </div>
-            <div v-if="hasMoreInstances" class="has-more item-wrapper">
-                <router-link :to="{name: 'ApplicationInstances', params: {id: application.id}}">
-                    <span>
-                        {{ remainingInstances }}
-                        More...
-                    </span>
-                    <ChevronRightIcon class="ff-icon" />
-                </router-link>
-            </div>
+            <HasMoreTile
+                v-if="hasMoreInstances"
+                link-to="ApplicationInstances"
+                :remaining="remainingInstances"
+                :application="application"
+                :search-query="searchQuery"
+            />
         </div>
     </section>
 </template>
 
 <script>
-import { ChevronRightIcon } from '@heroicons/vue/solid'
-
 import IconNodeRedSolid from '../../../../../components/icons/NodeRedSolid.js'
+
+import HasMoreTile from './HasMoreTile.vue'
 
 import InstanceTile from './InstanceTile.vue'
 
 export default {
     name: 'InstancesWrapper',
-    components: { ChevronRightIcon, IconNodeRedSolid, InstanceTile },
+    components: { HasMoreTile, IconNodeRedSolid, InstanceTile },
     props: {
         application: {
             type: Object,
             required: true,
             default: null
         },
-        isSearching: {
-            type: Boolean,
+        searchQuery: {
+            type: String,
             required: false,
-            default: false
+            default: ''
         }
     },
     emits: ['delete-instance'],
@@ -86,6 +84,9 @@ export default {
         },
         threeInstances () {
             return this.application.instanceCount === 3
+        },
+        isSearching () {
+            return this.searchQuery.length > 0
         }
     }
 }

--- a/frontend/src/pages/team/Applications/index.vue
+++ b/frontend/src/pages/team/Applications/index.vue
@@ -48,7 +48,7 @@
                     <li v-for="application in filteredApplications" :key="application.id" data-el="application-item">
                         <ApplicationListItem
                             :application="application"
-                            :is-searching="filterTerm.length > 0"
+                            :search-query="filterTerm"
                             @instance-deleted="fetchData(false)"
                             @device-deleted="fetchData(false)"
                         />

--- a/frontend/src/ui-components/components/data-table/DataTable.vue
+++ b/frontend/src/ui-components/components/data-table/DataTable.vue
@@ -194,7 +194,7 @@ export default {
         },
         filterTerm: {
             get () {
-                return this.search
+                return this.search || this.internalSearch
             },
             set (value) {
                 const valueChanged = value !== this.internalSearch
@@ -257,6 +257,11 @@ export default {
             } else {
                 return rows
             }
+        }
+    },
+    mounted () {
+        if (this.$route?.query?.searchQuery) {
+            this.internalSearch = this.$route.query.searchQuery
         }
     },
     methods: {

--- a/test/e2e/frontend/cypress/tests/applications/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/overview.spec.js
@@ -837,16 +837,283 @@ describe('FlowForge - Applications', () => {
                         cy.get('[data-el="application-instance-item"]').should('have.length', 1)
                         cy.get('[data-el="application-instance-item"]').contains('interesting instance name')
                     })
+            })
 
-                // cy.get('[data-el="applications-list"]').children().should('have.length', 3)
-                //
-                // // check that we have three apps after clearing the search input
-                // cy.get('[data-form="search"] input').clear()
-                // cy.get('[data-el="applications-list"]').children().should('have.length', 3)
-                //
-                // // check that we have a single app after searching a term unique to one
-                // cy.get('[data-form="search"] input').type('second')
-                // cy.get('[data-el="applications-list"]').children().should('have.length', 1).contains('My Second App')
+            it('carries the search queries onwards to the application devices page when clicking show more', () => {
+                const devices = [
+                    {
+                        id: '1',
+                        name: 'common device name',
+                        lastSeenAt: null,
+                        lastSeenMs: null,
+                        status: 'offline',
+                        mode: 'autonomous',
+                        isDeploying: false
+                    },
+                    {
+                        id: '2',
+                        name: 'not so common device name',
+                        lastSeenAt: null,
+                        lastSeenMs: null,
+                        status: 'offline',
+                        mode: 'autonomous',
+                        isDeploying: false
+                    },
+                    {
+                        id: '3',
+                        name: 'xyz device name with common element',
+                        lastSeenAt: null,
+                        lastSeenMs: null,
+                        status: 'offline',
+                        mode: 'autonomous',
+                        isDeploying: false
+                    },
+                    {
+                        id: '4',
+                        name: 'device name that shares common attributes',
+                        lastSeenAt: null,
+                        lastSeenMs: null,
+                        status: 'offline',
+                        mode: 'autonomous',
+                        isDeploying: false
+                    },
+                    {
+                        id: '5',
+                        name: 'device name and common key',
+                        lastSeenAt: null,
+                        lastSeenMs: null,
+                        status: 'offline',
+                        mode: 'autonomous',
+                        isDeploying: false
+                    }
+                ]
+                const instances = []
+
+                cy.intercept(
+                    'GET',
+                    '/api/*/teams/*/applications/status*',
+                    {
+                        count: 1,
+                        applications: [
+                            {
+                                id: '1',
+                                instances,
+                                devices
+                            }
+                        ]
+                    }
+                ).as('getAppStatuses')
+                cy.intercept('get', '/api/*/applications/*/devices*', {
+                    meta: {},
+                    count: 5,
+                    devices
+                })
+                    .as('getDevices')
+                cy.intercept(
+                    'GET',
+                    '/api/*/teams/*/applications*',
+                    {
+                        count: 1,
+                        applications: [
+                            {
+                                id: '1',
+                                name: 'My First App',
+                                description: 'My first empty app description',
+                                instancesSummary: {
+                                    count: 0,
+                                    instances
+                                },
+                                devicesSummary: {
+                                    count: 5,
+                                    devices
+                                }
+                            }
+                        ]
+                    }
+                ).as('getApplications')
+
+                cy.intercept('GET', '/api/*/applications/1', {
+                    id: '1',
+                    name: 'My First App',
+                    description: 'My first empty app description',
+                    team: {
+                        id: 'ateam',
+                        name: 'ateam',
+                        slug: 'ateam'
+                    }
+                }).as('getApplication')
+
+                cy.intercept('GET', '/api/*/applications/1/instances*', {
+                    count: 0,
+                    instances
+                }).as('getApplicationInstances')
+
+                cy.intercept('GET', '/api/*/applications/1/devices*', {
+                    count: 5,
+                    devices
+                }).as('getApplicationDevices')
+
+                cy.home()
+
+                cy.wait('@getAppStatuses')
+                cy.wait('@getApplications')
+
+                cy.get('[data-form="search"]').type('common')
+                cy.get('[data-el="has-more-tile"]').click()
+
+                cy.wait('@getApplication')
+                cy.wait('@getApplicationInstances')
+                cy.wait('@getApplicationDevices')
+
+                cy.get('[data-form="search"]').should('exist')
+                cy.get('[data-form="search"] input')
+                    .invoke('val')
+                    .then(val => {
+                        expect(val).to.equal('common')
+                    })
+            })
+
+            it('carries the search queries onwards to the application instances page when clicking show more', () => {
+                const instances = [
+                    {
+                        id: '1',
+                        name: 'common-instance-name',
+                        meta: {
+                            versions: {
+                                launcher: '2.3.1'
+                            },
+                            state: 'running'
+                        },
+                        url: 'https://www.google.com:123/search?q=rick+astley'
+                    },
+                    {
+                        id: '2',
+                        name: 'not-so-common-instance-name',
+                        meta: {
+                            versions: {
+                                launcher: '2.3.1'
+                            },
+                            state: 'running'
+                        },
+                        url: 'https://www.google.com:123/search?q=rick+astley'
+                    },
+                    {
+                        id: '3',
+                        name: 'xyz-instance-name-common-name',
+                        meta: {
+                            versions: {
+                                launcher: '2.3.1'
+                            },
+                            state: 'running'
+                        },
+                        url: 'https://www.google.com:123/search?q=rick+astley'
+                    },
+                    {
+                        id: '4',
+                        name: 'instance-name-that-has-common-el',
+                        meta: {
+                            versions: {
+                                launcher: '2.3.1'
+                            },
+                            state: 'running'
+                        },
+                        url: 'https://www.google.com:123/search?q=rick+astley'
+                    },
+                    {
+                        id: '5',
+                        name: 'another-common-instance-name-that-matches-application-name',
+                        meta: {
+                            versions: {
+                                launcher: '2.3.1'
+                            },
+                            state: 'running'
+                        },
+                        url: 'https://www.google.com:123/search?q=rick+astley'
+                    }
+                ]
+                const devices = []
+                cy.intercept(
+                    'GET',
+                    '/api/*/teams/*/applications/status*',
+                    {
+                        count: 1,
+                        applications: [
+                            {
+                                id: '1',
+                                instances,
+                                devices
+                            }
+                        ]
+                    }
+                ).as('getAppStatuses')
+                cy.intercept('get', '/api/*/applications/*/devices*', {
+                    meta: {},
+                    count: 0,
+                    devices
+                })
+                    .as('getDevices')
+                cy.intercept(
+                    'GET',
+                    '/api/*/teams/*/applications*',
+                    {
+                        count: 1,
+                        applications: [
+                            {
+                                id: '1',
+                                name: 'My First App',
+                                description: 'My first empty app description',
+                                instancesSummary: {
+                                    count: 5,
+                                    instances
+                                },
+                                devicesSummary: {
+                                    count: 0,
+                                    devices
+                                }
+                            }
+                        ]
+                    }
+                ).as('getApplications')
+
+                cy.intercept('GET', '/api/*/applications/1', {
+                    id: '1',
+                    name: 'My First App',
+                    description: 'My first empty app description',
+                    team: {
+                        id: 'ateam',
+                        name: 'ateam',
+                        slug: 'ateam'
+                    }
+                }).as('getApplication')
+
+                cy.intercept('GET', '/api/*/applications/*/instances*', {
+                    count: 5,
+                    instances
+                }).as('getApplicationInstances')
+
+                cy.intercept('GET', '/api/*/applications/*/instances/status', {
+                    count: 5,
+                    instances: []
+                }).as('getSomeStatuses')
+
+                cy.home()
+
+                cy.wait('@getAppStatuses')
+                cy.wait('@getApplications')
+
+                cy.get('[data-form="search"]').type('common')
+                cy.get('[data-el="has-more-tile"]').click()
+
+                cy.wait('@getApplication')
+                cy.wait('@getApplicationInstances')
+                cy.wait('@getSomeStatuses')
+
+                cy.get('[data-form="search"]').should('exist')
+                cy.get('[data-form="search"] input')
+                    .invoke('val')
+                    .then(val => {
+                        expect(val).to.equal('common')
+                    })
             })
         })
     })


### PR DESCRIPTION
## Description

carry the query string from the application search to instances/devices page

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4167

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

