### PR TITLE
Change editor & dashboard buttons to anchors

### DIFF
--- a/frontend/src/pages/instance/components/DashboardLink.vue
+++ b/frontend/src/pages/instance/components/DashboardLink.vue
@@ -1,10 +1,13 @@
 <template>
     <ff-button
         v-if="!hidden"
+        type="anchor"
         kind="secondary"
         data-action="open-dashboard"
+        :to="dashboardURL"
+        :target="target"
         :disabled="buttonDisabled"
-        @click.stop="openDashboard()"
+        class="whitespace-nowrap"
     >
         <template v-if="showText" #icon-left>
             <ChartPieIcon />
@@ -58,19 +61,19 @@ export default {
     computed: {
         buttonDisabled () {
             return this.disabled || !this.instance?.settings?.dashboard2UI
-        }
-    },
-    methods: {
-        openDashboard () {
-            if (this.disabled || !this.instance?.settings?.dashboard2UI) {
-                return
+        },
+        dashboardURL () {
+            if (this.buttonDisabled) {
+                return null
             }
             // The dashboard url will *always* be relative to the root as we
             // do not expose `httpNodeRoot` to customise the base path
             const baseURL = new URL(removeSlashes(this.instance.url, false, true))
             baseURL.pathname = removeSlashes(this.instance.settings.dashboard2UI, true, false)
-            const fixedTarget = '_db2_' + this.instance.id
-            window.open(baseURL.toString(), fixedTarget)
+            return baseURL.toString()
+        },
+        target () {
+            return '_db2_' + (this.instance?.id || '')
         }
     }
 }

--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -3,11 +3,13 @@
         <slot name="default">
             <ff-button
                 v-ff-tooltip:left="(editorDisabled || disabled) ? disabledReason : undefined"
+                type="anchor"
+                :to="editorURL"
                 kind="secondary"
                 data-action="open-editor"
-                :disabled="editorDisabled || disabled || !url"
+                :disabled="buttonDisabled"
                 class="whitespace-nowrap"
-                @click.stop="openEditor()"
+                @click.stop="openEditor"
             >
                 <template v-if="showText" #icon-left>
                     <ProjectIcon />
@@ -72,16 +74,23 @@ export default {
                 return this.$router.resolve({ name: 'instance-editor', params: { id: this.instance.id } }).fullPath
             }
 
+            return this.editorURL
+        },
+        editorURL () {
             return this.instance.url || this.instance.editor?.url
+        },
+        buttonDisabled: function () {
+            return this.editorDisabled || this.disabled || !this.url
         }
     },
     methods: {
-        openEditor () {
+        openEditor (evt) {
+            evt.preventDefault()
             if (this.disabled) {
-                return
+                return false
             }
-
             window.open(this.url, !this.isImmersiveEditor ? '_blank' : '_self')
+            return false
         }
     }
 }

--- a/frontend/src/ui-components/components/Button.vue
+++ b/frontend/src/ui-components/components/Button.vue
@@ -1,5 +1,17 @@
 <template>
-    <button ref="input" class="ff-btn transition-fade--color" :type="type" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" @click="go()">
+    <a v-if="type==='anchor'" ref="input" class="ff-btn transition-fade--color" :target="target" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :href="!to || disabled ? null : to" :aria-disabled="disabled ? 'true' : 'false'" :disabled="disabled">
+        <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
+            <slot name="icon-left"></slot>
+        </span>
+        <span v-if="isIconOnly" class="ff-btn--icon">
+            <slot name="icon"></slot>
+        </span>
+        <slot></slot>
+        <span v-if="hasIconRight" class="ff-btn--icon ff-btn--icon-right">
+            <slot name="icon-right"></slot>
+        </span>
+    </a>
+    <button v-else ref="input" class="ff-btn transition-fade--color" :type="type" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :disabled="disabled" @click="go()">
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
         </span>
