### PR TITLE
Allow Session expiry to be configured

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -185,6 +185,14 @@ Option        | Description
 
 For additional options, see [fastify-rate-limit](https://github.com/fastify/fastify-rate-limit#options) documentation.
 
+## Session timeouts
+
+Allows control of the maximum user session life.
+
+Option        | Description
+--------------|------------
+`sessions.maxDuration` | The maximum number of seconds a user session can last. Default: `604800` (1 week)
+`sessions.maxIdleDuration` | The maximum number of seconds a session can be idle. Must be less than `sessions.maxDuration`. Default: `115200` (32 hours)
 
 ## Support configuration
 

--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -110,6 +110,20 @@ module.exports = {
             }
         }
 
+        // need to check that maxIdleDuration is less than maxDuration
+        if (config.sessions) {
+            if (config.sessions.maxIdleDuration && config.sessions.maxDuration) {
+                if (config.sessions.maxIdleDuration > config.sessions.maxDuration) {
+                    throw new Error('Session maxIdleDuration longer than maxDuration')
+                    // config.sessions.maxIdleDuration = config.sessions.maxDuration
+                }
+            } else if (config.sessions.maxIdleDuration) {
+                if (config.sessions.maxIdleDuration > (60 * 60 * 24 * 7)) {
+                    throw new Error('Session maxIdleDuration longer than maxDuration')
+                }
+            }
+        }
+
         const defaultLogging = {
             level: 'info',
             http: 'warn',

--- a/forge/db/controllers/Session.js
+++ b/forge/db/controllers/Session.js
@@ -18,8 +18,8 @@ module.exports = {
         if (user && !user.suspended) {
             const session = await app.db.models.Session.create({
                 sid: generateToken(32, 'ffu'),
-                expiresAt: Date.now() + DEFAULT_WEB_SESSION_EXPIRY,
-                idleAt: Date.now() + DEFAULT_WEB_SESSION_IDLE_TIMEOUT,
+                expiresAt: Date.now() + (app.config.sessions?.maxDuration || DEFAULT_WEB_SESSION_EXPIRY),
+                idleAt: Date.now() + (app.config.sessions?.maxIdleDuration ? app.config.sessions?.maxIdleDuration * 0.9 : DEFAULT_WEB_SESSION_IDLE_TIMEOUT),
                 UserId: user.id,
                 mfa_verified: false
             })

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -22,6 +22,7 @@ const fp = require('fastify-plugin')
 // This defines how long the session cookie is valid for. This should match
 // the max session age defined in `forge/db/controllers/Session.DEFAULT_WEB_SESSION_EXPIRY
 // albeit in secs not millisecs due to cookie maxAge requirements
+// this can be overridden by `sessions.maxDurartion`
 const SESSION_MAX_AGE = 60 * 60 * 24 * 7 // 1 week in seconds
 
 // Options to apply to our session cookie
@@ -171,7 +172,7 @@ async function init (app, opts) {
         const session = await app.db.controllers.Session.createUserSession(username)
         if (session) {
             const cookieOptions = { ...SESSION_COOKIE_OPTIONS }
-            cookieOptions.maxAge = SESSION_MAX_AGE
+            cookieOptions.maxAge = app.config.sessions?.maxDuration || SESSION_MAX_AGE
             if (/^https:/.test(app.config.base_url)) {
                 // If base_url starts https then we can safely set the secure flag
                 // on the cookie

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -22,7 +22,7 @@ const fp = require('fastify-plugin')
 // This defines how long the session cookie is valid for. This should match
 // the max session age defined in `forge/db/controllers/Session.DEFAULT_WEB_SESSION_EXPIRY
 // albeit in secs not millisecs due to cookie maxAge requirements
-// this can be overridden by `sessions.maxDurartion`
+// this can be overridden by `sessions.maxDuration` in config yml file
 const SESSION_MAX_AGE = 60 * 60 * 24 * 7 // 1 week in seconds
 
 // Options to apply to our session cookie

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -940,10 +940,10 @@ describe('Accounts API', async function () {
         })
     })
 
-    describe.only('Session configuration', async function () {
+    describe('Session configuration', async function () {
         it('Incorrect configuration should fail', async function () {
             try {
-                const app = await setup({
+                await setup({
                     sessions: {
                         maxDuration: 300,
                         maxIdleDuration: 400
@@ -956,7 +956,7 @@ describe('Accounts API', async function () {
         })
         it('Incorrect maxIdle configuration should fail', async function () {
             try {
-                const app = await setup({
+                await setup({
                     sessions: {
                         maxIdleDuration: 604801
                     }
@@ -969,7 +969,6 @@ describe('Accounts API', async function () {
     })
 
     describe('Session length', async function () {
-        let testUser
         before(async function () {
             app = await setup({
                 sessions: {
@@ -977,7 +976,7 @@ describe('Accounts API', async function () {
                     maxIdleDuration: 120
                 }
             })
-            testUser = await app.factory.createUser({
+            await app.factory.createUser({
                 username: 'testUser',
                 name: 'Test User',
                 email: 'testReset@example.com',

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -939,4 +939,50 @@ describe('Accounts API', async function () {
             response.statusCode.should.equal(200)
         })
     })
+
+    describe('Session configuration', async function () {
+        it('Incorrect configuration should fail', async function () {
+            try {
+                const app = await setup({
+                    sessions: {
+                        maxDuration: 300,
+                        maxIdleDuration: 400
+                    }
+                })
+            } catch (err) {
+                return
+            }
+            should.fail('shouldn\'t get here')
+        })
+    })
+
+    describe('Session length', async function () {
+        let testUser
+        before(async function () {
+            app = await setup({
+                sessions: {
+                    maxDuration: 300,
+                    maxIdleDuration: 120
+                }
+            })
+            testUser = await app.factory.createUser({
+                username: 'testUser',
+                name: 'Test User',
+                email: 'testReset@example.com',
+                password: 'ttPassword'
+            })
+        })
+        after(async function () {
+            await app.close()
+        })
+        it('Short cookie session age', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/account/login',
+                payload: { username: 'testUser', password: 'ttPassword', remember: false }
+            })
+            response.statusCode.should.equal(200)
+            response.cookies[0].maxAge.should.equal(300)
+        })
+    })
 })

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -940,13 +940,25 @@ describe('Accounts API', async function () {
         })
     })
 
-    describe('Session configuration', async function () {
+    describe.only('Session configuration', async function () {
         it('Incorrect configuration should fail', async function () {
             try {
                 const app = await setup({
                     sessions: {
                         maxDuration: 300,
                         maxIdleDuration: 400
+                    }
+                })
+            } catch (err) {
+                return
+            }
+            should.fail('shouldn\'t get here')
+        })
+        it('Incorrect maxIdle configuration should fail', async function () {
+            try {
+                const app = await setup({
+                    sessions: {
+                        maxIdleDuration: 604801
                     }
                 })
             } catch (err) {


### PR DESCRIPTION
part of #4201

## Description

<!-- Describe your changes in detail -->
Allows the session expiry to be configured using

```
sessions:
  maxDuration: <time in seconds>
  maxIdleDuration: <time in seconds>
```

Defaults are 7 days for `maxDuration` and 32 hours for `maxIdleDuration`. If `maxIdleDuration` is more than `maxDuration` Forge app will fail to start with an error.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4201

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [x] Changes `flowforge.yml`?
    - [x] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template https://github.com/FlowFuse/helm/pull/443
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

No need to raise CloudProject issue as not changing on FF Cloud