### PR TITLE
Add crash notifications

### DIFF
--- a/forge/db/models/Notification.js
+++ b/forge/db/models/Notification.js
@@ -53,7 +53,8 @@ module.exports = {
                         where: {
                             reference,
                             UserId: user.id
-                        }
+                        },
+                        order: [['id', 'DESC']]
                     })
                 },
                 forUser: async (user, pagination = {}) => {

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -274,6 +274,23 @@ module.exports = {
                     // In this case the findAll above will return an array that includes null, this needs to be guarded against
                     return owners.filter((owner) => owner !== null)
                 },
+                /**
+                 * Get all members of the team optionally filtered by `role` array
+                 * @param {Array<Number> | null} roleFilter - Array of roles to filter by
+                 * @example
+                 * // Get all members of the team
+                 * const members = await team.getTeamMembers()
+                 * @example
+                 * // Get viewers only
+                 * const viewers = await team.getTeamMembers([Roles.Viewer])
+                 */
+                getTeamMembers: async function (roleFilter = null) {
+                    const where = { TeamId: this.id }
+                    if (roleFilter && Array.isArray(roleFilter)) {
+                        where.role = roleFilter
+                    }
+                    return (await M.TeamMember.findAll({ where, include: M.User })).filter(tm => tm && tm.User).map(tm => tm.User)
+                },
                 memberCount: async function (role) {
                     const where = {
                         TeamId: this.id

--- a/forge/notifications/index.js
+++ b/forge/notifications/index.js
@@ -7,9 +7,36 @@ module.exports = fp(async function (app, _opts) {
      * @param {string} type the type of the notification
      * @param {Object} data meta data for the notification - specific to the type
      * @param {string} reference a key that can be used to lookup this notification, for example: `invite:HASHID`
-     *
+     * @param {Object} [options]
+     * @param {boolean} [options.upsert] if true, updates the existing notification with the same reference & adds/increments `data.meta.counter`
+     * @param {boolean} [options.supersede] if true, marks existing notification (with the same reference) as read & adds a new one
      */
-    async function send (user, type, data, reference = null) {
+    async function send (user, type, data, reference = null, options = null) {
+        if (reference && options && typeof options === 'object') {
+            if (options.upsert) {
+                const existing = await app.db.models.Notification.byReference(reference, user)
+                if (existing && !existing.read) {
+                    const updatedData = Object.assign({}, existing.data, data)
+                    if (!updatedData.meta || typeof updatedData.meta !== 'object') {
+                        updatedData.meta = {}
+                    }
+                    if (typeof updatedData.meta.counter === 'number') {
+                        updatedData.meta.counter += 1
+                    } else {
+                        updatedData.meta.counter = 2 // if notification already exists, then this is the 2nd occurrence!
+                    }
+                    await existing.update({ data: updatedData })
+                    return existing
+                }
+            } else if (options.supersede) {
+                const existing = await app.db.models.Notification.byReference(reference, user)
+                if (existing && !existing.read) {
+                    existing.read = true
+                    await existing.save()
+                }
+            }
+        }
+
         return app.db.models.Notification.create({
             UserId: user.id,
             type,

--- a/frontend/src/components/notifications/Generic.vue
+++ b/frontend/src/components/notifications/Generic.vue
@@ -1,0 +1,121 @@
+<template>
+    <NotificationMessage
+        :notification="notification"
+        :selections="selections"
+        data-el="generic-notification" :to="to"
+    >
+        <template #icon>
+            <component :is="notificationData.iconComponent" />
+        </template>
+        <template #title>
+            {{ notificationData.title }}
+        </template>
+        <template #message>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <span v-html="notificationData.message" />
+        </template>
+    </NotificationMessage>
+</template>
+
+<script>
+import { defineAsyncComponent } from 'vue'
+
+import IconDeviceSolid from '../../components/icons/DeviceSolid.js'
+import IconNodeRedSolid from '../../components/icons/NodeRedSolid.js'
+import NotificationMessageMixin from '../../mixins/NotificationMessage.js'
+
+import NotificationMessage from './Notification.vue'
+
+export default {
+    name: 'GenericNotification',
+    components: { NotificationMessage, IconNodeRedSolid },
+    mixins: [NotificationMessageMixin],
+    data () {
+        return {
+            knownEvents: {
+                'instance-crashed': {
+                    icon: 'instance',
+                    title: 'Node-RED Instance Crashed',
+                    message: '"<i>{{instance.name}}</i>" has crashed'
+                },
+                'instance-safe-mode': {
+                    icon: 'instance',
+                    title: 'Node-RED Instance Safe Mode',
+                    message: '"<i>{{instance.name}}</i>" is running in safe mode'
+                },
+                'device-crashed': {
+                    icon: 'device',
+                    title: 'Node-RED Device Crashed',
+                    message: '"<i>{{device.name}}</i>" has crashed'
+                },
+                'device-safe-mode': {
+                    icon: 'device',
+                    title: 'Node-RED Device Safe Mode',
+                    message: '"<i>{{device.name}}</i>" is running in safe mode'
+                }
+            }
+        }
+    },
+    computed: {
+        to () {
+            if (typeof this.notification.data?.to === 'object') { return this.notification.data.to }
+            if (typeof this.notification.data?.to === 'string') { return { path: this.notification.data.to } }
+            if (typeof this.notification.data?.url === 'string') { return { url: this.notification.data.url } }
+            if (this.notification.data?.instance?.id) {
+                return {
+                    name: 'instance-overview',
+                    params: { id: this.notification.data.instance.id }
+                }
+            }
+            return null // no link
+        },
+        notificationData () {
+            const event = this.knownEvents[this.notification.type] || {}
+            event.createdAt = new Date(this.notification.createdAt).toLocaleString()
+            // get title and message
+            if (!event.title) {
+                event.title = this.notification.data?.title || this.notification.type.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
+            }
+            if (!event.message) {
+                event.message = this.notification.data?.message || `Event occurred at ${event.createdAt}`
+            }
+
+            // icon handling
+            event.icon = event.icon || this.notification.data?.icon
+            if (event.icon === 'instance' || event.icon === 'project') {
+                event.iconComponent = IconNodeRedSolid
+            } else if (event.icon === 'device') {
+                event.iconComponent = IconDeviceSolid
+            } else {
+                event.iconComponent = defineAsyncComponent(() => import('@heroicons/vue/solid').then(x => x[event.icon] || x.BellIcon))
+            }
+
+            // Perform known substitutions
+            event.title = this.substitutions(event.title)
+            event.message = this.substitutions(event.message)
+            return event
+        }
+    },
+    methods: {
+        substitutions (str) {
+            let result = str
+            const regex = /{{([^}]+)}}/g // find all {{key}} occurrences
+            let match = regex.exec(result)
+            while (match) {
+                const key = match[1]
+                const value = this.getObjectProperty(this.notification.data || {}, key) || key.split('.')[0].replace(/\b\w/g, l => l.toUpperCase())
+                result = result.replace(match[0], value)
+                match = regex.exec(result)
+            }
+            return result
+        },
+        getObjectProperty (obj, path) {
+            return (path || '').trim().split('.').reduce((acc, part) => acc && acc[part], obj)
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+
+</style>

--- a/frontend/src/components/notifications/Notification.vue
+++ b/frontend/src/components/notifications/Notification.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="message" :class="{ unread: !notification.read }" @click="go(to)">
+    <div class="message" :class="messageClass" @click="go(to)">
         <div class="body">
             <div class="icon ff-icon ff-icon-lg">
                 <slot name="icon" />
@@ -7,7 +7,11 @@
             <div class="text">
                 <div class="header">
                     <h4 class="title"><slot name="title" /></h4>
-                <!--            <ff-checkbox :model-value="isSelected" label="" @click.prevent.stop="toggleSelection" />-->
+                    <div class="counter">
+                        <slot name="counter">
+                            <ff-notification-pill v-if="counter" v-ff-tooltip:left="counter + ' occurrences'" :count="counter" />
+                        </slot>
+                    </div>
                 </div>
                 <div class="content">
                     <slot name="message" />
@@ -15,7 +19,9 @@
             </div>
         </div>
         <div class="footer">
-            <slot name="timestamp" />
+            <slot name="timestamp">
+                <span v-ff-tooltip:left="tooltip"> {{ notification.createdSince }} </span>
+            </slot>
         </div>
     </div>
 </template>
@@ -28,12 +34,36 @@ import userApi from '../../api/user.js'
 import NotificationMessageMixin from '../../mixins/NotificationMessage.js'
 
 export default {
-    name: 'TeamInvitationNotification',
+    name: 'NotificationBase',
     mixins: [NotificationMessageMixin],
     props: {
         to: {
             type: Object,
-            required: true
+            default: null
+        }
+    },
+    computed: {
+        counter () {
+            if (typeof this.notification.data?.meta?.counter === 'number' && this.notification.data?.meta?.counter > 1) {
+                return this.notification.data?.meta?.counter
+            }
+            return null
+        },
+        createdAt () {
+            return new Date(this.notification.createdAt).toLocaleString()
+        },
+        tooltip () {
+            if (this.counter) {
+                return `First occurrence: ${this.createdAt}`
+            }
+            return this.createdAt
+        },
+        messageClass () {
+            return {
+                unread: !this.notification.read,
+                warning: this.notification.data?.meta?.severity === 'warning',
+                error: this.notification.data?.meta?.severity === 'error'
+            }
         }
     },
     methods: {
@@ -42,10 +72,10 @@ export default {
             this.closeRightDrawer()
             this.notification.read = true
             userApi.markNotificationRead(this.notification.id)
-            if (to.url) {
-            // Handle external links
+            if (to?.url) {
+                // Handle external links
                 window.open(to.url, '_blank').focus()
-            } else {
+            } else if (to?.name || to?.path) {
                 this.$router.push(to)
             }
         }
@@ -54,8 +84,57 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.body.unread {
-    border-left: 3px solid blue;
-}
+.messages-wrapper {
+    $read: $ff-grey-400;
+    $info: blue;
+    $warning: $ff-yellow-600;
+    $error: $ff-red-500;
+    .message {
+        .icon {
+            min-width: 20px;
+            min-height: 20px;
+            max-width: fit-content;
+            max-height: fit-content;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
 
+        .counter {
+            margin-top: 0.2rem;
+
+            .ff-notification-pill {
+                background-color: $read;
+                color: white;
+                padding: 2px 7px;
+                border-radius: 6px;
+                font-size: 0.65rem;
+            }
+        }
+
+        &.unread {
+            border-left: 3px solid $info;
+
+            &.warning {
+                border-left: 3px solid $warning;
+
+                .counter .ff-notification-pill {
+                    background-color: $warning;
+                }
+            }
+
+            &.error {
+                border-left: 3px solid $error;
+
+                .counter .ff-notification-pill {
+                    background-color: $error;
+                }
+            }
+
+            .counter .ff-notification-pill {
+                background-color: $info;
+            }
+        }
+    }
+}
 </style>

--- a/frontend/src/components/notifications/invitations/Accepted.vue
+++ b/frontend/src/components/notifications/invitations/Accepted.vue
@@ -13,9 +13,6 @@
         <template #message>
             <i>"{{ inviteeName }}"</i> has accepted your invitation to join <i>"{{ teamName }}"</i> as a <i>"{{ role }}".</i>
         </template>
-        <template #timestamp>
-            {{ notification.createdSince }}
-        </template>
     </NotificationMessage>
 </template>
 

--- a/frontend/src/components/notifications/invitations/Received.vue
+++ b/frontend/src/components/notifications/invitations/Received.vue
@@ -13,9 +13,6 @@
         <template #message>
             You have been invited by <i>"{{ invitorName }}"</i> to join <i>"{{ teamName }}"</i>.
         </template>
-        <template #timestamp>
-            {{ notification.createdSince }}
-        </template>
     </NotificationMessage>
 </template>
 

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -90,7 +90,17 @@ const getters = {
 
     notifications: state => state.notifications,
     notificationsCount: state => state.notifications?.length || 0,
-    unreadNotificationsCount: state => state.notifications?.filter(n => !n.read).length || 0,
+    unreadNotificationsCount: state => {
+        const unread = state.notifications?.filter(n => !n.read) || []
+        let count = unread.length || 0
+        // check data.meta.counter for any notifications that have been grouped
+        unread.forEach(n => {
+            if (n.data.meta?.counter && typeof n.data.meta.counter === 'number' && n.data.meta.counter > 1) {
+                count += n.data.meta.counter - 1 // decrement by 1 as the first notification is already counted
+            }
+        })
+        return count
+    },
     hasNotifications: (state, getters) => getters.notificationsCount > 0,
 
     teamInvitations: state => state.invitations,

--- a/test/unit/forge/routes/api/userNotifications_spec.js
+++ b/test/unit/forge/routes/api/userNotifications_spec.js
@@ -18,9 +18,6 @@ describe('User Notifications API', async function () {
 
         await login('alice', 'aaPassword')
         await login('bob', 'bbPassword')
-        await login('chris', 'ccPassword')
-        await login('dave', 'ddPassword')
-        await login('eve', 'eePassword')
     }
 
     before(async function () {

--- a/test/unit/forge/routes/api/userNotifications_spec.js
+++ b/test/unit/forge/routes/api/userNotifications_spec.js
@@ -18,6 +18,9 @@ describe('User Notifications API', async function () {
 
         await login('alice', 'aaPassword')
         await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+        await login('dave', 'ddPassword')
+        await login('eve', 'eePassword')
     }
 
     before(async function () {


### PR DESCRIPTION
closes #4408

## Description

Firstly, my apologies for what looks and smells like feature creep. That was not the intention.  Initial implementation was done and as was soon discovered, the crash notifications were very quickly filling the notification area. This was discussed in slack and suggestions for change were made. Rather than throwing away good (and relevant) dev work, I kept it in.

* Adds the calls to `notification.send` for instances devices and devices
* Updates the `notification.send` API to support upserting and superseding
   * `options.supersede` was added first as discussed in slack. Essentially, this permits a repeated notification to to be auto-marked as read and its new (superseding) notification to be added
   * After some more show and tell & discussion in Slack, it was suggested a counter would be better. `options.upsert` was implemented to "update" an existing notification (or add is not existing) while adding a counter to the data. This permits multiple successive notifications to be shown as one item (with a pill/badge) and not fill up the notification panel with read notifications
* Adds supports hiding read notifications
  * This was added AFTER implementing `options.supersede` and discussed in slack as a viable option.
  * However, while useful (and therefore left in this PR) we switched track to using `options.upsert`.  It is left is as useful development and worthy of keeping as more notifications from other instances and occurrences could easily fill (and push unread items) down the list.
* Adds a `Generic` notification that simplifies and reduces boilerplate
* Updates the base Notification for common things like timestamp and styling (to reduce repeated coding in dedicated components)

### MVP parts of this.

Ideally, the notification API and DB tables would natively support `severity` and `counter` but as MVP, I added them into the `data` object of the notification under a `meta` object.  This may end up being a retro thing but until we have more notifications to add it is not fully clear - something to be aware of.


### Demo

#### Default view - [x] Hide Read

![image](https://github.com/user-attachments/assets/4c2e30f0-d608-47d4-ab47-9a4931624cbc)

#### View with [ ] Hide Read unchecked
![image](https://github.com/user-attachments/assets/0365a825-2c1a-4356-bd4e-8d98c54d0b07)

### Tests

`test/unit/forge/routes/logging/index_spec.js`

```
  Logging API
    adds notification
      ✔ for every member and owner when instance crashed (41ms)
      ✔ for every member and owner when device crashed
      ✔ for every member and owner when instance safe-mode
      ✔ for every member and owner when device safe-mode
```

`test/unit/forge/routes/api/userNotifications_spec.js` (was previously named [`userNotifications.js`](https://github.com/FlowFuse/flowfuse/blob/7cbaa77a9e99c51bd6cc6f769ed8d94a0d51b4c8/test/unit/forge/routes/api/userNotifications.js) and thus NEVER ran!

```
  User Notifications API
    User notifications
      ✔ Updates notification when options.upsert is set
      ✔ Updates notification when options.supersede is set
```



## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

