### PR TITLE
Send notification to inviter when a team invite is accepted

### DIFF
--- a/forge/db/controllers/Invitation.js
+++ b/forge/db/controllers/Invitation.js
@@ -107,11 +107,25 @@ module.exports = {
 
         // detail in audit log
         app.auditLog.Team.team.user.invite.accepted(user, null, invitation.team, invitedUser, role)
+
+        const team = {
+            id: invitation.team.hashid,
+            name: invitation.team.name,
+            slug: invitation.team.slug
+        }
+        const invitee = {
+            id: invitedUser.hashid,
+            username: invitedUser.username
+        }
+        const invitor = {
+            id: invitation.invitor.hashid,
+            username: invitation.invitor.username
+        }
         // send invitor a notification
         app.notifications.send(invitation.invitor, 'team-invite-accepted-invitor', {
-            team: invitation.team,
-            invitee: invitedUser,
-            invitor: invitation.invitor,
+            team,
+            invitee,
+            invitor,
             role
         })
     },

--- a/forge/db/controllers/Invitation.js
+++ b/forge/db/controllers/Invitation.js
@@ -105,7 +105,15 @@ module.exports = {
         await invitation.destroy()
         await app.notifications.remove(invitedUser, notificationReference)
 
+        // detail in audit log
         app.auditLog.Team.team.user.invite.accepted(user, null, invitation.team, invitedUser, role)
+        // send invitor a notification
+        app.notifications.send(invitation.invitor, 'team-invite-accepted-invitor', {
+            team: invitation.team,
+            invitee: invitedUser,
+            invitor: invitation.invitor,
+            role
+        })
     },
 
     rejectInvitation: async (app, invitation, user) => {

--- a/frontend/src/components/drawers/notifications/NotificationsDrawer.vue
+++ b/frontend/src/components/drawers/notifications/NotificationsDrawer.vue
@@ -30,7 +30,8 @@
 import { markRaw } from 'vue'
 import { mapGetters } from 'vuex'
 
-import TeamInvitationNotification from '../../notifications/TeamInvitationNotification.vue'
+import TeamInvitationAcceptedNotification from '../../notifications/invitations/Accepted.vue'
+import TeamInvitationReceivedNotification from '../../notifications/invitations/Received.vue'
 
 export default {
     name: 'NotificationsDrawer',
@@ -38,7 +39,8 @@ export default {
         return {
             notificationsComponentMap: {
                 // todo replace hardcoded value with actual notification type
-                'team-invite': markRaw(TeamInvitationNotification)
+                'team-invite': markRaw(TeamInvitationReceivedNotification),
+                'team-invite-accepted-invitor': markRaw(TeamInvitationAcceptedNotification)
             },
             selections: []
         }

--- a/frontend/src/components/notifications/invitations/Accepted.vue
+++ b/frontend/src/components/notifications/invitations/Accepted.vue
@@ -22,7 +22,7 @@
 <script>
 import { UserAddIcon } from '@heroicons/vue/solid'
 
-import { RoleNames, Roles } from '../../../../../forge/lib/roles.js'
+import { RoleNames } from '../../../../../forge/lib/roles.js'
 
 import NotificationMessageMixin from '../../../mixins/NotificationMessage.js'
 

--- a/frontend/src/components/notifications/invitations/Accepted.vue
+++ b/frontend/src/components/notifications/invitations/Accepted.vue
@@ -2,7 +2,7 @@
     <NotificationMessage
         :notification="notification"
         :selections="selections"
-        data-el="invitation-message" :to="{name: 'Team Members'}"
+        data-el="invitation-message" :to="to"
     >
         <template #icon>
             <UserAddIcon />
@@ -41,6 +41,12 @@ export default {
         },
         role () {
             return RoleNames[this.notification.data.role]
+        },
+        to () {
+            return {
+                name: 'TeamMembers',
+                params: { team_slug: this.notification.data.team.slug }
+            }
         }
     }
 }

--- a/frontend/src/components/notifications/invitations/Accepted.vue
+++ b/frontend/src/components/notifications/invitations/Accepted.vue
@@ -2,16 +2,16 @@
     <NotificationMessage
         :notification="notification"
         :selections="selections"
-        data-el="invitation-message" :to="{name: 'User Invitations'}"
+        data-el="invitation-message" :to="{name: 'Team Members'}"
     >
         <template #icon>
             <UserAddIcon />
         </template>
         <template #title>
-            Team Invitation
+            Team Invitation: Accepted
         </template>
         <template #message>
-            You have been invited by <i>"{{ invitorName }}"</i> to join <i>"{{ teamName }}"</i>.
+            <i>"{{ inviteeName }}"</i> has accepted your invitation to join <i>"{{ teamName }}"</i> as a <i>"{{ role }}".</i>
         </template>
         <template #timestamp>
             {{ notification.createdSince }}
@@ -22,20 +22,25 @@
 <script>
 import { UserAddIcon } from '@heroicons/vue/solid'
 
-import NotificationMessageMixin from '../../mixins/NotificationMessage.js'
+import { RoleNames, Roles } from '../../../../../forge/lib/roles.js'
 
-import NotificationMessage from './Notification.vue'
+import NotificationMessageMixin from '../../../mixins/NotificationMessage.js'
+
+import NotificationMessage from '../Notification.vue'
 
 export default {
-    name: 'TeamInvitationNotification',
+    name: 'TeamInvitationAcceptedNotification',
     components: { NotificationMessage, UserAddIcon },
     mixins: [NotificationMessageMixin],
     computed: {
-        invitorName () {
-            return this.notification.data.invitor.username
+        inviteeName () {
+            return this.notification.data.invitee.username
         },
         teamName () {
             return this.notification.data.team.name
+        },
+        role () {
+            return RoleNames[this.notification.data.role]
         }
     }
 }

--- a/frontend/src/components/notifications/invitations/Received.vue
+++ b/frontend/src/components/notifications/invitations/Received.vue
@@ -1,0 +1,46 @@
+<template>
+    <NotificationMessage
+        :notification="notification"
+        :selections="selections"
+        data-el="invitation-message" :to="{name: 'User Invitations'}"
+    >
+        <template #icon>
+            <UserAddIcon />
+        </template>
+        <template #title>
+            Team Invitation
+        </template>
+        <template #message>
+            You have been invited by <i>"{{ invitorName }}"</i> to join <i>"{{ teamName }}"</i>.
+        </template>
+        <template #timestamp>
+            {{ notification.createdSince }}
+        </template>
+    </NotificationMessage>
+</template>
+
+<script>
+import { UserAddIcon } from '@heroicons/vue/solid'
+
+import NotificationMessageMixin from '../../../mixins/NotificationMessage.js'
+
+import NotificationMessage from '../Notification.vue'
+
+export default {
+    name: 'TeamInvitationReceivedNotification',
+    components: { NotificationMessage, UserAddIcon },
+    mixins: [NotificationMessageMixin],
+    computed: {
+        invitorName () {
+            return this.notification.data.invitor.username
+        },
+        teamName () {
+            return this.notification.data.team.name
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+
+</style>

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -81,6 +81,7 @@ export default [
             {
                 path: 'members',
                 component: TeamMembers,
+                name: 'TeamMembers',
                 meta: {
                     title: 'Team - Members'
                 },


### PR DESCRIPTION
## Description

- Records a notification for the inviter when the invitee accepts an invitation as a new `team-invite-accepted-invitor` type
- Adds relevant `.vue` components to display the notification, which navigates to the team member's page when clicked.

<img width="522" alt="Screenshot 2024-08-15 at 20 10 34" src="https://github.com/user-attachments/assets/f90f5bde-a84e-4d2c-8ec1-6b3d62a2caa8">

Not sure what tests, if any, need to be added here?

## Related Issue(s)

Closes #4379 

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
