### PR TITLE
Add option to require contact via HS form for create/upgrade of team type

### DIFF
--- a/frontend/src/api/billing.js
+++ b/frontend/src/api/billing.js
@@ -39,10 +39,49 @@ const setTrialExpiry = async (teamId, trialEndsAt) => {
     })
 }
 
+const sendTeamTypeContact = async (user, teamType, pageName) => {
+    const hsPortalId = teamType.properties?.billing?.contactHSPortalId
+    const hsFormId = teamType.properties?.billing?.contactHSFormId
+    if (hsPortalId && hsFormId) {
+        return new Promise((resolve, reject) => {
+            const url = `https://api.hsforms.com/submissions/v3/integration/submit/${hsPortalId}/${hsFormId}`
+            const xhr = new XMLHttpRequest()
+            xhr.open('POST', url)
+            xhr.setRequestHeader('Content-Type', 'application/json')
+            const body = JSON.stringify({
+                submittedAt: '' + Date.now(),
+                fields: [{
+                    objectTypeId: '0-1',
+                    name: 'email',
+                    value: user.email
+                }],
+                context: {
+                    pageUri: window.location.href,
+                    pageName
+                }
+            })
+            xhr.onreadystatechange = () => {
+                if (xhr.readyState === 4) {
+                    switch (xhr.status) {
+                    case 200:
+                        resolve()
+                        break
+                    default:
+                        reject(xhr.responseText)
+                        break
+                    }
+                }
+            }
+            xhr.send(body)
+        })
+    }
+}
+
 export default {
     toCustomerPortal,
     getSubscriptionInfo,
     createSubscription,
     setupManualBilling,
-    setTrialExpiry
+    setTrialExpiry,
+    sendTeamTypeContact
 }

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -21,6 +21,14 @@
                 </FormRow>
                 <template v-if="billingEnabled">
                     <FormHeading>Billing</FormHeading>
+                    <div class="space-y-2">
+                        <FormRow v-model="input.properties.billing.requireContact" type="checkbox" class="mb-4">Require contact to upgrade</FormRow>
+                        <div v-if="input.properties.billing.requireContact" class="grid gap-2 grid-cols-2 pl-4">
+                            <FormRow v-model="input.properties.billing.contactHSPortalId" :type="editDisabled?'uneditable':''">HubSpot Portal Id</FormRow>
+                            <FormRow v-model="input.properties.billing.contactHSFormId" :type="editDisabled?'uneditable':''">HubSpot Form Id</FormRow>
+                        </div>
+                    </div>
+
                     <div class="grid gap-2 grid-cols-3">
                         <FormRow v-model="input.properties.billing.productId" :type="editDisabled?'uneditable':''">Product Id</FormRow>
                         <FormRow v-model="input.properties.billing.priceId" :type="editDisabled?'uneditable':''">Price Id</FormRow>
@@ -330,6 +338,10 @@ export default {
                         }
                     } else {
                         opts.properties.trial = { active: false }
+                    }
+                    if (!opts.properties.billing.requireContact) {
+                        delete opts.properties.billing.contactHSPortalId
+                        delete opts.properties.billing.contactHSFormId
                     }
                 }
                 formatNumber(opts.properties.features, 'fileStorageLimit')


### PR DESCRIPTION
Closes #4317 

Adds option on TeamType configuration to require users contact us, rather than allow self-service creation/upgrade to that type.


### TeamType config

If the Require contact to upgrade option is selected, hubspot portal/form ids can be provided.

<img width="579" alt="image" src="https://github.com/user-attachments/assets/ead68627-fb83-454d-908a-1f0bfc5f608e">

### UX

When creating a new team, or changing an existing team type, if they select a type that has been configured to require contact, they are shown this:

<img width="885" alt="image" src="https://github.com/user-attachments/assets/913309a1-f59c-49e2-8941-ed0532b1f9ab">


This *only* applies to non-admin users. If the user is an admin, then can select the type and create the team 'normally'.

### Hubspot

When clicking the 'contact sales' button, the configured hubspot form is submitted with the user's email and the details of the page they are on. The HS form can be then configured to trigger whatever business process is required.

I have created a suitable form in HS already called 'Enterprise Upgrade Request'.