### PR TITLE
Ability to add device from empty state

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -156,6 +156,21 @@
                                 </router-link>.
                             </p>
                         </template>
+                        <template #actions>
+                            <ff-button
+                                v-if="hasPermission('device:create')"
+                                class="font-normal"
+                                kind="primary"
+                                :disabled="teamDeviceLimitReached || teamRuntimeLimitReached"
+                                data-action="register-device"
+                                @click="showCreateDeviceDialog"
+                            >
+                                <template #icon-left>
+                                    <PlusSmIcon />
+                                </template>
+                                Add Device
+                            </ff-button>
+                        </template>
                     </EmptyState>
                 </template>
                 <div v-else class="ff-no-data ff-no-data-large">

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -173,6 +173,45 @@
                         </template>
                     </EmptyState>
                 </template>
+                <template v-else-if="displayingApplication">
+                    <EmptyState data-el="application-no-devices">
+                        <template #img>
+                            <img src="../images/empty-states/instance-devices.png">
+                        </template>
+                        <template #header>Connect your First Device</template>
+                        <template #message>
+                            <p>
+                                Here, you will see a list of Devices belonging to this Application.
+                            </p>
+                            <p>
+                                You can deploy <router-link class="ff-link" :to="{name: 'ApplicationSnapshots'}">Snapshots</router-link> of this Application to your connected Devices.
+                            </p>
+                            <p>
+                                A full list of your Team's Devices are available <router-link
+                                    class="ff-link"
+                                    :to="{name: 'TeamDevices', params: {team_slug: team.slug}}"
+                                >
+                                    here
+                                </router-link>.
+                            </p>
+                        </template>
+                        <template #actions>
+                            <ff-button
+                                v-if="hasPermission('device:create')"
+                                class="font-normal"
+                                kind="primary"
+                                :disabled="teamDeviceLimitReached || teamRuntimeLimitReached"
+                                data-action="register-device"
+                                @click="showCreateDeviceDialog"
+                            >
+                                <template #icon-left>
+                                    <PlusSmIcon />
+                                </template>
+                                Add Device
+                            </ff-button>
+                        </template>
+                    </EmptyState>
+                </template>
                 <div v-else class="ff-no-data ff-no-data-large">
                     <span data-el="no-devices">
                         No devices found.

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -195,7 +195,7 @@ export default {
                         //       in the project directly? Currently done as a two
                         //       step process
                         // eslint-disable-next-line promise/no-nesting
-                        return devicesApi.updateDevice(response.id, { project: this.instance.id }).then((response) => {
+                        return devicesApi.updateDevice(response.id, { instance: this.instance.id }).then((response) => {
                             // Reattach the credentials from the create request
                             // so they can be displayed to the user
                             response.credentials = creds


### PR DESCRIPTION
closes #4077
closes #4227


## Description

* Adds the empty state for Applications with "Add Device" Button
* Aligns the existing empty state for Instances by adding "Add Device" Button
* found and fixed issue where "Add Device" from instance did not actually assign the device to the instance (related issue #4227)

### Demo

#### Before
* "Empty State" missing from Application
* "Add Device" missing from instance 
* No possibility of adding device from Application/Instance device pages
![chrome_LH9vGgrOyY](https://github.com/user-attachments/assets/2d1e71e9-5f92-43a2-8b12-32029c7ba3ee)


#### After
* All pages have empty State and capability to "Add Device"
![chrome_0yIYz1fjj0](https://github.com/user-attachments/assets/89e74180-7a95-468f-aa76-68e539dcae94)



## Related Issue(s)

#4077
#4227

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

