### PR TITLE
4249 application device kebab menu not clearing devices

### DIFF
--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -106,7 +106,7 @@ module.exports = {
                     if (includeApplicationDevices) {
                         const include = {
                             model: M.Device,
-                            attributes: ['hashid', 'id', 'name', 'links', 'state', 'mode', 'updatedAt', 'lastSeenAt', 'editorConnected', 'editorToken']
+                            attributes: ['hashid', 'id', 'name', 'links', 'state', 'mode', 'updatedAt', 'lastSeenAt', 'editorConnected', 'editorToken', 'ownerType', 'ProjectId', 'ApplicationId']
                         }
 
                         if (associationsLimit) {

--- a/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
@@ -22,16 +22,10 @@
                     @click.stop="$emit('device-action',{action: 'edit', id: device.id})"
                 />
                 <ff-list-item
-                    v-if="device.ownerType === 'application' && (displayingTeam || displayingApplication)"
+                    v-if="(displayingTeam || displayingApplication)"
                     label="Remove from Application"
                     data-action="device-remove-from-application"
                     @click.stop="$emit('device-action',{action: 'removeFromApplication', id: device.id})"
-                />
-                <ff-list-item
-                    v-else-if="device.ownerType === 'instance' && (displayingTeam || displayingInstance)"
-                    label="Remove from Instance"
-                    data-action="device-remove-from-instance"
-                    @click.stop="$emit('device-action',{action: 'removeFromProject', id: device.id})"
                 />
                 <ff-list-item
                     kind="danger"

--- a/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
@@ -20,7 +20,7 @@
         </label>
         <div class="items-wrapper" :class="{one: singleDevice, two: twoDevices, three: threeDevices}">
             <div
-                v-for="device in devices"
+                v-for="device in visibleDevices"
                 :key="device.id"
                 class="item-wrapper"
             >
@@ -93,16 +93,21 @@ export default {
         }
     },
     emits: ['delete-device'],
+    data () {
+        return {
+            devices: this.application.devices
+        }
+    },
     computed: {
         hasMoreDevices () {
-            return this.application.deviceCount > this.devices.length
+            return this.application.deviceCount > this.visibleDevices.length
         },
         hasNoDevices () {
             return this.devices.length === 0
         },
         remainingDevices () {
             if (this.hasNoDevices || this.hasMoreDevices) {
-                return this.application.deviceCount - this.devices.length
+                return this.application.deviceCount - this.visibleDevices.length
             } else return 0
         },
         singleDevice () {
@@ -114,8 +119,8 @@ export default {
         threeDevices () {
             return this.application.deviceCount === 3
         },
-        devices () {
-            return this.application.devices.slice(0, 3)
+        visibleDevices () {
+            return this.devices.slice(0, 3)
         },
         isSearching () {
             return this.searchQuery.length > 0

--- a/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
@@ -126,6 +126,11 @@ export default {
             return this.searchQuery.length > 0
         }
     },
+    watch: {
+        'application.devices' (devices) {
+            this.devices = devices
+        }
+    },
     mounted () {
         this.fetchAllDeviceStatuses()
     },

--- a/test/e2e/frontend/cypress/tests/applications/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/overview.spec.js
@@ -1149,7 +1149,7 @@ describe('FlowForge - Applications', () => {
             })
         })
 
-        describe('device kebab menu', () => {
+        describe.only('device kebab menu', () => {
             const MENU_ITEMS = [
                 {
                     index: 0,
@@ -1157,24 +1157,21 @@ describe('FlowForge - Applications', () => {
                     dialogTitle: 'Update Device',
                     dialogDataEl: 'team-device-create-dialog'
                 },
-                // This item will be enabled once #4249 is resolved
-                // {
-                //     index: 1,
-                //     label: 'Remove From Application',
-                //     dialogTitle: 'Remove Device from Application',
-                //     dialogDataEl: 'platform-dialog'
-                // },
                 {
-                    // index: 2, // This item will be `2` once #4249 is resolved
                     index: 1,
+                    label: 'Remove from Application',
+                    dialogTitle: 'Remove Device from Application',
+                    dialogDataEl: 'platform-dialog'
+                },
+                {
+                    index: 2,
                     label: 'Regenerate Configuration',
                     dialogTitle: 'Device Configuration',
                     dialogDataEl: 'team-device-config-dialog',
                     dialogCancelButtonSelector: '.ff-dialog-actions > button.ff-btn--secondary'
                 },
                 {
-                    // index: 3, // This item will be `3` once #4249 is resolved
-                    index: 2,
+                    index: 3,
                     label: 'Delete Device',
                     dialogTitle: 'Delete Device',
                     dialogDataEl: 'platform-dialog'

--- a/test/e2e/frontend/cypress/tests/applications/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/overview.spec.js
@@ -1149,7 +1149,7 @@ describe('FlowForge - Applications', () => {
             })
         })
 
-        describe.only('device kebab menu', () => {
+        describe('device kebab menu', () => {
             const MENU_ITEMS = [
                 {
                     index: 0,


### PR DESCRIPTION
## Description

- exposed the device.ownerType on the applications view to correctly render the kebab menu
- addressed array/map discrepancy while also fixing the deviceWrapper component & deviceMixin incompatibility in which the mixin was trying to manipulate a computed prop on the deviceWrapper

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4249

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

