### PR TITLE
Fix incorrect status codes in tests

### DIFF
--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -66,7 +66,6 @@ describe('Team Devices API', function () {
         await login('bob', 'bbPassword')
         await login('chris', 'ccPassword')
         await login('dave', 'ddPassword')
-
     })
 
     async function login (username, password) {

--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -64,6 +64,9 @@ describe('Team Devices API', function () {
         TestObjects.tokens = {}
         await login('alice', 'aaPassword')
         await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+        await login('dave', 'ddPassword')
+
     })
 
     async function login (username, password) {
@@ -351,7 +354,7 @@ describe('Team Devices API', function () {
                             devices: [aTeamDevices.device1.hashid]
                         }
                     })
-                    response.statusCode.should.equal(401)
+                    response.statusCode.should.equal(403)
                     const result = response.json()
                     result.should.have.property('code', 'unauthorized')
                     result.should.have.property('error', 'unauthorized')
@@ -460,7 +463,7 @@ describe('Team Devices API', function () {
                 url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices/provisioning`,
                 cookies: { sid: TestObjects.tokens.chris }
             })
-            response.statusCode.should.equal(401)
+            response.statusCode.should.equal(403)
             const result = response.json()
             result.should.have.property('code', 'unauthorized')
             result.should.have.property('error', 'unauthorized')
@@ -531,7 +534,7 @@ describe('Team Devices API', function () {
                     instance: TestObjects.Project1.id
                 }
             })
-            response.statusCode.should.equal(401)
+            response.statusCode.should.equal(403)
             const result = response.json()
             result.should.have.property('code', 'unauthorized')
             result.should.have.property('error', 'unauthorized')
@@ -599,7 +602,7 @@ describe('Team Devices API', function () {
                     instance: null
                 }
             })
-            response.statusCode.should.equal(401)
+            response.statusCode.should.equal(403)
             const result = response.json()
             result.should.have.property('code', 'unauthorized')
             result.should.have.property('error', 'unauthorized')
@@ -671,7 +674,7 @@ describe('Team Devices API', function () {
                 url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices/provisioning/${TestObjects.provisioningTokens.token1.id}`,
                 cookies: { sid: TestObjects.tokens.chris }
             })
-            response.statusCode.should.equal(401)
+            response.statusCode.should.equal(403)
             const result = response.json()
             result.should.have.property('code', 'unauthorized')
             result.should.have.property('error', 'unauthorized')


### PR DESCRIPTION
Quick test fix up on issue found while working in these tests.

Operationally, the API code is doing the right thing but the tests were passing with a `401` instead of a `403` because the user was not logged in in the test
