### PR TITLE
Fix device tile kebab menu actions

### DIFF
--- a/frontend/src/mixins/DeviceActions.js
+++ b/frontend/src/mixins/DeviceActions.js
@@ -137,8 +137,16 @@ export default {
                 this.devices.set(device.id, localDevice)
             } else {
                 // working with compact application views
-                const localDevice = this.devices.find(e => e.id === device.id) || {} // if not found, we are adding a new device
-                Object.assign(localDevice, device, currentDeviceStatus)
+                const localDevice = this.devices.find(e => e.id === device.id)
+                if (!localDevice) {
+                    // not found - i.e. adding new device
+                    // in theory, this should never happen as devices cannot (currently) be added from application view
+                    // but we need to _do something_ in the case of a device not found in the list
+                    this.devices.push(Object.assign({}, device, currentDeviceStatus))
+                } else {
+                    // found - i.e. update existing device
+                    Object.assign(localDevice, device, currentDeviceStatus)
+                }
             }
         },
 

--- a/frontend/src/mixins/DeviceActions.js
+++ b/frontend/src/mixins/DeviceActions.js
@@ -41,7 +41,14 @@ export default {
     emits: ['delete-device'],
     methods: {
         deviceAction (action, deviceId) {
-            const device = this.devices.get(deviceId)
+            let device
+            if (this.devices instanceof Map) {
+                // working with DevicesBrowser component
+                device = this.devices.get(deviceId)
+            } else {
+                // working with compact application views
+                device = this.devices.find(e => e.id === deviceId)
+            }
             if (action === 'edit') {
                 this.showEditDeviceDialog(device)
             } else if (action === 'delete') {
@@ -123,8 +130,16 @@ export default {
             } else {
                 this.allDeviceStatuses.set(device.id, device)
             }
-
-            this.devices.set(device.id, device)
+            if (this.devices instanceof Map) {
+                // working with DevicesBrowser component
+                const localDevice = this.devices.get(device.id)
+                Object.assign(localDevice, device, currentDeviceStatus)
+                this.devices.set(device.id, localDevice)
+            } else {
+                // working with compact application views
+                const localDevice = this.devices.find(e => e.id === device.id)
+                Object.assign(localDevice, device, currentDeviceStatus)
+            }
         },
 
         deviceCreated (device) {
@@ -146,7 +161,13 @@ export default {
                 this.deviceCountDeltaSincePageLoad--
             }
             this.allDeviceStatuses.delete(device.id)
-            this.devices.delete(device.id)
+            if (this.devices instanceof Map) {
+                // working with DevicesBrowser component
+                this.devices.delete(device.id)
+            } else {
+                // working with compact application views
+                this.devices = this.devices.filter(e => e.id !== device.id)
+            }
 
             if ( // updates the application device count if present
                 Object.hasOwnProperty.call(this, 'application') &&

--- a/frontend/src/mixins/DeviceActions.js
+++ b/frontend/src/mixins/DeviceActions.js
@@ -132,12 +132,12 @@ export default {
             }
             if (this.devices instanceof Map) {
                 // working with DevicesBrowser component
-                const localDevice = this.devices.get(device.id)
+                const localDevice = this.devices.get(device.id) || {} // if not found, we are adding a new device
                 Object.assign(localDevice, device, currentDeviceStatus)
                 this.devices.set(device.id, localDevice)
             } else {
                 // working with compact application views
-                const localDevice = this.devices.find(e => e.id === device.id)
+                const localDevice = this.devices.find(e => e.id === device.id) || {} // if not found, we are adding a new device
                 Object.assign(localDevice, device, currentDeviceStatus)
             }
         },

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog ref="dialog" header="Device Configuration">
+    <ff-dialog ref="dialog" header="Device Configuration" data-el="team-device-config-dialog">
         <template #default>
             <form class="text-gray-800">
                 <template v-if="!hasCredentials">


### PR DESCRIPTION
closes #4246

## Description

* Support both Maps and Arrays of devices in the mixin until such time as we only have one kind of device list in the application
  * This was quickest & least disruptive approach to resolving the issue at hand
* Add E2E tests that ensures the correct dialog IS actually shown for each item in the kebab menu
   * NOTE: Until #4249 is resolved, one of the dialog tests is disabled



## Related Issue(s)

#4246

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

