### PR TITLE
Clear device group target snapshot

### DIFF
--- a/docs/user/device-groups.md
+++ b/docs/user/device-groups.md
@@ -67,3 +67,7 @@ When a pipeline stage is operated and it deploys to a device group, that device 
 
 Subsequently, if you remove a device from a group and the device is running the active pipeline snapshot,
 the device snapshot will be cleared, effectively resetting the device to a blank state.
+
+### Removing the snapshot from a device group
+
+Under the settings of a device group, you can remove the target snapshot. This will also clear the snapshot of all devices in the group.

--- a/forge/ee/routes/applicationDeviceGroups/index.js
+++ b/forge/ee/routes/applicationDeviceGroups/index.js
@@ -10,8 +10,6 @@
 const { ValidationError } = require('sequelize')
 
 const { UpdatesCollection } = require('../../../auditLog/formatters.js')
-const { registerPermissions } = require('../../../lib/permissions.js')
-const { Roles } = require('../../../lib/roles.js')
 const { DeviceGroupMembershipValidationError } = require('../../db/controllers/DeviceGroup.js')
 
 // Declare getLogger function to provide type hints / quick code nav / code completion
@@ -23,15 +21,6 @@ const getApplicationLogger = (app) => { return app.auditLog.Application }
  */
 module.exports = async function (app) {
     const deviceGroupLogger = getApplicationLogger(app).application.deviceGroup
-
-    registerPermissions({
-        'application:device-group:create': { description: 'Create a device group', role: Roles.Owner },
-        'application:device-group:list': { description: 'List device groups', role: Roles.Member },
-        'application:device-group:update': { description: 'Update a device group', role: Roles.Owner },
-        'application:device-group:delete': { description: 'Delete a device group', role: Roles.Owner },
-        'application:device-group:read': { description: 'View a device group', role: Roles.Member },
-        'application:device-group:membership:update': { description: 'Update a device group membership', role: Roles.Owner }
-    })
 
     // pre-handler for all routes in this file
     app.addHook('preHandler', async (request, reply) => {

--- a/forge/ee/routes/applicationDeviceGroups/index.js
+++ b/forge/ee/routes/applicationDeviceGroups/index.js
@@ -183,7 +183,8 @@ module.exports = async function (app) {
                 type: 'object',
                 properties: {
                     name: { type: 'string' },
-                    description: { type: 'string' }
+                    description: { type: 'string' },
+                    targetSnapshotId: { type: ['string', 'null'] }
                 }
             },
             params: {
@@ -207,10 +208,17 @@ module.exports = async function (app) {
         const group = request.deviceGroup
         const name = request.body.name
         const description = request.body.description
+        const targetSnapshotId = request.body.targetSnapshotId
         try {
-            const originalDetails = { name: group.name, description: group.description }
-            const updatedGroup = await app.db.controllers.DeviceGroup.updateDeviceGroup(group, { name, description })
-            const newDetails = { name: updatedGroup.name, description: updatedGroup.description }
+            // gather before details for audit log
+            const originalDetails = { name: group.name, description: group.description, targetSnapshotId: null }
+            originalDetails.targetSnapshotId = group.targetSnapshotId ? app.db.models.ProjectSnapshot.encodeHashid(group.targetSnapshotId) : null
+            // perform update
+            const updatedGroup = await app.db.controllers.DeviceGroup.updateDeviceGroup(group, { name, description, targetSnapshotId })
+            // gather after details for audit log
+            const newDetails = { name: updatedGroup.name, description: updatedGroup.description, targetSnapshotId: null }
+            newDetails.targetSnapshotId = updatedGroup.targetSnapshotId ? app.db.models.ProjectSnapshot.encodeHashid(updatedGroup.targetSnapshotId) : null
+            // log the update
             const updates = new UpdatesCollection()
             updates.pushDifferences(originalDetails, newDetails)
             await deviceGroupLogger.updated(request.session.User, null, request.application, group, updates)

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -110,7 +110,17 @@ const Permissions = {
     'platform:debug': { description: 'View platform debug information', role: Roles.Admin },
     'platform:stats': { description: 'View platform stats information', role: Roles.Admin },
     'platform:stats:token': { description: 'Create/Delete platform stats token', role: Roles.Admin },
-    'platform:audit-log': { description: 'View platform audit log', role: Roles.Admin }
+    'platform:audit-log': { description: 'View platform audit log', role: Roles.Admin },
+
+    // *** EE Permissions ***
+
+    // Device Groups
+    'application:device-group:create': { description: 'Create a device group', role: Roles.Owner },
+    'application:device-group:list': { description: 'List device groups', role: Roles.Member },
+    'application:device-group:update': { description: 'Update a device group', role: Roles.Owner },
+    'application:device-group:delete': { description: 'Delete a device group', role: Roles.Owner },
+    'application:device-group:read': { description: 'View a device group', role: Roles.Member },
+    'application:device-group:membership:update': { description: 'Update a device group membership', role: Roles.Owner }
 }
 
 module.exports = {

--- a/frontend/src/api/application.js
+++ b/frontend/src/api/application.js
@@ -321,10 +321,12 @@ const deleteDeviceGroup = async (applicationId, groupId) => {
  * Update a device group
  * @param {string} applicationId - The ID of application
  * @param {string} groupId - The ID of the group
- * @param {object} group
+ * @param {object} name - The new name for the group (use `undefined` to keep the current name)
+ * @param {object} description - The new description for the group (use `undefined` to keep the current description)
+ * @param {string} targetSnapshotId - The new target snapshot ID for the group (use `undefined` to keep the current target, use `null` to remove the target)
  */
-const updateDeviceGroup = async (applicationId, groupId, name, description) => {
-    return client.put(`/api/v1/applications/${applicationId}/device-groups/${groupId}`, { name, description })
+const updateDeviceGroup = async (applicationId, groupId, name, description, targetSnapshotId = undefined) => {
+    return client.put(`/api/v1/applications/${applicationId}/device-groups/${groupId}`, { name, description, targetSnapshotId })
 }
 
 /**

--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -23,7 +23,6 @@
                     <InfoCard header="">
                         <template #content>
                             <InfoCardRow property="Target Snapshot:">
-                                hello
                                 <template #value>
                                     <span class="flex gap-2 pr-2" data-el="device-group-target-snapshot">
                                         <span class="flex items-center space-x-2 pt-1 text-gray-500 italic">

--- a/frontend/src/pages/application/DeviceGroup/settings.vue
+++ b/frontend/src/pages/application/DeviceGroup/settings.vue
@@ -8,22 +8,39 @@
             A description of the group
         </FormRow>
         <ff-button size="small" :disabled="!unsavedChanges || hasError" @click="saveSettings()">Save Settings</ff-button>
-        <FormHeading class="text-red-700">Danger Zone</FormHeading>
-        <FormRow wrapperClass="block">
-            Note that these action cannot be undone.
-            <template #input>
-                <div class="flex justify-between items-center">
-                    <ff-button kind="danger" @click="deleteGroup">Delete Device Group</ff-button>
+
+        <template v-if="hasPermission('application:device-group:update')">
+            <FormHeading class="text-red-700">Clear Target Snapshot</FormHeading>
+            <div class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
+                <div class="flex-grow">
+                    <div class="max-w-sm pr-2">Clearing the groups target snapshot will reset the target of all devices in the group.</div>
                 </div>
-            </template>
-        </FormRow>
+                <div class="min-w-fit flex-shrink-0">
+                    <ff-button class="w-36" kind="danger" data-action="clear-device-group-target-snapshot" :disabled="!hasTargetSnapshot" @click="clearTargetSnapshot">Clear Target</ff-button>
+                </div>
+            </div>
+        </template>
+        <template v-if="hasPermission('application:device-group:delete')">
+            <FormHeading class="text-red-700">Delete Device Group</FormHeading>
+            <div class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
+                <div class="flex-grow">
+                    <div class="max-w-sm pr-2">Deleting the device group will reset all devices in the group. This action cannot be undone.</div>
+                </div>
+                <div class="min-w-fit flex-shrink-0">
+                    <ff-button class="w-36" kind="danger" data-action="delete-device-group" @click="deleteGroup">Delete Group</ff-button>
+                </div>
+            </div>
+        </template>
     </form>
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import ApplicationApi from '../../../api/application.js'
 import FormHeading from '../../../components/FormHeading.vue'
 import FormRow from '../../../components/FormRow.vue'
+import permissionsMixin from '../../../mixins/Permissions.js'
 import Alerts from '../../../services/alerts.js'
 import Dialog from '../../../services/dialog.js'
 
@@ -33,6 +50,7 @@ export default {
         FormRow,
         FormHeading
     },
+    mixins: [permissionsMixin],
     props: {
         application: {
             type: Object,
@@ -56,11 +74,15 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['teamMembership']),
         unsavedChanges () {
             return this.deviceGroup ? (this.input.name !== this.deviceGroup.name || this.input.description !== this.deviceGroup.description) : false
         },
         hasError () {
             return !!this.errors.name
+        },
+        hasTargetSnapshot () {
+            return !!this.deviceGroup?.targetSnapshot
         }
     },
     watch: {
@@ -88,7 +110,7 @@ export default {
             if (!this.application.id) {
                 return
             }
-            const response = await ApplicationApi.updateDeviceGroup(this.application.id, this.deviceGroup.id, this.input.name, this.input.description)
+            const response = await ApplicationApi.updateDeviceGroup(this.application.id, this.deviceGroup.id, this.input.name, this.input.description, undefined)
             if (response.status === 200) {
                 this.$emit('device-group-updated')
                 Alerts.emit('Device Group settings saved', 'confirmation')
@@ -122,6 +144,31 @@ export default {
                     }
                 } catch (error) {
                     const msg = error.response?.data?.error || 'Error deleting device group'
+                    Alerts.emit(msg, 'warning', 5000)
+                }
+            })
+        },
+        clearTargetSnapshot () {
+            if (!this.application.id || !this.deviceGroup.id) {
+                return
+            }
+            Dialog.show({
+                header: 'Clear Target Snapshot',
+                kind: 'danger',
+                text: `Are you sure you want to clear the target snapshot?
+                       This will cause all devices in the group to to have their target snapshot setting cleared.`,
+                confirmLabel: 'Clear'
+            }, async () => {
+                try {
+                    const response = await ApplicationApi.updateDeviceGroup(this.application.id, this.deviceGroup.id, undefined, undefined, null)
+                    if (response.status === 200) {
+                        this.$emit('device-group-updated')
+                        Alerts.emit('Device Group Target Snapshot was cleared', 'confirmation')
+                    } else {
+                        Alerts.emit('Failed to clear the Target Snapshot', 'warning', 5000)
+                    }
+                } catch (error) {
+                    const msg = error.response?.data?.error || 'Error clearing device groups Target Snapshot'
                     Alerts.emit(msg, 'warning', 5000)
                 }
             })


### PR DESCRIPTION
## Description

* Updates controller `updateDeviceGroup` to permit setting `targetSnapshot`
* Updates backend API route `put('/:groupId'` of `forge/ee/routes/applicationDeviceGroups/index.js` to accept `targetSnapshotId` of type `string` or `null`
* Updates front end device settings page and adds a "Clear Target" button in the danger section

### Demo capture
![chrome_XyK8GnljSa](https://github.com/user-attachments/assets/51512daa-9a93-4531-a070-b660c2383c2b)


### Tests added in `test/unit/forge/ee/routes/api/applicationDeviceGroups_spec.js`
```
  Application Device Groups API
    Update Device Group
      ✔ Updates name only (140ms)
      ✔ Updates description only (141ms)
      ✔ Updates targetSnapshot for group and devices (148ms)
      ✔ Clears targetSnapshot for group and devices (143ms)
      ✔ Fails when invalid targetSnapshotId is provided (136ms)
```

### Tests updated in `test/unit/forge/ee/routes/api/applicationDeviceGroups_spec.js`
```
  Application Device Groups API
    Update Device Group
      ✔ Owner can update a device group (148ms)
      ✔ Cannot update a device group with empty name (101ms)
      ✔ Non Owner can not update a device group (89ms)
      ✔ Non Member can not update a device group (84ms)
```


### TODO
- [x] tests
- [x] check + if necessary update existing docs (including any old screenshots)


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

