### PR TITLE
Hide npmrc secrets from frontend

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -103,13 +103,19 @@ module.exports = async function (app) {
             delete project.settings?.palette?.catalogue
         } else {
             if (request.teamMembership.role < Roles.Owner || request.project.ProjectTemplate.policy.palette.npmrc === false) {
-                if (project.settings?.palette?.npmrc) {
+                if (project.settings?.palette?.npmrc !== undefined) {
                     let temp = project.settings.palette.npmrc
                     temp = temp.replace(/_authToken="?(.*)"?/g, '_authToken="xxxxxxx"')
                     temp = temp.replace(/_auth="?(.*)"?/g, '_auth="xxxxxxx"')
                     temp = temp.replace(/_password="?(.*)"?/, '_password="xxxxxxx"')
                     project.settings.palette.npmrc = temp
-                    // don't save so as not to update the database.
+                }
+                if (project.template.settings?.palette?.npmrc !== undefined) {
+                    let temp = project.template.settings.palette.npmrc
+                    temp = temp.replace(/_authToken="?(.*)"?/g, '_authToken="xxxxxxx"')
+                    temp = temp.replace(/_auth="?(.*)"?/g, '_auth="xxxxxxx"')
+                    temp = temp.replace(/_password="?(.*)"?/, '_password="xxxxxxx"')
+                    project.template.settings.palette.npmrc = temp
                 }
             }
         }

--- a/frontend/src/pages/admin/Template/sections/NPMRegistry.vue
+++ b/frontend/src/pages/admin/Template/sections/NPMRegistry.vue
@@ -24,7 +24,7 @@
                 <div v-else class="flex flex-col sm:flex-row">
                     <div class="space-y-4 w-full sm:mr-8">
                         <FormRow containerClass="none">
-                            <template #input><textarea v-model="obfuscated" :disabled="readOnly" class="font-mono w-full" placeholder=".npmrc" rows="8" /></template>
+                            <template #input><textarea v-model="editable.settings.palette_npmrc" :disabled="readOnly" class="font-mono w-full" placeholder=".npmrc" rows="8" /></template>
                         </FormRow>
                     </div>
                     <LockSetting v-model="editable.policy.palette_npmrc" :editTemplate="editTemplate" :changed="editable.changed.policy.palette_npmrc" />
@@ -97,14 +97,6 @@ export default {
                 return true
             }
             return SemVer.satisfies(SemVer.coerce(launcherVersion), '>=1.11.3')
-        },
-        obfuscated () {
-            if (this.editable.settings.palette_npmrc) {
-                const text = this.editable.settings.palette_npmrc.replace(/_authToken="?(.*)"?/g, '_authToken="xxxxxxx"')
-                return text
-            } else {
-                return ''
-            }
         }
     },
     watch: {

--- a/test/unit/forge/ee/routes/api/project_spec.js
+++ b/test/unit/forge/ee/routes/api/project_spec.js
@@ -128,8 +128,7 @@ describe('Projects API - with billing enabled', function () {
         })
     })
 })
