### PR TITLE
Allow AWS SES sourceArn to be set

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -139,8 +139,9 @@ This assumes that the instance is running with a Service Account that has a AWS 
 
 Option        | Description
 --------------|------------
-`email.ses.region` | The AWS region to connect to
-`email.ses.sourceArn` | The AWS ARN of a Identity to send email as
+`email.ses.region` | The AWS region to connect to. Default `unset`
+`email.ses.sourceArn` | The AWS ARN of a SES Identity to send email as. Default: `unset`
+`email.ses.fromArn` | The AWS ARN of a SES Identity to set as the from field. Default to value of `email.ses.sourceArn`
 
 
 ## Telemetry configuration

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -140,6 +140,7 @@ This assumes that the instance is running with a Service Account that has a AWS 
 Option        | Description
 --------------|------------
 `email.ses.region` | The AWS region to connect to
+`email.ses.sourceArn` | The AWS ARN of a Identity to send email as
 
 
 ## Telemetry configuration

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -83,7 +83,8 @@ module.exports = fp(async function (app, _opts) {
 
                 if (sesConfig.sourceArn) {
                     mailDefaults.ses = {
-                        sourceArn: sesConfig.sourceArn
+                        SourceArn: sesConfig.sourceArn,
+                        FromArn: sesConfig.FromArn ? sesConfig.FromArn: sesConfig.sourceArn
                     }
                 }
 

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -81,6 +81,12 @@ module.exports = fp(async function (app, _opts) {
                     defaultProvider
                 })
 
+                if (sesConfig.sourceArn) {
+                    mailDefaults['ses'] = {
+                        sourceArn: sesConfig.sourceArn
+                    }
+                }
+
                 mailTransport = nodemailer.createTransport({
                     SES: { ses, aws }
                 }, mailDefaults)

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -84,7 +84,7 @@ module.exports = fp(async function (app, _opts) {
                 if (sesConfig.sourceArn) {
                     mailDefaults.ses = {
                         SourceArn: sesConfig.sourceArn,
-                        FromArn: sesConfig.FromArn ? sesConfig.FromArn: sesConfig.sourceArn
+                        FromArn: sesConfig.FromArn ? sesConfig.FromArn : sesConfig.sourceArn
                     }
                 }
 

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -82,7 +82,7 @@ module.exports = fp(async function (app, _opts) {
                 })
 
                 if (sesConfig.sourceArn) {
-                    mailDefaults['ses'] = {
+                    mailDefaults.ses = {
                         sourceArn: sesConfig.sourceArn
                     }
                 }


### PR DESCRIPTION
part of FlowFuse/flowfuse#4173

## Description

<!-- Describe your changes in detail -->
Allows mail to be sent via AWS SES with a authorised identity

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4173 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

