### PR TITLE
Fix limbo state after leaving last team

### DIFF
--- a/frontend/src/pages/account/Teams/Teams.vue
+++ b/frontend/src/pages/account/Teams/Teams.vue
@@ -36,6 +36,7 @@ export default {
     },
     computed: {
         ...mapState('account', ['user', 'teams', 'settings']),
+        ...mapState('account', ['teamMembership', 'team']),
         teamCount () {
             return this.teams ? this.teams.length : 0
         }
@@ -64,7 +65,10 @@ export default {
                 try {
                     await teamApi.removeTeamMember(row.id, this.user.id)
                     alerts.emit(`${this.user.username} successfully removed from ${row.name}`, 'confirmation')
-                    this.$store.dispatch('account/refreshTeams')
+                    await this.$store.dispatch('account/refreshTeams')
+                    if (!this.teamCount) {
+                        await this.$store.dispatch('account/setTeam', null)
+                    }
                 } catch (err) {
                     alerts.emit(`Failed to remove ${this.user.username} from ${row.name}: ${err.response.data.error}`, 'warning')
                     console.warn(err)

--- a/frontend/src/pages/account/Teams/Teams.vue
+++ b/frontend/src/pages/account/Teams/Teams.vue
@@ -36,7 +36,6 @@ export default {
     },
     computed: {
         ...mapState('account', ['user', 'teams', 'settings']),
-        ...mapState('account', ['teamMembership', 'team']),
         teamCount () {
             return this.teams ? this.teams.length : 0
         }

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -326,12 +326,12 @@ const actions = {
                 return
             }
         } else {
-            if (!currentTeam || currentTeam.id === team.id) {
+            if (!currentTeam || currentTeam.id === team?.id) {
                 state.commit('clearPendingTeamChange')
                 return
             }
         }
-        if (team.id) {
+        if (team?.id) {
             teamMembership = await teamApi.getTeamUserMembership(team.id)
         }
         state.commit('setTeam', team)


### PR DESCRIPTION
closes #4026

## Description

* Awaits teams refresh
* checks team count, if zero, sets own team to null
  * this causes links in sidebar to correctly change from "back to dashboard" to "back to create team"

### Before
![msedge_FV52eeS0X8](https://github.com/user-attachments/assets/44e03388-68f2-45e7-9189-fa3616c4dc77)

### After
![msedge_wLFTIgQnvV](https://github.com/user-attachments/assets/207f05ba-cd11-4f45-a9d3-65aaea776210)


## Related Issue(s)

#4026

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

