### PR TITLE
Only get tokens if team feature enabled

### DIFF
--- a/frontend/src/mixins/Features.js
+++ b/frontend/src/mixins/Features.js
@@ -41,6 +41,9 @@ export default {
         },
         isStaticAssetFeatureEnabled () {
             return this.isStaticAssetFeatureEnabledForPlatform && this.isStaticAssetsFeatureEnabledForTeam
+        },
+        isHTTPBearerTokensFeatureEnabledForTeam () {
+            return this.settings.features.httpBearerTokens && this.team.type.properties.features.teamHttpSecurity
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -50,6 +50,7 @@ import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
 import FormHeading from '../../../components/FormHeading.vue'
+import featuresMixin from '../../../mixins/Features.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
 import alerts from '../../../services/alerts.js'
 import TokenCreated from '../../account/Security/dialogs/TokenCreated.vue'
@@ -76,7 +77,7 @@ export default {
         TokenCreated,
         TokenDialog
     },
-    mixins: [permissionsMixin],
+    mixins: [permissionsMixin, featuresMixin],
     inheritAttrs: false,
     props: {
         project: {
@@ -157,7 +158,7 @@ export default {
     mounted () {
         this.checkAccess()
         this.getSettings()
-        if (this.settings.features.httpBearerTokens && this.team.type.properties.features.teamHttpSecurity) {
+        if (this.isHTTPBearerTokensFeatureEnabledForTeam()) {
             this.getTokens()
         }
     },

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -157,7 +157,7 @@ export default {
     mounted () {
         this.checkAccess()
         this.getSettings()
-        if (this.settings.features.httpBearerTokens) {
+        if (this.settings.features.httpBearerTokens && this.team.type.properties.features.teamHttpSecurity) {
             this.getTokens()
         }
     },


### PR DESCRIPTION
fixes #4382

## Description

<!-- Describe your changes in detail -->
Prevents the UI from trying to access Bearer tokens if the FlowFuse User Authentication is not enabled for the team.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4382 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

