### PR TITLE
4461 add file asset service visibility selector

### DIFF
--- a/frontend/src/api/assets.js
+++ b/frontend/src/api/assets.js
@@ -4,7 +4,10 @@ const getFiles = function (instanceId, path) {
     // remove leading / from path
     path = path.replace(/^\//, '')
     return client.get(`/api/v1/projects/${instanceId}/files/_/${encodeURIComponent(path || '')}`).then(res => {
-        return res.data.files
+        return {
+            files: res.data.files,
+            folder: res.data.folder
+        }
     })
 }
 

--- a/frontend/src/api/assets.js
+++ b/frontend/src/api/assets.js
@@ -30,6 +30,14 @@ const updateFolder = function (instanceId, pwd, oldName, newName) {
     })
 }
 
+const updateVisibility = function (instanceId, pwd, visibility, staticPath = '') {
+    // remove leading / from path
+    pwd = pwd.replace(/^\//, '')
+    return client.put(`/api/v1/projects/${instanceId}/files/_/${encodeURIComponent(pwd)}`, {
+        share: visibility === 'public' ? { root: staticPath } : {}
+    })
+}
+
 const deleteItem = function (instanceId, path) {
     // remove leading / from path
     path = path.replace(/^\//, '')
@@ -52,6 +60,7 @@ export default {
     getFiles,
     createFolder,
     updateFolder,
+    updateVisibility,
     deleteItem,
     uploadFile
 }

--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -132,6 +132,10 @@ export default {
             required: false,
             default: '',
             type: String
+        },
+        instance: {
+            required: true,
+            type: Object
         }
     },
     emits: ['change-directory', 'items-updated'],
@@ -224,7 +228,7 @@ export default {
                     component: {
                         is: markRaw(ItemFilePath),
                         extraProps: {
-                            isBaseUrl: true,
+                            aseUrl: this.instance?.url,
                             breadcrumbs: this.breadcrumbs,
                             prepend: this.publicFolderPath,
                             isNotAvailable: !this.isPublicFolder

--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -153,6 +153,21 @@ export default {
         folder () {
             return [...this.breadcrumbs].pop()
         },
+        isPublicFolder () {
+            if (!this.folder) {
+                return false
+            }
+
+            return Object.prototype.hasOwnProperty.call(this.folder, 'share') &&
+                Object.prototype.hasOwnProperty.call(this.folder.share, 'root')
+        },
+        publicFolderPath () {
+            if (!this.isPublicFolder) {
+                return null
+            }
+
+            return this.folder.share.root
+        },
         instanceId () {
             return this.$route.params.id
         },
@@ -200,6 +215,21 @@ export default {
                             folder: this.folder?.name || ''
                         }
                     }
+                },
+                {
+                    key: 'url',
+                    label: 'URL',
+                    sortable: true,
+                    component: {
+                        is: markRaw(ItemFilePath),
+                        extraProps: {
+                            isBaseUrl: true,
+                            breadcrumbs: this.breadcrumbs,
+                            prepend: this.publicFolderPath,
+                            isNotAvailable: !this.isPublicFolder
+                        }
+                    },
+                    hidden: true
                 },
                 {
                     key: 'lastModified',

--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -228,7 +228,7 @@ export default {
                     component: {
                         is: markRaw(ItemFilePath),
                         extraProps: {
-                            aseUrl: this.instance?.url,
+                            baseURL: this.instance?.url,
                             breadcrumbs: this.breadcrumbs,
                             prepend: this.publicFolderPath,
                             isNotAvailable: !this.isPublicFolder

--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -119,13 +119,9 @@ export default {
             required: true,
             type: Object
         },
-        folder: {
-            required: true,
-            type: Object
-        },
         breadcrumbs: {
             required: true,
-            type: Object
+            type: Array
         },
         disabled: {
             required: false,
@@ -154,15 +150,21 @@ export default {
         }
     },
     computed: {
+        folder () {
+            return [...this.breadcrumbs].pop()
+        },
         instanceId () {
             return this.$route.params.id
         },
         pwd () {
-            return [...this.breadcrumbs].filter(b => b).join('/').replace('//', '/')
+            return [...this.breadcrumbs.map(crumb => crumb.name)]
+                .filter(b => b)
+                .join('/')
+                .replace('//', '/')
         },
         baseURI () {
             // clear null values
-            const breadcrumbs = this.breadcrumbs.filter(n => n)
+            const breadcrumbs = this.breadcrumbs.map(crumb => crumb.name).filter(n => n)
             return breadcrumbs.join('/').replace('//', '/')
         },
         columns () {
@@ -195,7 +197,7 @@ export default {
                         is: markRaw(ItemFilePath),
                         extraProps: {
                             breadcrumbs: this.breadcrumbs,
-                            folder: this.folder.name || ''
+                            folder: this.folder?.name || ''
                         }
                     }
                 },
@@ -207,7 +209,7 @@ export default {
             ]
         },
         noDataMessages () {
-            return this.noDataMessage.length ? this.noDataMessage : `No files in '${this.folder.name || 'Storage'}'`
+            return this.noDataMessage.length ? this.noDataMessage : `No files in '${this.folder?.name || 'Storage'}'`
         }
     },
     methods: {
@@ -215,7 +217,7 @@ export default {
             this.$refs[dialog].show()
         },
         createFolder () {
-            const pwd = this.baseURI + '/' + (this.folder.name || '')
+            const pwd = this.baseURI + '/' + (this.folder?.name || '')
             this.loading = true
             AssetsAPI.createFolder(this.instanceId, pwd, this.forms.newFolder.name)
                 .then(() => this.$emit('items-updated'))

--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -212,6 +212,7 @@ export default {
                         is: markRaw(ItemFilePath),
                         extraProps: {
                             breadcrumbs: this.breadcrumbs,
+                            prepend: '/data/storage',
                             folder: this.folder?.name || ''
                         }
                     }

--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -158,7 +158,7 @@ export default {
             return this.$route.params.id
         },
         pwd () {
-            return [...this.breadcrumbs, this.folder.name].filter(b => b).join('/').replace('//', '/')
+            return [...this.breadcrumbs].filter(b => b).join('/').replace('//', '/')
         },
         baseURI () {
             // clear null values
@@ -292,7 +292,7 @@ export default {
             })
         },
         uploadFile () {
-            const pwd = this.baseURI + '/' + (this.folder.name || '')
+            const pwd = this.baseURI + '/'
             const filename = this.forms.file.name
             this.loading = true
             AssetsAPI.uploadFile(this.instanceId, pwd, filename, this.forms.file)

--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -251,9 +251,8 @@ export default {
             this.$refs[dialog].show()
         },
         createFolder () {
-            const pwd = this.baseURI + '/' + (this.folder?.name || '')
             this.loading = true
-            AssetsAPI.createFolder(this.instanceId, pwd, this.forms.newFolder.name)
+            AssetsAPI.createFolder(this.instanceId, this.baseURI, this.forms.newFolder.name)
                 .then(() => this.$emit('items-updated'))
                 .catch(error => {
                     console.error(error)

--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -216,7 +216,6 @@ export default {
                         is: markRaw(ItemFilePath),
                         extraProps: {
                             breadcrumbs: this.breadcrumbs,
-                            prepend: '/data/storage',
                             folder: this.folder?.name || ''
                         }
                     }

--- a/frontend/src/components/file-browser/VisibilitySelector.vue
+++ b/frontend/src/components/file-browser/VisibilitySelector.vue
@@ -119,7 +119,7 @@ export default {
                     .filter(p => p)
                     .shift()
                 if (!this.restrictedStaticFilePaths.includes(removeSlashes(startingPath))) {
-                    this.selected('public', this.staticPath)
+                    this.selected('public', this.staticPath.replace(/^\//, ''))
                     this.clearStaticPath()
                 } else {
                     Alerts.emit('Unable to set a restricted static path', 'warning')

--- a/frontend/src/components/file-browser/VisibilitySelector.vue
+++ b/frontend/src/components/file-browser/VisibilitySelector.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dropdown :disabled="isDisabled">
+    <ff-dropdown :disabled="isDisabled" data-el="visibility-selector">
         <template #placeholder>
             <div v-if="isCurrentFolderPublic" class="flex gap-2"><GlobeAltIcon class="ff-icon" /> Public</div>
             <div v-else class="flex gap-2"><ProjectIcon class="ff-icon" /> Node-RED Only</div>

--- a/frontend/src/components/file-browser/VisibilitySelector.vue
+++ b/frontend/src/components/file-browser/VisibilitySelector.vue
@@ -1,0 +1,70 @@
+<template>
+    <ff-dropdown :disabled="isRootFolder">
+        <template #placeholder>
+            <div class="flex gap-2"><ProjectIcon class="ff-icon" /> Node-RED Only</div>
+        </template>
+        <template #default>
+            <ff-dropdown-option data-action="select-private" @click="selected('private')">
+                <div class="flex gap-2"><ProjectIcon class="ff-icon" /> Node-RED Only</div>
+            </ff-dropdown-option>
+            <ff-dropdown-option data-action="select-public" @click="showStaticPathSelectionDialog">
+                <div class="flex gap-2"><GlobeAltIcon class="ff-icon" /> Public</div>
+            </ff-dropdown-option>
+        </template>
+    </ff-dropdown>
+    <ff-dialog
+        ref="selectStaticPath" data-el="select-static-path-dialog"
+        header="Select a static path"
+        @confirm="confirmStaticPath"
+    >
+        <p style="margin-bottom: 12px">
+            Please set the static path mapping
+        </p>
+        <ff-text-input v-model="staticPath" placeholder="Static Path" />
+    </ff-dialog>
+</template>
+
+<script>
+import { GlobeAltIcon } from '@heroicons/vue/outline'
+
+import ProjectIcon from '../../components/icons/Projects.js'
+export default {
+    name: 'VisibilitySelector',
+    components: { ProjectIcon, GlobeAltIcon },
+    inheritAttrs: false,
+    props: {
+        breadcrumbs: {
+            type: Array,
+            required: true
+        }
+    },
+    emits: ['selected'],
+    data () {
+        return {
+            staticPath: ''
+        }
+    },
+    computed: {
+        isRootFolder () {
+            return this.breadcrumbs.length === 0
+        }
+    },
+    methods: {
+        selected (visibility, path) {
+            this.$emit('selected', { visibility, path })
+        },
+        showStaticPathSelectionDialog () {
+            this.$refs.selectStaticPath.show()
+        },
+        confirmStaticPath () {
+            this.selected('public', this.staticPath)
+            this.staticPath = ''
+        }
+    }
+
+}
+</script>
+
+<style scoped lang="scss">
+
+</style>

--- a/frontend/src/components/file-browser/VisibilitySelector.vue
+++ b/frontend/src/components/file-browser/VisibilitySelector.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dropdown :disabled="isRootFolder">
+    <ff-dropdown :disabled="isDisabled">
         <template #placeholder>
             <div v-if="isCurrentFolderPublic" class="flex gap-2"><GlobeAltIcon class="ff-icon" /> Public</div>
             <div v-else class="flex gap-2"><ProjectIcon class="ff-icon" /> Node-RED Only</div>
@@ -94,6 +94,13 @@ export default {
             }
 
             return restrictions.map(restriction => removeSlashes(restriction))
+        },
+        isDisabled () {
+            if (this.isRootFolder) {
+                return true
+            }
+
+            return this.instance?.meta?.state !== 'running'
         }
     },
     methods: {

--- a/frontend/src/components/file-browser/VisibilitySelector.vue
+++ b/frontend/src/components/file-browser/VisibilitySelector.vue
@@ -1,10 +1,11 @@
 <template>
     <ff-dropdown :disabled="isRootFolder">
         <template #placeholder>
-            <div class="flex gap-2"><ProjectIcon class="ff-icon" /> Node-RED Only</div>
+            <div v-if="isCurrentFolderPublic" class="flex gap-2"><GlobeAltIcon class="ff-icon" /> Public</div>
+            <div v-else class="flex gap-2"><ProjectIcon class="ff-icon" /> Node-RED Only</div>
         </template>
         <template #default>
-            <ff-dropdown-option data-action="select-private" @click="selected('private')">
+            <ff-dropdown-option data-action="select-private" :disabled="!isCurrentFolderPublic" @click="selected('private')">
                 <div class="flex gap-2"><ProjectIcon class="ff-icon" /> Node-RED Only</div>
             </ff-dropdown-option>
             <ff-dropdown-option data-action="select-public" @click="showStaticPathSelectionDialog">
@@ -47,11 +48,27 @@ export default {
     computed: {
         isRootFolder () {
             return this.breadcrumbs.length === 0
+        },
+        currentFolder () {
+            if (this.breadcrumbs.length > 0) {
+                return this.breadcrumbs[this.breadcrumbs.length - 1]
+            }
+            return null
+        },
+        isCurrentFolderPublic () {
+            if (!this.currentFolder) {
+                return false
+            }
+
+            return Object.prototype.hasOwnProperty.call(this.currentFolder, 'share') &&
+                Object.prototype.hasOwnProperty.call(this.currentFolder.share, 'root')
         }
     },
     methods: {
         selected (visibility, path) {
-            this.$emit('selected', { visibility, path })
+            if (visibility === 'private' && !this.isCurrentFolderPublic) {
+                // do nothing
+            } else this.$emit('selected', { visibility, path })
         },
         showStaticPathSelectionDialog () {
             this.$refs.selectStaticPath.show()
@@ -65,6 +82,32 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
+<style lang="scss">
+.ff-dropdown {
+  min-width: 130px;
 
+  .ff-dropdown-selected {
+    padding-left: 0;
+    padding-right: 0;
+    border: none;
+  }
+
+  .ff-dropdown-options {
+    border: 1px solid $ff-grey-200 !important;
+
+    .ff-dropdown-option {
+      background: white !important;
+      border: none !important;
+
+      &[disabled="true"] {
+        color: $ff-grey-600;
+        cursor: not-allowed;
+      }
+
+      &:hover {
+        background-color: $ff-grey-200 !important;
+      }
+    }
+  }
+}
 </style>

--- a/frontend/src/components/file-browser/VisibilitySelector.vue
+++ b/frontend/src/components/file-browser/VisibilitySelector.vue
@@ -16,6 +16,7 @@
     <ff-dialog
         ref="selectStaticPath" data-el="select-static-path-dialog"
         header="Select a static path"
+        :disablePrimary="staticPath.length === 0"
         @confirm="confirmStaticPath"
     >
         <p style="margin-bottom: 12px">
@@ -74,8 +75,10 @@ export default {
             this.$refs.selectStaticPath.show()
         },
         confirmStaticPath () {
-            this.selected('public', this.staticPath)
-            this.staticPath = ''
+            if (this.staticPath.length > 0) {
+                this.selected('public', this.staticPath)
+                this.staticPath = ''
+            }
         }
     }
 

--- a/frontend/src/components/file-browser/VisibilitySelector.vue
+++ b/frontend/src/components/file-browser/VisibilitySelector.vue
@@ -114,7 +114,6 @@ export default {
                 if (!this.restrictedStaticFilePaths.includes(removeSlashes(startingPath))) {
                     this.selected('public', this.staticPath)
                     this.clearStaticPath()
-                    Alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
                 } else {
                     Alerts.emit('Unable to set a restricted static path', 'warning')
                 }

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -46,18 +46,16 @@ export default {
     computed: {
         path () {
             const breadcrumbs = this.isBaseUrl ? [] : this.breadcrumbs
-            const path = [
+            return [
                 this.prepend,
                 ...breadcrumbs.map(crumb => crumb.name),
                 this.name
             ].join('/')
-            // clear leading slash
-            return path.replace(/^\//, '')
         }
     },
     methods: {
         copyPath () {
-            navigator.clipboard.writeText('/' + this.path)
+            navigator.clipboard.writeText(this.path)
 
             // show "Copied" notification
             this.$refs.copied.style.display = 'inline'

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -57,7 +57,7 @@ export default {
     },
     methods: {
         copyPath () {
-            navigator.clipboard.writeText(this.path)
+            navigator.clipboard.writeText('/' + this.path)
 
             // show "Copied" notification
             this.$refs.copied.style.display = 'inline'

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -18,11 +18,6 @@ export default {
     },
     inheritAttrs: false,
     props: {
-        type: {
-            required: false,
-            type: String,
-            default: 'file'
-        },
         name: {
             required: false,
             type: String,
@@ -41,11 +36,17 @@ export default {
             required: false,
             default: false,
             type: Boolean
+        },
+        isBaseUrl: {
+            required: false,
+            default: false,
+            type: Boolean
         }
     },
     computed: {
         path () {
-            const path = [this.prepend, ...this.breadcrumbs.map(crumb => crumb.name), this.name].join('/')
+            const breadcrumbs = this.isBaseUrl ? [[...this.breadcrumbs].pop()] : this.breadcrumbs
+            const path = [this.prepend, ...breadcrumbs.map(crumb => crumb.name), this.name].join('/')
             // clear leading slash
             return path.replace(/^\//, '')
         }

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -1,9 +1,10 @@
 <template>
-    <div v-if="type === 'file'" class="ff-row-file--copy" @click="copyPath">
-        {{ path }}
-        <DuplicateIcon class="ff-icon" />
+    <div v-if="!isNotAvailable" class="ff-row-file--copy">
+        <span class="path" :title="path">{{ path }}</span>
+        <DuplicateIcon class="ff-icon" @click="copyPath" @click.prevent.stop />
         <span ref="copied" class="ff-copied">Copied!</span>
     </div>
+    <span v-else class="not-available">Not Available</span>
 </template>
 
 <script>
@@ -18,25 +19,33 @@ export default {
     inheritAttrs: false,
     props: {
         type: {
-            required: true,
-            type: String
+            required: false,
+            type: String,
+            default: 'file'
         },
         name: {
-            required: true,
-            type: String
-        },
-        folder: {
-            required: true,
-            type: String
+            required: false,
+            type: String,
+            default: ''
         },
         breadcrumbs: {
             default: null,
             type: Array
+        },
+        prepend: {
+            required: false,
+            default: '',
+            type: String
+        },
+        isNotAvailable: {
+            required: false,
+            default: false,
+            type: Boolean
         }
     },
     computed: {
         path () {
-            const path = [...this.breadcrumbs, this.folder, this.name].join('/')
+            const path = [this.prepend, ...this.breadcrumbs, this.name].join('/')
             // clear leading slash
             return path.replace(/^\//, '')
         }
@@ -60,9 +69,14 @@ export default {
 .ff-row-file--copy {
     position: relative;
     &:hover {
-        cursor: pointer;
         color: $ff-blue-600;
     }
+
+  .ff-icon {
+    &:hover {
+      cursor: pointer;
+    }
+  }
 }
 
 .ff-copied {
@@ -74,5 +88,9 @@ export default {
     margin-top: -3px;
     margin-left: 3px;
     display: none;
+}
+
+.not-available {
+  opacity: .4;
 }
 </style>

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -45,8 +45,12 @@ export default {
     },
     computed: {
         path () {
-            const breadcrumbs = this.isBaseUrl ? [[...this.breadcrumbs].pop()] : this.breadcrumbs
-            const path = [this.prepend, ...breadcrumbs.map(crumb => crumb.name), this.name].join('/')
+            const breadcrumbs = this.isBaseUrl ? [] : this.breadcrumbs
+            const path = [
+                this.prepend,
+                ...breadcrumbs.map(crumb => crumb.name),
+                this.name
+            ].join('/')
             // clear leading slash
             return path.replace(/^\//, '')
         }

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -37,15 +37,19 @@ export default {
             default: false,
             type: Boolean
         },
-        isBaseUrl: {
+        baseUrl: {
             required: false,
-            default: false,
-            type: Boolean
+            default: null,
+            type: String
         }
     },
     computed: {
         path () {
-            const breadcrumbs = this.isBaseUrl ? [] : this.breadcrumbs
+            if (this.baseUrl) {
+                const url = new URL(this.baseUrl)
+                return [url.origin, this.prepend, this.name].join('/')
+            }
+            const breadcrumbs = this.baseUrl ? [] : this.breadcrumbs
             return [
                 this.prepend,
                 ...breadcrumbs.map(crumb => crumb.name),

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -49,11 +49,14 @@ export default {
                 const url = new URL(this.baseURL)
                 return [url.origin, this.prepend, this.name].join('/')
             }
-            return [
+            const path = [
                 this.prepend,
                 ...this.breadcrumbs.map(crumb => crumb.name),
                 this.name
             ].join('/')
+
+            // clear leading slash
+            return path.replace(/^\//, '')
         }
     },
     methods: {

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -37,22 +37,21 @@ export default {
             default: false,
             type: Boolean
         },
-        baseUrl: {
+        baseURL: {
             required: false,
             default: null,
-            type: String
+            type: [String, null]
         }
     },
     computed: {
         path () {
-            if (this.baseUrl) {
-                const url = new URL(this.baseUrl)
+            if (this.baseURL && this.baseURL.length > 0) {
+                const url = new URL(this.baseURL)
                 return [url.origin, this.prepend, this.name].join('/')
             }
-            const breadcrumbs = this.baseUrl ? [] : this.breadcrumbs
             return [
                 this.prepend,
-                ...breadcrumbs.map(crumb => crumb.name),
+                ...this.breadcrumbs.map(crumb => crumb.name),
                 this.name
             ].join('/')
         }

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="!isNotAvailable" class="ff-row-file--copy">
         <span class="path" :title="path">{{ path }}</span>
-        <DuplicateIcon class="ff-icon" @click="copyPath" @click.prevent.stop />
+        <DuplicateIcon v-if="path.length" class="ff-icon" @click="copyPath" @click.prevent.stop />
         <span ref="copied" class="ff-copied">Copied!</span>
     </div>
     <span v-else class="not-available">Not Available</span>

--- a/frontend/src/components/file-browser/cells/FilePath.vue
+++ b/frontend/src/components/file-browser/cells/FilePath.vue
@@ -29,7 +29,7 @@ export default {
             default: ''
         },
         breadcrumbs: {
-            default: null,
+            default: () => [],
             type: Array
         },
         prepend: {
@@ -45,7 +45,7 @@ export default {
     },
     computed: {
         path () {
-            const path = [this.prepend, ...this.breadcrumbs, this.name].join('/')
+            const path = [this.prepend, ...this.breadcrumbs.map(crumb => crumb.name), this.name].join('/')
             // clear leading slash
             return path.replace(/^\//, '')
         }

--- a/frontend/src/composables/String.js
+++ b/frontend/src/composables/String.js
@@ -20,3 +20,14 @@ export const dateToSlug = (date) => {
 
     return `${year}-${month}-${day}_${hours}-${minutes}`
 }
+
+// utility function to remove leading and trailing slashes
+export const removeSlashes = (str, leading = true, trailing = true) => {
+    if (leading && str.startsWith('/')) {
+        str = str.slice(1)
+    }
+    if (trailing && str.endsWith('/')) {
+        str = str.slice(0, -1)
+    }
+    return str
+}

--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -11,6 +11,7 @@
         </div>
         <FolderBreadcrumbs
             :breadcrumbs="breadcrumbs"
+            :instance="instance"
             @go-back="goBack"
             @selected-visibility="onVisibilitySelected"
         />
@@ -154,12 +155,14 @@ export default {
                     if (payload.visibility === 'private') {
                         delete this.breadcrumbs[this.breadcrumbs.length - 1].share
                     } else {
-                        this.breadcrumbs[this.breadcrumbs.length - 1] = {
-                            ...this.breadcrumbs[this.breadcrumbs.length - 1],
-                            share: {
-                                root: payload.path
-                            }
-                        }
+                        // update the last entry in the breadcrumbs with the updated visibility
+                        // disabled as the folder visibility is not reflected until the instance is restarted
+                        // this.breadcrumbs[this.breadcrumbs.length - 1] = {
+                        //     ...this.breadcrumbs[this.breadcrumbs.length - 1],
+                        //     share: {
+                        //         root: payload.path
+                        //     }
+                        // }
                     }
                 })
                 .catch(err => console.warn(err))

--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -6,10 +6,10 @@
             <FeatureUnavailable v-else-if="!launcherSatisfiesVersion" :message="launcherVersionMessage" :only-custom-message="true" />
         </div>
         <FolderBreadcrumbs
-            :current-directory="currentDirectory"
             :breadcrumbs="breadcrumbs"
             @clicked="breadcrumbClicked"
             @go-back="goBack"
+            @selected-visibility="onVisibilitySelected"
         />
         <FileBrowser
             :breadcrumbs="breadcrumbs"
@@ -133,6 +133,18 @@ export default {
             } else {
                 this.changeDirectory({ name: this.breadcrumbs.pop() })
             }
+        },
+        onVisibilitySelected (payload) {
+            AssetsAPI.updateVisibility(
+                this.instance.id,
+                this.breadcrumbs.join('/').replace('//', '/'),
+                payload.visibility,
+                payload.path
+            ).then((res) => {
+                this.loadContents()
+            }).catch(err => {
+                console.log(err)
+            })
         }
     }
 }

--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -3,7 +3,11 @@
         <div class="banner-wrapper">
             <FeatureUnavailable v-if="!isStaticAssetFeatureEnabledForPlatform" />
             <FeatureUnavailableToTeam v-else-if="!isStaticAssetsFeatureEnabledForTeam" />
-            <FeatureUnavailable v-else-if="!launcherSatisfiesVersion" :message="launcherVersionMessage" :only-custom-message="true" />
+            <FeatureUnavailable
+                v-else-if="!launcherSatisfiesVersion"
+                :message="launcherVersionMessage"
+                :only-custom-message="true"
+            />
         </div>
         <FolderBreadcrumbs
             :breadcrumbs="breadcrumbs"
@@ -111,7 +115,7 @@ export default {
                 }
 
                 const filepath = breadcrumbs.map(crumb => crumb.name).join('/')
-                AssetsAPI.getFiles(this.instance.id, filepath)
+                return AssetsAPI.getFiles(this.instance.id, filepath)
                     .then(files => {
                         this.files = files
                     })
@@ -145,8 +149,18 @@ export default {
                 payload.visibility,
                 payload.path
             )
+                .then((res) => this.loadContents())
                 .then((res) => {
-                    this.loadContents()
+                    if (payload.visibility === 'private') {
+                        delete this.breadcrumbs[this.breadcrumbs.length - 1].share
+                    } else {
+                        this.breadcrumbs[this.breadcrumbs.length - 1] = {
+                            ...this.breadcrumbs[this.breadcrumbs.length - 1],
+                            share: {
+                                root: payload.path
+                            }
+                        }
+                    }
                 })
                 .catch(err => console.warn(err))
         }
@@ -155,7 +169,7 @@ export default {
 </script>
 
 <style lang="scss">
-.banner-wrapper > div{
+.banner-wrapper > div {
   margin-top: 0;
 }
 </style>

--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -18,6 +18,7 @@
         <FileBrowser
             :breadcrumbs="breadcrumbs"
             :items="sortedFiles"
+            :instance="instance"
             :disabled="!isFeatureEnabled"
             :no-data-message="!isInstanceRunning ? instanceSuspendedMessage : ''"
             @items-updated="loadContents"

--- a/frontend/src/pages/instance/components/DashboardLink.vue
+++ b/frontend/src/pages/instance/components/DashboardLink.vue
@@ -25,16 +25,7 @@
 
 import { ChartPieIcon } from '@heroicons/vue/outline'
 
-// utility function to remove leading and trailing slashes
-const removeSlashes = (str, leading = true, trailing = true) => {
-    if (leading && str.startsWith('/')) {
-        str = str.slice(1)
-    }
-    if (trailing && str.endsWith('/')) {
-        str = str.slice(0, -1)
-    }
-    return str
-}
+import { removeSlashes } from '../../../composables/String.js'
 
 export default {
     name: 'DashboardLink',

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -22,6 +22,10 @@ export default {
         breadcrumbs: {
             required: true,
             type: Array
+        },
+        instance: {
+            required: true,
+            type: Object
         }
     },
     emits: ['go-back', 'selected-visibility'],
@@ -108,7 +112,8 @@ export default {
                             }
                         }),
                         extraProps: {
-                            breadcrumbs: this.breadcrumbs
+                            breadcrumbs: this.breadcrumbs,
+                            instance: this.instance
                         }
                     }
                 },

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -13,8 +13,9 @@ import { ArrowLeftIcon } from '@heroicons/vue/outline'
 
 import { markRaw } from 'vue'
 
+import VisibilitySelector from '../../../components/file-browser/VisibilitySelector.vue'
 import ItemFilePath from '../../../components/file-browser/cells/FilePath.vue'
-import ProjectIcon from '../../../components/icons/Projects.js'
+import breadcrumb from '../../../ui-components/components/Breadcrumb.vue'
 
 export default {
     name: 'FolderBreadcrumbs',
@@ -22,22 +23,26 @@ export default {
         breadcrumbs: {
             required: true,
             type: Object
-        },
-        currentDirectory: {
-            required: true,
-            type: Object
         }
     },
-    emits: ['clicked', 'go-back'],
+    emits: ['clicked', 'go-back', 'selected-visibility'],
     computed: {
+        breadcrumb () {
+            return breadcrumb
+        },
+        currentDirectory () {
+            return this.breadcrumbs.length > 0
+                ? this.breadcrumbs[this.breadcrumbs.length - 1]
+                : 'Storage'
+        },
         rows () {
             return [
                 {
                     back: '',
                     activeDirectory: 'active-directory',
-                    visibility: 'asd visibility',
-                    folderPath: 'asd folderPath',
-                    baseUrl: 'asd baseUrl'
+                    visibility: 'visibility',
+                    folderPath: 'folder-path',
+                    baseUrl: 'baseUrl'
                 }
             ]
         },
@@ -69,7 +74,7 @@ export default {
                     component: {
                         is: markRaw({
                             props: ['currentDirectory'],
-                            template: '<div :title="this.currentDirectory?.name">{{ this.currentDirectory?.name ||  "Storage"}}</div>'
+                            template: '<div :title="this.currentDirectory">{{ this.currentDirectory }}</div>'
                         }),
                         extraProps: {
                             currentDirectory: this.currentDirectory
@@ -81,10 +86,16 @@ export default {
                     label: 'Visibility',
                     component: {
                         is: markRaw({
-                            template: '<div class="flex gap-2"><ProjectIcon class="ff-icon" /> Node-RED Only</div>',
-                            components: { ProjectIcon },
-                            inheritAttrs: false
-                        })
+                            template: '<VisibilitySelector :breadcrumbs="breadcrumbs" @selected="selectedVisibility"/>',
+                            components: { VisibilitySelector },
+                            props: ['breadcrumbs'],
+                            methods: {
+                                selectedVisibility: this.selectedVisibility
+                            }
+                        }),
+                        extraProps: {
+                            breadcrumbs: this.breadcrumbs
+                        }
                     }
                 },
                 {
@@ -120,6 +131,9 @@ export default {
     methods: {
         goBack () {
             this.$emit('go-back', '')
+        },
+        selectedVisibility (visibility) {
+            this.$emit('selected-visibility', visibility)
         }
     }
 }

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -138,7 +138,7 @@ export default {
                             breadcrumbs: this.breadcrumbs,
                             prepend: this.folderStaticPath,
                             isNotAvailable: !this.isCurrentDirectoryPublic || !this.isInstanceRunning,
-                            baseUrl: this.instance?.url
+                            baseURL: this.instance?.url
                         }
                     }
                 }

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -138,7 +138,7 @@ export default {
                             breadcrumbs: this.breadcrumbs,
                             prepend: this.folderStaticPath,
                             isNotAvailable: !this.isCurrentDirectoryPublic || !this.isInstanceRunning,
-                            isBaseUrl: true
+                            baseUrl: this.instance?.url
                         }
                     }
                 }

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -15,25 +15,24 @@ import { markRaw } from 'vue'
 
 import VisibilitySelector from '../../../components/file-browser/VisibilitySelector.vue'
 import ItemFilePath from '../../../components/file-browser/cells/FilePath.vue'
-import breadcrumb from '../../../ui-components/components/Breadcrumb.vue'
 
 export default {
     name: 'FolderBreadcrumbs',
     props: {
         breadcrumbs: {
             required: true,
-            type: Object
+            type: Array
         }
     },
-    emits: ['clicked', 'go-back', 'selected-visibility'],
+    emits: ['go-back', 'selected-visibility'],
     computed: {
-        breadcrumb () {
-            return breadcrumb
-        },
         currentDirectory () {
             return this.breadcrumbs.length > 0
                 ? this.breadcrumbs[this.breadcrumbs.length - 1]
-                : 'Storage'
+                : null
+        },
+        currentDirectoryName () {
+            return this.currentDirectory ? this.currentDirectory.name : 'Storage'
         },
         rows () {
             return [
@@ -77,7 +76,7 @@ export default {
                             template: '<div :title="this.currentDirectory">{{ this.currentDirectory }}</div>'
                         }),
                         extraProps: {
-                            currentDirectory: this.currentDirectory
+                            currentDirectory: this.currentDirectoryName
                         }
                     }
                 },

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -131,7 +131,8 @@ export default {
                         extraProps: {
                             breadcrumbs: this.breadcrumbs,
                             prepend: this.folderStaticPath,
-                            isNotAvailable: !this.isCurrentDirectoryPublic
+                            isNotAvailable: !this.isCurrentDirectoryPublic,
+                            isBaseUrl: true
                         }
                     }
                 }

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -97,6 +97,9 @@ export default {
                         extraProps: {
                             currentDirectory: this.currentDirectoryName
                         }
+                    },
+                    style: {
+                        width: '200px'
                     }
                 },
                 {
@@ -115,6 +118,9 @@ export default {
                             breadcrumbs: this.breadcrumbs,
                             instance: this.instance
                         }
+                    },
+                    style: {
+                        width: '200px'
                     }
                 },
                 {

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -124,7 +124,6 @@ export default {
                         is: markRaw(ItemFilePath),
                         extraProps: {
                             breadcrumbs: this.breadcrumbs,
-                            prepend: '/data/storage',
                             isNotAvailable: !this.isInstanceRunning
                         }
                     }

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -1,0 +1,126 @@
+<template>
+    <div class="ff-breadcrumbs disable-last mb-7" data-el="folder-breadcrumbs">
+        <ff-data-table
+            :rows="rows"
+            :columns="columns"
+        />
+    </div>
+</template>
+
+<script>
+
+import { ArrowLeftIcon } from '@heroicons/vue/outline'
+
+import { markRaw } from 'vue'
+
+import ItemFilePath from '../../../components/file-browser/cells/FilePath.vue'
+import ProjectIcon from '../../../components/icons/Projects.js'
+
+export default {
+    name: 'FolderBreadcrumbs',
+    props: {
+        breadcrumbs: {
+            required: true,
+            type: Object
+        },
+        currentDirectory: {
+            required: true,
+            type: Object
+        }
+    },
+    emits: ['clicked', 'go-back'],
+    computed: {
+        rows () {
+            return [
+                {
+                    back: '',
+                    activeDirectory: 'active-directory',
+                    visibility: 'asd visibility',
+                    folderPath: 'asd folderPath',
+                    baseUrl: 'asd baseUrl'
+                }
+            ]
+        },
+        columns () {
+            return [
+                {
+                    key: 'back',
+                    label: '',
+                    component: {
+                        is: markRaw({
+                            props: ['shouldDisplayBackButton'],
+                            template: '<arrow-left-icon class="ff-icon cursor-pointer" @click="goBack" v-if="shouldDisplayBackButton"/>',
+                            components: { ArrowLeftIcon },
+                            methods: {
+                                goBack: this.goBack
+                            }
+                        }),
+                        extraProps: {
+                            shouldDisplayBackButton: this.shouldDisplayTheBackButton
+                        }
+                    },
+                    style: {
+                        width: '50px'
+                    }
+                },
+                {
+                    key: 'activeDirectory',
+                    label: 'Active Directory',
+                    component: {
+                        is: markRaw({
+                            props: ['currentDirectory'],
+                            template: '<div :title="this.currentDirectory?.name">{{ this.currentDirectory?.name ||  "Storage"}}</div>'
+                        }),
+                        extraProps: {
+                            currentDirectory: this.currentDirectory
+                        }
+                    }
+                },
+                {
+                    key: 'visibility',
+                    label: 'Visibility',
+                    component: {
+                        is: markRaw({
+                            template: '<div class="flex gap-2"><ProjectIcon class="ff-icon" /> Node-RED Only</div>',
+                            components: { ProjectIcon },
+                            inheritAttrs: false
+                        })
+                    }
+                },
+                {
+                    key: 'folderPath',
+                    label: 'Folder Path',
+                    component: {
+                        is: markRaw(ItemFilePath),
+                        extraProps: {
+                            breadcrumbs: this.breadcrumbs,
+                            prepend: '/data/storage'
+                        }
+                    }
+                },
+                {
+                    key: 'baseUrl',
+                    label: 'Base URL',
+                    component: {
+                        is: markRaw(ItemFilePath),
+                        extraProps: {
+                            breadcrumbs: this.breadcrumbs,
+                            prepend: '/data/storage',
+                            isNotAvailable: true
+                        }
+                    }
+                }
+
+            ]
+        },
+        shouldDisplayTheBackButton () {
+            return this.breadcrumbs.length > 0
+        }
+    },
+    methods: {
+        goBack () {
+            this.$emit('go-back', '')
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -34,6 +34,21 @@ export default {
         currentDirectoryName () {
             return this.currentDirectory ? this.currentDirectory.name : 'Storage'
         },
+        isCurrentDirectoryPublic () {
+            if (!this.currentDirectory) {
+                return false
+            }
+
+            return Object.prototype.hasOwnProperty.call(this.currentDirectory, 'share') &&
+              Object.prototype.hasOwnProperty.call(this.currentDirectory.share, 'root')
+        },
+        folderStaticPath () {
+            if (!this.isCurrentDirectoryPublic) {
+                return ''
+            }
+
+            return this.currentDirectory.share.root
+        },
         rows () {
             return [
                 {
@@ -115,8 +130,8 @@ export default {
                         is: markRaw(ItemFilePath),
                         extraProps: {
                             breadcrumbs: this.breadcrumbs,
-                            prepend: '/data/storage',
-                            isNotAvailable: true
+                            prepend: this.folderStaticPath,
+                            isNotAvailable: !this.isCurrentDirectoryPublic
                         }
                     }
                 }

--- a/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
+++ b/frontend/src/pages/instance/components/FolderBreadcrumbs.vue
@@ -124,7 +124,8 @@ export default {
                         is: markRaw(ItemFilePath),
                         extraProps: {
                             breadcrumbs: this.breadcrumbs,
-                            prepend: '/data/storage'
+                            prepend: '/data/storage',
+                            isNotAvailable: !this.isInstanceRunning
                         }
                     }
                 },
@@ -136,7 +137,7 @@ export default {
                         extraProps: {
                             breadcrumbs: this.breadcrumbs,
                             prepend: this.folderStaticPath,
-                            isNotAvailable: !this.isCurrentDirectoryPublic,
+                            isNotAvailable: !this.isCurrentDirectoryPublic || !this.isInstanceRunning,
                             isBaseUrl: true
                         }
                     }
@@ -144,7 +145,14 @@ export default {
 
             ]
         },
+        isInstanceRunning () {
+            return this.instance?.meta?.state === 'running'
+        },
         shouldDisplayTheBackButton () {
+            if (!this.isInstanceRunning) {
+                return false
+            }
+
             return this.breadcrumbs.length > 0
         }
     },

--- a/test/e2e/frontend/cypress/tests-ee/instances/assets.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/instances/assets.spec.js
@@ -374,7 +374,7 @@ describe('FlowForge - Instance - Assets', () => {
             cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
                 .should('not.be.visible')
             cy.get('[data-el="folder-breadcrumbs"]').contains('Storage')
-            cy.get('[data-el="folder-breadcrumbs"]').contains('data/storage/')
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="ff-data-cell"]:nth-child(4) .path').should('be.empty')
         })
 
         it('displays an enabled visibility selector on nested folders and correct folder path', () => {
@@ -400,7 +400,7 @@ describe('FlowForge - Instance - Assets', () => {
                 .should('not.be.visible')
 
             cy.get('[data-el="folder-breadcrumbs"]').contains('Storage')
-            cy.get('[data-el="folder-breadcrumbs"]').contains('data/storage/')
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="ff-data-cell"]:nth-child(4) .path').should('be.empty')
 
             cy.get('[data-el="files-table"] table tbody tr').contains('hello_world').click()
             cy.wait('@getNestedFiles')
@@ -410,9 +410,9 @@ describe('FlowForge - Instance - Assets', () => {
             cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
                 .should('be.visible')
 
-            cy.get('[data-el="folder-breadcrumbs"]').contains('hello_world')
-            cy.get('[data-el="folder-breadcrumbs"]').contains('data/storage/hello_world')
-            cy.get('[data-el="folder-breadcrumbs"]').contains('Not Available')
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="ff-data-cell"]:nth-child(2)').contains('hello_world')
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="ff-data-cell"]:nth-child(4)').contains('hello_world/')
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="ff-data-cell"]:nth-child(5)').contains('Not Available')
         })
 
         it('prevents users to set private visibility when the folder is private', () => {

--- a/test/e2e/frontend/cypress/tests-ee/instances/assets.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/instances/assets.spec.js
@@ -15,7 +15,7 @@ function interceptTeamFeature () {
         .as('getTeam')
 }
 
-function interceptInstanceMeta () {
+function interceptInstanceMeta (body = {}) {
     cy.intercept('GET', '/api/*/projects/*', (req) => req.reply(res => {
         // this.instance?.meta?.versions?.launcher
         res.body = {
@@ -26,7 +26,8 @@ function interceptInstanceMeta () {
                         launcher: '2.8.0'
                     }
                 }
-            }
+            },
+            ...body
         }
         return res
     })).as('getInstanceStatus')
@@ -345,6 +346,232 @@ describe('FlowForge - Instance - Assets', () => {
             cy.get('[data-el="folder-breadcrumbs"]').should('not.contain', 'hello_world')
 
             cy.get('[data-el="files-table"] table tbody').contains('hello_world')
+        })
+    })
+
+    describe('the Folder Breadcrumbs', () => {
+        beforeEach(() => {
+            interceptTeamFeature()
+            interceptInstanceMeta()
+
+            navigateToProject('BTeam', 'instance-2-1', 'assets')
+        })
+
+        it('displays a disabled visibility selector on the default root folder and correct folder path', () => {
+            interceptFiles([
+                { name: 'hello_world', type: 'directory', lastModified: new Date() }
+            ])
+            cy.wait('@getFiles')
+
+            cy.intercept('GET', '/api/*/projects/*/files/_/hello_world', ({
+                meta: { },
+                files: [],
+                count: 0
+            })).as('getNestedFiles')
+
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"]')
+                .click()
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
+                .should('not.be.visible')
+            cy.get('[data-el="folder-breadcrumbs"]').contains('Storage')
+            cy.get('[data-el="folder-breadcrumbs"]').contains('data/storage/')
+        })
+
+        it('displays an enabled visibility selector on nested folders and correct folder path', () => {
+            interceptFiles([
+                { name: 'hello_world', type: 'directory', lastModified: new Date() }
+            ])
+            cy.intercept('GET', '/api/*/projects/*/files/_/hello_world', ({
+                meta: { },
+                files: [],
+                count: 0
+            })).as('getNestedFiles')
+            cy.wait('@getFiles')
+
+            cy.intercept('GET', '/api/*/projects/*/files/_/hello_world', ({
+                meta: { },
+                files: [],
+                count: 0
+            })).as('getNestedFiles')
+
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"]')
+                .click()
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
+                .should('not.be.visible')
+
+            cy.get('[data-el="folder-breadcrumbs"]').contains('Storage')
+            cy.get('[data-el="folder-breadcrumbs"]').contains('data/storage/')
+
+            cy.get('[data-el="files-table"] table tbody tr').contains('hello_world').click()
+            cy.wait('@getNestedFiles')
+
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"]')
+                .click()
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
+                .should('be.visible')
+
+            cy.get('[data-el="folder-breadcrumbs"]').contains('hello_world')
+            cy.get('[data-el="folder-breadcrumbs"]').contains('data/storage/hello_world')
+            cy.get('[data-el="folder-breadcrumbs"]').contains('Not Available')
+        })
+
+        it('prevents users to set private visibility when the folder is private', () => {
+            const spy = cy.spy().as('updateVisibilityCall')
+            cy.intercept('PUT', '/api/*/projects/*/files/_/hello_world', spy)
+            interceptFiles([
+                { name: 'hello_world', type: 'directory', lastModified: new Date() }
+            ])
+            cy.intercept('GET', '/api/*/projects/*/files/_/hello_world', ({
+                meta: { },
+                files: [],
+                count: 0
+            })).as('getNestedFiles')
+            cy.wait('@getFiles')
+
+            cy.get('[data-el="files-table"] table tbody tr').contains('hello_world').click()
+            cy.wait('@getNestedFiles')
+
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"]')
+                .click()
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
+                .should('be.visible')
+                .within(() => {
+                    cy.get('[data-action="select-private"]').click()
+                    cy.get('@updateVisibilityCall').should('not.have.been.called')
+                })
+        })
+
+        it('allows users to set private visibility when the folder is public', () => {
+            const spy = cy.spy().as('updateVisibilityCall')
+            cy.intercept('PUT', '/api/*/projects/*/files/_/hello_world', spy)
+            interceptFiles([
+                {
+                    name: 'hello_world',
+                    type: 'directory',
+                    lastModified: new Date(),
+                    share: {
+                        root: 'hello_public'
+                    }
+                }
+            ])
+            cy.intercept('GET', '/api/*/projects/*/files/_/hello_world', ({
+                meta: { },
+                files: [],
+                count: 0
+            })).as('getNestedFiles')
+            cy.wait('@getFiles')
+
+            cy.get('[data-el="files-table"] table tbody tr').contains('hello_world').click()
+            cy.wait('@getNestedFiles')
+
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"]')
+                .click()
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
+                .should('be.visible')
+                .within(() => {
+                    cy.get('[data-action="select-private"]').click()
+                    cy.get('@updateVisibilityCall').should('have.been.called', 1)
+                })
+        })
+
+        it('allows users to set public visibility when the directory is private', () => {
+            cy.intercept('PUT', '/api/*/projects/*/files/_/hello_world', { }).as('updateVisibility')
+            interceptFiles([
+                {
+                    name: 'hello_world',
+                    type: 'directory',
+                    lastModified: new Date()
+                }
+            ])
+            cy.intercept('GET', '/api/*/projects/*/files/_/hello_world', ({
+                meta: { },
+                files: [],
+                count: 0
+            })).as('getNestedFiles')
+            cy.wait('@getFiles')
+
+            cy.get('[data-el="files-table"] table tbody tr').contains('hello_world').click()
+            cy.wait('@getNestedFiles')
+
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"]')
+                .click()
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
+                .should('be.visible')
+                .within(() => {
+                    cy.get('[data-action="select-public"]').click()
+                })
+
+            cy.get('[data-el="select-static-path-dialog"]')
+                .should('be.visible')
+            cy.get('[data-el="select-static-path-dialog"] input').type('public_path')
+            cy.get('[data-el="select-static-path-dialog"]').within(() => {
+                cy.get('[data-action="dialog-confirm"]').click()
+            })
+
+            cy.wait('@updateVisibility')
+            cy.get('[data-el="notification-alert"]').should('be.visible')
+            cy.get('[data-el="notification-alert"]').contains('Instance settings successfully updated. Restart the instance to apply the changes.')
+        })
+
+        it('allows users to set public visibility when the directory is public', () => {
+            cy.intercept('PUT', '/api/*/projects/*/files/_/hello_world', { }).as('updateVisibility')
+            interceptFiles([
+                {
+                    name: 'hello_world',
+                    type: 'directory',
+                    lastModified: new Date(),
+                    share: {
+                        root: 'public-path'
+                    }
+                }
+            ])
+            cy.intercept('GET', '/api/*/projects/*/files/_/hello_world', ({
+                meta: { },
+                files: [],
+                count: 0
+            })).as('getNestedFiles')
+            cy.wait('@getFiles')
+
+            cy.get('[data-el="files-table"] table tbody tr').contains('hello_world').click()
+            cy.wait('@getNestedFiles')
+
+            cy.get('[data-el="folder-breadcrumbs"]').contains('public-path/')
+
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"]')
+                .click()
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
+                .should('be.visible')
+                .within(() => {
+                    cy.get('[data-action="select-public"]').click()
+                })
+
+            cy.get('[data-el="select-static-path-dialog"]')
+                .should('be.visible')
+            cy.get('[data-el="select-static-path-dialog"] input').type('public_path')
+            cy.get('[data-el="select-static-path-dialog"]').within(() => {
+                cy.get('[data-action="dialog-confirm"]').click()
+            })
+
+            cy.wait('@updateVisibility')
+            cy.get('[data-el="notification-alert"]').should('be.visible')
+            cy.get('[data-el="notification-alert"]').contains('Instance settings successfully updated. Restart the instance to apply the changes.')
+        })
+
+        it('is disabled when the instance state is not running', () => {
+            interceptInstanceMeta({ meta: { state: 'suspended' } })
+
+            cy.get('[data-el="status-badge-suspended"]').should('exist')
+            cy.get('[data-el="files-table"]').contains('The instance must be running to access its assets.')
+
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"]').click()
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="visibility-selector"] .ff-dropdown-options')
+                .should('not.be.visible')
+
+            // checking folder path
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="ff-data-cell"]:nth-child(4)').contains('Not Available')
+
+            // checking Base URL
+            cy.get('[data-el="folder-breadcrumbs"] [data-el="ff-data-cell"]:nth-child(5)').contains('Not Available')
         })
     })
 })


### PR DESCRIPTION
## Description

add file asset service visibility selector and integrate it with the existing api
added a new key on the staticAsset api to include the current folder 
added the url column in the files list
added alerts

## Related Issue(s)
branched out of https://github.com/FlowFuse/flowfuse/pull/4473
closes https://github.com/FlowFuse/flowfuse/issues/4461

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

