### PR TITLE
4439 hide instance asset tab from users

### DIFF
--- a/frontend/src/mixins/Permissions.js
+++ b/frontend/src/mixins/Permissions.js
@@ -1,7 +1,7 @@
 import { mapState } from 'vuex'
 
 import { Permissions } from '../../../forge/lib/permissions.js'
-import { Roles } from '../../../forge/lib/roles.js'
+import { RoleNames, Roles } from '../../../forge/lib/roles.js'
 
 export default {
     computed: {
@@ -26,6 +26,21 @@ export default {
                 }
             }
             return true
+        },
+        /**
+         *
+         * @param {'dashboard', 'viewer', 'member', 'owner'} role
+         *
+         * @return Boolean
+         */
+        hasAMinimumTeamRoleOf (role) {
+            if (this.isVisitingAdmin) {
+                return true
+            }
+
+            const [roleValue] = Object.entries(RoleNames).find(([key, value]) => value === role) || []
+
+            return this.teamMembership?.role >= roleValue
         }
     }
 }

--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -97,6 +97,10 @@ export default {
         }
     },
     mounted () {
+        if (!this.hasAMinimumTeamRoleOf('member')) {
+            return this.$router.push({ name: 'instance-overview' })
+        }
+
         this.loadContents()
     },
     methods: {

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -113,7 +113,7 @@ export default {
                 { label: 'Overview', to: { name: 'instance-overview', params: { id: this.instance.id } }, tag: 'instance-overview' },
                 { label: 'Devices', to: { name: 'instance-devices', params: { id: this.instance.id } }, tag: 'instance-remote' },
                 { label: 'Snapshots', to: { name: 'instance-snapshots', params: { id: this.instance.id } }, tag: 'instance-snapshots' },
-                { label: 'Assets', to: { name: 'instance-assets', params: { id: this.instance.id } }, tag: 'instance-assets' },
+                { label: 'Assets', to: { name: 'instance-assets', params: { id: this.instance.id } }, tag: 'instance-assets', hidden: !this.hasAMinimumTeamRoleOf('member') },
                 { label: 'Audit Log', to: { name: 'instance-audit-log', params: { id: this.instance.id } }, tag: 'instance-activity' },
                 { label: 'Node-RED Logs', to: { name: 'instance-logs', params: { id: this.instance.id } }, tag: 'instance-logs' },
                 { label: 'Settings', to: { name: 'instance-settings', params: { id: this.instance.id } }, tag: 'instance-settings' }

--- a/frontend/src/ui-components/components/tabs/Tabs.vue
+++ b/frontend/src/ui-components/components/tabs/Tabs.vue
@@ -32,17 +32,18 @@ export default {
     emits: ['tab-selected'],
     data () {
         return {
-            selectedIndex: -1,
-            scopedTabs: []
+            selectedIndex: -1
         }
     },
-    watch: {
-        tabs: function () {
-            this.scopedTabs = this.tabs
+    computed: {
+        scopedTabs () {
+            return this.tabs.filter(tab => {
+                if (Object.prototype.hasOwnProperty.call(tab, 'hidden')) {
+                    return !tab.hidden
+                }
+                return true
+            })
         }
-    },
-    mounted () {
-        this.scopedTabs = this.tabs
     },
     methods: {
         selectTab (i) {


### PR DESCRIPTION
## Description

Hid the instance assets tab from users without sufficient permissions (<= viewer)
Added redirect safeguard for users that manually attempt to access the tab
Added the ability to filter page navigation tabs based on a hidden property
Added a new permissions check that allows to check permission based on team role name

## Related Issue(s)

fixes https://github.com/FlowFuse/flowfuse/issues/4439

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

