### PR TITLE
Don't overwrite theme with pipeline

### DIFF
--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -230,7 +230,7 @@ module.exports = {
     mergeSettings: function (app, existingSettings, settings, { mergeEnvVars = false, mergeEditorSettings = false, targetTemplate = undefined } = {}) {
         // Quick deep clone that is safe as we know settings are JSON-safe
         const result = JSON.parse(JSON.stringify(existingSettings))
-        const skipList = ['disableEditor', 'page_title', 'header_title']
+        const skipList = ['disableEditor', 'page_title', 'header_title', 'theme']
         templateFields.forEach((name) => {
             if (mergeEditorSettings && skipList.includes(name)) {
                 return

--- a/test/unit/forge/ee/routes/api/pipeline_spec.js
+++ b/test/unit/forge/ee/routes/api/pipeline_spec.js
@@ -2952,8 +2952,8 @@ describe('Pipelines API', function () {
                 TestObjects.projectType,
                 { start: false }
             )
-            await instanceStart.updateSetting('settings', { theme: 'forge-light', page: { title: 'startProject' } })
-            await instanceEnd.updateSetting('settings', { theme: 'forge-dark', page: { title: 'endProject' } })
+            await instanceStart.updateSetting('settings', { theme: 'forge-light', page: { title: 'startProject' }, header: { title: 'startProject' } })
+            await instanceEnd.updateSetting('settings', { theme: 'forge-dark', page: { title: 'endProject' }, header: { title: 'endProject' } })
             const pipeline = await app.factory.createPipeline({ name: 'overwrite-fields-pipeine' }, app.application)
             const startStage = await app.factory.createPipelineStage({ name: 'start', instanceId: instanceStart.id }, pipeline)
             await app.factory.createPipelineStage({ name: 'end', source: startStage.hashid, instanceId: instanceEnd.id }, pipeline)
@@ -2971,6 +2971,8 @@ describe('Pipelines API', function () {
             endSettings.should.have.property('theme', 'forge-dark')
             endSettings.should.have.property('page')
             endSettings.page.should.have.property('title', 'endProject')
+            endSettings.should.have.property('header')
+            endSettings.header.should.have.property('title', 'endProject')
         })
     })
 })

--- a/test/unit/forge/ee/routes/api/pipeline_spec.js
+++ b/test/unit/forge/ee/routes/api/pipeline_spec.js
@@ -2897,4 +2897,80 @@ describe('Pipelines API', function () {
             endSettings.palette.npmrc.should.equal('from start')
         })
     })
+
+    describe('Don\'t overwrite fields', function () {
+        async function isDeployComplete (instance) {
+            const instanceStatusResponse = (await app.inject({
+                method: 'GET',
+                url: `/api/v1/projects/${instance.id}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })).json()
+
+            return instanceStatusResponse?.meta?.isDeploying === false
+        }
+        function waitForDeployToComplete (instance) {
+            return new Promise((resolve, reject) => {
+                const refreshIntervalId = setInterval(async () => {
+                    if (await isDeployComplete(instance)) {
+                        clearInterval(refreshIntervalId)
+                        resolve()
+                    }
+                }, 250)
+            })
+        }
+        it('keep title', async function () {
+            const startTemplate = await app.factory.createProjectTemplate(
+                {
+                    name: 'startTemplate',
+                    settings: {
+                        palette: {
+                            catalogue: ['https://www.first.com'],
+                            npmrc: 'from start'
+                        }
+                    },
+                    policy: {
+                        palette: {
+                            catalogue: true
+                        }
+                    }
+                },
+                app.user
+            )
+            const instanceStart = await app.factory.createInstance(
+                { name: 'startProject' },
+                TestObjects.application,
+                TestObjects.stack,
+                startTemplate,
+                TestObjects.projectType,
+                { start: false }
+            )
+            const instanceEnd = await app.factory.createInstance(
+                { name: 'endProject' },
+                TestObjects.application,
+                TestObjects.stack,
+                startTemplate,
+                TestObjects.projectType,
+                { start: false }
+            )
+            await instanceStart.updateSetting('settings', { theme: 'forge-light', page: { title: 'startProject' } })
+            await instanceEnd.updateSetting('settings', { theme: 'forge-dark', page: { title: 'endProject' } })
+            const pipeline = await app.factory.createPipeline({ name: 'overwrite-fields-pipeine' }, app.application)
+            const startStage = await app.factory.createPipelineStage({ name: 'start', instanceId: instanceStart.id }, pipeline)
+            await app.factory.createPipelineStage({ name: 'end', source: startStage.hashid, instanceId: instanceEnd.id }, pipeline)
+
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/pipelines/${pipeline.hashid}/stages/${startStage.hashid}/deploy`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+
+            response.statusCode.should.equal(200)
+            await waitForDeployToComplete(instanceEnd)
+            await instanceEnd.reload()
+            const endSettings = await app.db.controllers.Project.getRuntimeSettings(instanceEnd)
+            endSettings.should.have.property('theme', 'forge-dark')
+            endSettings.should.have.property('page')
+            endSettings.page.should.have.property('title', 'endProject')
+        })
+    })
 })


### PR DESCRIPTION
fix for #4418

## Description

<!-- Describe your changes in detail -->
Don't overwrite the target instances theme when deploying a pipeline as this can be used to help tell the difference between dev/prod instances.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4418 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

