### PR TITLE
Fix: Remove dialog mixin from the DevicesBrowser

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -318,7 +318,6 @@ import { mapState } from 'vuex'
 import deviceApi from '../api/devices.js'
 import teamApi from '../api/team.js'
 import deviceActionsMixin from '../mixins/DeviceActions.js'
-import DialogMixin from '../mixins/Dialog.js'
 import permissionsMixin from '../mixins/Permissions.js'
 
 import DeviceAssignedToLink from '../pages/application/components/cells/DeviceAssignedToLink.vue'
@@ -359,7 +358,7 @@ export default {
         EmptyState,
         DevicesStatusBar
     },
-    mixins: [permissionsMixin, deviceActionsMixin, DialogMixin],
+    mixins: [permissionsMixin, deviceActionsMixin],
     inheritAttrs: false,
     props: {
         // One of the two must be provided

--- a/frontend/src/services/dialog.js
+++ b/frontend/src/services/dialog.js
@@ -15,8 +15,12 @@ export default {
     // this is used in Platform.vue in order to control the showing/hiding
     // of the app's main dialog
     bind: function (el, fcn) {
-        dialog = el
-        subscriptions.push(fcn)
+        if (!el) {
+            throw new Error('No dialog element provided')
+        } else {
+            dialog = el
+            subscriptions.push(fcn)
+        }
     },
 
     /**

--- a/test/e2e/frontend/cypress/tests/applications/devices.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/devices.spec.js
@@ -1,0 +1,44 @@
+describe('FlowForge - Application - Devices', () => {
+    let application
+    function navigateToApplication (teamName, projectName) {
+        cy.request('GET', '/api/v1/user/teams')
+            .then((response) => {
+                const team = response.body.teams.find(
+                    (team) => team.name === teamName
+                )
+                return cy.request('GET', `/api/v1/teams/${team.id}/applications`)
+            })
+            .then((response) => {
+                application = response.body.applications.find(
+                    (app) => app.name === projectName
+                )
+                cy.visit(`/application/${application.id}/instances`)
+                cy.wait('@getApplication')
+            })
+    }
+
+    beforeEach(() => {
+        cy.intercept('GET', '/api/*/applications/*').as('getApplication')
+
+        cy.login('bob', 'bbPassword')
+        cy.home()
+        navigateToApplication('BTeam', 'application-2')
+    })
+
+    it('should list any devices associated to an application', () => {
+        cy.visit(`/application/${application.id}/devices`)
+        cy.url().should('include', `/application/${application.id}/devices`)
+
+        cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 3)
+    })
+
+    it('is presented with a dialog confirmation when choosing "Remove from Application"', () => {
+        cy.visit(`/application/${application.id}/devices`)
+        cy.url().should('include', `/application/${application.id}/devices`)
+
+        cy.get('[data-el="platform-dialog"]').should('not.be.visible')
+        cy.get('[data-el="devices-browser"] tbody').find('tr').eq(0).find('[data-el="kebab-menu"]').click()
+        cy.get('[data-action="device-remove-from-application"]').click()
+        cy.get('[data-el="platform-dialog"]').should('be.visible')
+    })
+})


### PR DESCRIPTION
## Description

- Dialog mixin should not have been included in the DevicesBrowser
- Purpose of the Dialog mixin was to group together copy/pasted code from `Platform.vue` and `Plain.vue` to regsiter global dialog elements for the `Dialog` service.
- I've also put a shield in place ot prevent accidental calling of the `bind` in the future.

## Related Issue(s)

Closes #4248 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->