### PR TITLE
Move notification tray out of ff-view

### DIFF
--- a/frontend/src/components/drawers/RightDrawer.vue
+++ b/frontend/src/components/drawers/RightDrawer.vue
@@ -23,7 +23,8 @@ export default {
   position: absolute;
   border-left: 1px solid $ff-grey-300;
   background: white;
-  height: 100%;
+  height: calc(100% - 60px);
+  top: 60px;
   right: -1000px;
   z-index: 500;
   width: 100%;

--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -7,9 +7,9 @@
             </div>
             <div class="ff-view">
                 <div id="platform-banner" />
-                <RightDrawer />
                 <slot />
             </div>
+            <RightDrawer />
             <TransitionGroup class="ff-notifications" name="notifications-list" tag="div">
                 <ff-notification-toast
                     v-for="(a, $index) in alertsReversed" :key="a.timestamp"


### PR DESCRIPTION
Fixes #4239
## Description

Moves the `<RightDrawer>` component up a layer in the DOM so it isn't attached to the scrollable main view. Adjusts its CSS so it displays below the header.