### PR TITLE
Add an user education modal to trial users

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -52,6 +52,7 @@
         <template v-else>
             <Login />
         </template>
+        <EducationModal />
     </div>
 </template>
 
@@ -61,6 +62,7 @@ import { mapState } from 'vuex'
 import Loading from './components/Loading.vue'
 import Offline from './components/Offline.vue'
 import LicenseBanner from './components/banners/LicenseBanner.vue'
+import EducationModal from './components/dialogs/EducationModal.vue'
 import FFLayoutBox from './layouts/Box.vue'
 import FFLayoutPlain from './layouts/Plain.vue'
 import FFLayoutPlatform from './layouts/Platform.vue'
@@ -72,6 +74,7 @@ import UnverifiedEmail from './pages/UnverifiedEmail.vue'
 export default {
     name: 'App',
     components: {
+        EducationModal,
         Login,
         PasswordExpired,
         UnverifiedEmail,

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -32,6 +32,7 @@
                     <router-view />
                 </ff-layout-plain>
             </template>
+            <EducationModal />
         </template>
         <!-- Password Reset Required -->
         <template v-else-if="user && user.password_expired">
@@ -52,7 +53,6 @@
         <template v-else>
             <Login />
         </template>
-        <EducationModal />
     </div>
 </template>
 

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -73,6 +73,7 @@ import { AcademicCapIcon, AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIc
 import { ref } from 'vue'
 import { mapActions, mapGetters, mapState } from 'vuex'
 
+import product from '../../services/product.js'
 import navigationMixin from '../mixins/Navigation.js'
 import permissionsMixin from '../mixins/Permissions.js'
 
@@ -188,6 +189,7 @@ export default {
         ...mapActions('ux', ['activateTour']),
         openEducationModal () {
             this.activateTour('education')
+            product.capture('clicked-open-education-modal')
         }
     }
 }

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -73,9 +73,9 @@ import { AcademicCapIcon, AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIc
 import { ref } from 'vue'
 import { mapActions, mapGetters, mapState } from 'vuex'
 
-import product from '../../services/product.js'
 import navigationMixin from '../mixins/Navigation.js'
 import permissionsMixin from '../mixins/Permissions.js'
+import product from '../services/product.js'
 
 import NavItem from './NavItem.vue'
 import NotificationsButton from './NotificationsButton.vue'

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -69,9 +69,9 @@
     </div>
 </template>
 <script>
-import { AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIcon, QuestionMarkCircleIcon, UserAddIcon } from '@heroicons/vue/solid'
+import { AcademicCapIcon, AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIcon, QuestionMarkCircleIcon, UserAddIcon } from '@heroicons/vue/solid'
 import { ref } from 'vue'
-import { mapGetters, mapState } from 'vuex'
+import { mapActions, mapGetters, mapState } from 'vuex'
 
 import navigationMixin from '../mixins/Navigation.js'
 import permissionsMixin from '../mixins/Permissions.js'
@@ -92,7 +92,7 @@ export default {
     mixins: [navigationMixin, permissionsMixin],
     computed: {
         ...mapState('account', ['user', 'team', 'teams']),
-        ...mapGetters('account', ['notifications', 'hasAvailableTeams', 'defaultUserTeam', 'canCreateTeam']),
+        ...mapGetters('account', ['notifications', 'hasAvailableTeams', 'defaultUserTeam', 'canCreateTeam', 'isTrialAccount']),
         ...mapGetters('ux', ['shouldShowLeftMenu']),
         navigationOptions () {
             return [
@@ -118,7 +118,16 @@ export default {
                     tag: 'documentation',
                     onclick: this.to,
                     onclickparams: { url: 'https://flowfuse.com/docs/' }
-                }, {
+                },
+                this.isTrialAccount
+                    ? {
+                        label: 'Getting Started',
+                        icon: AcademicCapIcon,
+                        tag: 'getting-started',
+                        onclick: this.openEducationModal
+                    }
+                    : undefined,
+                {
                     label: 'Sign Out',
                     icon: LogoutIcon,
                     tag: 'sign-out',
@@ -175,6 +184,10 @@ export default {
                     action: 'invite'
                 }
             })
+        },
+        ...mapActions('ux', ['activateTour']),
+        openEducationModal () {
+            this.activateTour('education')
         }
     }
 }

--- a/frontend/src/components/dialogs/EducationModal.vue
+++ b/frontend/src/components/dialogs/EducationModal.vue
@@ -9,8 +9,8 @@
                 <ul class="options">
                     <li v-for="(option, $key) in helpOptions" :key="$key">
                         <a :href="option.href" class="ff-link" target="_blank" @click="capturePostHog(option)">
-                            <ChevronRightIcon class="ff-icon" />
                             <span>{{ option.title }}</span>
+                            <ExternalLinkIcon class="ff-icon" />
                         </a>
                     </li>
                 </ul>
@@ -38,14 +38,14 @@
 </template>
 
 <script>
-import { ChevronRightIcon } from '@heroicons/vue/solid'
+import { ExternalLinkIcon } from '@heroicons/vue/solid'
 import { mapActions, mapGetters } from 'vuex'
 
 import product from '../../services/product.js'
 
 export default {
     name: 'EducationModal',
-    components: { ChevronRightIcon },
+    components: { ExternalLinkIcon },
     data () {
         return {
             isClosing: false,
@@ -112,7 +112,7 @@ export default {
 <style scoped lang="scss">
 .education-modal {
   position: absolute;
-  bottom: 5px;
+  top: 65px;
   right: 5px;
   width: 350px;
   background: $ff-white;
@@ -147,19 +147,18 @@ export default {
         transition: ease-in-out .3s;
         position: relative;
         line-height: 2;
-
-        .ff-icon {
-          transition: ease-in-out .3s;
-          position: relative;
-          left: 0;
-        }
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        border: 1px solid $ff-grey-200;
+        align-items: center;
+        padding: 5px;
+        color: $ff-black;
 
         &:hover {
           text-decoration: none;
-
-          .ff-icon {
-            left: 3px;
-          }
+          border: 1px solid $ff-blue-700;
+          color: $ff-blue-700;
         }
       }
     }

--- a/frontend/src/components/dialogs/EducationModal.vue
+++ b/frontend/src/components/dialogs/EducationModal.vue
@@ -117,6 +117,10 @@ export default {
 
   .ff-dialog-content {
     padding: 10px 10px 5px 10px;
+
+    p {
+      line-height: 1.5;
+    }
   }
 
   .ff-dialog-actions {

--- a/frontend/src/components/dialogs/EducationModal.vue
+++ b/frontend/src/components/dialogs/EducationModal.vue
@@ -8,20 +8,20 @@
                 <p class="message mb-7">Where would you like to get started?</p>
                 <ul class="options">
                     <li>
-                        <a class="ff-link" href="https://flowfuse.com/docs/user/devops-pipelines/">
+                        <a class="ff-link" target="_blank" href="https://flowfuse.com/docs/user/devops-pipelines/">
                             <ChevronRightIcon class="ff-icon" />
                             Create a DevOps Pipeline
                         </a>
                     </li>
                     <li>
-                        <a class="ff-link" href="https://flowfuse.com/docs/user/projectnodes/#flowfuse-project-nodes">
+                        <a class="ff-link" target="_blank" href="https://flowfuse.com/docs/user/projectnodes/#flowfuse-project-nodes">
                             <ChevronRightIcon class="ff-icon" />
                             Set up Project Nodes
                         </a>
                     </li>
                     <li>
                         <a
-                            class="ff-link"
+                            class="ff-link" target="_blank"
                             href="https://flowfuse.com/blog/2024/04/how-to-build-an-application-with-node-red-dashboard-2/"
                         >
                             <ChevronRightIcon class="ff-icon" />
@@ -29,7 +29,7 @@
                         </a>
                     </li>
                     <li>
-                        <a class="ff-link" href="https://www.youtube.com/watch?v=47EvfmJji-k">
+                        <a class="ff-link" target="_blank" href="https://www.youtube.com/watch?v=47EvfmJji-k">
                             <ChevronRightIcon class="ff-icon" />
                             Create a Node-RED flow
                         </a>

--- a/frontend/src/components/dialogs/EducationModal.vue
+++ b/frontend/src/components/dialogs/EducationModal.vue
@@ -117,7 +117,7 @@ export default {
   width: 350px;
   background: $ff-white;
   border: 1px solid $ff-grey-300;
-  box-shadow: -6px -6px 10px rgba(0, 0, 0, .2);
+  box-shadow: -6px 6px 10px rgba(0, 0, 0, .2);
   margin: 0;
 
   .ff-dialog-content {

--- a/frontend/src/components/dialogs/EducationModal.vue
+++ b/frontend/src/components/dialogs/EducationModal.vue
@@ -60,18 +60,25 @@
 
 <script>
 import { ChevronRightIcon } from '@heroicons/vue/solid'
+import { mapActions, mapState } from 'vuex'
 
 export default {
     name: 'EducationModal',
     components: { ChevronRightIcon },
     data () {
         return {
-            isOpen: true,
             isClosing: false,
             closingTimer: 0
         }
     },
+    computed: {
+        ...mapState('ux', ['tours']),
+        isOpen () {
+            return this.tours.education
+        }
+    },
     methods: {
+        ...mapActions('ux', ['deactivateTour']),
         triggerClose () {
             if (this.isClosing) {
                 this.closeModal()
@@ -90,7 +97,7 @@ export default {
             }
         },
         closeModal () {
-            this.isOpen = false
+            this.deactivateTour('education')
             this.isClosing = false
             this.closingTimer = 0
         }

--- a/frontend/src/components/dialogs/EducationModal.vue
+++ b/frontend/src/components/dialogs/EducationModal.vue
@@ -60,7 +60,7 @@
 
 <script>
 import { ChevronRightIcon } from '@heroicons/vue/solid'
-import { mapActions, mapState } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 
 export default {
     name: 'EducationModal',
@@ -72,10 +72,9 @@ export default {
         }
     },
     computed: {
-        ...mapState('ux', ['tours']),
-        isOpen () {
-            return this.tours.education
-        }
+        ...mapGetters({
+            isOpen: 'ux/shouldShowEducationModal'
+        })
     },
     methods: {
         ...mapActions('ux', ['deactivateTour']),

--- a/frontend/src/components/dialogs/EducationModal.vue
+++ b/frontend/src/components/dialogs/EducationModal.vue
@@ -7,31 +7,10 @@
             <template v-if="!isClosing">
                 <p class="message mb-7">Where would you like to get started?</p>
                 <ul class="options">
-                    <li>
-                        <a class="ff-link" target="_blank" href="https://flowfuse.com/docs/user/devops-pipelines/">
+                    <li v-for="(option, $key) in helpOptions" :key="$key">
+                        <a :href="option.href" class="ff-link" target="_blank" @click="capturePostHog(option)">
                             <ChevronRightIcon class="ff-icon" />
-                            Create a DevOps Pipeline
-                        </a>
-                    </li>
-                    <li>
-                        <a class="ff-link" target="_blank" href="https://flowfuse.com/docs/user/projectnodes/#flowfuse-project-nodes">
-                            <ChevronRightIcon class="ff-icon" />
-                            Set up Project Nodes
-                        </a>
-                    </li>
-                    <li>
-                        <a
-                            class="ff-link" target="_blank"
-                            href="https://flowfuse.com/blog/2024/04/how-to-build-an-application-with-node-red-dashboard-2/"
-                        >
-                            <ChevronRightIcon class="ff-icon" />
-                            Build a Dashboard
-                        </a>
-                    </li>
-                    <li>
-                        <a class="ff-link" target="_blank" href="https://www.youtube.com/watch?v=47EvfmJji-k">
-                            <ChevronRightIcon class="ff-icon" />
-                            Create a Node-RED flow
+                            <span>{{ option.title }}</span>
                         </a>
                     </li>
                 </ul>
@@ -62,6 +41,8 @@
 import { ChevronRightIcon } from '@heroicons/vue/solid'
 import { mapActions, mapGetters } from 'vuex'
 
+import product from '../../services/product.js'
+
 export default {
     name: 'EducationModal',
     components: { ChevronRightIcon },
@@ -74,7 +55,28 @@ export default {
     computed: {
         ...mapGetters({
             isOpen: 'ux/shouldShowEducationModal'
-        })
+        }),
+        helpOptions () {
+            return [
+                {
+                    title: 'Create a DevOps Pipeline',
+                    href: 'https://flowfuse.com/docs/user/devops-pipelines/'
+                },
+                {
+                    title: 'Set up Project Nodes',
+                    href: 'https://flowfuse.com/docs/user/projectnodes/#flowfuse-project-nodes/'
+                },
+                {
+                    title: 'Build a Dashboard',
+                    href: 'https://flowfuse.com/blog/2024/04/how-to-build-an-application-with-node-red-dashboard-2/'
+                },
+                {
+                    title: 'Create a Node-RED flow',
+                    href: 'https://www.youtube.com/watch?v=47EvfmJji-k/'
+                }
+
+            ]
+        }
     },
     methods: {
         ...mapActions('ux', ['deactivateTour']),
@@ -99,6 +101,9 @@ export default {
             this.deactivateTour('education')
             this.isClosing = false
             this.closingTimer = 0
+        },
+        capturePostHog (option) {
+            product.capture('clicked-trial-education-link', option)
         }
     }
 }

--- a/frontend/src/components/dialogs/EducationModal.vue
+++ b/frontend/src/components/dialogs/EducationModal.vue
@@ -1,0 +1,172 @@
+<template>
+    <div v-if="isOpen" class="ff-dialog-box education-modal">
+        <div class="ff-dialog-header text-center" data-sentry-unmask>
+            Welcome to your free trial of FlowFuse!
+        </div>
+        <div class="ff-dialog-content">
+            <template v-if="!isClosing">
+                <p class="message mb-7">Where would you like to get started?</p>
+                <ul class="options">
+                    <li>
+                        <a class="ff-link" href="https://flowfuse.com/docs/user/devops-pipelines/">
+                            <ChevronRightIcon class="ff-icon" />
+                            Create a DevOps Pipeline
+                        </a>
+                    </li>
+                    <li>
+                        <a class="ff-link" href="https://flowfuse.com/docs/user/projectnodes/#flowfuse-project-nodes">
+                            <ChevronRightIcon class="ff-icon" />
+                            Set up Project Nodes
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            class="ff-link"
+                            href="https://flowfuse.com/blog/2024/04/how-to-build-an-application-with-node-red-dashboard-2/"
+                        >
+                            <ChevronRightIcon class="ff-icon" />
+                            Build a Dashboard
+                        </a>
+                    </li>
+                    <li>
+                        <a class="ff-link" href="https://www.youtube.com/watch?v=47EvfmJji-k">
+                            <ChevronRightIcon class="ff-icon" />
+                            Create a Node-RED flow
+                        </a>
+                    </li>
+                </ul>
+            </template>
+            <template v-else>
+                <p class="text-center">
+                    You can access these resources at any time by clicking the drop-down arrow in the upper-right corner.
+                </p>
+            </template>
+        </div>
+        <div class="ff-dialog-actions">
+            <ff-button type="secondary" @click="triggerClose">
+                <template v-if="!isClosing">Close</template>
+                <template v-else>Dismiss</template>
+            </ff-button>
+        </div>
+        <div v-if="isClosing" class="loader-wrapper">
+            <div class="loader">
+                <div class="w-full bg-gray-200 full h-1 dark:bg-gray-700">
+                    <div class="bg-blue-600 h-1 full csm-loader" :style="{width: closingTimer + '%'}" />
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { ChevronRightIcon } from '@heroicons/vue/solid'
+
+export default {
+    name: 'EducationModal',
+    components: { ChevronRightIcon },
+    data () {
+        return {
+            isOpen: true,
+            isClosing: false,
+            closingTimer: 0
+        }
+    },
+    methods: {
+        triggerClose () {
+            if (this.isClosing) {
+                this.closeModal()
+            } else {
+                this.isClosing = true
+
+                const intervalId = setInterval(() => {
+                    this.closingTimer += 0.225
+
+                    if (this.closingTimer >= 100) {
+                        clearInterval(intervalId)
+                    }
+                }, 10)
+
+                setTimeout(() => this.closeModal(), 5000)
+            }
+        },
+        closeModal () {
+            this.isOpen = false
+            this.isClosing = false
+            this.closingTimer = 0
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.education-modal {
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  width: 350px;
+  background: $ff-white;
+  border: 1px solid $ff-grey-300;
+  box-shadow: -6px -6px 10px rgba(0, 0, 0, .2);
+  margin: 0;
+
+  .ff-dialog-content {
+    padding: 10px 10px 5px 10px;
+  }
+
+  .ff-dialog-actions {
+    padding: 5px 10px 10px 10px;
+  }
+
+  .title {
+    margin-bottom: 20px;
+    text-align: center;
+    border-bottom: 1px solid $ff-grey-200;
+    padding-bottom: 15px;
+  }
+
+  .options {
+    li {
+      margin-bottom: 5px;
+
+      a {
+        transition: ease-in-out .3s;
+        position: relative;
+        line-height: 2;
+
+        .ff-icon {
+          transition: ease-in-out .3s;
+          position: relative;
+          left: 0;
+        }
+
+        &:hover {
+          text-decoration: none;
+
+          .ff-icon {
+            left: 3px;
+          }
+        }
+      }
+    }
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .loader-wrapper {
+    position: relative;
+
+    .loader {
+      position: absolute;
+      z-index: 1000;
+      right: 0;
+      bottom: -7px;
+      height: 10px;
+      width: 100%;
+    }
+
+  }
+}
+</style>

--- a/frontend/src/services/product.js
+++ b/frontend/src/services/product.js
@@ -32,7 +32,7 @@ function identify (userId, set, setonce) {
  * a proeprty $set or $set_once which in turn can be an object to bind properties to the associated user
  * @param {Object} groups - ties a given 'group' to the event. Optional keys: 'team', 'application', 'instance', 'device'
  */
-function capture (event, properties, groups) {
+function capture (event, properties, groups = undefined) {
     if (!properties) {
         properties = {}
     }

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -81,7 +81,7 @@ const getters = {
         !state.team.billing?.active
     },
     isTrialAccount (state) {
-        return state.team.billing?.trial
+        return state.team?.billing?.trial
     },
     isAdminUser: (state) => !!state.user.admin,
     defaultUserTeam: (state, getters) => {

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -73,12 +73,15 @@ const getters = {
     offline (state) {
         return state.offline
     },
-    noBilling (state) {
+    noBilling (state, getters) {
         return !state.user.admin &&
         state.features.billing &&
         (!state.team.billing?.unmanaged) &&
-        (!state.team.billing?.trial || state.team.billing?.trialEnded) &&
+        (!getters.isTrialAccount || state.team.billing?.trialEnded) &&
         !state.team.billing?.active
+    },
+    isTrialAccount (state) {
+        return state.team.billing?.trial
     },
     isAdminUser: (state) => !!state.user.admin,
     defaultUserTeam: (state, getters) => {

--- a/frontend/src/store/ux.js
+++ b/frontend/src/store/ux.js
@@ -12,6 +12,9 @@ const state = () => ({
 const getters = {
     shouldShowLeftMenu: (state, getters, rootState, rootGetters) => (route) => {
         return rootGetters['account/hasAvailableTeams'] || route.path.includes('/account/')
+    },
+    shouldShowEducationModal: (state) => {
+        return state.tours.education
     }
 }
 

--- a/frontend/src/store/ux.js
+++ b/frontend/src/store/ux.js
@@ -4,7 +4,8 @@ const state = () => ({
         component: null
     },
     tours: {
-        welcome: false
+        welcome: false,
+        education: false
     }
 })
 
@@ -41,7 +42,10 @@ const actions = {
     activateTour ({ commit }, tour) {
         commit('activateTour', tour)
     },
-    deactivateTour ({ commit }, tour) {
+    deactivateTour ({ commit, state }, tour) {
+        if (tour === 'welcome') {
+            commit('activateTour', 'education')
+        }
         commit('deactivateTour', tour)
     }
 }


### PR DESCRIPTION
## Description

Adds an user education modal to trial users

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4500

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

