### PR TITLE
Allow Uppercase letters in initial admin username

### DIFF
--- a/forge/routes/setup/index.js
+++ b/forge/routes/setup/index.js
@@ -80,7 +80,7 @@ module.exports = async function (app) {
             reply.code(404).send()
             return
         }
-        if (/^(admin|root)$/.test(request.body.username) || !/^[a-z0-9-_]+$/.test(request.body.username)) {
+        if (/^(admin|root)$/.test(request.body.username) || !/^[a-z0-9-_]+$/i.test(request.body.username)) {
             reply.code(400).send({ error: 'invalid username' })
             return
         }

--- a/frontend/src/pages/setup/CreateAdminUser.vue
+++ b/frontend/src/pages/setup/CreateAdminUser.vue
@@ -81,7 +81,7 @@ export default {
     watch: {
         'input.username': function (v) {
             if (v && !/^[a-z0-9-_]+$/i.test(v)) {
-                this.errors.username = 'Must only contain a-z 0-9 - _'
+                this.errors.username = 'Must only contain a-z A-Z 0-9 - _'
             } else {
                 this.errors.username = ''
             }


### PR DESCRIPTION
fixes #4229

## Description

<!-- Describe your changes in detail -->
The initial admin user had tighter constraints than normal users (no uppercase).

Now matches normal user rules.


## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4229

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

