### PR TITLE
Mask both quoted and unquoted registry tokens

### DIFF
--- a/frontend/src/pages/admin/Template/sections/NPMRegistry.vue
+++ b/frontend/src/pages/admin/Template/sections/NPMRegistry.vue
@@ -100,7 +100,7 @@ export default {
         },
         obfuscated () {
             if (this.editable.settings.palette_npmrc) {
-                const text = this.editable.settings.palette_npmrc.replace(/_authToken="(.*)"/g, '_authToken="xxxxxxx"')
+                const text = this.editable.settings.palette_npmrc.replace(/_authToken="?(.*)"?/g, '_authToken="xxxxxxx"')
                 return text
             } else {
                 return ''


### PR DESCRIPTION
fixes #4217

## Description

<!-- Describe your changes in detail -->
Original regex only matched quoted tokens, updated to make quotes optional

No need to use `replaceAll` when using a regex match.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

