### PR TITLE
Update so locked template fields are not overwritten

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -201,9 +201,12 @@ module.exports = {
                     snapshotSettings.palette = snapshotSettings.palette || {}
                     snapshotSettings.palette.modules = []
                 }
+                if (!project.ProjectTemplate) {
+                    project = await app.db.models.Project.byId(project.id)
+                }
                 const newSettings = app.db.controllers.ProjectTemplate.validateSettings(snapshotSettings, project.ProjectTemplate)
                 const currentProjectSettings = await project.getSetting('settings') || {} // necessary?
-                const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings, { mergeEnvVars, mergeEditorSettings })
+                const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings, { mergeEnvVars, mergeEditorSettings, targetTemplate: project.ProjectTemplate })
                 await project.updateSetting('settings', updatedSettings, { transaction: t }) // necessary?
             }
             await t.commit() // all good, commit the transaction

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -237,6 +237,7 @@ module.exports = {
 
             // skip if locked in target template
             if (targetTemplate) {
+                // explicit test for false to allow for things not in the policy
                 if (getTemplateValue(targetTemplate.policy, name) === false) {
                     return
                 }

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -237,7 +237,7 @@ module.exports = {
 
             // skip if locked in target template
             if (targetTemplate) {
-                if (!getTemplateValue(targetTemplate.policy, name)) {
+                if (getTemplateValue(targetTemplate.policy, name) === false) {
                     return
                 }
             }

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -226,7 +226,7 @@ module.exports = {
    * @param {boolean} options.mergeEnvVars if true, merge the env vars (new keys added, existing keys untouched, removed keys untouched)
    * @param {boolean} options.mergeEditorSettings if false (default), will overwrite all settings. If true, it will merge the settings together - only overwriting certain ones.
    */
-    mergeSettings: function (app, existingSettings, settings, { mergeEnvVars = false, mergeEditorSettings = false } = {}) {
+    mergeSettings: function (app, existingSettings, settings, { mergeEnvVars = false, mergeEditorSettings = false, targetTemplate = undefined } = {}) {
         // Quick deep clone that is safe as we know settings are JSON-safe
         const result = JSON.parse(JSON.stringify(existingSettings))
         const skipList = ['disableEditor', 'page_title', 'header_title']
@@ -235,6 +235,12 @@ module.exports = {
                 return
             }
 
+            // skip if locked in target template
+            if (targetTemplate) {
+                if (!getTemplateValue(targetTemplate.policy, name)) {
+                    return
+                }
+            }
             const value = getTemplateValue(settings, name)
             if (value !== undefined) {
                 setTemplateValue(result, name, value)

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -225,6 +225,7 @@ module.exports = {
    * @param {*} options options for the merge
    * @param {boolean} options.mergeEnvVars if true, merge the env vars (new keys added, existing keys untouched, removed keys untouched)
    * @param {boolean} options.mergeEditorSettings if false (default), will overwrite all settings. If true, it will merge the settings together - only overwriting certain ones.
+   * @param {object} options.targetTemplate - a template object containing its `policy`. When this parameter is provided, any items that are in the policy and are `locked`, will be skipped.
    */
     mergeSettings: function (app, existingSettings, settings, { mergeEnvVars = false, mergeEditorSettings = false, targetTemplate = undefined } = {}) {
         // Quick deep clone that is safe as we know settings are JSON-safe


### PR DESCRIPTION
fix for #4198

## Description

<!-- Describe your changes in detail -->
When merging snapshots do not overwrite settings that are locked in the template

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4198

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

