### PR TITLE
Adds rate limits to assistant route

### DIFF
--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -28,6 +28,18 @@ module.exports = async function (app) {
      * use an alternative means of accessing it.
     */
     app.post('/:method', {
+        config: {
+            rateLimit: app.config.rate_limits
+                ? {
+                    hook: 'preHandler', // apply the rate as a preHandler so that session is available
+                    max: 5, // max requests per window
+                    timeWindow: 30000, // 30 seconds
+                    keyGenerator: (request) => {
+                        return request.session?.ownerId || request.ip
+                    }
+                }
+                : false
+        },
         schema: {
             hide: true, // dont show in swagger
             body: {

--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -103,13 +103,16 @@ module.exports = async function (app) {
         if (serviceToken) {
             headers.Authorization = `Bearer ${serviceToken}`
         }
-        const response = await axios.post(url, {
-            ...request.body
-        }, {
-            headers,
-            timeout: requestTimeout
-        })
-
-        reply.send(response.data)
+        try {
+            const response = await axios.post(url, {
+                ...request.body
+            }, {
+                headers,
+                timeout: requestTimeout
+            })
+            reply.send(response.data)
+        } catch (error) {
+            reply.code(error.response?.status || 500).send({ code: error.response?.data?.code || 'unexpected_error', error: error.response?.data?.error || error.message })
+        }
     })
 }

--- a/test/unit/forge/routes/api/rateLimits/rateLimits_spec.js
+++ b/test/unit/forge/routes/api/rateLimits/rateLimits_spec.js
@@ -162,6 +162,7 @@ describe('Endpoint Rate Limiting', () => {
             { url: '/account/register', method: 'POST', shouldLimit: true },
             { url: '/account/forgot_password', method: 'POST', shouldLimit: true },
             { url: '/account/reset_password/:token', method: 'POST', shouldLimit: true },
+            { url: '/api/v1/assistant/:method', method: 'POST', shouldLimit: true, customLimits: true },
             // routes that are never rate limited
             { url: '/api/comms/auth/client', method: 'POST', shouldLimit: false },
             { url: '/api/comms/auth/acl', method: 'POST', shouldLimit: false },
@@ -281,7 +282,11 @@ describe('Endpoint Rate Limiting', () => {
                     it(`Route ${route.method} ${route.url} should be rate limited`, async function () {
                         const routeConfig = route.fastifyRoute.config
                         routeConfig.should.have.property('rateLimit').and.be.an.Object()
-                        if (routeConfig.rateLimit.hard) {
+                        if (route.customLimits) {
+                            // should have one of the following properties: max, timeWindow, keyGenerator
+                            const hasKeys = Object.keys(routeConfig.rateLimit).some((key) => ['max', 'timeWindow', 'keyGenerator'].includes(key))
+                            should(hasKeys).be.true()
+                        } else if (routeConfig.rateLimit.hard) {
                             routeConfig.rateLimit.should.have.property('max')
                             routeConfig.rateLimit.max.should.be.equalOneOf(5, 2)
                             routeConfig.rateLimit.should.have.property('timeWindow')
@@ -395,7 +400,11 @@ describe('Endpoint Rate Limiting', () => {
                     it(`Route ${route.method} ${route.url} should be rate limited`, async function () {
                         const routeConfig = route.fastifyRoute.config
                         routeConfig.should.have.property('rateLimit').and.be.an.Object()
-                        if (routeConfig.rateLimit.hard) {
+                        if (route.customLimits) {
+                            // should have one of the following properties: max, timeWindow, keyGenerator
+                            const hasKeys = Object.keys(routeConfig.rateLimit).some((key) => ['max', 'timeWindow', 'keyGenerator'].includes(key))
+                            should(hasKeys).be.true()
+                        } else if (routeConfig.rateLimit.hard) {
                             routeConfig.rateLimit.should.have.property('max')
                             routeConfig.rateLimit.max.should.be.equalOneOf(5, 2)
                             routeConfig.rateLimit.should.have.property('timeWindow')


### PR DESCRIPTION
## Description

* Adds default rate limits to POST `api/v1/assistant/:method` of 5 requests per 30 sec
  * see https://github.com/FlowFuse/security/issues/92#issuecomment-2225045049 for reasoning and calcs
  * IMPORTANT NOTE: Although the docs for rate-limit state a function can be used for custom `timeWindow`:  
     ![image](https://github.com/user-attachments/assets/eb239c71-e9f0-4e0d-83e4-e721066ab76d)
     this is NOT yet in NPM and as such, we cannot programmatically limit `trial` teams to have a larger `timeWindow` via the rate-limit plugin as was proposed in the linked discussion.  That will come later. For now, rate limiting is put in place as an overall protection of of the route
* Updates tests

## Related Issue(s)

https://github.com/FlowFuse/security/issues/94



## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

