### PR TITLE
UX Fixes for Users Without Assigned Teams

### DIFF
--- a/frontend/src/components/NotificationsButton.vue
+++ b/frontend/src/components/NotificationsButton.vue
@@ -44,7 +44,6 @@ export default {
 .notifications-button-wrapper {
 
   .notifications-button {
-    border-left: 1px solid $ff-grey-500;
     color: white;
     display: flex;
     align-items: center;

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -1,14 +1,15 @@
 <template>
     <div class="ff-header" data-sentry-unmask>
         <!-- Mobile: Toggle(Team & Team Admin Options) -->
-        <i class="ff-header--mobile-toggle" :class="{'active': mobileMenuOpen}">
+        <i v-if="team" class="ff-header--mobile-toggle" :class="{'active': mobileMenuOpen}">
             <MenuIcon class="ff-avatar" @click="$emit('menu-toggle')" />
         </i>
         <!-- FlowFuse Logo -->
         <img class="ff-logo" src="/ff-logo--wordmark-caps--dark.png" @click="home()">
         <!-- Mobile: Toggle(User Options) -->
-        <div v-if="team" class="flex">
-            <i class="ff-header--mobile-usertoggle" :class="{'active': mobileTeamSelectionOpen}">
+        <div class="flex ff-mobile-navigation-right">
+            <NotificationsButton class="ff-header--mobile-notificationstoggle" :class="{'active': mobileTeamSelectionOpen}" />
+            <i v-if="teams.length > 0" class="ff-header--mobile-usertoggle" :class="{'active': mobileTeamSelectionOpen}">
                 <img :src="team.avatar" class="ff-avatar" @click="mobileTeamSelectionOpen = !mobileTeamSelectionOpen">
             </i>
             <i class="ff-header--mobile-usertoggle" :class="{'active': mobileUserOptionsOpen}">
@@ -35,9 +36,9 @@
                 @click="mobileTeamSelectionOpen = false; $router.push({name: 'CreateTeam'})"
             />
         </div>
-        <div class="hidden lg:flex">
+        <div class="hidden lg:flex ff-desktop-navigation-right">
             <ff-team-selection data-action="team-selection" />
-            <div class="px-4 flex flex-col justify-center ff-border-left" v-if="showInviteButton">
+            <div class="px-4 flex flex-col justify-center" v-if="showInviteButton">
                 <ff-button kind="secondary" @click="inviteTeamMembers">
                     <template #icon-left><UserAddIcon /></template>
                     Invite Members
@@ -45,7 +46,13 @@
             </div>
             <!-- Desktop: User Options -->
             <NotificationsButton />
-            <ff-dropdown v-if="user" class="ff-navigation ff-user-options" options-align="right" data-action="user-options" data-cy="user-options">
+            <ff-dropdown
+                v-if="user"
+                class="ff-navigation ff-user-options hidden lg:flex xl:flex md:flex sm:flex"
+                options-align="right"
+                data-action="user-options"
+                data-cy="user-options"
+            >
                 <template #placeholder>
                     <div class="ff-user">
                         <img :src="user.avatar" class="ff-avatar">

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="ff-header" data-sentry-unmask>
         <!-- Mobile: Toggle(Team & Team Admin Options) -->
-        <i v-if="team" class="ff-header--mobile-toggle" :class="{'active': mobileMenuOpen}">
+        <i v-if="shouldDisplayMenuToggle" class="ff-header--mobile-toggle" :class="{'active': mobileMenuOpen}">
             <MenuIcon class="ff-avatar" @click="$emit('menu-toggle')" />
         </i>
         <!-- FlowFuse Logo -->
@@ -91,6 +91,7 @@ export default {
     computed: {
         ...mapState('account', ['user', 'team', 'teams']),
         ...mapGetters('account', ['notifications', 'hasAvailableTeams']),
+        ...mapGetters('ux', ['shouldShowLeftMenu']),
         navigationOptions () {
             return [
                 {
@@ -125,6 +126,9 @@ export default {
         },
         showInviteButton () {
             return this.$route.name !== 'TeamMembers'
+        },
+        shouldDisplayMenuToggle () {
+            return this.shouldShowLeftMenu(this.$route)
         }
     },
     watch: {

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -9,7 +9,7 @@
         <!-- Mobile: Toggle(User Options) -->
         <div class="flex ff-mobile-navigation-right">
             <NotificationsButton class="ff-header--mobile-notificationstoggle" :class="{'active': mobileTeamSelectionOpen}" />
-            <i v-if="!hasAvailableTeams" class="ff-header--mobile-usertoggle" :class="{'active': mobileTeamSelectionOpen}">
+            <i v-if="hasAvailableTeams" class="ff-header--mobile-usertoggle" :class="{'active': mobileTeamSelectionOpen}">
                 <img :src="team.avatar" class="ff-avatar" @click="mobileTeamSelectionOpen = !mobileTeamSelectionOpen">
             </i>
             <i class="ff-header--mobile-usertoggle" :class="{'active': mobileUserOptionsOpen}">

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -9,7 +9,7 @@
         <!-- Mobile: Toggle(User Options) -->
         <div class="flex ff-mobile-navigation-right">
             <NotificationsButton class="ff-header--mobile-notificationstoggle" :class="{'active': mobileTeamSelectionOpen}" />
-            <i v-if="teams.length > 0" class="ff-header--mobile-usertoggle" :class="{'active': mobileTeamSelectionOpen}">
+            <i v-if="!hasAvailableTeams" class="ff-header--mobile-usertoggle" :class="{'active': mobileTeamSelectionOpen}">
                 <img :src="team.avatar" class="ff-avatar" @click="mobileTeamSelectionOpen = !mobileTeamSelectionOpen">
             </i>
             <i class="ff-header--mobile-usertoggle" :class="{'active': mobileUserOptionsOpen}">
@@ -90,7 +90,7 @@ export default {
     mixins: [navigationMixin],
     computed: {
         ...mapState('account', ['user', 'team', 'teams']),
-        ...mapGetters('account', ['notifications']),
+        ...mapGetters('account', ['notifications', 'hasAvailableTeams']),
         navigationOptions () {
             return [
                 {

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -7,7 +7,7 @@
         <!-- FlowFuse Logo -->
         <img class="ff-logo" src="/ff-logo--wordmark-caps--dark.png" @click="home()">
         <!-- Mobile: Toggle(User Options) -->
-        <div class="flex ff-mobile-navigation-right">
+        <div class="flex ff-mobile-navigation-right" data-el="mobile-nav-right">
             <NotificationsButton class="ff-header--mobile-notificationstoggle" :class="{'active': mobileTeamSelectionOpen}" />
             <i v-if="hasAvailableTeams" class="ff-header--mobile-usertoggle" :class="{'active': mobileTeamSelectionOpen}">
                 <img :src="team.avatar" class="ff-avatar" @click="mobileTeamSelectionOpen = !mobileTeamSelectionOpen">
@@ -36,7 +36,7 @@
                 @click="mobileTeamSelectionOpen = false; $router.push({name: 'CreateTeam'})"
             />
         </div>
-        <div class="hidden lg:flex ff-desktop-navigation-right">
+        <div class="hidden lg:flex ff-desktop-navigation-right" data-el="desktop-nav-right">
             <ff-team-selection data-action="team-selection" />
             <div class="px-4 flex flex-col justify-center" v-if="showInviteButton">
                 <ff-button kind="secondary" @click="inviteTeamMembers">

--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -14,7 +14,7 @@
                 <ff-dropdown-option>
                     <nav-item v-for="t in teams" :key="t.id" :label="t.name" :avatar="t?.avatar" @click="selectTeam(t)" data-action="switch-team" />
                 </ff-dropdown-option>
-                <ff-dropdown-option>
+                <ff-dropdown-option v-if="canCreateTeam">
                     <nav-item label="Create New Team" :icon="plusIcon" @click="createTeam(t);" data-action="create-team" />
                 </ff-dropdown-option>
             </ul>
@@ -24,7 +24,7 @@
 
 <script>
 import { PlusIcon } from '@heroicons/vue/solid'
-import { mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 
 import NavItem from './NavItem.vue'
 
@@ -35,7 +35,15 @@ export default {
         NavItem
     },
     computed: {
-        ...mapState('account', ['team', 'teams'])
+        ...mapState('account', ['team', 'teams', 'settings']),
+        ...mapGetters('account', ['isAdminUser']),
+        canCreateTeam () {
+            if (this.isAdminUser) {
+                return true
+            }
+
+            return Object.prototype.hasOwnProperty.call(this.settings, 'team:create') && this.settings['team:create']
+        }
     },
     data () {
         return {

--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="ff-layout--platform">
         <PageHeader :mobileMenuOpen="mobileMenuOpen" @menu-toggle="toggleMenu" />
-        <div class="ff-layout--platform--wrapper">
+        <div class="ff-layout--platform--wrapper" :class="{closed: !hasAvailableTeams}">
             <div id="platform-sidenav" class="ff-navigation" :class="{'open': mobileMenuOpen}" data-sentry-unmask>
                 <!-- Each view uses a <Teleport> to fill this -->
             </div>
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 
 import InterviewPopup from '../components/InterviewPopup.vue'
 import PageHeader from '../components/PageHeader.vue'
@@ -55,7 +55,8 @@ export default {
         }
     },
     computed: {
-        ...mapState('product', ['interview'])
+        ...mapState('product', ['interview']),
+        ...mapGetters('account', ['hasAvailableTeams'])
     },
     watch: {
         $route: function () {

--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="ff-layout--platform">
         <PageHeader :mobileMenuOpen="mobileMenuOpen" @menu-toggle="toggleMenu" />
-        <div class="ff-layout--platform--wrapper" :class="{closed: !hasAvailableTeams}">
+        <div class="ff-layout--platform--wrapper" :class="{closed: !shouldShowMenu}">
             <div id="platform-sidenav" class="ff-navigation" :class="{'open': mobileMenuOpen}" data-sentry-unmask>
                 <!-- Each view uses a <Teleport> to fill this -->
             </div>
@@ -56,7 +56,10 @@ export default {
     },
     computed: {
         ...mapState('product', ['interview']),
-        ...mapGetters('account', ['hasAvailableTeams'])
+        ...mapGetters('account', ['hasAvailableTeams']),
+        shouldShowMenu () {
+            return this.hasAvailableTeams || this.$route.path.includes('/account/')
+        }
     },
     watch: {
         $route: function () {

--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="ff-layout--platform">
         <PageHeader :mobileMenuOpen="mobileMenuOpen" @menu-toggle="toggleMenu" />
-        <div class="ff-layout--platform--wrapper" :class="{closed: !shouldShowMenu}">
+        <div class="ff-layout--platform--wrapper" :class="{closed: !isMenuVisible}">
             <div id="platform-sidenav" class="ff-navigation" :class="{'open': mobileMenuOpen}" data-sentry-unmask>
                 <!-- Each view uses a <Teleport> to fill this -->
             </div>
@@ -57,8 +57,9 @@ export default {
     computed: {
         ...mapState('product', ['interview']),
         ...mapGetters('account', ['hasAvailableTeams']),
-        shouldShowMenu () {
-            return this.hasAvailableTeams || this.$route.path.includes('/account/')
+        ...mapGetters('ux', ['shouldShowLeftMenu']),
+        isMenuVisible () {
+            return this.shouldShowLeftMenu(this.$route)
         }
     },
     watch: {

--- a/frontend/src/pages/account/NoTeamsUser.vue
+++ b/frontend/src/pages/account/NoTeamsUser.vue
@@ -1,8 +1,8 @@
 <template>
-    <form class="px-4 sm:px-6 lg:px-8 mt-4 space-y-4 text-center">
+    <form class="py-8 text-center">
         <p class="text-gray-700 text-lg">You need to be in a team to create projects.</p>
         <p v-if="invitationCount === 0 && !user.admin && !settings['team:create']" class="text-gray-700 text-lg mt-10 ">Ask an Admin or Team Owner to add you to a team.</p>
-        <div class="flex justify-center" :class="invitationCount > 0?'sm:grid-cols-2':'max-w-xs mx-auto'">
+        <div class="pt-4 justify-center flex gap-5" :class="invitationCount > 0?'sm:grid-cols-2':'max-w-xs mx-auto'">
             <router-link v-if="user.admin || settings['team:create']" to="/team/create" class="forge-button-secondary p-4 sm:h-36 inline-flex sm:flex-col items-center sm:justify-center gap-4">
                 <UserGroupIcon class="w-10" />
                 Create a new team

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -94,7 +94,8 @@ const getters = {
     hasNotifications: (state, getters) => getters.notificationsCount > 0,
 
     teamInvitations: state => state.invitations,
-    teamInvitationsCount: state => state.invitations?.length || 0
+    teamInvitationsCount: state => state.invitations?.length || 0,
+    hasAvailableTeams: state => state.teams.length > 0
 }
 
 const mutations = {

--- a/frontend/src/store/ux.js
+++ b/frontend/src/store/ux.js
@@ -5,7 +5,11 @@ const state = () => ({
     }
 })
 
-const getters = {}
+const getters = {
+    shouldShowLeftMenu: (state, getters, rootState, rootGetters) => (route) => {
+        return rootGetters['account/hasAvailableTeams'] || route.path.includes('/account/')
+    }
+}
 
 const mutations = {
     openRightDrawer (state, { component }) {

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -406,7 +406,6 @@ $nav_height: 60px;
         }
     }
     .ff-dropdown {
-        //display: none;
         height: calc(#{$nav_height} - 2px);
         color: white;
         min-width: $sidenav_width;
@@ -420,9 +419,6 @@ $nav_height: 60px;
             justify-content: space-between;
             align-items: center;
             border: none;
-            //border-width: 0 0 0 1px;
-            //border-color: $ff-grey-500;
-            //border-radius: 0;
             background-color: $ff-grey-800;
             &:hover {
                 background-color: $ff-grey-700;

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -251,7 +251,7 @@ $nav_height: 60px;
     .ff-dropdown-options {
         position: absolute;
         min-width: $sidenav_width;
-        display: none;
+        display: block;
         z-index: 10;
         border-bottom: 0;
         max-height: initial;
@@ -344,6 +344,7 @@ $nav_height: 60px;
         padding: 16px;
         svg {
             fill: white;
+            min-width: 24px;
         }
         &.active {
             cursor: pointer;
@@ -354,6 +355,7 @@ $nav_height: 60px;
         padding: 16px;
         img {
             padding: 0;
+            min-width: 24px;
         }
         &.active {
             cursor: pointer;
@@ -392,8 +394,19 @@ $nav_height: 60px;
     .ff-navigation-right {
         height: 100%;
     }
+    .ff-desktop-navigation-right {
+        & > * {
+            border-left: 1px solid $ff-grey-500;
+        }
+    }
+    .ff-mobile-navigation-right {
+        img, 
+        button {
+            cursor: pointer;
+        }
+    }
     .ff-dropdown {
-        display: none;
+        //display: none;
         height: calc(#{$nav_height} - 2px);
         color: white;
         min-width: $sidenav_width;
@@ -406,9 +419,10 @@ $nav_height: 60px;
             display: flex;
             justify-content: space-between;
             align-items: center;
-            border-width: 0 0 0 1px;
-            border-color: $ff-grey-500;
-            border-radius: 0;
+            border: none;
+            //border-width: 0 0 0 1px;
+            //border-color: $ff-grey-500;
+            //border-radius: 0;
             background-color: $ff-grey-800;
             &:hover {
                 background-color: $ff-grey-700;
@@ -445,6 +459,10 @@ $nav_height: 60px;
     .ff-user-options {
         width: auto;
         min-width: $nav_height;
+        
+        &.ff-navigation {
+            left: auto;
+        }
         .ff-dropdown-options {
             width: $sidenav_width;
         }
@@ -650,6 +668,9 @@ $nav_height: 60px;
     &.open {
         left: 0;
     }
+    &.closed {
+        left: -$sidenav_width;
+    }
     &.ff-navigation-right.open {
         left: initial;
         right: 0;
@@ -701,6 +722,13 @@ $nav_height: 60px;
     /* Platform */
     .ff-layout--platform--wrapper {
         grid-template-columns: $sidenav_width 1fr;
+        
+        &.closed {
+            grid-template-columns: 1fr;
+            #platform-sidenav {
+                display: none;
+            }
+        }
     }
     .ff-navigation {
         left: 0;
@@ -710,14 +738,12 @@ $nav_height: 60px;
         .ff-header--mobile-toggle {
             display: none;
         }
-        .ff-header--mobile-usertoggle {
+        .ff-header--mobile-usertoggle,
+        .ff-header--mobile-notificationstoggle {
             display: none;
         }
         img.ff-logo {
             padding: 16px;
-        }
-        .ff-dropdown {
-            display: block;
         }
     }
 }

--- a/test/e2e/frontend/cypress/tests/invitations.spec.js
+++ b/test/e2e/frontend/cypress/tests/invitations.spec.js
@@ -22,7 +22,9 @@ describe('FlowFuse platform invitees', () => {
 
     it('can reject an invitation to a new team', () => {
         // should show one pending invite
-        cy.get('[data-el="notification-pill"]').should('have.text', '2')
+        cy.get('[data-el="desktop-nav-right"]').within(() => {
+            cy.get('[data-el="notification-pill"]').should('have.text', '2')
+        })
 
         // user should see a message
         cy.get('[data-nav="team-invites"]').should('be.visible')
@@ -46,7 +48,9 @@ describe('FlowFuse platform invitees', () => {
 
     it('can accept an invitation to a new team and is navigated to the team\'s dashboard', () => {
         // should show one pending invite
-        cy.get('[data-el="notification-pill"]').should('have.text', '1')
+        cy.get('[data-el="desktop-nav-right"]').within(() => {
+            cy.get('[data-el="notification-pill"]').should('have.text', '1')
+        })
 
         // user should see a message
         cy.get('[data-nav="team-invites"]').should('be.visible')

--- a/test/e2e/frontend/cypress/tests/notifications.spec.js
+++ b/test/e2e/frontend/cypress/tests/notifications.spec.js
@@ -66,11 +66,13 @@ describe('FlowForge - Notifications', () => {
 
                 cy.get('[data-el="right-drawer"').should('not.be.visible')
 
-                cy.get('[data-el="notifications-button"')
-                    .should('exist')
-                    .contains(2)
+                cy.get('[data-el="desktop-nav-right"]').within(() => {
+                    cy.get('[data-el="notifications-button"')
+                        .should('exist')
+                        .contains(2)
 
-                cy.get('[data-el="notifications-button"').click()
+                    cy.get('[data-el="notifications-button"').click()
+                })
 
                 cy.get('[data-el="right-drawer"').should('be.visible')
 
@@ -135,11 +137,13 @@ describe('FlowForge - Notifications', () => {
 
                 cy.get('[data-el="right-drawer"').should('not.be.visible')
 
-                cy.get('[data-el="notifications-button"')
-                    .should('exist')
-                    .contains(1)
+                cy.get('[data-el="desktop-nav-right"]').within(() => {
+                    cy.get('[data-el="notifications-button"')
+                        .should('exist')
+                        .contains(1)
 
-                cy.get('[data-el="notifications-button"').click()
+                    cy.get('[data-el="notifications-button"').click()
+                })
 
                 cy.get('[data-el="right-drawer"').should('be.visible')
 


### PR DESCRIPTION
## Description

- hide the burgher menu and left menu for users without a team (no point in opening or showing an empty menu)
- display the right user navigation button when no team present while hiding teams selector when no teams are available
- hide invite members button on mobile devices to preserve nav width integrity
- display the right notifications button on mobile
- ui tweaks to the NoTeamUSer component that is being shown when a user does not have a team
- hide the team selector 'create team' button if the platform settings do not allow users to create teams

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/3850

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

