### PR TITLE
Remove vue-template-compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,6 @@
                 "tailwindcss": "^2.2.19",
                 "vitest": "^1.1.0",
                 "vue-loader": "^17.4.2",
-                "vue-template-compiler": "^2.7.16",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4",
                 "webpack-dev-server": "^4.15.1",
@@ -10665,12 +10664,6 @@
             "version": "1.11.8",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
             "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==",
-            "dev": true
-        },
-        "node_modules/de-indent": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-            "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
             "dev": true
         },
         "node_modules/debug": {
@@ -23570,16 +23563,6 @@
                 "vue": "^3.2.0"
             }
         },
-        "node_modules/vue-template-compiler": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-            "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
-            "dev": true,
-            "dependencies": {
-                "de-indent": "^1.0.2",
-                "he": "^1.2.0"
-            }
-        },
         "node_modules/vuex": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
@@ -31986,12 +31969,6 @@
             "version": "1.11.8",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
             "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==",
-            "dev": true
-        },
-        "de-indent": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-            "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
             "dev": true
         },
         "debug": {
@@ -41394,16 +41371,6 @@
             "integrity": "sha512-dqUcs8tUeG+ssgWhcPbjHvazML16Oga5w34uCUmsk7i0BcnskoLGwjpa15fqMr2Fa5JgVBrdL2MEgqz6XZ/6IQ==",
             "requires": {
                 "@vue/devtools-api": "^6.5.1"
-            }
-        },
-        "vue-template-compiler": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-            "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
-            "dev": true,
-            "requires": {
-                "de-indent": "^1.0.2",
-                "he": "^1.2.0"
             }
         },
         "vuex": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,6 @@
         "tailwindcss": "^2.2.19",
         "vitest": "^1.1.0",
         "vue-loader": "^17.4.2",
-        "vue-template-compiler": "^2.7.16",
         "webpack": "^5.88.2",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1",


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This has a security CVE but should be Vue 2.0 only and we are using Vue 3.x

I removed the dev-dep and ran `npm run build` without error so I think it was left over from earlier work and is no longer needed

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/security/dependabot/53

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

