### PR TITLE
ci: Enable BOM feature for the Enterprise Team on pre-staging environment

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -290,7 +290,8 @@ curl -ks -w "\n" -XPOST \
                         "protectedInstance":true,
                         "editorLimits":true,
                         "customHostnames":true,
-                        "staticAssets":true
+                        "staticAssets":true,
+                        "bom":true
                     },
                     "instances": {
                         "'"$projectTypeId"'": {


### PR DESCRIPTION
## Description

This pull request enables Bill of Materials (BOM) feature on pre-staging environment for Enterprise Team configuration.

## Related Issue(s)

closes https://github.com/FlowFuse/CloudProject/issues/523

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

