### PR TITLE
PostHog: Add "team-created" event when teams are automatically created server-side

### DIFF
--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -12,6 +12,14 @@ module.exports = {
         // Reinflate the object now the user has been added
         const team = await app.db.models.Team.bySlug(newTeam.slug)
 
+        // Record in our Product tracking
+        app.product.capture(user.username, '$ff-team-created', {
+            'team-name': team.name,
+            'created-at': team.createdAt
+        }, {
+            team: team.id
+        })
+
         return team
     },
 


### PR DESCRIPTION
## Description

Uses the server-side `product` API to `capture` an `$ff-team-created` event when user's teams are created automatically.

Verified in our test environment:

<img width="1438" alt="Screenshot 2024-10-15 at 16 31 22" src="https://github.com/user-attachments/assets/7caf1a66-289b-4cc5-8973-8889c4f31b9b">

## Related Issue(s)

Closes #4623 