### PR TITLE
Ensure personal instance is created in personal team on signup

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -510,35 +510,30 @@ async function init (app, opts) {
             tags: ['Authentication', 'X-HIDDEN']
         }
     }, async (request, reply) => {
+        let sessionUser
+        if (request.sid) {
+            request.session = await app.db.controllers.Session.getOrExpire(request.sid)
+            sessionUser = request.session?.User
+        }
+        let verifiedUser
         try {
-            let sessionUser
-            if (request.sid) {
-                request.session = await app.db.controllers.Session.getOrExpire(request.sid)
-                sessionUser = request.session?.User
-            }
-            let verifiedUser
-            try {
-                verifiedUser = await app.db.controllers.User.verifyEmailToken(sessionUser, request.body.token)
-            } catch (err) {
-                const resp = { code: 'invalid_request', error: err.toString() }
-                await app.auditLog.User.account.verify.verifyToken(request.session?.User, resp)
-                reply.code(400).send(resp)
-                return
-            }
-
-            await completeUserSignup(app, verifiedUser)
-            reply.send({ status: 'okay' })
+            verifiedUser = await app.db.controllers.User.verifyEmailToken(sessionUser, request.body.token)
+            await app.auditLog.User.account.verify.verifyToken(verifiedUser, null)
         } catch (err) {
-            if (err.message === 'team_limit_reached') {
-                const resp = { code: 'team_limit_reached', error: 'Unable to auto create user team: license limit reached' }
-                reply.code(400).send(resp)
-                return
-            }
-            app.log.error(`/account/verify/token error - ${err.toString()}`)
-            const resp = { code: 'unexpected_error', error: err.toString() }
+            const resp = { code: 'invalid_request', error: err.toString() }
             await app.auditLog.User.account.verify.verifyToken(request.session?.User, resp)
             reply.code(400).send(resp)
+            return
         }
+        try {
+            await completeUserSignup(app, verifiedUser)
+        } catch (err) {
+            // At this point, the user is verified. So we need to respond with success.
+            // However, an error was hit whilst completing their post-signup tasks.
+            await app.auditLog.User.account.verify.verifyToken(sessionUser, { error: err.toString() })
+            app.log.error(`/account/verify/token error - ${err.toString()}`)
+        }
+        reply.send({ status: 'okay' })
     })
 
     /**

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -49,6 +49,7 @@ describe('Accounts API', async function () {
             app.settings.set('user:signup', false)
             app.settings.set('team:user:invite:external', false)
             app.settings.set('user:team:auto-create', false)
+            app.settings.set('team:user:invite:external', false)
         })
 
         async function expectRejection (opts, reason) {
@@ -424,6 +425,157 @@ describe('Accounts API', async function () {
 
                 application.Instances.length.should.equal(1)
                 application.Instances[0].safeName.should.match(/team-pez-cuckow-user5-(\w)+/)
+
+                // cleanup else this becomes the new default and breaks other tests
+                newTeamType.active = false
+                await newTeamType.save()
+                app.settings.set('user:team:auto-create:teamType', null)
+            })
+
+            it('Creates instance in personal team when invites to other teams present', async function () {
+                app.settings.set('user:signup', true)
+                app.settings.set('user:team:auto-create', true)
+                app.settings.set('user:team:auto-create:instanceType', app.projectType.hashid)
+                app.settings.set('team:user:invite:external', true)
+
+                // Allow this new project type to be used by the new team type
+                const teamTypeProperties = { instances: {} }
+                teamTypeProperties.instances[app.projectType.hashid] = {
+                    active: true,
+                    limit: 2,
+                    free: 2
+                }
+                const newTeamType = await app.db.models.TeamType.create({
+                    name: 'new-starter-test-1',
+                    properties: teamTypeProperties
+                })
+                app.settings.set('user:team:auto-create:teamType', newTeamType.hashid)
+
+                // Create existing team
+                const existingTeam = await app.factory.createTeam({ name: 'ExistingTeam' })
+                await existingTeam.addUser(app.adminUser, { through: { role: app.factory.Roles.Roles.Owner } })
+                // Alice invite External User to ExistingTeam
+                await login('alice', 'aaPassword')
+                const inviteResponse = await app.inject({
+                    method: 'POST',
+                    url: `/api/v1/teams/${existingTeam.hashid}/invitations`,
+                    cookies: { sid: TestObjects.tokens.alice },
+                    payload: {
+                        user: 'user6@example.com',
+                        role: app.factory.Roles.Roles.Owner
+                    }
+                })
+                const result = inviteResponse.json()
+                result.should.have.property('status', 'okay')
+
+                const response = await registerUser({
+                    username: 'user6',
+                    password: '12345678',
+                    name: 'Pez Cuckow',
+                    email: 'user6@example.com'
+                })
+                response.statusCode.should.equal(200)
+
+                // Process only runs after email verification
+                const user = await app.db.models.User.findOne({ where: { username: 'user6' } })
+                const verificationToken = await app.db.controllers.User.generateEmailVerificationToken(user)
+                const verifyResponse = await app.inject({
+                    method: 'POST',
+                    url: '/account/verify/token',
+                    payload: {
+                        token: verificationToken.token
+                    },
+                    cookies: { sid: TestObjects.tokens.user6 }
+                })
+                verifyResponse.statusCode.should.equal(200)
+
+                const teams = await app.db.models.Team.forUser(user)
+                // User is member of both personal & invited team
+                teams.should.have.length(2)
+
+                // Find the personal team
+                const userTeam = teams.find(t => t.TeamId !== existingTeam.id).Team
+
+                // Verify the resources were created in that team and not the existing team
+                const applications = await app.db.models.Application.byTeam(userTeam.id, { includeInstances: true })
+                applications.length.should.equal(1)
+
+                const application = applications[0]
+                application.name.should.match('Pez Cuckow\'s Application')
+
+                application.Instances.length.should.equal(1)
+                application.Instances[0].safeName.should.match(/team-pez-cuckow-user6-(\w)+/)
+
+                // cleanup else this becomes the new default and breaks other tests
+                newTeamType.active = false
+                await newTeamType.save()
+                app.settings.set('user:team:auto-create:teamType', null)
+            })
+
+            it('Skips creating instance in personal team when invited to other team with instance', async function () {
+                app.settings.set('user:signup', true)
+                app.settings.set('user:team:auto-create', true)
+                app.settings.set('user:team:auto-create:instanceType', app.projectType.hashid)
+                app.settings.set('team:user:invite:external', true)
+
+                // Allow this new project type to be used by the new team type
+                const teamTypeProperties = { instances: {} }
+                teamTypeProperties.instances[app.projectType.hashid] = {
+                    active: true,
+                    limit: 2,
+                    free: 2
+                }
+                const newTeamType = await app.db.models.TeamType.create({
+                    name: 'new-starter-test-2',
+                    properties: teamTypeProperties
+                })
+                app.settings.set('user:team:auto-create:teamType', newTeamType.hashid)
+
+                // Alice invite External User to ATeam - that already has instances
+                await login('alice', 'aaPassword')
+                const inviteResponse = await app.inject({
+                    method: 'POST',
+                    url: `/api/v1/teams/${app.team.hashid}/invitations`,
+                    cookies: { sid: TestObjects.tokens.alice },
+                    payload: {
+                        user: 'user7@example.com',
+                        role: app.factory.Roles.Roles.Owner
+                    }
+                })
+                const result = inviteResponse.json()
+                result.should.have.property('status', 'okay')
+
+                const response = await registerUser({
+                    username: 'user7',
+                    password: '12345678',
+                    name: 'Pedro Peterson',
+                    email: 'user7@example.com'
+                })
+                response.statusCode.should.equal(200)
+
+                // Process only runs after email verification
+                const user = await app.db.models.User.findOne({ where: { username: 'user7' } })
+                const verificationToken = await app.db.controllers.User.generateEmailVerificationToken(user)
+                const verifyResponse = await app.inject({
+                    method: 'POST',
+                    url: '/account/verify/token',
+                    payload: {
+                        token: verificationToken.token
+                    },
+                    cookies: { sid: TestObjects.tokens.user7 }
+                })
+                verifyResponse.statusCode.should.equal(200)
+
+                const teams = await app.db.models.Team.forUser(user)
+                // User is member of both personal & invited team
+                teams.should.have.length(2)
+
+                // Find the personal team
+                const userTeam = teams.find(t => t.TeamId !== app.team.id).Team
+
+                // Verify the resources were not created as the existing team already had an instance
+                const applications = await app.db.models.Application.byTeam(userTeam.id, { includeInstances: true })
+                applications.length.should.equal(0)
 
                 // cleanup else this becomes the new default and breaks other tests
                 newTeamType.active = false


### PR DESCRIPTION
We had received a couple reports that after invite a user to the platform, they were getting a 'verification failed' error when entering the verification code. Clicking the 'resend email' didn't do anything. However they found they could click logout and log in again and all was well.

Via the audit logs, I could see we were:
1. creating their personal team
2. creating an application
3. *not* creating an instance

On further examination, I could create this locally based on the following conditions:

1. An Enterprise team is created by existing user. No instances are created.
2. An external user is invited to join the team
3. The external user receives invite and signs up
4. They receive the verification code, which they submit correctly
5. The verification code is confirm and their email is marked verified
6. The signup code then completes their signup by:
    1. Creates a personal team
    2. Accepts the invite - so they are now a member of both personal team and enterprise team
    3. Checks there are no instances in any of their team - so auto-creates a new instance
    4. The code picks the first team in their list to create the new app/instance in. However, *this happens to be the Enterprise team*.
    5. Because the Enterprise team is picked, the attempt to create a Starter instance fails - as starter isn't allowed in enterprise.
    6. The error bubbles up and appears in the front end as a 'verification failure' - even though the verification succeeded

 This fixes that by:

1. Guarantees that *if* it decides to create the starter instance, it will get created in their personal team
2. Ensures the verify end point always reports success once its gets past the verification step. Any subsequent errors creating their team/etc are *not* verification issues and are logged separately.