### PR TITLE
Ensure team slug is passed for nested views

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -37,7 +37,7 @@
         </div>
         <div class="hidden lg:flex">
             <ff-team-selection data-action="team-selection" />
-            <div class="px-4 flex flex-col justify-center ff-border-left">
+            <div class="px-4 flex flex-col justify-center ff-border-left" v-if="showInviteButton">
                 <ff-button kind="secondary" @click="inviteTeamMembers">
                     <template #icon-left><UserAddIcon /></template>
                     Invite Members
@@ -122,6 +122,9 @@ export default {
                     onclick: this.signOut
                 }
             ].filter(option => option !== undefined)
+        },
+        showInviteButton () {
+            return this.$route.name !== 'TeamMembers'
         }
     },
     watch: {

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -158,6 +158,9 @@ export default {
         inviteTeamMembers () {
             this.$router.push({
                 name: 'TeamMembers',
+                params: {
+                    team_slug: this.team.slug
+                },
                 query: {
                     action: 'invite'
                 }


### PR DESCRIPTION
## Description

When on a nested view, the `to.params.team_slug` isn't populated because the `team` slug doesn't exist in the nested URL. To be safe, we should pass this explicitly into the `$route.push()`

## Related Issue(s)

Closes #4200