### PR TITLE
Do not store modified email when deduping email list

### DIFF
--- a/forge/routes/api/teamInvitations.js
+++ b/forge/routes/api/teamInvitations.js
@@ -113,9 +113,17 @@ module.exports = async function (app) {
         const namesOnlyDeduplicated = [...new Set(namesOnly.map(u => u.trim().toLowerCase()))].map(u => namesOnly.find(n => n.trim().toLowerCase() === u))
         // use a regex to determine if the user is an email address
         const emailsOnly = userDetails.filter(u => u.match(/^[^@]+@[^@]+$/))
-        const emailsOnlyDeduplicated = [...new Set(emailsOnly.map(u => getCanonicalEmail(u)))]
+        // Deduplicate the list based on the canonical email, but keep the as-provided
+        // email in the list
+        const emailsOnlyDeduplicated = {}
+        emailsOnly.forEach(email => {
+            const canonicalEmail = getCanonicalEmail(email)
+            if (!emailsOnlyDeduplicated[canonicalEmail]) {
+                emailsOnlyDeduplicated[canonicalEmail] = email
+            }
+        })
         // recombine the deduplicated lists
-        const userDetailsDeduplicated = [...namesOnlyDeduplicated, ...emailsOnlyDeduplicated]
+        const userDetailsDeduplicated = [...namesOnlyDeduplicated, ...Object.values(emailsOnlyDeduplicated)]
 
         // limit to 5 invites at a time
         if (userDetailsDeduplicated.length > 5) {


### PR DESCRIPTION
Fixes #4222 

## Description

A previous fix (#2543) was applied to de-duplicate the emails provided in the Team Invite flow, including stripping `.` from gmail addresses.

However, stripping the `.` lead to an unexpected behaviour:

1. User invites `foo.bar@gmail.com`
2. Owner of that email receives it at `foobar@gmail.com`, follows the link
3. Sees the email field pre-filled as `foobar@gmail.com` - corrects it to their preferred address `foo.bar@gmail.com`
4. They sign-up, but with a *different* email than stored in the team invite - so they don't get added to the team

This fixes this scenario by still deduplicating the emails via their canonical version, but it then stores the unaltered email rather than the canonical version. This better aligns with the expected result.
