### PR TITLE
Add missing alert notification for create folder error

### DIFF
--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -220,7 +220,10 @@ export default {
             this.loading = true
             AssetsAPI.createFolder(this.instanceId, pwd, this.forms.newFolder.name)
                 .then(() => this.$emit('items-updated'))
-                .catch(error => console.error(error))
+                .catch(error => {
+                    console.error(error)
+                    Alerts.emit(error.response.data.error, 'warning')
+                })
                 .finally(() => {
                     this.forms.newFolder.name = ''
                     this.loading = false


### PR DESCRIPTION
## Description

Add missing alert notification for create folder error

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/4422

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

