### PR TITLE
Fix linting issue in ci/Dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as builder
+FROM node:18-alpine AS builder
 
 RUN apk add --no-cache --virtual build-base g++ make py3-pip sqlite-dev python3
 


### PR DESCRIPTION
Noticed we've started getting this appear in PR reviews recently. The file in question hasn't changed in 8 months, so I don't know why this has started appearing. It's only a warning and doesn't get surfaced anywhere... but this PR should get rid of it.

<img width="702" alt="image" src="https://github.com/user-attachments/assets/cb82391b-8b28-4dd5-aea5-249a9da28907">
