### PR TITLE
ci: Set NR4 as a default stack on pre-staging

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -154,7 +154,7 @@ curl -ks -w "\n" -XPOST \
   https://$FLOWFUSE_URL/api/v1/project-types/
 
 ### Create stacks
-create_stack "NR-40x" "Default" 100 256 "flowfuse/node-red:$(get_latest_image_tag "4.0.x")"
+create_stack "Default" "Default" 100 256 "flowfuse/node-red:$(get_latest_image_tag "4.0.x")"
 create_stack "NR-30x" "3.0.x" 100 256 "flowfuse/node-red:latest"
 create_stack "NR-31x" "3.1.x" 100 256 "flowfuse/node-red:$(get_latest_image_tag "3.1.x")"
 

--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -154,9 +154,10 @@ curl -ks -w "\n" -XPOST \
   https://$FLOWFUSE_URL/api/v1/project-types/
 
 ### Create stacks
-create_stack "Default" "Default" 100 256 "flowfuse/node-red"
+create_stack "NR-40x" "Default" 100 256 "flowfuse/node-red:$(get_latest_image_tag "4.0.x")"
+create_stack "NR-30x" "3.0.x" 100 256 "flowfuse/node-red:latest"
 create_stack "NR-31x" "3.1.x" 100 256 "flowfuse/node-red:$(get_latest_image_tag "3.1.x")"
-create_stack "NR-40x" "4.0.x" 100 256 "flowfuse/node-red:$(get_latest_image_tag "4.0.x")"
+
 
 ### Link Default to project type
 echo "Linking stack to project type"

--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -154,9 +154,9 @@ curl -ks -w "\n" -XPOST \
   https://$FLOWFUSE_URL/api/v1/project-types/
 
 ### Create stacks
-create_stack "Default" "Default" 100 256 "flowfuse/node-red:$(get_latest_image_tag "4.0.x")"
-create_stack "NR-30x" "3.0.x" 100 256 "flowfuse/node-red:latest"
-create_stack "NR-31x" "3.1.x" 100 256 "flowfuse/node-red:$(get_latest_image_tag "3.1.x")"
+create_stack "Default" "Default" 30 256 "flowfuse/node-red:$(get_latest_image_tag "4.0.x")"
+create_stack "NR-30x" "3.0.x" 30 256 "flowfuse/node-red:latest"
+create_stack "NR-31x" "3.1.x" 30 256 "flowfuse/node-red:$(get_latest_image_tag "3.1.x")"
 
 
 ### Link Default to project type


### PR DESCRIPTION
## Description

This pull request sets Node-RED v4 as a default stack version for pre-staging environments.
Additionally, it updates the cpu resources limits for projects created within pre-staging environment.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/475

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

