### PR TITLE
Add warning about file nodes to Assets page

### DIFF
--- a/frontend/src/components/banners/FeatureUnavailable.vue
+++ b/frontend/src/components/banners/FeatureUnavailable.vue
@@ -5,10 +5,12 @@
         data-el="page-banner-feature-unavailable"
     >
         <SparklesIcon class="ff-icon mr-2" style="stroke-width: 1px;" />
-        <div>
-            {{ message }}.
-            <span v-if="!onlyCustomMessage">Please <a class="ff-link" href="https://flowfuse.com/docs/upgrade/open-source-to-premium/" target="_blank" rel="noopener noreferrer">upgrade</a> your instance of FlowFuse in order to use it.</span>
-        </div>
+        <slot name="default">
+            <div>
+                {{ message }}.
+                <span v-if="!onlyCustomMessage">Please <a class="ff-link" href="https://flowfuse.com/docs/upgrade/open-source-to-premium/" target="_blank" rel="noopener noreferrer">upgrade</a> your instance of FlowFuse in order to use it.</span>
+            </div>
+        </slot>
         <SparklesIcon class="ff-icon ml-2" style="stroke-width: 1px;" />
     </div>
 </template>

--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -106,9 +106,6 @@ export default {
         fileNodesDisabled () {
             const settingsFile = this.instance.settings.palette?.nodesExcludes?.includes('10-file.js')
             const templateFile = this.instance.template.settings.palette?.nodesExcludes?.includes('10-file.js')
-            console.log(this.instance.settings.palette?.nodesExcludes)
-            console.log(this.instance.template.settings.palette.nodesExcludes)
-            console.log(settingsFile || templateFile)
             return settingsFile || templateFile
         }
     },

--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -8,6 +8,15 @@
                 :message="launcherVersionMessage"
                 :only-custom-message="true"
             />
+            <FeatureUnavailable
+                v-if="fileNodesDisabled"
+                :message="fileNodesMessage"
+                :onlyCustomMessage="true"
+            >
+                <template #default>
+                    <p>This Instance currently has the default Node-RED File nodes disabled. Please remove '10-file.js' from the <router-link class="ff-link" :to="{ name: 'instance-settings-palette', params: { id: instance.id } }">exclude</router-link> list or contact your administrator</p>
+                </template>
+            </FeatureUnavailable>
         </div>
         <FolderBreadcrumbs
             :breadcrumbs="breadcrumbs"
@@ -93,6 +102,14 @@ export default {
             const folders = this.files.filter(file => file.type === 'directory').sort()
 
             return [...folders, ...files]
+        },
+        fileNodesDisabled () {
+            const settingsFile = this.instance.settings.palette?.nodesExcludes?.includes('10-file.js')
+            const templateFile = this.instance.template.settings.palette?.nodesExcludes?.includes('10-file.js')
+            console.log(this.instance.settings.palette?.nodesExcludes)
+            console.log(this.instance.template.settings.palette.nodesExcludes)
+            console.log(settingsFile || templateFile)
+            return settingsFile || templateFile
         }
     },
     watch: {


### PR DESCRIPTION
fixes #4447

## Description

<!-- Describe your changes in detail -->

Adds baner if default file nodes are disabled
![image](https://github.com/user-attachments/assets/94dad5da-a436-4311-8ca2-06e81393ccbf)

This is to prompt users on Orignial FF Cloud Default Templates to contact support to fix

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4447

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

