### PR TITLE
Add egress to banned list of instance names

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -32,7 +32,8 @@ const BANNED_NAME_LIST = [
     'status',
     'billing',
     'mqtt',
-    'broker'
+    'broker',
+    'egress'
 ]
 
 /** @type {FFModel} */


### PR DESCRIPTION
part of FlowFuse/CloudProject#521

## Description

<!-- Describe your changes in detail -->
This is so we can have a DNS entry for the FF Cloud egress IP address

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/CloudProject#521

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

