### PR TITLE
Allow users to delete accounts even when they have active teams (reapplied)

### DIFF
--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -110,7 +110,7 @@ module.exports = {
                         const deviceCount = await team.Team.deviceCount()
                         const members = await team.Team.memberCount()
 
-                        ownedTeams.push(team)
+                        ownedTeams.push(team.Team)
 
                         // throw error if the team has other members assigned to it
                         if (members > 1) {

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -99,14 +99,43 @@ module.exports = {
                 // determine if this user owns any teams
                 // throw an error if we would orphan any teams
                 const teams = await app.db.models.Team.forUser(user)
+                const teamBlockers = []
+                const ownedTeams = []
                 for (const team of teams) {
                     const owners = await team.Team.getOwners()
                     const isOwner = owners.find((owner) => owner.id === user.id)
 
-                    // if this user is the only owner of this team, throw an error
                     if (isOwner && owners.length <= 1) {
-                        throw new Error('Cannot delete the last owner of a team')
+                        const instanceCount = await team.Team.instanceCount()
+                        const deviceCount = await team.Team.deviceCount()
+                        const members = await team.Team.memberCount()
+
+                        ownedTeams.push(team)
+
+                        // throw error if the team has other members assigned to it
+                        if (members > 1) {
+                            teamBlockers.push(`Team ${team.Team.name} which is being deleted alongside your account still has users in it.`)
+                        }
+
+                        // throw error if the team has remaining instances assigned to it
+                        if (instanceCount > 0) {
+                            teamBlockers.push(`Team ${team.Team.name} which is being deleted alongside your account still has instances assigned to it.`)
+                        }
+
+                        // throw error if the team has remaining devices assigned to it
+                        if (deviceCount > 0) {
+                            teamBlockers.push(`Team ${team.Team.name} which is being deleted alongside your account still has devices assigned to it.`)
+                        }
                     }
+                }
+
+                if (teamBlockers.length) {
+                    throw new Error(teamBlockers[0])
+                }
+
+                // delete remaining owned teams
+                for (const ownedTeam of ownedTeams) {
+                    await ownedTeam.destroy()
                 }
 
                 // Need to do this in beforeDestroy as the Session.UserId field

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -591,23 +591,6 @@ module.exports = async function (app) {
                 await app.auditLog.Team.team.device.deleted(request.session.User, null, request.team, device)
             }
 
-            if (app.license.active() && app.billing) {
-                const subscription = await request.team.getSubscription()
-                if (subscription) {
-                    if (!subscription.isTrial() && !subscription.isUnmanaged()) {
-                        const subId = subscription.subscription || 'unknown'
-                        try {
-                            await app.billing.closeSubscription(subscription)
-                        } catch (err) {
-                            app.log.warn(`Error canceling subscription ${subId} for team ${request.team.hashid}`)
-                            app.log.warn(err)
-                        }
-                    }
-                    // Delete the subscription
-                    await subscription.destroy()
-                }
-            }
-
             await request.team.destroy()
             await app.auditLog.Platform.platform.team.deleted(request.session.User, null, request.team)
             await app.auditLog.Team.team.deleted(request.session.User, null, request.team)

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -750,10 +750,10 @@ describe('Billing routes', function () {
             })
 
             it('Handles cancellation for unknown teams but with a subscription (team manually deleted)', async () => {
-                const team = await app.factory.createTeam({ name: 'team-02' })
-                await app.factory.createSubscription(team, 'sub_unknown_123', 'cus_unknown_123')
-                await team.destroy()
-
+                await app.db.models.Subscription.create({
+                    customer: 'cus_unknown_123',
+                    subscription: 'sub_unknown_123'
+                })
                 const response = await (app.inject({
                     method: 'POST',
                     url: callbackURL,

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -846,13 +846,21 @@ describe('User API', async function () {
 
             await app.factory.createApplication({ name: 'senate-app-2' }, nabooTeam)
 
-            // Padme now attempts to delete own account: should succeed even though it has instances attached to the team
+            // Padme now attempts to delete own account: should succeed even though it has applications attached to the team
+            // but no instances or devices
             const response = await app.inject({
                 method: 'DELETE',
                 url: '/api/v1/user',
                 cookies: { sid: TestObjects.tokens.amidala }
             })
             response.statusCode.should.equal(200)
+
+            // Verify the team has been deleted
+
+            const team = await app.db.models.Team.byId(nabooTeam.id)
+            // Careful using raw sequelize objects and should.js
+            // Cannot use `should.not.exist(team)` as it causes a hang
+            ;(team === null).should.be.true('Team should have been deleted')
         })
     })
 

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -19,6 +19,10 @@ describe('User API', async function () {
         TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam', TeamTypeId: app.defaultTeamType.id })
         TestObjects.Project1 = app.project
         TestObjects.tokens = {}
+        TestObjects.application = app.application
+        TestObjects.stack = app.stack
+        TestObjects.projectType = app.projectType
+        TestObjects.template = app.template
         await setupUsers()
     }
     async function setupUsers () {
@@ -740,7 +744,7 @@ describe('User API', async function () {
             const json = response.json()
             json.should.have.property('error', 'Error: Cannot delete the last platform administrator')
         })
-        it('Last owner of a team cannot delete own account', async function () {
+        it('Last owner of a team cannot delete own account when the team has other members present', async function () {
             await login('frank', 'ffPassword')
             // delete bob so that grace becomes the remaining owner of team B
             await TestObjects.bob.destroy()
@@ -753,7 +757,66 @@ describe('User API', async function () {
             })
             response.statusCode.should.equal(400)
             const json = response.json()
-            json.should.have.property('error', 'Error: Cannot delete the last owner of a team')
+            json.should.have.property('error', 'Error: Team BTeam which is being deleted alongside your account still has users in it.')
+        })
+        it('Last owner of a team cannot delete own account when the team has instances present', async function () {
+            const amidala = await app.db.models.User.create({ username: 'amidala', name: 'Padme Amidala', email: 'amidala@example.com', email_verified: true, password: 'paPassword', admin: false, sso_enabled: false })
+            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam', TeamTypeId: app.defaultTeamType.id })
+
+            await nabooTeam.addUser(amidala, { through: { role: Roles.Owner } })
+
+            await login('amidala', 'paPassword')
+
+            const nabooTeamApplication = await app.factory.createApplication({ name: 'senate-app' }, nabooTeam)
+
+            // we create an instance so Padme won't be able to delete her account
+            await app.factory.createInstance(
+                { name: 'instance' },
+                nabooTeamApplication,
+                TestObjects.stack,
+                TestObjects.template,
+                TestObjects.projectType
+            )
+
+            // Padme now attempts to delete own account: should fail as she still has instances attached to her team
+            const response = await app.inject({
+                method: 'DELETE',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.amidala }
+            })
+            response.statusCode.should.equal(400)
+            const json = response.json()
+            json.should.have.property('error', 'Error: Team nabooTeam which is being deleted alongside your account still has instances assigned to it.')
+        })
+        it('Last owner of a team cannot delete own account when the team has devices present', async function () {
+            const amidala = await app.db.models.User.create({ username: 'amidala', name: 'Padme Amidala', email: 'amidala@example.com', email_verified: true, password: 'paPassword', admin: false, sso_enabled: false })
+            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam2', TeamTypeId: app.defaultTeamType.id })
+
+            await nabooTeam.addUser(amidala, { through: { role: Roles.Owner } })
+
+            await login('amidala', 'paPassword')
+
+            const nabooTeamApplication = await app.factory.createApplication({ name: 'senate-app' }, nabooTeam)
+
+            // we create a device so Padme won't be able to delete her account
+            await app.factory.createDevice(
+                {
+                    name: 'some-device'
+                },
+                nabooTeam,
+                null,
+                nabooTeamApplication
+            )
+
+            // Padme now attempts to delete own account: should fail as owned team has devices attached
+            const response = await app.inject({
+                method: 'DELETE',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.amidala }
+            })
+            response.statusCode.should.equal(400)
+            const json = response.json()
+            json.should.have.property('error', 'Error: Team nabooTeam2 which is being deleted alongside your account still has devices assigned to it.')
         })
         it('Non admin user who is a team member can delete own account', async function () {
             await login('grace', 'ggPassword')
@@ -770,6 +833,24 @@ describe('User API', async function () {
                 method: 'DELETE',
                 url: '/api/v1/user',
                 cookies: { sid: TestObjects.tokens.grace }
+            })
+            response.statusCode.should.equal(200)
+        })
+        it('Team owner can delete own account if no other members, instances or devices exist', async function () {
+            const amidala = await app.db.models.User.create({ username: 'amidala', name: 'Padme Amidala', email: 'amidala@example.com', email_verified: true, password: 'paPassword', admin: false, sso_enabled: false })
+            const nabooTeam = await app.db.models.Team.create({ name: 'nabooTeam3', TeamTypeId: app.defaultTeamType.id })
+
+            await nabooTeam.addUser(amidala, { through: { role: Roles.Owner } })
+
+            await login('amidala', 'paPassword')
+
+            await app.factory.createApplication({ name: 'senate-app-2' }, nabooTeam)
+
+            // Padme now attempts to delete own account: should succeed even though it has instances attached to the team
+            const response = await app.inject({
+                method: 'DELETE',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.amidala }
             })
             response.statusCode.should.equal(200)
         })


### PR DESCRIPTION
 - Reverts FlowFuse/flowfuse#4528
 - Reapplies https://github.com/FlowFuse/flowfuse/pull/4354

Includes fix to ensure Team Subscription is cleared on delete.
