### PR TITLE
fix: Asset upload dialog

### DIFF
--- a/frontend/src/components/FileUpload.vue
+++ b/frontend/src/components/FileUpload.vue
@@ -65,6 +65,8 @@ export default {
             clear () {
                 this.file = null
                 this.errors = null
+                // clear the input so that the same file can be selected again
+                this.$refs.fileUpload.value = ''
                 this.$emit('update:modelValue', null)
             }
         }

--- a/frontend/src/components/FileUpload.vue
+++ b/frontend/src/components/FileUpload.vue
@@ -64,6 +64,7 @@ export default {
         return {
             clear () {
                 this.file = null
+                this.errors = null
                 this.$emit('update:modelValue', null)
             }
         }
@@ -78,7 +79,7 @@ export default {
         onFileChange (event) {
             const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
             this.file = event.target && event.target.files && event.target.files[0]
-
+            this.errors = null
             // check against max file size
             if (this.file.size > MAX_FILE_SIZE) {
                 this.file = null


### PR DESCRIPTION
closes #4456
closes #4458 

## Description

Fixes asset upload
* clear 5mb warning when selecting file < 5mb
* clear input value to permit same file selection

## Related Issue(s)

#4456
#4458 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

