### PR TITLE
Allow a team without subscription to go unmanaged

### DIFF
--- a/forge/ee/db/controllers/Subscription.js
+++ b/forge/ee/db/controllers/Subscription.js
@@ -28,6 +28,15 @@ module.exports = {
             return newSubscription
         }
     },
+    createUnmanagedSubscription: async function (app, team) {
+        const newSubscription = await app.db.models.Subscription.create({
+            customer: '',
+            subscription: '',
+            status: app.db.models.Subscription.STATUS.UNMANAGED
+        })
+        await newSubscription.setTeam(team)
+        return newSubscription
+    },
     createTrialSubscription: async function (app, team, trialEndsAt) {
         const newSubscription = await app.db.models.Subscription.create({
             customer: '',

--- a/test/unit/forge/ee/lib/billing/index_spec.js
+++ b/test/unit/forge/ee/lib/billing/index_spec.js
@@ -361,6 +361,21 @@ describe('Billing', function () {
             stripe.subscriptions.del.called.should.be.true()
             stripe.subscriptions.del.lastCall.args[0].should.equal('sub_1234')
         })
+        it('puts team without existing subscription into unmanaged mode', async function () {
+            const team1 = await app.factory.createTeam({ name: 'UnmanagedTeam2' })
+            await team1.addUser(app.user, { through: { role: Roles.Owner } })
+
+            await app.billing.enableManualBilling(team1)
+
+            const sub = await team1.getSubscription()
+            // Check the updated states for an unmanaged subscription are correct
+            sub.isActive().should.be.false()
+            sub.isUnmanaged().should.be.true()
+            sub.isTrial().should.be.false()
+            sub.isTrialEnded().should.be.true()
+            sub.subscription.should.equal('')
+            sub.customer.should.equal('')
+        })
     })
 
     describe('addProject', function () {


### PR DESCRIPTION
Fixes #4296 

## Description

The ability to mark a team as unmanaged assumed a team would either be in a trial state, or have billing setup.

It didn't handle the case where a user creates a new team (so not in trial mode), then backs out of setting up stripe.

This fixes that by handling teams without a `Subscription` object.


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

