### PR TITLE
cI: Notify on `Install test` workflow failure

### DIFF
--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -69,7 +69,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "<${{ github.server_url }}/${{ github.repository }}/actions/workflows/install-test.yaml|${{ github.workflow }}>` workflow failed to complete successfully."
+                  "text": "<${{ github.server_url }}/${{ github.repository }}/actions/workflows/install-test.yaml|${{ github.workflow }}> workflow failed to complete successfully."
                 }
               },
               {

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -58,7 +58,7 @@ jobs:
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": ":x: ${{ github.workflow.name }} workflow failed",
+                  "text": ":x: ${{ github.workflow }} workflow failed",
                   "emoji": true
                 }
               },
@@ -70,7 +70,7 @@ jobs:
                 "fields": [
                   {
                     "type": "mrkdwn",
-                    "text": "${{ github.workflow.name }} failed to complete successfully."
+                    "text": "${{ github.workflow }} failed to complete successfully."
                   },
                   {
                     "type": "mrkdwn",

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   install:
+    name: Install and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v4
@@ -32,3 +33,51 @@ jobs:
       - name: test access
         run: |
           curl -L -v http://localhost:3000
+
+  notify-slack:
+    name: Notify about test failure
+    needs: [install]
+    if: failure()
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Post to a Slack channel
+      id: slack
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        channel-id: 'C03AP45RSFP'
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":fire: Install Test workflow failed",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Status:*\n$':x: Failure '
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "`${{ github.workflow.name }}` failed to complete successfully."
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Workflow run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>"
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_GHBOT_TOKEN }}

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -67,20 +67,17 @@ jobs:
               },
               {
                 "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "`${{ github.workflow }}` workflow failed to complete successfully."
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": " ",
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Workflow run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>"
-                  }
-                ]
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "<${{ github.server_url }}/${{ github.repository }}/actions/workflows/install-test.yaml|${{ github.workflow }}>` workflow failed to complete successfully."
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Workflow run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>"
+                }
               }
             ]
           }

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -69,10 +69,6 @@ jobs:
                 "fields": [
                   {
                     "type": "mrkdwn",
-                    "text": "*Status:*\n$':x: Failure '
-                  },
-                  {
-                    "type": "mrkdwn",
                     "text": "`${{ github.workflow.name }}` failed to complete successfully."
                   },
                   {

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -74,7 +74,7 @@ jobs:
                   },
                   {
                     "type": "mrkdwn",
-                    "text": "",
+                    "text": " ",
                   },
                   {
                     "type": "mrkdwn",

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -70,7 +70,11 @@ jobs:
                 "fields": [
                   {
                     "type": "mrkdwn",
-                    "text": "${{ github.workflow }} failed to complete successfully."
+                    "text": "`${{ github.workflow }}` workflow failed to complete successfully."
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "",
                   },
                   {
                     "type": "mrkdwn",

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -3,8 +3,6 @@ on:
   schedule:
     - cron: '45 23 * * *'
   workflow_dispatch:
-  push:
-
 
 jobs:
   install:
@@ -34,10 +32,6 @@ jobs:
       - name: test access
         run: |
           curl -L -v http://localhost:3000
-      - name: simulate the error
-        run: |
-          echo "This is the error"
-          exit 1
 
   notify-slack:
     name: Notify about test failure
@@ -50,7 +44,7 @@ jobs:
       id: slack
       uses: slackapi/slack-github-action@v1.26.0
       with:
-        channel-id: 'C03AP45RSFP'
+        channel-id: 'C067BD0377F'
         payload: |
           {
             "blocks": [

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '45 23 * * *'
   workflow_dispatch:
+  push:
 
 
 jobs:
@@ -57,7 +58,7 @@ jobs:
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": ":fire: Install Test workflow failed",
+                  "text": ":x: ${{ github.workflow.name }} workflow failed",
                   "emoji": true
                 }
               },
@@ -69,7 +70,7 @@ jobs:
                 "fields": [
                   {
                     "type": "mrkdwn",
-                    "text": "`${{ github.workflow.name }}` failed to complete successfully."
+                    "text": "${{ github.workflow.name }} failed to complete successfully."
                   },
                   {
                     "type": "mrkdwn",

--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -33,6 +33,10 @@ jobs:
       - name: test access
         run: |
           curl -L -v http://localhost:3000
+      - name: simulate the error
+        run: |
+          echo "This is the error"
+          exit 1
 
   notify-slack:
     name: Notify about test failure


### PR DESCRIPTION
## Description

This pull request adds a possibility to send a Slack notification on `Install test` workflow failure.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4145

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

