### PR TITLE
Remove the file browser entry selectors because we don't support bulk operations

### DIFF
--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -2,7 +2,6 @@
     <ff-data-table
         :rows="items"
         :columns="columns"
-        :show-row-checkboxes="true"
         :show-search="true"
         :rows-selectable="isRowSelectable"
         :no-data-message="noDataMessages"


### PR DESCRIPTION
## Description

Remove the file browser entry selectors because we don't support bulk operations

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4430

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

