### PR TITLE
Show missing application selection error in the right place

### DIFF
--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -128,7 +128,11 @@ export default {
             } catch (err) {
                 this.instanceDetails = instanceFields
                 if (err.response?.status === 409) {
-                    this.errors.name = err.response.data.error
+                    if (err.response.data?.code === 'invalid_application_name') {
+                        this.errors.applicationName = err.response.data.error
+                    } else {
+                        this.errors.name = err.response.data.error
+                    }
                 } else if (err.response?.status === 400) {
                     Alerts.emit('Failed to create instance: ' + err.response.data.error, 'warning', 7500)
                 } else {

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -23,7 +23,7 @@
             <FormRow
                 v-model="input.applicationId"
                 :options="applications"
-                :error="errors.applicationId || submitErrors?.applicationId"
+                :error="!input.applicationId ? (errors.applicationId || submitErrors?.applicationId) : undefined"
                 :disabled="applicationFieldsLocked"
                 data-form="application-id"
             >

--- a/frontend/src/pages/team/createInstance.vue
+++ b/frontend/src/pages/team/createInstance.vue
@@ -165,7 +165,11 @@ export default {
             } catch (err) {
                 this.instanceDetails = instanceFields
                 if (err.response?.status === 409) {
-                    this.errors.name = err.response.data.error
+                    if (err.response.data?.code === 'invalid_application_name') {
+                        this.errors.applicationId = 'Select an Application'
+                    } else {
+                        this.errors.name = err.response.data.error
+                    }
                 } else if (err.response?.status === 400) {
                     Alerts.emit('Failed to create instance: ' + err.response.data.error, 'warning', 7500)
                 } else {


### PR DESCRIPTION
Fixes #4299 

In the case an Application wasn't selected when submitting the form, the 'name must be set' message was being displayed against the Instance name field.

This was because any error on the api call was setting the error message against the 'name' field.

In the case of an application name error, it needed setting on either applicationName (when creating an app as well) or applicationId when selecting from existing apps.

This fixes all of that, and ensures the error is cleared when an application is selected.