### PR TITLE
Fix link in device deploy docs

### DIFF
--- a/docs/device-agent/deploy.md
+++ b/docs/device-agent/deploy.md
@@ -38,7 +38,7 @@ When running in the default of Fleet Mode, the device agent does not allow local
 Node-RED editor. This ensures the device is running the deployed snapshot without modification.
 
 When running on FlowFuse Cloud, or a premium licensed FlowFuse instance (with the
-[MQTT broker enabled](https://flowfuse.com/docs/install/local/#setting-up-mosquitto-(optional))
+[MQTT broker enabled](https://flowfuse.com/docs/contribute/local/#setting-up-mosquitto-(optional))
 the device can be placed in Developer Mode that enables remote access to the editor. 
 
 This can then be used to develop the flows directly on the device and a new snapshot
@@ -68,7 +68,7 @@ editor is only available when:
 * The device is in Developer Mode
 
 * When running on FlowFuse Cloud, or a premium licensed FlowFuse instance (with the
-[MQTT broker enabled](https://flowfuse.com/docs/install/local/#setting-up-mosquitto-(optional))
+[MQTT broker enabled](https://flowfuse.com/docs/contribute/local/#setting-up-mosquitto-(optional))
 the device can be placed in Developer Mode that enables remote access to the editor.
 
 Whilst in Developer Mode the device will not receive new updates from the platform.


### PR DESCRIPTION
Since the local install docs got moved to contributing this breaks this link

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

