### PR TITLE
Only clear PH data if there is user session to clear

### DIFF
--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -255,7 +255,10 @@ const actions = {
         } catch (err) {
             // Not logged in
             commit('clearPending')
-            window.posthog?.reset()
+            // do we have a user session to clear?
+            if (state.user) {
+                window.posthog?.reset()
+            }
 
             if (router.currentRoute.value.meta.requiresLogin !== false) {
                 if (router.currentRoute.value.path !== '/') {


### PR DESCRIPTION
## Description

- We cleared PH cookies if a user times out
- However, this had the effect that anonymous users (signing up for the first time for example) were having ID's reset mis sign up, and we lost conversion data
- Now, we check if we have any known `state.user` before clearing the cookies on an unauthenticated request.

## Related Issue(s)

Closes #4326 