### PR TITLE
Allow users to delete accounts even when they have active teams

### DIFF
--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -101,11 +101,31 @@ module.exports = {
                 const teams = await app.db.models.Team.forUser(user)
                 for (const team of teams) {
                     const owners = await team.Team.getOwners()
+                    // const teamMemberCount = await team.Team.memberCount()
+
                     const isOwner = owners.find((owner) => owner.id === user.id)
 
-                    // if this user is the only owner of this team, throw an error
                     if (isOwner && owners.length <= 1) {
-                        throw new Error('Cannot delete the last owner of a team')
+                        const instanceCount = await team.Team.instanceCount()
+                        const deviceCount = await team.Team.deviceCount()
+                        const members = await team.Team.memberCount()
+
+                        // throw error if the team has other members assigned to it
+                        if (members > 1) {
+                            throw new Error(`Team ${team.Team.name} which is being deleted alongside your account still has users in it.`)
+                        }
+
+                        // throw error if the team has remaining instances assigned to it
+                        if (instanceCount > 0) {
+                            throw new Error(`Team ${team.Team.name} which is being deleted alongside your account still has instances assigned to it.`)
+                        }
+
+                        // throw error if the team has remaining devices assigned to it
+                        if (deviceCount > 0) {
+                            throw new Error(`Team ${team.Team.name} which is being deleted alongside your account still has devices assigned to it.`)
+                        }
+
+                        await team.Team.destroy()
                     }
                 }
 

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -134,7 +134,9 @@ module.exports = {
                 }
 
                 // delete remaining owned teams
-                teamOwnerships.forEach(team => team.Team.destroy())
+                for (const ownedTeam of teamOwnerships) {
+                    await ownedTeam.destroy()
+                }
 
                 // Need to do this in beforeDestroy as the Session.UserId field
                 // is set to NULL when user is deleted.

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -100,7 +100,7 @@ module.exports = {
                 // throw an error if we would orphan any teams
                 const teams = await app.db.models.Team.forUser(user)
                 const teamBlockers = []
-                const teamOwnerships = []
+                const ownedTeams = []
                 for (const team of teams) {
                     const owners = await team.Team.getOwners()
                     const isOwner = owners.find((owner) => owner.id === user.id)
@@ -110,7 +110,7 @@ module.exports = {
                         const deviceCount = await team.Team.deviceCount()
                         const members = await team.Team.memberCount()
 
-                        teamOwnerships.push(team)
+                        ownedTeams.push(team)
 
                         // throw error if the team has other members assigned to it
                         if (members > 1) {
@@ -134,7 +134,7 @@ module.exports = {
                 }
 
                 // delete remaining owned teams
-                for (const ownedTeam of teamOwnerships) {
+                for (const ownedTeam of ownedTeams) {
                     await ownedTeam.destroy()
                 }
 

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -790,7 +790,7 @@ describe('User API', async function () {
         })
         it('Last owner of a team cannot delete own account when the team has devices present', async function () {
             const amidala = await app.db.models.User.create({ username: 'amidala', name: 'Padme Amidala', email: 'amidala@example.com', email_verified: true, password: 'paPassword', admin: false, sso_enabled: false })
-            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam', TeamTypeId: app.defaultTeamType.id })
+            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam2', TeamTypeId: app.defaultTeamType.id })
 
             await nabooTeam.addUser(amidala, { through: { role: Roles.Owner } })
 
@@ -801,10 +801,7 @@ describe('User API', async function () {
             // we create a device so Padme won't be able to delete her account
             await app.factory.createDevice(
                 {
-                    name: 'unnamed-devisasdce',
-                    type: 'unnasdamed-type',
-                    credentialSecret: 'zxc',
-                    agentVersion: '1.11.0asd'
+                    name: 'some-device'
                 },
                 nabooTeam,
                 null,
@@ -819,7 +816,7 @@ describe('User API', async function () {
             })
             response.statusCode.should.equal(400)
             const json = response.json()
-            json.should.have.property('error', 'Error: Team nabooTeam which is being deleted alongside your account still has devices assigned to it.')
+            json.should.have.property('error', 'Error: Team nabooTeam2 which is being deleted alongside your account still has devices assigned to it.')
         })
         it('Non admin user who is a team member can delete own account', async function () {
             await login('grace', 'ggPassword')
@@ -841,13 +838,13 @@ describe('User API', async function () {
         })
         it('Team owner can delete own account if no other members, instances or devices exist', async function () {
             const amidala = await app.db.models.User.create({ username: 'amidala', name: 'Padme Amidala', email: 'amidala@example.com', email_verified: true, password: 'paPassword', admin: false, sso_enabled: false })
-            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam', TeamTypeId: app.defaultTeamType.id })
+            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam3', TeamTypeId: app.defaultTeamType.id })
 
             await nabooTeam.addUser(amidala, { through: { role: Roles.Owner } })
 
             await login('amidala', 'paPassword')
 
-            await app.factory.createApplication({ name: 'senate-app' }, nabooTeam)
+            await app.factory.createApplication({ name: 'senate-app-2' }, nabooTeam)
 
             // Padme now attempts to delete own account: should fail as she still has instances attached to her team
             const response = await app.inject({

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -846,7 +846,7 @@ describe('User API', async function () {
 
             await app.factory.createApplication({ name: 'senate-app-2' }, nabooTeam)
 
-            // Padme now attempts to delete own account: should fail as she still has instances attached to her team
+            // Padme now attempts to delete own account: should succeed even though it has instances attached to the team
             const response = await app.inject({
                 method: 'DELETE',
                 url: '/api/v1/user',

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -808,7 +808,7 @@ describe('User API', async function () {
                 nabooTeamApplication
             )
 
-            // frank now attempts to delete own account: should fail as frank is the last owner of team B
+            // Padme now attempts to delete own account: should fail as owned team has devices attached
             const response = await app.inject({
                 method: 'DELETE',
                 url: '/api/v1/user',

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -19,6 +19,10 @@ describe('User API', async function () {
         TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam', TeamTypeId: app.defaultTeamType.id })
         TestObjects.Project1 = app.project
         TestObjects.tokens = {}
+        TestObjects.application = app.application
+        TestObjects.stack = app.stack
+        TestObjects.projectType = app.projectType
+        TestObjects.template = app.template
         await setupUsers()
     }
     async function setupUsers () {
@@ -740,7 +744,7 @@ describe('User API', async function () {
             const json = response.json()
             json.should.have.property('error', 'Error: Cannot delete the last platform administrator')
         })
-        it('Last owner of a team cannot delete own account', async function () {
+        it('Last owner of a team cannot delete own account when the team has other members present', async function () {
             await login('frank', 'ffPassword')
             // delete bob so that grace becomes the remaining owner of team B
             await TestObjects.bob.destroy()
@@ -753,7 +757,69 @@ describe('User API', async function () {
             })
             response.statusCode.should.equal(400)
             const json = response.json()
-            json.should.have.property('error', 'Error: Cannot delete the last owner of a team')
+            json.should.have.property('error', 'Error: Team BTeam which is being deleted alongside your account still has users in it.')
+        })
+        it('Last owner of a team cannot delete own account when the team has instances present', async function () {
+            const amidala = await app.db.models.User.create({ username: 'amidala', name: 'Padme Amidala', email: 'amidala@example.com', email_verified: true, password: 'paPassword', admin: false, sso_enabled: false })
+            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam', TeamTypeId: app.defaultTeamType.id })
+
+            await nabooTeam.addUser(amidala, { through: { role: Roles.Owner } })
+
+            await login('amidala', 'paPassword')
+
+            const nabooTeamApplication = await app.factory.createApplication({ name: 'senate-app' }, nabooTeam)
+
+            // we create an instance so Padme won't be able to delete her account
+            await app.factory.createInstance(
+                { name: 'instance' },
+                nabooTeamApplication,
+                TestObjects.stack,
+                TestObjects.template,
+                TestObjects.projectType
+            )
+
+            // Padme now attempts to delete own account: should fail as she still has instances attached to her team
+            const response = await app.inject({
+                method: 'DELETE',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.amidala }
+            })
+            response.statusCode.should.equal(400)
+            const json = response.json()
+            json.should.have.property('error', 'Error: Team nabooTeam which is being deleted alongside your account still has instances assigned to it.')
+        })
+        it('Last owner of a team cannot delete own account when the team has devices present', async function () {
+            const amidala = await app.db.models.User.create({ username: 'amidala', name: 'Padme Amidala', email: 'amidala@example.com', email_verified: true, password: 'paPassword', admin: false, sso_enabled: false })
+            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam', TeamTypeId: app.defaultTeamType.id })
+
+            await nabooTeam.addUser(amidala, { through: { role: Roles.Owner } })
+
+            await login('amidala', 'paPassword')
+
+            const nabooTeamApplication = await app.factory.createApplication({ name: 'senate-app' }, nabooTeam)
+
+            // we create a device so Padme won't be able to delete her account
+            await app.factory.createDevice(
+                {
+                    name: 'unnamed-devisasdce',
+                    type: 'unnasdamed-type',
+                    credentialSecret: 'zxc',
+                    agentVersion: '1.11.0asd'
+                },
+                nabooTeam,
+                null,
+                nabooTeamApplication
+            )
+
+            // frank now attempts to delete own account: should fail as frank is the last owner of team B
+            const response = await app.inject({
+                method: 'DELETE',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.amidala }
+            })
+            response.statusCode.should.equal(400)
+            const json = response.json()
+            json.should.have.property('error', 'Error: Team nabooTeam which is being deleted alongside your account still has devices assigned to it.')
         })
         it('Non admin user who is a team member can delete own account', async function () {
             await login('grace', 'ggPassword')
@@ -770,6 +836,24 @@ describe('User API', async function () {
                 method: 'DELETE',
                 url: '/api/v1/user',
                 cookies: { sid: TestObjects.tokens.grace }
+            })
+            response.statusCode.should.equal(200)
+        })
+        it('Team owner can delete own account if no other members, instances or devices exist', async function () {
+            const amidala = await app.db.models.User.create({ username: 'amidala', name: 'Padme Amidala', email: 'amidala@example.com', email_verified: true, password: 'paPassword', admin: false, sso_enabled: false })
+            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam', TeamTypeId: app.defaultTeamType.id })
+
+            await nabooTeam.addUser(amidala, { through: { role: Roles.Owner } })
+
+            await login('amidala', 'paPassword')
+
+            await app.factory.createApplication({ name: 'senate-app' }, nabooTeam)
+
+            // Padme now attempts to delete own account: should fail as she still has instances attached to her team
+            const response = await app.inject({
+                method: 'DELETE',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.amidala }
             })
             response.statusCode.should.equal(200)
         })


### PR DESCRIPTION
## Description

Allows users to delete their account if they have teams they are owner of.
Users are still prevented from deleting their accounts if the owner team has members, instances or devices assigned to it.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4292

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

