### PR TITLE
Better sanitization of team names in invite email

### DIFF
--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -153,6 +153,9 @@ module.exports = fp(async function (app, _opts) {
         const template = templates[templateName] || loadTemplate(templateName)
         const templateContext = { forgeURL, user, ...context }
         templateContext.safeName = sanitizeText(user.name || 'user')
+        if (templateContext.teamName) {
+            templateContext.teamName = sanitizeText(templateContext.teamName)
+        }
         const mail = {
             to: user.email,
             subject: template.subject(templateContext, { allowProtoPropertiesByDefault: true, allowProtoMethodsByDefault: true }),

--- a/forge/postoffice/templates/TeamInvitation.js
+++ b/forge/postoffice/templates/TeamInvitation.js
@@ -1,15 +1,15 @@
 module.exports = {
-    subject: 'Invitation to join team {{{invite.team.name}}} on FlowFuse',
+    subject: 'Invitation to join team {{{teamName.text}}} on FlowFuse',
     text:
 `Hello!
 
-You've been invited to join team {{{invite.team.name}}} on the FlowFuse platform.
+You've been invited to join team {{{teamName.text}}} on the FlowFuse platform.
 
 {{{ signupLink }}}
 `,
     html:
 `<p>Hello!</p>
-<p>You've been invited to join team {{invite.team.name}} on the FlowFuse platform.</p>
+<p>You've been invited to join team {{{teamName.html}}} on the FlowFuse platform.</p>
 <p><a href="{{{ signupLink }}}">Sign Up!</a></p>
 `
 }

--- a/forge/routes/api/teamInvitations.js
+++ b/forge/routes/api/teamInvitations.js
@@ -171,7 +171,7 @@ module.exports = async function (app) {
                                 invite.invitee,
                                 'TeamInvitation',
                                 {
-                                    invite,
+                                    teamName: invite.team.name,
                                     signupLink: `${app.config.base_url}/account/teams/invitations`
                                 }
                             )


### PR DESCRIPTION
## Description

Email clients like to render things that look like URLs as clickable links. We had taken some precautions against this, but some gaps still remained.

This PR sanitises the team name in the HTML email by inserting invisible `<br>` elements after any `.`.