### PR TITLE
Add versions info to Project model

### DIFF
--- a/forge/db/migrations/20240920-01-add-versions-to-project.js
+++ b/forge/db/migrations/20240920-01-add-versions-to-project.js
@@ -1,0 +1,19 @@
+/**
+ * Add versions to Project table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        await context.addColumn('Projects', 'versions', {
+            type: DataTypes.TEXT,
+            defaultValue: null
+        })
+    },
+    down: async (context) => {
+    }
+}


### PR DESCRIPTION
Part of #4522 

This captures the versions info returned by the launcher into a new `versions` property of the `Project` model.

The `versions` property stores the version info in the following format:

```
{
   "node-red": { "current": "4.0.2" }
}
```

The launcher also reports back `node` and `launcher` versions - which get stored as well.

The choice of `current` is for future consideration of storing the node module information in one place - where there may be a difference between the `wanted` and the `current` version. The choice of key names is based on those used by `npm outdated` output.

***This PR includes a migration***

We also have https://github.com/FlowFuse/flowfuse/pull/4518 open that contains a migration. Depending which one merges first, the other will need to rename its migration file to ensure the ordering is preserved.