### PR TITLE
Fix bulk intermittent e2e tests

### DIFF
--- a/test/e2e/frontend/cypress/tests/devices/bulk.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/bulk.spec.js
@@ -32,6 +32,10 @@ describe('FlowForge - Devices', () => {
             cy.wait(['@getDevices']).then(({ response }) => {
                 const devices = response.body.devices
 
+                // initial checks to help better understand test fail output
+                expect(devices).to.be.an('array')
+                expect(devices.length).to.be.greaterThan(3)
+
                 // select a single device
                 cy.get('[data-el="devices-browser"] tbody tr').eq(0).find('.checkbox').click()
                 // click the "Delete" button
@@ -79,6 +83,10 @@ describe('FlowForge - Devices', () => {
             // wait for the devices API call to complete
             cy.wait(['@getDevices']).then(({ response }) => {
                 const devices = response.body.devices
+
+                // initial checks to help better understand test fail output
+                expect(devices).to.be.an('array')
+                expect(devices.length).to.be.greaterThan(3)
 
                 // wait for device browser to load table
                 cy.get('[data-el="devices-browser"] tbody tr').should('have.length', devices.length)

--- a/test/e2e/frontend/cypress/tests/devices/bulk.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/bulk.spec.js
@@ -1,3 +1,4 @@
+/// <reference types="cypress" />
 describe('FlowForge - Devices', () => {
     beforeEach(() => {
         cy.login('bob', 'bbPassword')
@@ -51,9 +52,17 @@ describe('FlowForge - Devices', () => {
 
                 // select all devices
                 cy.get('[data-el="devices-browser"] thead .checkbox').click()
+
+                // introduce a small delay to ensure the devices are selected before continuing
+                // eslint-disable-next-line cypress/no-unnecessary-waiting
+                cy.wait(30)
+
+                // ensure the delete button is now enabled
+                cy.get('[data-action="bulk-delete-devices"]').should('not.be.disabled')
                 // click the "Delete" button
                 cy.get('[data-action="bulk-delete-devices"]').click()
                 // ensure the dialog is visible and has the correct number of devices listed
+                cy.get('[data-el="team-bulk-device-delete-dialog"]').should('be.visible')
                 cy.get('[data-el="team-bulk-device-delete-dialog"] ul li').should('have.length', devices.length)
 
                 // ensure all device names are displayed in the dialog
@@ -71,17 +80,30 @@ describe('FlowForge - Devices', () => {
             cy.wait(['@getDevices']).then(({ response }) => {
                 const devices = response.body.devices
 
+                // wait for device browser to load table
+                cy.get('[data-el="devices-browser"] tbody tr').should('have.length', devices.length)
+
                 // find 3 sacrificial devices with names ending "bulk-test-#" (where # is 1 ~ 3)
                 const sacrificialDevices = devices.filter((device) => device.name.match(/bulk-test-\d$/))
-                // select the sacrificial devices. NOTE the .chekbox is in col0 but the text is in col1
+
+                // select the sacrificial devices. NOTE the .checkbox is in col0 but the text is in col1
                 sacrificialDevices.forEach((device) => {
-                    cy.get('[data-el="devices-browser"] tbody tr').contains(device.name).parent().closest('tr').find('.checkbox').click()
+                    cy.get('[data-el="devices-browser"] tbody tr').contains(device.name).parent().parent().find('.checkbox').click()
                 })
 
+                // introduce a delay to ensure the devices are selected before continuing
+                // eslint-disable-next-line cypress/no-unnecessary-waiting
+                cy.wait(30)
+
+                // ensure 3 devices are selected
+                cy.get('[data-el="devices-browser"] tbody tr input[type="checkbox"]:checked').should('have.length', 3)
+
                 // click the "Delete" button
+                cy.get('[data-action="bulk-delete-devices"]').should('not.be.disabled')
                 cy.get('[data-action="bulk-delete-devices"]').click()
 
-                // click the "Confirm" button
+                // click the dialog "Confirm" button
+                cy.get('[data-el="team-bulk-device-delete-dialog"]').should('be.visible')
                 cy.get('[data-el="team-bulk-device-delete-dialog"] button').contains('Confirm').click()
 
                 // wait for the devices API call to complete


### PR DESCRIPTION
## Description

Fix intermittent e2e test fails on bulk ops.

Based on the captured logs, it seems to be always after selecting ff-check items. As though the "click" of an ff-check is somewhat async. Example:
![image](https://github.com/user-attachments/assets/f52531ee-24b0-429d-9b30-2eee6dfd421f)

Changes:
* Add some preliminary array length checks to aid with debugging when the test fails
* Add short 30ms delay AFTER checking checkboxes (handle async element)
* Add additional interlocks (like dialog shown, delete button enabled) etc that should cause `cy` to `wait` for elements

I did manage to get the e2e test to fail locally (took about 10 runs) but after these changes it _appears_ to be stable 🤞 


## Related Issue(s)

No issue, just random, intermittent test fails.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