-describe.only('npmrc values should be hidden from none owners', function () {
-
+describe('npmrc values should be hidden from none owners', function () {
     const TestObjects = {}
 
     let app
@@ -146,8 +145,7 @@ describe.only('npmrc values should be hidden from none owners', function () {
         TestObjects.tokens[username] = response.cookies[0].value
     }
 
-    before( async function () {
-
+    before(async function () {
         app = await setup()
         sandbox.stub(app.billing, 'addProject')
         sandbox.stub(app.billing, 'removeProject')
@@ -233,7 +231,7 @@ describe.only('npmrc values should be hidden from none owners', function () {
         TestObjects.lockedInstance = lockedInstance
     })
 
-    after( async function () {
+    after(async function () {
         await app.close()
     })
 

--- a/test/unit/forge/ee/routes/api/project_spec.js
+++ b/test/unit/forge/ee/routes/api/project_spec.js
@@ -9,6 +9,8 @@ const FF_UTIL = require('flowforge-test-utils')
 
 const { START_DELAY, STOP_DELAY } = FF_UTIL.require('forge/containers/stub/index.js')
 
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
 describe('Projects API - with billing enabled', function () {
     const sandbox = sinon.createSandbox()
 
@@ -124,5 +126,145 @@ describe('Projects API - with billing enabled', function () {
                 should.equal(app.billing.addProject.calledOnce, true)
             })
         })
+    })
+})
+describe.only('npmrc values should be hidden from none owners', function () {
+
+    const TestObjects = {}
+
+    let app
+    const sandbox = sinon.createSandbox()
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    before( async function () {
+
+        app = await setup()
+        sandbox.stub(app.billing, 'addProject')
+        sandbox.stub(app.billing, 'removeProject')
+
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
+
+        // ATeam create in setup()
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+
+        TestObjects.ApplicationA = app.application
+
+        await TestObjects.ATeam.addUser(TestObjects.bob, { through: { role: Roles.Member } })
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+        await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+
+        // TestObjects.tokens.alice = (await app.db.controllers.AccessToken.createTokenForPasswordReset(TestObjects.alice)).token
+        TestObjects.tokens.project = (await app.project.refreshAuthTokens()).token
+
+        TestObjects.projectType1 = app.projectType
+        TestObjects.stack1 = app.stack
+
+        const props = TestObjects.ATeam.TeamType.properties
+        props.features.customCatalogs = true
+        TestObjects.ATeam.TeamType.properties = props
+        await TestObjects.ATeam.TeamType.save()
+
+        const unlockedTemplate = await app.factory.createProjectTemplate(
+            {
+                name: 'startTemplate',
+                settings: {
+                    palette: {
+                        catalogue: ['https://www.first.com'],
+                        npmrc: '//_authToken=token'
+                    }
+                },
+                policy: {
+                    palette: {
+                        npmrc: true
+                    }
+                }
+            },
+            app.user
+        )
+        const lockedTemplate = await app.factory.createProjectTemplate(
+            {
+                name: 'endTemplate',
+                settings: {
+                    palette: {
+                        catalogue: ['https://www.second.com', 'https://third.com'],
+                        npmrc: '//_authToken=token'
+                    }
+                },
+                policy: {
+                    palette: {
+                        npmrc: false
+                    }
+                }
+            },
+            app.user
+        )
+        const unlockedInstance = await app.factory.createInstance(
+            { name: 'unlocked' },
+            TestObjects.ApplicationA,
+            TestObjects.stack,
+            unlockedTemplate,
+            TestObjects.projectType,
+            { start: true }
+        )
+        TestObjects.unlockedInstance = unlockedInstance
+        const lockedInstance = await app.factory.createInstance(
+            { name: 'locked' },
+            TestObjects.ApplicationA,
+            TestObjects.stack,
+            lockedTemplate,
+            TestObjects.projectType,
+            { start: true }
+        )
+        TestObjects.lockedInstance = lockedInstance
+    })
+
+    after( async function () {
+        await app.close()
+    })
+
+    it('npmrc should be shown to owner if unlocked', async function () {
+        const response = await app.inject({
+            method: 'GET',
+            url: `/api/v1/projects/${TestObjects.unlockedInstance.id}`,
+            cookies: { sid: TestObjects.tokens.alice }
+        })
+        response.statusCode.should.equal(200)
+        const body = response.json()
+        body.template.settings.palette.npmrc.should.equal('//_authToken=token')
+    })
+    it('npmrc should be hidden from owner if locked', async function () {
+        const response = await app.inject({
+            method: 'GET',
+            url: `/api/v1/projects/${TestObjects.lockedInstance.id}`,
+            cookies: { sid: TestObjects.tokens.alice }
+        })
+        response.statusCode.should.equal(200)
+        const body = response.json()
+        body.template.settings.palette.npmrc.should.equal('//_authToken="xxxxxxx"')
+    })
+    it('npmrc should be hidden from member', async function () {
+        const response = await app.inject({
+            method: 'GET',
+            url: `/api/v1/projects/${TestObjects.unlockedInstance.id}`,
+            cookies: { sid: TestObjects.tokens.bob }
+        })
+        response.statusCode.should.equal(200)
+        const body = response.json()
+        body.template.settings.palette.npmrc.should.equal('//_authToken="xxxxxxx"')
     })
 })


### PR DESCRIPTION
fixes FlowFuse/security#96

## Description

<!-- Describe your changes in detail -->
Prevents npmrc secrets being sent to the browser

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/security#96

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

