### PR TITLE
Pipelines: Adds missing [data-action="pipeline-add"] on empty state button

### DIFF
--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -83,6 +83,7 @@
                     params: { applicationId: application.id },
                 }"
                 :disabled="!featureEnabled"
+                data-action="pipeline-add"
             >
                 <template #icon-left><PlusSmIcon /></template>
                 Add Pipeline

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -40,7 +40,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         const PIPELINE_NAME = `My New Pipeline - ${Math.random().toString(36).substring(2, 7)}`
 
         // Add pipeline
-        cy.get('[data-action="pipeline-add"]').click()
+        cy.get('[data-el="empty-state"] [data-action="pipeline-add"]').click()
         cy.get('[data-form="pipeline-form"]').should('be.visible')
 
         cy.get('[data-form="pipeline-name"] input').type(PIPELINE_NAME)
@@ -113,7 +113,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         const PIPELINE_NAME = `My New Pipeline - ${Math.random().toString(36).substring(2, 7)}`
 
         // Add pipeline
-        cy.get('[data-action="pipeline-add"]').click()
+        cy.get('[data-el="empty-state"] [data-action="pipeline-add"]').click()
         cy.get('[data-form="pipeline-name"] input').type(PIPELINE_NAME)
         cy.get('[data-action="create-pipeline"]').click()
 


### PR DESCRIPTION
## Description

In PH analysis of the DevOps feature set, we're missing events because the empty state button didn't have the `data-action` property set.