### PR TITLE
Fix import of snapshots and improve test coverage

### DIFF
--- a/forge/db/controllers/Snapshot.js
+++ b/forge/db/controllers/Snapshot.js
@@ -149,9 +149,10 @@ module.exports = {
             description: snapshot.description || '',
             credentialSecret,
             settings: {
-                settings: snapshot.settings || {},
-                env: snapshot.env || {},
-                modules: snapshot.modules || {}
+                settings: snapshot.settings?.settings || {},
+                env: snapshot.settings?.env || {},
+                modules: snapshot.settings?.modules || {}
+
             },
             flows: {
                 flows: snapshot.flows.flows || [],


### PR DESCRIPTION
The import path was putting the `settings`/`env`/`module` properties at the wrong level of the snapshot. The unit test coverage for the function didn't verify these things.

This fixes all of that.