### PR TITLE
Ensure user has selected an available team type on upgrade

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -531,7 +531,7 @@ async function init (app, opts) {
             // At this point, the user is verified. So we need to respond with success.
             // However, an error was hit whilst completing their post-signup tasks.
             await app.auditLog.User.account.verify.verifyToken(sessionUser, { error: err.toString() })
-            app.log.error(`/account/verify/token error - ${err.toString()}`)
+            app.log.error(`/account/verify/token error - ${err.stack}`)
         }
         reply.send({ status: 'okay' })
     })

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -133,7 +133,11 @@ export default {
     computed: {
         ...mapState('account', ['user', 'team', 'features']),
         formValid () {
-            return !this.isUnmanaged && this.input.teamTypeId && (!this.isTypeChange || this.input.teamTypeId !== this.team.type.id) && this.upgradeErrors.length === 0
+            return !this.isUnmanaged &&
+                    this.input.teamTypeId &&
+                    this.isSelectionAvailable &&
+                    (!this.isTypeChange || this.input.teamTypeId !== this.team.type.id) &&
+                    this.upgradeErrors.length === 0
         },
         billingEnabled () {
             return this.features.billing
@@ -157,6 +161,16 @@ export default {
             return this.billingEnabled &&
                    !this.user.admin &&
                    this.input.teamType && this.input.teamType.properties?.billing?.requireContact
+        },
+        isSelectionAvailable () {
+            if (this.input.teamTypeId) {
+                // Ensure that this.inputs.teamTypeId is one of the available types
+                if (this.teamTypes.length === 0) {
+                    return false
+                }
+                return !!this.teamTypes.find(tt => tt.id === this.input.teamTypeId)
+            }
+            return false
         },
         isCurrentUnavailable () {
             if (this.teamTypes.length === 0) {


### PR DESCRIPTION
With the new pricing model in place we are in a transition period when trials started before last Friday have a team type of `starter`. When said teams come to setup billing they are presented with the choice of team type to select to setup billing for.

With the new pricing model in place, the `starter` team is now inactive and the new `Starter` team is shown in the list.

However, the existing checks on the page don't disable the `Setup Billing` button if no selection has been made - allowing the user to setup billing on with the old `starter` details.

This fixes that - ensuring the button is disabled until they have selected one of the active team types.