### PR TITLE
Dashboard URL setting clarification

### DIFF
--- a/frontend/src/pages/admin/Template/components/LockSetting.vue
+++ b/frontend/src/pages/admin/Template/components/LockSetting.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="">
-        <div v-if="locked" v-ff-tooltip="'This setting has been locked by the Project\'s Template.'">
+        <div v-if="locked" v-ff-tooltip="tooltip">
             <LockClosedIcon class="w-4 mb-2" />
         </div>
         <FormRow v-else-if="editTemplate" v-model="localValue" class="w-24" type="select" :options="[{label:'Editable', value:true},{label:'Locked', value:false}]">
@@ -34,6 +34,10 @@ export default {
         editTemplate: {
             type: Boolean,
             default: false
+        },
+        tooltip: {
+            type: String,
+            default: 'This setting has been locked by the Project\'s Template.'
         }
     },
     emits: ['update:modelValue'],

--- a/frontend/src/pages/admin/Template/sections/Editor.vue
+++ b/frontend/src/pages/admin/Template/sections/Editor.vue
@@ -42,12 +42,29 @@
                 <FormRow v-model="editable.settings.dashboardUI" :error="editable.errors.dashboardUI" :disabled="!editTemplate && !editable.policy.dashboardUI" type="text">
                     Dashboard URL Path
                     <template #description>
-                        The path used to serve the node-red-dashboard UI
+                        <div>The path used to serve the legacy node-red-dashboard UI</div>
+                        <div>
+                            NOTE: node-red-dashboard <a href="https://flowfuse.com/blog/2024/06/dashboard-1-deprecated/" class="ff-link" target="_blank" rel="noopener noreferrer">is deprecated</a>
+                        </div>
                     </template>
                     <template #append><ChangeIndicator :value="editable.changed.settings.dashboardUI" /></template>
                 </FormRow>
             </div>
             <LockSetting v-model="editable.policy.dashboardUI" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.dashboardUI" />
+        </div>
+        <div class="flex flex-col sm:flex-row">
+            <div class="w-full max-w-md sm:mr-8">
+                <FormRow type="text">
+                    FlowFuse Dashboard URL Path
+                    <template #description>
+                        The path used to serve the <a href="https://dashboard.flowfuse.com/" class="ff-link" target="_blank" rel="noopener noreferrer">FlowFuse Dashboard</a>
+                    </template>
+                    <template #input>
+                        <div data-el="form-row-uneditable" class="w-full uneditable undefined text-gray-300">/dashboard</div>
+                    </template>
+                </FormRow>
+            </div>
+            <LockSetting class="flex justify-end flex-col" tooltip="This setting is fixed and cannot be changed." />
         </div>
         <div class="flex flex-col sm:flex-row">
             <div class="w-full max-w-md sm:mr-8">

--- a/frontend/src/pages/admin/Template/sections/Editor.vue
+++ b/frontend/src/pages/admin/Template/sections/Editor.vue
@@ -40,7 +40,7 @@
         <div class="flex flex-col sm:flex-row">
             <div class="w-full max-w-md sm:mr-8">
                 <FormRow v-model="editable.settings.dashboardUI" :error="editable.errors.dashboardUI" :disabled="!editTemplate && !editable.policy.dashboardUI" type="text">
-                    Dashboard URL Path
+                    Legacy Dashboard URL Path
                     <template #description>
                         <div>The path used to serve the legacy node-red-dashboard UI</div>
                         <div>


### PR DESCRIPTION
closes #4091

## Description

* Clarifies which dashboard the URL is referring to
* Adds Dashboard 2.0 URL (fixed for now)
* Adds URL links to FlowFuse docs for depreciation notice and new dashboard 2

![image](https://github.com/user-attachments/assets/ca80ed32-3498-4fe1-97ea-1595624179a1)


## Related Issue(s)

#4091

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

