### PR TITLE
Add license and trial status to assistant request

### DIFF
--- a/test/unit/forge/routes/api/assistant_spec.js
+++ b/test/unit/forge/routes/api/assistant_spec.js
@@ -213,7 +213,11 @@ describe('Assistant API', async function () {
                 axios.post.calledOnce.should.be.true()
                 axios.post.args[0][2].headers.should.have.properties({
                     'ff-owner-type': 'project',
-                    'ff-owner-id': TestObjects.instance.id
+                    'ff-owner-id': TestObjects.instance.id,
+                    'ff-team-id': TestObjects.ATeam.hashid,
+                    'ff-license-active': false,
+                    'ff-license-type': 'CE',
+                    'ff-license-tier': null
                 })
             })
             it('contains owner info in headers for a device', async function () {
@@ -227,7 +231,11 @@ describe('Assistant API', async function () {
                 axios.post.calledOnce.should.be.true()
                 axios.post.args[0][2].headers.should.have.properties({
                     'ff-owner-type': 'device',
-                    'ff-owner-id': TestObjects.device.hashid
+                    'ff-owner-id': TestObjects.device.hashid,
+                    'ff-team-id': TestObjects.ATeam.hashid,
+                    'ff-license-active': false,
+                    'ff-license-type': 'CE',
+                    'ff-license-tier': null
                 })
             })
         }


### PR DESCRIPTION
## Description

Builds on https://github.com/FlowFuse/flowfuse/pull/4182 and adds additional header info (license status, tier, trial status) to assistant requests so that actions and decisions can be made accordingly

## Related Issue(s)

https://github.com/FlowFuse/security/issues/95
Part of https://github.com/FlowFuse/security/issues/92#issuecomment-2225045049

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

