### PR TITLE
ci: Disable resources constraint for local database instance on pre-staging environments

### DIFF
--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -9,7 +9,9 @@ postgresql:
   persistence:
     enabled: false
   primary:
-    resources: {}
+    resources:
+      limits: {}
+      requests: {}
     nodeAffinityPreset:
       type: "hard"
       key: "role"

--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -10,8 +10,9 @@ postgresql:
     enabled: false
   primary:
     resources:
-      limits: {}
-      requests: {}
+      requests:
+        cpu: 1m
+        memory: 1M
     nodeAffinityPreset:
       type: "hard"
       key: "role"

--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -9,6 +9,7 @@ postgresql:
   persistence:
     enabled: false
   primary:
+    resources: {}
     nodeAffinityPreset:
       type: "hard"
       key: "role"

--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -12,7 +12,7 @@ postgresql:
     resources:
       requests:
         cpu: 1m
-        memory: 1M
+        memory: 1Mi
     nodeAffinityPreset:
       type: "hard"
       key: "role"


### PR DESCRIPTION
## Description

This pull request disables the default resource requests for the local PostgreSQL database instance used in the pre-staging environment. As a result, more pre-staging environments can be created without the need to increase cluster resources.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