@@ -18,7 +30,7 @@ export default {
     name: 'ff-button',
     props: {
         type: {
-            default: 'button', // "button" or "submit"
+            default: 'button', // "button", "submit" or "anchor"
             type: String
         },
         kind: {
@@ -33,12 +45,21 @@ export default {
             default: null,
             type: [String, Object]
         },
+        /** Only applicable to type="anchor" */
+        target: {
+            default: '_self',
+            type: [String]
+        },
         hasRightIcon: {
             default: true,
             type: Boolean
         },
         hasLeftIcon: {
             default: true,
+            type: Boolean
+        },
+        disabled: {
+            default: false,
             type: Boolean
         }
     },
@@ -58,12 +79,14 @@ export default {
     },
     methods: {
         go: function () {
-            if (this.to) {
+            if (!this.disabled && this.to) {
                 this.$router.push(this.to)
             }
         },
         focus () {
-            this.$refs.input?.focus()
+            if (!this.disabled) {
+                this.$refs.input?.focus()
+            }
         },
         blur () {
             this.$refs.input?.blur()

--- a/frontend/src/ui-components/components/Button.vue
+++ b/frontend/src/ui-components/components/Button.vue
@@ -1,5 +1,5 @@
 <template>
-    <a v-if="type==='anchor'" ref="input" class="ff-btn transition-fade--color" :target="target" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :href="!to || disabled ? null : to" :aria-disabled="disabled===true?'true':null" :disabled="disabled===true?'true':null">
+    <a v-if="type==='anchor'" ref="input" class="ff-btn transition-fade--color" :target="target" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :href="(!to || disabled) ? null : to" :aria-disabled="disabled===true?'true':null" :disabled="disabled===true?'true':null">
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
         </span>

--- a/frontend/src/ui-components/components/Button.vue
+++ b/frontend/src/ui-components/components/Button.vue
@@ -1,5 +1,5 @@
 <template>
-    <a v-if="type==='anchor'" ref="input" class="ff-btn transition-fade--color" :target="target" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :href="!to || disabled ? null : to" :aria-disabled="disabled ? 'true' : 'false'" :disabled="disabled">
+    <a v-if="type==='anchor'" ref="input" class="ff-btn transition-fade--color" :target="target" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :href="!to || disabled ? null : to" :aria-disabled="disabled===true?'true':null" :disabled="disabled===true?'true':null">
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
         </span>
@@ -11,7 +11,7 @@
             <slot name="icon-right"></slot>
         </span>
     </a>
-    <button v-else ref="input" class="ff-btn transition-fade--color" :type="type" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :disabled="disabled" @click="go()">
+    <button v-else ref="input" class="ff-btn transition-fade--color" :type="type" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :disabled="disabled===true?'true':null" @click="go()">
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
         </span>
@@ -59,7 +59,7 @@ export default {
             type: Boolean
         },
         disabled: {
-            default: false,
+            default: null,
             type: Boolean
         }
     },

--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -182,7 +182,8 @@
     }
   }
 
-  &:disabled {
+  &:disabled,
+  &[disabled=true] {
     cursor: not-allowed;
     border-color: $ff-grey-200;
     color: $ff-grey-400;

--- a/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
@@ -103,7 +103,7 @@ describe('FlowForge - Team Overview (Home) - With License', () => {
                     cy.get('[data-el="application-instances"]').find('.item-wrapper').should('have.length', 2)
                     cy.get('[data-el="application-instances"] .item-wrapper:contains("instance-2-with-devices")').within(() => {
                         cy.get('[data-el="status-badge-stopped"]').should('exist')
-                        cy.get('[data-action="open-editor"]').should('be.disabled')
+                        cy.get('[data-action="open-editor"]').should('have.attr', 'disabled')
                         cy.get('[data-el="kebab-menu"]').should('exist')
                     })
 

--- a/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
@@ -111,7 +111,7 @@ describe('FlowForge - Team Overview (Home) - With License', () => {
                         cy.contains('instance-2-1')
                         cy.get('[data-el="status-badge-running"]').should('exist')
                         cy.contains('http://instance-2-1.example.com')
-                        cy.get('[data-action="open-editor"]').should('be.enabled')
+                        cy.get('[data-action="open-editor"]').should('not.have.attr', 'disabled')
                         cy.get('[data-el="kebab-menu"]').should('exist')
                     })
 

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -77,7 +77,7 @@ describe('FlowFuse platform admin users', () => {
         cy.wait('@getApplicationInstances')
 
         cy.get('[data-el="banner-project-as-admin"]').should('exist')
-        cy.get('[data-action="open-editor"]').should('be.disabled')
+        cy.get('[data-action="open-editor"]').should('have.attr', 'disabled')
 
         cy.get('[data-el="cloud-instances"] tr').contains('instance-2-1').click()
 

--- a/test/e2e/frontend/cypress/tests/applications/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/overview.spec.js
@@ -188,7 +188,7 @@ describe('FlowForge - Applications', () => {
                 .parent()
                 .parent()
                 .within(() => {
-                    cy.get('[data-action="open-editor"]').should('be.disabled')
+                    cy.get('[data-action="open-editor"]').should('have.attr', 'disabled')
                     cy.get('[data-el="kebab-menu"]').should('exist')
                     cy.contains('https://www.google.com:456/search?q=rick+ross')
                 })

--- a/test/e2e/frontend/cypress/tests/instances/editor.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances/editor.spec.js
@@ -235,7 +235,9 @@ describe('FlowForge - Instance editor', () => {
                 })
 
             cy.get('[data-el="tabs-drawer"]').within(() => {
-                cy.get('[data-action="open-dashboard"]').should('exist').should('be.disabled')
+                // cy.get('[data-action="open-dashboard"]').should('exist').should('be.disabled')
+                // anchors with disabled attribute fail the above assertion! so we need to check the attribute directly
+                cy.get('[data-action="open-dashboard"]').should('exist').should('have.attr', 'disabled')
             })
         })
     })


### PR DESCRIPTION
closes #4355 

## Description

* Adds `type="anchor"` support to `ff-button` 
* Changes the dashboard button to type anchor
* Changes the editor button to type anchor but still supports left click into immersive mode

NOTE: 3 tests using `should('be.disabled')` needed to be changed to test for attr `disabled` instead.  See https://github.com/cypress-io/cypress/issues/5903 

NOTE: The new anchor operates exactly like the old button. 
* If Left Clicking "Editor" and it is _immersive ready_, it will be shown immersive however, if the user middle clicks or right clicks, the editor can be opened in a new tab (as per browser behaviour)
* Left clicking the dashboard opens as a new tab as it always did (targeted to a specific `target` to prevent multiple windows) however now it isa n anchor, middle click and right click _can_ open another instance in a new tab (as per browser behaviour)


## Related Issue(s)

#4355 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

