### PR TITLE
Surface the "Invite Members" button to the main navigation

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -37,6 +37,12 @@
         </div>
         <div class="hidden lg:flex">
             <ff-team-selection data-action="team-selection" />
+            <div class="px-4 flex flex-col justify-center ff-border-left">
+                <ff-button kind="secondary" @click="inviteTeamMembers">
+                    <template #icon-left><UserAddIcon /></template>
+                    Invite Members
+                </ff-button>
+            </div>
             <!-- Desktop: User Options -->
             <ff-dropdown v-if="user" class="ff-navigation ff-user-options" options-align="right" data-action="user-options" data-cy="user-options">
                 <template #placeholder>
@@ -56,7 +62,7 @@
     </div>
 </template>
 <script>
-import { AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIcon, QuestionMarkCircleIcon, UserGroupIcon } from '@heroicons/vue/solid'
+import { AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIcon, QuestionMarkCircleIcon, UserAddIcon, UserGroupIcon } from '@heroicons/vue/solid'
 import { ref } from 'vue'
 import { mapGetters, mapState } from 'vuex'
 
@@ -129,7 +135,8 @@ export default {
     components: {
         NavItem,
         'ff-team-selection': TeamSelection,
-        MenuIcon
+        MenuIcon,
+        UserAddIcon
     },
     data () {
         return {
@@ -147,6 +154,14 @@ export default {
     methods: {
         to (route) {
             window.open(route.url, '_blank')
+        },
+        inviteTeamMembers () {
+            this.$router.push({
+                name: 'TeamMembers',
+                query: {
+                    action: 'invite'
+                }
+            })
         }
     }
 }

--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -6,8 +6,8 @@
         <ff-data-table data-el="members-table" :columns="userColumns" :rows="users" :show-search="true" search-placeholder="Search Team Members..." :search-fields="['name', 'username', 'role']">
             <template v-if="hasPermission('team:user:invite')" #actions>
                 <ff-button data-action="member-invite-button" :disabled="teamUserLimitReached" kind="primary" @click="inviteMember">
-                    <template #icon-left><PlusSmIcon class="w-4" /></template>
-                    Invite Member
+                    <template #icon-left><UserAddIcon class="w-4" /></template>
+                    Invite Members
                 </ff-button>
             </template>
             <template v-if="canEditUser" #context-menu="{row}">
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-import { PlusSmIcon } from '@heroicons/vue/outline'
+import { UserAddIcon } from '@heroicons/vue/solid'
 import { markRaw } from 'vue'
 import { mapState } from 'vuex'
 
@@ -43,7 +43,7 @@ export default {
         ChangeTeamRoleDialog,
         ConfirmTeamUserRemoveDialog,
         FeatureUnavailableToTeam,
-        PlusSmIcon,
+        UserAddIcon,
         InviteMemberDialog
     },
     mixins: [permissionsMixin],
@@ -82,6 +82,11 @@ export default {
     },
     mounted () {
         this.fetchData()
+
+        // do we auto-open the dialog?
+        if (this.$route.query.action === 'invite') {
+            this.inviteMember()
+        }
     },
     methods: {
         inviteMember () {

--- a/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
+++ b/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
@@ -3,11 +3,11 @@
         <template #default>
             <form class="space-y-2" @submit.prevent>
                 <template v-if="!responseErrors">
-                    <p v-if="!exceedsUserLimit">Invite a user to join the team by username<span v-if="externalEnabled"> or email</span>.</p>
+                    <p v-if="!exceedsUserLimit">Invite a user to join the team by username<span v-if="externalEnabled"> or email</span>. Please use a comma-separated list to invite multiple new users.</p>
                     <p v-if="hasUserLimit">Your team can have a maximum of {{ team.type.properties.userLimit }} members.</p>
                     <p v-if="exceedsUserLimit">You currently have {{ totalMembers }} (including existing invites) so cannot invite any more.</p>
-                    <div v-if="!exceedsUserLimit" class="space-y-4">
-                        <FormRow id="userInfo" v-model="input.userInfo" :error="errors.userInfo" :placeholder="'username'+(externalEnabled?' or email':'')" />
+                    <div v-if="!exceedsUserLimit" class="space-y-4 pt-2">
+                        <FormRow id="userInfo" v-model="input.userInfo" :error="errors.userInfo" :placeholder="'username, username2, ...' + (externalEnabled?' or email1, email2, ...':'')" />
                         <ff-radio-group v-model="input.role" orientation="vertical" :options="roleOptions" />
                     </div>
                 </template>

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -88,7 +88,7 @@ export default [
                     return `/team/${to.params.team_slug}/members/general`
                 },
                 children: [
-                    { path: 'general', component: TeamMembersMembers },
+                    { path: 'general', name: 'TeamMembers', component: TeamMembersMembers },
                     { path: 'invitations', component: TeamMembersInvitations }
                 ]
             },

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -384,6 +384,10 @@ $nav_height: 60px;
             }
         }
     }
+    .ff-border-left {
+        border-width: 0 0 0 1px;
+        border-color: $ff-grey-500;
+    }
     .ff-navigation-right {
         height: 100%;
     }


### PR DESCRIPTION
## Description

- Adds "Invite Members" button to the primary navigation (desktop view only for now)
- Cleans up messaging in the "Invite Members" dialog to make it clear you can invite multiple users
- Adds support for `?action=invite` to the Team Members page which will automatically open the "Invite Members" dialog upon navigation

<img width="1728" alt="Screenshot 2024-07-16 at 16 13 28" src="https://github.com/user-attachments/assets/4bce83e0-4d02-4f21-801c-41247845122d">


## Related Issue(s)

Closes #4181 
