### PR TITLE
Add explicit PH event for verification

### DIFF
--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -19,6 +19,7 @@ const verifyMFAToken = (token) => {
     return client.post('/account/login/token', {
         token
     }).then((res) => {
+        product.capture('$ff-user-verified')
         return res.data
     })
 }


### PR DESCRIPTION
## Description

- If a user presses `<enter>` on the verification code, it's very difficult to reliably track that in PH as we have no unique form identifier, or unique URL for the verification form.
- The other challenge with relying on the autocapture events is that even if an incorrect code is submitted, we still register the click as a successful "verify"
- A cleaner way to handle this is have an explicit event called when the API responds successfully, which this PR adds