### PR TITLE
Fix tags indentation

### DIFF
--- a/docs/hardware/ctrlx-device-agent.md
+++ b/docs/hardware/ctrlx-device-agent.md
@@ -3,7 +3,7 @@ navTitle: ctrlX - Device Agent
 navOrder: 3
 meta:
    description: Learn to install and configure the FlowFuse Device Agent on ctrlX devices for seamless integration with FlowFuse, ensuring efficient device management.
-  tags:
+   tags:
       - ctrlx
       - device agent
       - flowfuse


### PR DESCRIPTION
## Description

We're getting this error on website build:
```
11:34:22 AM: [11ty] Problem writing Eleventy templates: (more in DEBUG output)
11:34:22 AM: [11ty] 1. Having trouble reading front matter from template ./src/docs/hardware/ctrlx-device-agent.md (via TemplateContentFrontMatterError)
11:34:22 AM: [11ty] 2. bad indentation of a mapping entry at line 9, column 3:
11:34:22 AM: [11ty]       tags:
11:34:22 AM: [11ty]       ^ (via YAMLException)
11:34:22 AM: [11ty]
11:34:22 AM: [11ty] Original error stack trace: YAMLException: bad indentation of a mapping entry at line 9, column 3:
11:34:22 AM: [11ty]       tags:
11:34:22 AM: [11ty]       ^
```

This change should fix that

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

