### PR TITLE
Fix accessing team as dashboard user

### DIFF
--- a/frontend/src/services/product.js
+++ b/frontend/src/services/product.js
@@ -60,8 +60,8 @@ function setTeam (team) {
             'count-instances': team.instanceCount,
             'count-devices': team.deviceCount,
             'count-members': team.memberCount,
-            'team-type-id': team.type.id,
-            'team-type-name': team.type.name
+            'team-type-id': team.type?.id,
+            'team-type-name': team.type?.name
         }
         if ('billing' in team) {
             props['billing-active'] = team.billing.active


### PR DESCRIPTION
Fixes #4214

## Description

When accessing a team as a Dashboard user, the API response provides a much stripped-down object.

This response doesn't include the team `type` property - which the recently updated product service was assuming would be present. This is causing an error to be thrown.

We can debate whether the api response should include the `type` property, but this is the quick fix for the immediate problem in production.

With this fix applied, the user will see the existing dashboard placeholder page.

<img width="774" alt="image" src="https://github.com/user-attachments/assets/2d410a69-aa8d-49ad-b943-97ee58d7f22d">

