### PR TITLE
Only show warning if 10-file.js active

### DIFF
--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -109,7 +109,13 @@ export default {
         fileNodesDisabled () {
             const settingsFile = this.instance.settings.palette?.nodesExcludes?.includes('10-file.js')
             const templateFile = this.instance.template.settings.palette?.nodesExcludes?.includes('10-file.js')
-            return settingsFile || templateFile
+            if (this.includes.settings.palette?.nodesExcludes) {
+                // override template so only need to check settings
+                return settingsFile
+            } else {
+                // not overriding template so only need to check template
+                return templateFile
+            }
         }
     },
     watch: {

--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -109,7 +109,7 @@ export default {
         fileNodesDisabled () {
             const settingsFile = this.instance.settings.palette?.nodesExcludes?.includes('10-file.js')
             const templateFile = this.instance.template.settings.palette?.nodesExcludes?.includes('10-file.js')
-            if (this.includes.settings.palette?.nodesExcludes) {
+            if (this.instance.settings.palette?.nodesExcludes) {
                 // override template so only need to check settings
                 return settingsFile
             } else {


### PR DESCRIPTION
fixes #4617

## Description

<!-- Describe your changes in detail -->
The original test only checked if it was present in both, but the instance settings only override the template if there is a value. 

So if there is a `settings.palette.nodeExcludes` value this will override the template value.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4617

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

