### PR TITLE
adds a fallback for missing semver/installed node-red versions for k8/docker deployments

### DIFF
--- a/frontend/src/pages/application/Dependencies/Dependencies.vue
+++ b/frontend/src/pages/application/Dependencies/Dependencies.vue
@@ -118,7 +118,7 @@ export default {
                 .reduce((acc, currentInstance) => {
                     currentInstance.dependencies.forEach(dep => {
                         const searchTerm = this.searchTerm.trim()
-                        const installedDependencyVersion = dep.version.installed ?? dep.version.semver
+                        const installedDependencyVersion = dep.version?.installed ?? dep.version?.semver ?? 'N/A'
                         const dependencyNameMatchesSearch = dep.name.toLowerCase().includes(searchTerm.toLowerCase())
                         const dependencyVersionMatchesSearch = installedDependencyVersion.toLowerCase().includes(searchTerm.toLowerCase())
                         const matchesInstanceName = currentInstance.name.toLowerCase().includes(searchTerm.toLowerCase())


### PR DESCRIPTION
## Description

adds a version fallback when version.installed/version.semver is missing from the bom payload

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/4519

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

