### PR TITLE
Improve user feedback when developer mode change fails

### DIFF
--- a/frontend/src/pages/device/components/DeveloperModeToggle.vue
+++ b/frontend/src/pages/device/components/DeveloperModeToggle.vue
@@ -28,6 +28,14 @@ export default {
         device: {
             type: Object,
             required: true
+        },
+        disabled: {
+            type: Boolean,
+            default: false
+        },
+        disabledReason: {
+            type: String,
+            default: null
         }
     },
     emits: ['mode-change'],
@@ -40,12 +48,15 @@ export default {
     },
     computed: {
         toggleDisabled () {
-            return this.unsupportedVersion || this.busy
+            return this.disabled || this.unsupportedVersion || this.busy
         },
         developerMode () {
             return this.device?.mode === 'developer'
         },
         toggleTip () {
+            if (this.disabled && this.disabledReason) {
+                return this.disabledReason
+            }
             if (this.unsupportedVersion) {
                 return 'Developer Mode unavailable'
             } else {

--- a/frontend/src/pages/device/components/DeveloperModeToggle.vue
+++ b/frontend/src/pages/device/components/DeveloperModeToggle.vue
@@ -89,7 +89,18 @@ export default {
             this.$emit('mode-change', devModeOn ? 'developer' : 'autonomous', (err, _result) => {
                 if (err) {
                     console.warn('Error setting developer mode', err)
-                    alerts.emit(err.message, 'warning', 7000)
+                    const basicError = 'An error occurred while attempting to change developer mode.'
+                    if (err.response && typeof err.response.status === 'number') {
+                        if (err.response.status === 403) {
+                            alerts.emit('You do not have permission to change developer mode', 'warning', 7000)
+                        } else if (err.response.status === 401) {
+                            alerts.emit('You are not authorized to change developer mode', 'warning', 7000)
+                        } else {
+                            alerts.emit(basicError, 'warning', 7000)
+                        }
+                    } else {
+                        alerts.emit(basicError, 'warning', 7000)
+                    }
                 } else if (_result) {
                     this.developerModeLocal = _result.mode === 'developer'
                 }

--- a/frontend/src/pages/device/components/DeveloperModeToggle.vue
+++ b/frontend/src/pages/device/components/DeveloperModeToggle.vue
@@ -91,9 +91,7 @@ export default {
                     console.warn('Error setting developer mode', err)
                     const basicError = 'An error occurred while attempting to change developer mode.'
                     if (err.response && typeof err.response.status === 'number') {
-                        if (err.response.status === 403) {
-                            alerts.emit('You do not have permission to change developer mode', 'warning', 7000)
-                        } else if (err.response.status === 401) {
+                        if (err.response.status === 401 || err.response.status === 403) {
                             alerts.emit('You are not authorized to change developer mode', 'warning', 7000)
                         } else {
                             alerts.emit(basicError, 'warning', 7000)

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -40,7 +40,7 @@
                         is still there and affects the button height in this div group)
                     -->
                     <div class="space-x-2 flex align-center" style="height: 34px;">
-                        <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" @mode-change="setDeviceMode" />
+                        <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" :disabled="disableModeToggle" :disabledReason="disableModeToggleReason" @mode-change="setDeviceMode" />
                         <button v-if="!isVisitingAdmin" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">
                             Device Editor
                             <span class="ff-btn--icon ff-btn--icon-right">
@@ -188,8 +188,10 @@ export default {
     computed: {
         ...mapState('account', ['teamMembership', 'team', 'features', 'settings']),
         isVisitingAdmin: function () {
-            // return true
             return this.teamMembership.role === Roles.Admin
+        },
+        isOwner: function () {
+            return this.teamMembership.role === Roles.Owner
         },
         isDevModeAvailable: function () {
             return !!this.features.deviceEditor
@@ -199,6 +201,24 @@ export default {
         },
         deviceRunning () {
             return this.device?.status === 'running'
+        },
+        disableModeToggle: function () {
+            return !this.isDevModeAvailable ||
+                !this.device ||
+                !this.agentSupportsDeviceAccess ||
+                !this.isOwner
+        },
+        disableModeToggleReason: function () {
+            if (!this.device) {
+                return 'No Device selected'
+            }
+            if (!this.agentSupportsDeviceAccess) {
+                return 'Device Agent V0.8 or greater is required'
+            }
+            if (!this.isOwner) {
+                return 'Only an owner can change the Device Mode'
+            }
+            return undefined
         },
         editorAvailable: function () {
             return this.isDevModeAvailable &&


### PR DESCRIPTION
closes #4468

## Description

Presents a friendlier toast than "Request failed with status code 403"

Now displays relevant toast text with a fall back to a friendlier message if the error is generic or unrecognised.
* Status 403: "You do not have permission to change developer mode"
* Status 401: "You are not authorized to change developer mode"
* Otherwise: "An error occurred while attempting to change developer mode"

## Related Issue(s)

#4468

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

