### PR TITLE
Add blueprint count to telemetry ping

### DIFF
--- a/forge/housekeeper/tasks/telemetryMetrics/004-platform.js
+++ b/forge/housekeeper/tasks/telemetryMetrics/004-platform.js
@@ -1,6 +1,8 @@
 module.exports = async (app) => {
     let sharedLibraryEntries = 0
+    let blueprintCount = 0
     if (app.license.active()) {
+        blueprintCount = await app.db.models.FlowTemplate?.count()
         sharedLibraryEntries = await app.db.models.StorageSharedLibrary?.count()
     }
     const licenseType = () => {
@@ -27,6 +29,7 @@ module.exports = async (app) => {
         'platform.counts.projectTemplates': await app.db.models.ProjectStack.count(),
         'platform.counts.projectStacks': await app.db.models.ProjectTemplate.count(),
         'platform.counts.libraryEntries': await app.db.models.StorageLibrary.count(),
+        'platform.counts.blueprints': blueprintCount,
         'platform.counts.sharedLibraryEntries': sharedLibraryEntries,
 
         'platform.config.driver': app.config.driver.type,


### PR DESCRIPTION
This will include `platform.counts.blueprints` so we get some visibility on self-hosted usage of blueprints. Note this only records how many blueprints they have - not if they are being deployed.

Ping collector already updated via https://github.com/FlowFuse/usage-ping-collector/pull/28 - and deployed.

