### PR TITLE
ci: Enable FlowFuse Assistant on pre-staging environment

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -161,6 +161,11 @@ jobs:
         run: |
           aws eks update-kubeconfig --region eu-west-1 --name ${{ secrets.EKS_CLUSTER_NAME }}
 
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@v1
+        with:
+          version: 2.25.0
+
       - name: Check out FlowFuse/helm repository (to access latest helm chart)
         uses: actions/checkout@v4
         with:
@@ -179,6 +184,8 @@ jobs:
           fi
 
       - name: Deploy
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           helm upgrade --install \
             --create-namespace \
@@ -195,6 +202,7 @@ jobs:
             --set forge.license=${{ secrets.PRE_STAGING_LICENSE }} \
             --set forge.aws.IAMRole=arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/flowforge_service_account_role \
             --set forge.email.ses.sourceArn=arn:aws:ses:eu-west-1:${{ secrets.AWS_ACCOUNT_ID }}:identity/flowfuse.com \
+            --set forge.assistant.enabled=$(op read op://ci/staging_flowfuse/assistant_enabled) \
             flowfuse-pr-${{ env.PR_NUMBER }} ./helm-repo/helm/flowforge
 
       - name: Initial setup

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -202,7 +202,8 @@ jobs:
             --set forge.license=${{ secrets.PRE_STAGING_LICENSE }} \
             --set forge.aws.IAMRole=arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/flowforge_service_account_role \
             --set forge.email.ses.sourceArn=arn:aws:ses:eu-west-1:${{ secrets.AWS_ACCOUNT_ID }}:identity/flowfuse.com \
-            --set forge.assistant.enabled=$(op read op://ci/staging_flowfuse/assistant_enabled) \
+            --set forge.assistant.service.url=$(op read op://ci/staging_flowfuse/assistant_url) \
+            --set forge.assistant.service.token=$(op read op://ci/staging_flowfuse/assistant_token) \
             flowfuse-pr-${{ env.PR_NUMBER }} ./helm-repo/helm/flowforge
 
       - name: Initial setup

--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -8,6 +8,8 @@ forge:
   email:
     ses:
       region: eu-west-1
+  assistant:
+    enabled: true
 
 
 postgresql:


### PR DESCRIPTION
## Description

This pull request enables FlowFuse Assistant on pre-staging environment.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/475

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

