### PR TITLE
Fix broken nabvbar on 404

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -10,7 +10,7 @@
         <div class="flex ff-mobile-navigation-right" data-el="mobile-nav-right">
             <NotificationsButton class="ff-header--mobile-notificationstoggle" :class="{'active': mobileTeamSelectionOpen}" />
             <i v-if="hasAvailableTeams" class="ff-header--mobile-usertoggle" :class="{'active': mobileTeamSelectionOpen}">
-                <img :src="team.avatar" class="ff-avatar" @click="mobileTeamSelectionOpen = !mobileTeamSelectionOpen">
+                <img :src="team ? team.avatar : defaultUserTeam.avatar" class="ff-avatar" @click="mobileTeamSelectionOpen = !mobileTeamSelectionOpen">
             </i>
             <i class="ff-header--mobile-usertoggle" :class="{'active': mobileUserOptionsOpen}">
                 <img :src="user.avatar" class="ff-avatar" @click="mobileUserOptionsOpen = !mobileUserOptionsOpen">
@@ -32,6 +32,7 @@
                 @click="mobileTeamSelectionOpen = false; $router.push({name: 'Team', params: {team_slug: team.slug}})"
             />
             <nav-item
+                v-if="canCreateTeam"
                 label="Create New Team" :icon="plusIcon"
                 @click="mobileTeamSelectionOpen = false; $router.push({name: 'CreateTeam'})"
             />
@@ -91,7 +92,7 @@ export default {
     mixins: [navigationMixin, permissionsMixin],
     computed: {
         ...mapState('account', ['user', 'team', 'teams']),
-        ...mapGetters('account', ['notifications', 'hasAvailableTeams']),
+        ...mapGetters('account', ['notifications', 'hasAvailableTeams', 'defaultUserTeam', 'canCreateTeam']),
         ...mapGetters('ux', ['shouldShowLeftMenu']),
         navigationOptions () {
             return [

--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dropdown class="ff-team-selection">
+    <ff-dropdown v-if="hasAvailableTeams" class="ff-team-selection">
         <template #placeholder>
             <div v-if="team" class="flex grow items-center">
                 <img :src="team.avatar" class="ff-avatar">

--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -1,11 +1,16 @@
 <template>
-    <ff-dropdown v-if="team" class="ff-team-selection">
+    <ff-dropdown class="ff-team-selection">
         <template #placeholder>
-            <div class="flex grow items-center">
+            <div v-if="team" class="flex grow items-center">
                 <img :src="team.avatar" class="ff-avatar">
                 <div class="ff-team-selection-name">
                     <label>TEAM:</label>
                     <h5>{{ team.name }}</h5>
+                </div>
+            </div>
+            <div v-else class="flex grow items-center">
+                <div class="ff-team-selection-name">
+                    <h5>Select a team</h5>
                 </div>
             </div>
         </template>
@@ -36,14 +41,7 @@ export default {
     },
     computed: {
         ...mapState('account', ['team', 'teams', 'settings']),
-        ...mapGetters('account', ['isAdminUser']),
-        canCreateTeam () {
-            if (this.isAdminUser) {
-                return true
-            }
-
-            return Object.prototype.hasOwnProperty.call(this.settings, 'team:create') && this.settings['team:create']
-        }
+        ...mapGetters('account', ['hasAvailableTeams', 'canCreateTeam'])
     },
     data () {
         return {

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -85,6 +85,14 @@ const getters = {
         const defaultTeamId = state.user.defaultTeam || getters.teams[0]?.id
         return state.teams.find(team => team.id === defaultTeamId)
     },
+    canCreateTeam (state, getters) {
+        if (getters.isAdminUser) {
+            return true
+        }
+
+        return Object.prototype.hasOwnProperty.call(getters.settings, 'team:create') &&
+            getters.settings['team:create']
+    },
     blueprints: state => state.teamBlueprints[state.team?.id] || [],
     defaultBlueprint: (state, getters) => getters.blueprints?.find(blueprint => blueprint.default),
 


### PR DESCRIPTION
## Description

- fixes disabled navBar when invalid team reached (from 404 page)
- display the team selector on desktop and mobile viewports (up untill now it was hidden because no team was selected)
- fixes the mobile team selector create a team button being present even though the user was not allowed to create a team

https://github.com/user-attachments/assets/4fba873d-50c4-402e-859c-d36bbacf62dc


## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4402

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

