### PR TITLE
Fix enabling sso group allocation in admin settings

### DIFF
--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -191,7 +191,7 @@ export default {
         },
         isGroupOptionsValid () {
             return !this.input.options.groupMapping || (
-                (this.input.options.type === 'saml' ? this.isGroupAssertionNameValid : this.isGroupsDNValid) &&
+                (this.input.type === 'saml' ? this.isGroupAssertionNameValid : this.isGroupsDNValid) &&
                   this.isGroupAdminNameValid
             )
         },


### PR DESCRIPTION
The 'update' button never becomes enabled when toggling group membership - because the condition was looking at the wrong thing.