### PR TITLE
Ensure subscription is deleted from db when team is deleted

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -539,8 +539,18 @@ module.exports = async function (app) {
 
             if (app.license.active() && app.billing) {
                 const subscription = await request.team.getSubscription()
-                if (subscription && !subscription.isTrial() && !subscription.isUnmanaged()) {
-                    await app.billing.closeSubscription(subscription)
+                if (subscription) {
+                    if (!subscription.isTrial() && !subscription.isUnmanaged()) {
+                        const subId = subscription.subscription || 'unknown'
+                        try {
+                            await app.billing.closeSubscription(subscription)
+                        } catch (err) {
+                            app.log.warn(`Error canceling subscription ${subId} for team ${request.team.hashid}`)
+                            app.log.warn(err)
+                        }
+                    }
+                    // Delete the subscription
+                    await subscription.destroy()
                 }
             }
 


### PR DESCRIPTION
## Description

Spotted whilst working on the suspend team feature.

The db relation between Team and Subscription has on delete constraint configured to set null. This will orphan the subscription objects in the database.

The code was correctly closing the subscription on stripe when deleting the team, but it then needed to also delete the subscription object. This does that.

I've chosen not to fix the db relation in this PR as this is the only path that deletes teams - and would prefer we only delete the subscription object after closing it on stripe. If the DB auto-deleted the subscription object, we could end up leaving subscriptions active on stripe.

Having checked on FFC production, there is some tidy up to do as we have a fair number os Subscription objects with TeamId set to null. But there is zero impact having them there currently.