### PR TITLE
show full buttons when instance count is 1

### DIFF
--- a/frontend/src/pages/instance/components/DashboardLink.vue
+++ b/frontend/src/pages/instance/components/DashboardLink.vue
@@ -6,17 +6,21 @@
         :disabled="buttonDisabled"
         @click.stop="openDashboard()"
     >
-        <template v-if="showExternalLink" #icon-right>
-            <ExternalLinkIcon />
+        <template v-if="showText" #icon-right>
+            <ChartPieIcon />
         </template>
-        <slot name="default">
+        <template v-else #icon>
+            <ChartPieIcon />
+        </template>
+        <template v-if="showText">
             Dashboard
-        </slot>
+        </template>
     </ff-button>
 </template>
 
 <script>
-import { ExternalLinkIcon } from '@heroicons/vue/solid'
+
+import { ChartPieIcon } from '@heroicons/vue/outline'
 
 // utility function to remove leading and trailing slashes
 const removeSlashes = (str, leading = true, trailing = true) => {
@@ -31,7 +35,7 @@ const removeSlashes = (str, leading = true, trailing = true) => {
 
 export default {
     name: 'DashboardLink',
-    components: { ExternalLinkIcon },
+    components: { ChartPieIcon },
     inheritAttrs: false,
     props: {
         disabled: {
@@ -46,7 +50,7 @@ export default {
             default: null,
             type: Object
         },
-        showExternalLink: {
+        showText: {
             type: Boolean,
             default: true
         }

--- a/frontend/src/pages/instance/components/DashboardLink.vue
+++ b/frontend/src/pages/instance/components/DashboardLink.vue
@@ -6,7 +6,7 @@
         :disabled="buttonDisabled"
         @click.stop="openDashboard()"
     >
-        <template v-if="showText" #icon-right>
+        <template v-if="showText" #icon-left>
             <ChartPieIcon />
         </template>
         <template v-else #icon>

--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -9,7 +9,7 @@
                 class="whitespace-nowrap"
                 @click.stop="openEditor()"
             >
-                <template v-if="showText" #icon-right>
+                <template v-if="showText" #icon-left>
                     <ProjectIcon />
                 </template>
                 <template v-else #icon>

--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -7,27 +7,33 @@
                 data-action="open-editor"
                 :disabled="editorDisabled || disabled || !url"
                 class="whitespace-nowrap"
-                :has-right-icon="!isImmersiveEditor"
                 @click.stop="openEditor()"
             >
-                <template #icon-right>
-                    <ExternalLinkIcon />
+                <template v-if="showText" #icon-right>
+                    <ProjectIcon />
                 </template>
-                {{ editorDisabled ? 'Editor Disabled' : 'Open Editor' }}
+                <template v-else #icon>
+                    <ProjectIcon />
+                </template>
+                <template v-if="showText">
+                    {{ editorDisabled ? 'Editor Disabled' : 'Open Editor' }}
+                </template>
             </ff-button>
         </slot>
     </div>
 </template>
 
 <script>
-import { ExternalLinkIcon } from '@heroicons/vue/solid'
+
 import SemVer from 'semver'
 
 import { mapState } from 'vuex'
 
+import ProjectIcon from '../../../components/icons/Projects.js'
+
 export default {
     name: 'InstanceEditorLink',
-    components: { ExternalLinkIcon },
+    components: { ProjectIcon },
     inheritAttrs: false,
     props: {
         editorDisabled: {
@@ -45,6 +51,10 @@ export default {
         instance: {
             type: Object,
             required: true
+        },
+        showText: {
+            default: true,
+            type: Boolean
         }
     },
     computed: {

--- a/frontend/src/pages/team/Applications/components/compact/InstanceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstanceTile.vue
@@ -40,9 +40,9 @@
                 v-if="instance.settings?.dashboard2UI"
                 :instance="instance"
                 :disabled="!editorAvailable"
-                :show-external-link="false"
+                :show-external-link="showButtonLabels"
             >
-                <ChartPieIcon class="ff-icon" />
+                <ChartPieIcon v-if="!showButtonLabels" class="ff-icon" />
             </DashboardLink>
 
             <InstanceEditorLink
@@ -52,7 +52,7 @@
                 :url="instance.url"
                 :instance="instance"
             >
-                <ff-button kind="secondary" data-action="open-editor" class="whitespace-nowrap" :disabled="!isInstanceRunning">
+                <ff-button v-if="!showButtonLabels" kind="secondary" data-action="open-editor" class="whitespace-nowrap" :disabled="!isInstanceRunning">
                     <ProjectIcon class="ff-btn--icon ff-icon" />
                 </ff-button>
             </InstanceEditorLink>
@@ -117,6 +117,10 @@ export default {
         instance: {
             required: true,
             type: Object
+        },
+        showButtonLabels: {
+            type: Boolean,
+            default: true
         }
     },
     emits: ['delete-instance'],

--- a/frontend/src/pages/team/Applications/components/compact/InstanceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstanceTile.vue
@@ -40,10 +40,8 @@
                 v-if="instance.settings?.dashboard2UI"
                 :instance="instance"
                 :disabled="!editorAvailable"
-                :show-external-link="showButtonLabels"
-            >
-                <ChartPieIcon v-if="!showButtonLabels" class="ff-icon" />
-            </DashboardLink>
+                :show-text="showButtonLabels"
+            />
 
             <InstanceEditorLink
                 v-if="!localInstance.ha?.replicas !== undefined"
@@ -51,11 +49,8 @@
                 :editorDisabled="!!(localInstance.settings?.disableEditor)"
                 :url="instance.url"
                 :instance="instance"
-            >
-                <ff-button v-if="!showButtonLabels" kind="secondary" data-action="open-editor" class="whitespace-nowrap" :disabled="!isInstanceRunning">
-                    <ProjectIcon class="ff-btn--icon ff-icon" />
-                </ff-button>
-            </InstanceEditorLink>
+                :show-text="showButtonLabels"
+            />
 
             <ff-kebab-menu @click.stop>
                 <ff-list-item
@@ -87,10 +82,7 @@
 </template>
 
 <script>
-import { ChartPieIcon } from '@heroicons/vue/outline'
-
 import InstanceStatusPolling from '../../../../../components/InstanceStatusPolling.vue'
-import ProjectIcon from '../../../../../components/icons/Projects.js'
 import AuditMixin from '../../../../../mixins/Audit.js'
 import instanceActionsMixin from '../../../../../mixins/InstanceActions.js'
 import permissionsMixin from '../../../../../mixins/Permissions.js'
@@ -105,11 +97,9 @@ export default {
     name: 'InstanceTile',
     components: {
         DashboardLink,
-        ProjectIcon,
         FfKebabMenu,
         InstanceStatusBadge,
         InstanceStatusPolling,
-        ChartPieIcon,
         InstanceEditorLink
     },
     mixins: [AuditMixin, permissionsMixin, instanceActionsMixin],

--- a/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
@@ -25,7 +25,7 @@
                 data-el="application-instance-item"
                 class="item-wrapper"
             >
-                <InstanceTile :instance="instance" @delete-instance="$emit('delete-instance', $event)" />
+                <InstanceTile :instance="instance" :showButtonLabels="hasOnlyOneInstance" @delete-instance="$emit('delete-instance', $event)" />
             </div>
             <HasMoreTile
                 v-if="hasMoreInstances"
@@ -67,6 +67,9 @@ export default {
         },
         hasMoreInstances () {
             return this.application.instanceCount > this.instances.length
+        },
+        hasOnlyOneInstance () {
+            return this.application.instanceCount === 1
         },
         hasNoInstances () {
             return this.instances.length === 0


### PR DESCRIPTION
closes #4199

## Description

Show full buttons when only 1 instance in application condensed view.

<details><summary>Outdated</summary>
<p>

**superseded - see threaded comments below**

![image](https://github.com/user-attachments/assets/5cb73a42-7942-49c6-a360-1b64697ef937)


</p>
</details> 

### TODO - follow up issue to raise once merged: 

- [ ] Buttons no longer provide a visual cue as to whether they are internal (immersive) or external (pop-out)


## Related Issue(s)

Closes #4199

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

