### PR TITLE
improved alert notification messages on asset service file/folder upload

### DIFF
--- a/frontend/src/components/file-browser/FileBrowser.vue
+++ b/frontend/src/components/file-browser/FileBrowser.vue
@@ -254,10 +254,7 @@ export default {
             this.loading = true
             AssetsAPI.createFolder(this.instanceId, this.baseURI, this.forms.newFolder.name)
                 .then(() => this.$emit('items-updated'))
-                .catch(error => {
-                    console.error(error)
-                    Alerts.emit(error.response.data.error, 'warning')
-                })
+                .catch(() => Alerts.emit(`Unable to create folder with name '${this.forms.newFolder.name}'`, 'warning'))
                 .finally(() => {
                     this.forms.newFolder.name = ''
                     this.loading = false
@@ -278,10 +275,7 @@ export default {
                     this.forms.newFolder = { name: '' }
                     this.$emit('items-updated')
                 })
-                .catch(error => {
-                    console.error(error)
-                    Alerts.emit(error.response.data.error, 'warning')
-                })
+                .catch(() => Alerts.emit(`Unable to update folder name to '${this.forms.newFolder.name}'`, 'warning'))
                 .finally(() => {
                     this.loading = false
                 })
@@ -332,10 +326,7 @@ export default {
             this.loading = true
             AssetsAPI.uploadFile(this.instanceId, pwd, filename, this.forms.file)
                 .then(() => this.$emit('items-updated'))
-                .catch(error => {
-                    console.error(error)
-                    Alerts.emit(error.response.data.error, 'warning')
-                })
+                .catch(() => Alerts.emit('Unable to upload file', 'warning'))
                 .finally(() => {
                     this.forms.file = null
                     this.$refs.fileUpload.clear()


### PR DESCRIPTION
## Description

improved alert notification messages on asset service file/folder upload

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4467

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

