### PR TITLE
Site wide audit log better formatting when updates object is to be displayed

### DIFF
--- a/frontend/src/components/audit-log/AuditEntryUpdates.vue
+++ b/frontend/src/components/audit-log/AuditEntryUpdates.vue
@@ -14,7 +14,7 @@
                         Old value: '{{ update.old }}'
                     </template>
                 </template>
-                <template v-if="!update.old && update.new">
+                <template v-else-if="!update.old && update.new">
                     Set: '{{ update.key }}'.
                     <template v-if="includeValues(update)">
                         Value: '{{ update.new }}'
@@ -60,6 +60,11 @@ export default {
         includeValues (updateItem) {
             if (!updateItem) {
                 return false
+            }
+            const oldType = typeof updateItem.old
+            const newType = typeof updateItem.new
+            if (oldType === 'boolean' && newType === 'boolean') {
+                return true // allow boolean value changes to be shown by default
             }
             if (ALLOW_DETAILS.includes(updateItem.key)) {
                 return true

--- a/frontend/src/components/audit-log/AuditEntryUpdates.vue
+++ b/frontend/src/components/audit-log/AuditEntryUpdates.vue
@@ -1,16 +1,71 @@
 <template>
-    <template v-for="(update, $index) in updates" :key="update.key">
-        '{{ update.key }}' has been changed from '{{ update.old }}' to '{{ update.new }}'<template v-if="$index < updates.length - 1">, </template>
-    </template>
+    <ul v-if="updates">
+        <li v-for="(update) in updates" :key="update.key">
+            <template v-if="update.dif === 'created' || update.dif === 'new'">
+                Added: '{{ update.key }}'.
+                <template v-if="includeValues(update)">
+                    Value: '{{ update.new }}'.
+                </template>
+            </template>
+            <template v-else-if="update.dif === 'updated'">
+                <template v-if="update.old && !update.new">
+                    Cleared: '{{ update.key }}'.
+                    <template v-if="includeValues(update)">
+                        Old value: '{{ update.old }}'
+                    </template>
+                </template>
+                <template v-if="!update.old && update.new">
+                    Set: '{{ update.key }}'.
+                    <template v-if="includeValues(update)">
+                        Value: '{{ update.new }}'
+                    </template>
+                </template>
+                <template v-else>
+                    Changed: '{{ update.key }}'.
+                    <template v-if="includeValues(update)">
+                        Old value: '{{ update.old }}'. New value: '{{ update.new }}'.
+                    </template>
+                </template>
+            </template>
+            <template v-else-if="update.dif === 'deleted'">
+                Deleted: '{{ update.key }}'.
+                <template v-if="includeValues(update)">
+                    Old value: '{{ update.old }}'
+                </template>
+            </template>
+            <template v-else>{{ update.dif || 'Unknown action on ' }} property: '{{ update.key }}'.</template>
+        </li>
+    </ul>
 </template>
 
 <script>
+
+// Array of keys that are allowed to have extra details shown
+const ALLOW_DETAILS = ['name', 'type', 'slug', 'autoSnapshot', /.+\.enabled$/, /.+\.name$/, /.+\.version$/i]
+
 export default {
     name: 'AuditEntryUpdates',
     props: {
-        updates: {
-            type: Array,
+        entry: {
+            type: Object,
             required: true
+        }
+    },
+    computed: {
+        updates () {
+            return this.entry.body?.updates && this.entry.body.updates.length ? this.entry.body.updates : null
+        }
+    },
+    methods: {
+        includeValues (updateItem) {
+            if (!updateItem) {
+                return false
+            }
+            if (ALLOW_DETAILS.includes(updateItem.key)) {
+                return true
+            }
+            const regexTests = ALLOW_DETAILS.filter((allowDetail) => allowDetail instanceof RegExp)
+            return regexTests.some((regex) => regex.test(updateItem.key))
         }
     }
 }

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -48,21 +48,19 @@
     </template>
     <template v-else-if="entry.event === 'team.user.role-changed' || entry.event === 'user.roleChanged'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.user">The role for '{{ entry.body.user.name }}' has been changed <AuditEntryUpdates :updates="entry.body.updates" />.</span>
+        <span v-if="!error && entry.body?.user">The role for '{{ entry.body.user.name }}' has been changed.</span>
         <span v-else-if="!error">User data not found in audit entry.</span>
     </template>
 
     <!-- Team Settings Events -->
     <template v-else-if="entry.event === 'team.settings.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.updates">The following updates have been made to the team settings: <AuditEntryUpdates :updates="entry.body.updates" />.</span>
-        <span v-else-if="!error">Updates not found in audit entry.</span>
+        <span v-if="!error">Team settings have been changed.</span>
     </template>
 
     <!-- Team Type Events -->
     <template v-else-if="entry.event === 'team.type.changed'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <!-- <span v-if="!error && entry.body?.updates">The team type changed from '{{ entry.body.updates.typeName?.old || entry.body.updates.type.old }}' to '{{ entry.body.updates.typeName?.new || entry.body.updates.type.new }}'.</span> -->
         <span v-if="!error && entry.body?.info">The team type changed from '{{ entry.body.info.old.name }}' to '{{ entry.body.info.new.name }}'.</span>
         <span v-else-if="!error">Details not found in audit entry.</span>
     </template>
@@ -107,7 +105,7 @@
     </template>
     <template v-else-if="entry.event === 'team.device.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.device">Device '{{ entry.body.device?.name }}' has been updated with the following changes: <AuditEntryUpdates :updates="entry.body.updates" />.</span>
+        <span v-if="!error && entry.body?.device">Device '{{ entry.body.device?.name }}' has been updated.</span>
         <span v-else-if="!error">Device data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'team.device.assigned'">
@@ -134,7 +132,7 @@
     </template>
     <template v-else-if="entry.event === 'team.device.provisioning.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.info">Token name '{{ entry.body.info.tokenName }}' with ID '{{ entry.body.info.tokenId }}' has been updated with the following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
+        <span v-if="!error && entry.body?.info">Token name '{{ entry.body.info.tokenName }}' with ID '{{ entry.body.info.tokenId }}' has been updated.</span>
         <span v-else-if="!error">Provisioning data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'team.device.provisioning.deleted'">
@@ -254,7 +252,7 @@
     </template>
     <template v-else-if="entry.event === 'users.updated-user'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.user">User '{{ entry.body.user?.name }}' has been updated, with the following changes {{ entry.body.updates }}.</span>
+        <span v-if="!error && entry.body?.user">User '{{ entry.body.user?.name }}' has been updated.</span>
         <span v-else-if="!error">User data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'users.auto-created-team'">
@@ -309,7 +307,7 @@
     </template>
     <template v-else-if="entry.event === 'platform.project-type.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.projectType">Instance type '{{ entry.body.projectType }}' has been updated with the following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
+        <span v-if="!error && entry.body?.projectType">Instance type '{{ entry.body.projectType }}' has been updated.</span>
         <span v-else-if="!error">Instance Type data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'platform.stack.created'">
@@ -324,13 +322,12 @@
     </template>
     <template v-else-if="entry.event === 'platform.stack.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.stack">Node-RED Version '{{ entry.body.stack.name }}' has been updated with the following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
+        <span v-if="!error && entry.body?.stack">Node-RED Version '{{ entry.body.stack.name }}' has been updated.</span>
         <span v-else-if="!error">Node-RED Version data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'platform.settings.updated' || entry.event === 'platform.settings.update'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.updates">Platform settings have been updated with the following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
-        <span v-else-if="!error">Update data not found in audit entry.</span>
+        <span v-if="!error">Platform settings have been updated.</span>
     </template>
 
     <!-- Application Events -->
@@ -341,8 +338,7 @@
     </template>
     <template v-else-if="entry.event === 'application.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.updates">The following updates have been made to the Application: <AuditEntryUpdates :updates="entry.body.updates" />.</span>
-        <span v-else-if="!error">Updates not found in audit entry.</span>
+        <span v-if="!error">The Application has been updated.</span>
     </template>
     <template v-else-if="entry.event === 'application.deleted'">
         <label>{{ AuditEvents[entry.event] }}</label>
@@ -356,7 +352,7 @@
     </template>
     <template v-else-if="entry.event === 'application.pipeline.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.pipeline">DevOps Pipeline '{{ entry.body.pipeline?.name }}' was updated {{ entry.body.application ? `in Application '${entry.body.application.name}'` : '' }} with the following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
+        <span v-if="!error && entry.body?.pipeline">DevOps Pipeline '{{ entry.body.pipeline?.name }}' was updated {{ entry.body.application ? `in Application '${entry.body.application.name}'` : '' }}.</span>
         <span v-else-if="!error">Pipeline data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'application.pipeline.deleted'">
@@ -394,8 +390,7 @@
     </template>
     <template v-else-if="entry.event === 'application.device.snapshot.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body && entry.body.updates">Snapshot '{{ entry.body.snapshot?.name }}' of Application owned Device '{{ entry.body.device?.name }}' has been been updated has with following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
-        <span v-else-if="!error">Change data not found in audit entry.</span>
+        <span v-if="!error">Snapshot '{{ entry.body.snapshot?.name }}' of Application owned Device '{{ entry.body.device?.name }}' has been been updated</span>
     </template>
     <template v-else-if="entry.event === 'application.device.snapshot.deleted'">
         <label>{{ AuditEvents[entry.event] }}</label>
@@ -419,14 +414,14 @@
     </template>
     <template v-else-if="entry.event === 'device.settings.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.device">Device '{{ entry.body.device?.name }}' has had the following changes made to its settings: <AuditEntryUpdates :updates="entry.body.updates" /></span>
+        <span v-if="!error && entry.body?.device">Device '{{ entry.body.device?.name }}' has had changes made to its settings.</span>
         <span v-else-if="!error">Instance data not found in audit entry.</span>
     </template>
 
     <!-- Application Device Group Events -->
     <template v-else-if="entry.event === 'application.deviceGroup.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.deviceGroup">Device Group '{{ entry.body.deviceGroup?.name }}' was updated for Application '{{ entry.body.application?.name }}' with the following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
+        <span v-if="!error && entry.body?.deviceGroup">Device Group '{{ entry.body.deviceGroup?.name }}' was updated for Application '{{ entry.body.application?.name }}'.</span>
         <span v-else-if="!error">Device Group data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'application.deviceGroup.created'">
@@ -538,7 +533,7 @@
     </template>
     <template v-else-if="entry.event === 'project.settings.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.project">Instance '{{ entry.body.project?.name }}' has had the following changes made to its settings: <AuditEntryUpdates :updates="entry.body.updates" /></span>
+        <span v-if="!error && entry.body?.project">Instance '{{ entry.body.project?.name }}' has had changes made to its settings.</span>
         <span v-else-if="!error">Instance data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'project.snapshot.created'">
@@ -548,7 +543,7 @@
     </template>
     <template v-else-if="entry.event === 'project.snapshot.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body && entry.body.updates">Snapshot '{{ entry.body.snapshot?.name }}' of Instance '{{ entry.body.project?.name }}' has been been updated has with following changes: <AuditEntryUpdates :updates="entry.body.updates" /></span>
+        <span v-if="!error && entry.body">Snapshot '{{ entry.body.snapshot?.name }}' of Instance '{{ entry.body.project?.name }}' has been been updated.</span>
         <span v-else-if="!error">Change data not found in audit entry.</span>
     </template>
     <template v-else-if="entry.event === 'project.device.snapshot.created'">
@@ -587,7 +582,7 @@
     </template>
     <template v-else-if="entry.event === 'project.httpToken.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error">HTTP Bearer Token has been Updated <AuditEntryUpdates :updates="entry.body.updates" />.</span>
+        <span v-if="!error">HTTP Bearer Token has been updated.</span>
     </template>
     <template v-else-if="entry.event === 'project.httpToken.deleted'">
         <label>{{ AuditEvents[entry.event] }}</label>
@@ -665,8 +660,20 @@
                 <ChevronRightIcon class="ff-icon ff-icon-sm" />
                 Show Error
             </summary>
-            <span>
+            <span class="font-mono ml-3 whitespace-pre">
                 {{ entry.body }}
+                <ChevronDownIcon class="ff-icon ff-icon-sm" />
+            </span>
+        </details>
+    </template>
+    <template v-if="updates">
+        <details class="ff-audit-entry--error">
+            <summary>
+                <ChevronRightIcon class="ff-icon ff-icon-sm" />
+                Show Details
+            </summary>
+            <span class="font-mono ml-3 whitespace-pre">
+                <AuditEntryUpdates :entry="entry" />
                 <ChevronDownIcon class="ff-icon ff-icon-sm" />
             </span>
         </details>
@@ -691,6 +698,9 @@ export default {
     computed: {
         error: function () {
             return this.entry.body?.error !== undefined
+        },
+        updates: function () {
+            return this.entry.body?.updates && this.entry.body.updates.length ? this.entry.body.updates : null
         }
     },
     setup () {


### PR DESCRIPTION
closes #4071

## Description

As discussed in the issue, there are several places where audit log can be a bit too verbose. Rather than handling idividual cases it was suggested that details should be hidden by default and a "better default formatter" should be employed.

From this, the following has been implemented:

* Removes individual use of `AuditEntryUpdates` component and places it at the end
  * New autit log entries will no longer have to explicitly include this
* By default (unless old/new are BOOLS or explicitly a permitted "named" key (e.g. `name`, `type`, `enabled`, `version`) the OLD and NEW values are NOT shown.
  * This inhibits large values from things like description fields being rendered
  * This prevents env values being show
* There is scope for adjust the logic around what is NOT shown in the `AuditEntryUpdates` component as it now receives the full audit entry (e.g. there are now possibilities of inspecting the audit event name and explicitly hiding update details.)

Additionally, a monospaced font has been set and `whitespace-pre` on the details for updates AND errors has been further improve readability.

I have been through a whole bunch of audit log entries with updates and this PR provides a good balance of detail and readability. Future iterations can expand or reduce further based on explicit criteria.

### Screenshots of before and after 

~~As I cannot expect the reviewer to perform every action and check formatting I will update this PR with screenshots before witching out of draft.~~

![image](https://github.com/user-attachments/assets/1ad6bcd7-c11b-46dd-95ac-c8c4d81815e6)

![image](https://github.com/user-attachments/assets/ea9b6f81-40d1-4ec6-a651-a5a05cfdf97e)

![image](https://github.com/user-attachments/assets/bbbc0941-406f-439f-8893-7ffdd1a655c2)

![image](https://github.com/user-attachments/assets/83a08126-98de-4e7f-a17e-ee2fa158fae6)

![image](https://github.com/user-attachments/assets/94015372-eacf-4b3b-afda-e58e78c907ae)


#### Errors before and after
![image](https://github.com/user-attachments/assets/897b771a-43db-4b87-b489-9c76cf1bffba)


#### Overview before & after

![image](https://github.com/user-attachments/assets/96efb41d-f7df-40a0-98fe-8e7bb8dcb07d)

![image](https://github.com/user-attachments/assets/afb65f92-b056-4cfc-aabd-6a9e5dbc78a1)




## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

