### PR TITLE
Don't try and create default items more than once

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -457,7 +457,7 @@ module.exports = async (options = {}) => {
         await server.db.controllers.TeamType.ensureDefaultTypeExists()
 
         // Create ff-admin
-        if (server.config.create_admin) {
+        if (server.config.create_admin && !app.settings.get('setup:initialised')) {
             await createAdminUser(server)
             await finishSetup(server)
         }

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -457,7 +457,7 @@ module.exports = async (options = {}) => {
         await server.db.controllers.TeamType.ensureDefaultTypeExists()
 
         // Create ff-admin
-        if (server.config.create_admin && !app.settings.get('setup:initialised')) {
+        if (server.config.create_admin && !server.settings.get('setup:initialised')) {
             await createAdminUser(server)
             await finishSetup(server)
         }


### PR DESCRIPTION
fixes #4453

## Description

<!-- Describe your changes in detail -->
Prevents default team type, temaplate and stack from being recreated at startup

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4453

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

