### PR TITLE
Clear query action on invite page

### DIFF
--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -85,6 +85,7 @@ export default {
 
         // do we auto-open the dialog?
         if (this.$route.query.action === 'invite') {
+            this.$router.replace({ query: null })
             this.inviteMember()
         }
     },


### PR DESCRIPTION
## Description

Minor UX papercut improvement.

The `?action=invite` query param is used to trigger the invite dialog when loading the team members page.

Whilst testing invites I'd frequently use the invite members button (thus getting the `?action=invite` query param), then do something in another window to handle the invite from the other user's view, then come back and refresh the page to see the members list updated... only to get the invite dialog reappearing.

This PR clears the query param prior to showing the dialog so a refresh of the page won't re-trigger it.