### PR TITLE
remove image logo alt name to fix gmail email summary

### DIFF
--- a/forge/postoffice/layouts/default.js
+++ b/forge/postoffice/layouts/default.js
@@ -33,8 +33,7 @@ module.exports = (htmlContent) => {
                                             <td align="center" valign="top"
                                                 style="border-collapse:collapse;font-family:Helvetica,Arial,sans-serif;color:#33475b;word-break:break-word;text-align:center;padding:16px 20px;font-size:0px">
                                                 <a href="https://flowfuse.com/" style="color:#00a4bd" target="_blank">
-                                                    <img alt="ff-logo--wordmark--dark"
-                                                         src="https://flowfuse.com/handbook/images/logos/ff-logo--wordmark--dark.png"
+                                                    <img src="https://flowfuse.com/handbook/images/logos/ff-logo--wordmark--dark.png"
                                                          style="outline:none;text-decoration:none;border:none;max-width:100%;font-size:16px"
                                                          width="183" align="middle" data-bit="iit">
                                                 </a>


### PR DESCRIPTION
## Description

removed logo img alt name so it won't appear in the summary on gmail

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4593

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

