### PR TITLE
Make the immersive editor collapse button permanently visible when the drawer is open

### DIFF
--- a/frontend/src/pages/instance/Editor/index.vue
+++ b/frontend/src/pages/instance/Editor/index.vue
@@ -19,7 +19,7 @@
             <drawer-trigger @click="toggleDrawer" />
 
             <middle-close-button
-                :is-visible="drawer.isHoveringOverResize"
+                :is-visible="drawer.open"
                 @click="toggleDrawer"
             />
 


### PR DESCRIPTION
## Description

Make the immersive editor collapse button permanently visible when the drawer is open

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4564

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

