### PR TITLE
Add UI for Device Group Env Setup

### DIFF
--- a/frontend/src/api/application.js
+++ b/frontend/src/api/application.js
@@ -343,6 +343,17 @@ const updateDeviceGroupMembership = async (applicationId, groupId, { add, remove
 }
 
 /**
+ * Update the settings of a device group
+ * NOTE: Only ENV VARS are supported at the moment
+ * @param {string} applicationId - The ID of application
+ * @param {string} groupId - The ID of the group
+ * @param {{ env: [{name: String, value: String}]}} settings - The new settings for the group
+ */
+const updateDeviceGroupSettings = async (applicationId, groupId, settings) => {
+    return client.put(`/api/v1/applications/${applicationId}/device-groups/${groupId}/settings`, settings)
+}
+
+/**
  * Get a list of Dependencies / Bill of Materials
  * @param applicationId
  * @returns {Promise<axios.AxiosResponse<any>>}
@@ -373,5 +384,6 @@ export default {
     deleteDeviceGroup,
     updateDeviceGroup,
     updateDeviceGroupMembership,
+    updateDeviceGroupSettings,
     getDependencies
 }

--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -208,7 +208,8 @@ const iconMap = {
         'application.deviceGroup.created',
         'application.deviceGroup.updated',
         'application.deviceGroup.deleted',
-        'application.deviceGroup.members.changed'
+        'application.deviceGroup.members.changed',
+        'application.deviceGroup.settings.updated'
     ],
     beaker: [
         'team.device.developer-mode.enabled',

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -441,7 +441,12 @@
     </template>
     <template v-else-if="entry.event === 'application.deviceGroup.members.changed'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && entry.body?.deviceGroup">Device Group '{{ entry.body.deviceGroup?.name }}' members in Application '{{ entry.body.application?.name }} updated: {{ entry.body?.info?.info ?? 'No changes' }}.</span>
+        <span v-if="!error && entry.body?.deviceGroup">Device Group '{{ entry.body.deviceGroup?.name }}' members in Application '{{ entry.body.application?.name }}' updated: {{ entry.body?.info?.info ?? 'No changes' }}.</span>
+        <span v-else-if="!error">Device Group data not found in audit entry.</span>
+    </template>
+    <template v-else-if="entry.event === 'application.deviceGroup.settings.updated'">
+        <label>{{ AuditEvents[entry.event] }}</label>
+        <span v-if="!error && entry.body?.deviceGroup">Device Group '{{ entry.body.deviceGroup?.name }}' settings in Application '{{ entry.body.application?.name }}' updated.</span>
         <span v-else-if="!error">Device Group data not found in audit entry.</span>
     </template>
 

--- a/frontend/src/data/audit-events.json
+++ b/frontend/src/data/audit-events.json
@@ -55,7 +55,8 @@
         "application.deviceGroup.created": "Device Group Created",
         "application.deviceGroup.updated": "Device Group Updated",
         "application.deviceGroup.deleted": "Device Group Deleted",
-        "application.deviceGroup.members.changed": "Device Group Members Changed"
+        "application.deviceGroup.members.changed": "Device Group Members Changed",
+        "application.deviceGroup.settings.updated": "Device Group Settings Updated"
     },
     "project": {
         "project.created": "Instance Created",

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -3,9 +3,21 @@
         <FormHeading>
             <div class="flex">
                 <div class="mr-4">Environment Variables</div>
+                <div v-if="hasInfoDialog" class="flex justify-center mr-4"><InformationCircleIcon class="w-5 cursor-pointer hover:text-blue-700" @click="openInfoDialog()" /></div>
                 <div class="flex justify-center"><ChangeIndicator :value="editable.changed.env" /></div>
             </div>
         </FormHeading>
+        <ff-dialog v-if="hasInfoDialog" ref="help-dialog" class="ff-dialog-box--info" :header="helpHeader || 'FlowFuse Info'">
+            <template #default>
+                <div class="flex gap-8">
+                    <slot name="pictogram"><img src="../../../../images/pictograms/snapshot_red.png"></slot>
+                    <div><slot name="helptext" /></div>
+                </div>
+            </template>
+            <template #actions>
+                <ff-button @click="$refs['help-dialog'].close()">Close</ff-button>
+            </template>
+        </ff-dialog>
         <div class="min-w-min">
             <!-- NOTE:  `:columns:[,,,]` is necessary to instruct the empty row to apply a col-span of 4 -->
             <ff-data-table
@@ -100,8 +112,7 @@
 </template>
 
 <script>
-
-import { DocumentDownloadIcon, ExclamationIcon, LockClosedIcon, PlusSmIcon, TrashIcon } from '@heroicons/vue/outline'
+import { DocumentDownloadIcon, ExclamationIcon, InformationCircleIcon, LockClosedIcon, PlusSmIcon, TrashIcon } from '@heroicons/vue/outline'
 
 import FormHeading from '../../../../components/FormHeading.vue'
 import FormRow from '../../../../components/FormRow.vue'
@@ -121,7 +132,8 @@ export default {
         TrashIcon,
         PlusSmIcon,
         LockClosedIcon,
-        ExclamationIcon
+        ExclamationIcon,
+        InformationCircleIcon
     },
     props: {
         editTemplate: {
@@ -135,6 +147,11 @@ export default {
         readOnly: {
             type: Boolean,
             default: false
+        },
+        helpHeader: {
+            // for the dialog that opens, e.g. "FlowFuse - Device Group Environment Variables"
+            type: String,
+            default: null
         }
     },
     emits: ['update:modelValue'],
@@ -164,6 +181,9 @@ export default {
         },
         noDataMessage: function () {
             return this.search === '' ? 'No environment variables' : 'Not found! Try a different search term.'
+        },
+        hasInfoDialog () {
+            return !!this.$slots.helptext
         }
     },
     watch: {
@@ -196,6 +216,9 @@ export default {
         this.validate()
     },
     methods: {
+        openInfoDialog () {
+            this.$refs['help-dialog'].show()
+        },
         validate () {
             const envVars = this.editable?.settings?.env || []
             this.updateLookup()

--- a/frontend/src/pages/application/DeviceGroup/Settings/Environment.vue
+++ b/frontend/src/pages/application/DeviceGroup/Settings/Environment.vue
@@ -1,0 +1,179 @@
+<template>
+    <form class="space-y-6">
+        <TemplateSettingsEnvironment v-model="editable" :readOnly="!hasPermission('device:edit-env')" :editTemplate="false" :helpHeader="'Device Group Environment Variables'">
+            <template #helptext>
+                <p>Environment variables entered here will be merged with the environment variables defined in the member devices.</p>
+                <p>
+                    The following rules apply:
+                    <ul class="list-disc pl-5">
+                        <li>Values set in the Device take precedence over values set in the Device Group.</li>
+                        <li>Removing a device from the group will remove these variables from the device.</li>
+                        <li>The devices environment variables are never modified, they are only merged at runtime.</li>
+                    </ul>
+                </p>
+                <p>Updating these environment variables will cause devices in the group to be restarted when a change is detected.</p>
+            </template>
+        </TemplateSettingsEnvironment>
+        <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
+            <ff-button size="small" :disabled="!unsavedChanges || hasError" @click="saveSettings()">Save Settings</ff-button>
+        </div>
+        <div class="ff-banner ff-banner-warning w-full max-w-5xl">
+            <span>
+                <ExclamationCircleIcon class="ff-icon mr-2" />
+                <span class="relative top-0.5">Note: Updating environment variables can cause devices in the group to be restarted.</span>
+            </span>
+
+            <ChevronRightIcon class="ff-icon align-self-right" />
+        </div>
+    </form>
+</template>
+
+<script>
+import { ExclamationCircleIcon } from '@heroicons/vue/outline'
+import { mapState } from 'vuex'
+
+import applicationApi from '../../../../api/application.js'
+import permissionsMixin from '../../../../mixins/Permissions.js'
+import alerts from '../../../../services/alerts.js'
+import dialog from '../../../../services/dialog.js'
+import TemplateSettingsEnvironment from '../../../admin/Template/sections/Environment.vue'
+
+/**
+ * @typedef {Object} EnvVar
+ * @property {string} name
+ * @property {string} value
+ */
+
+export default {
+    name: 'ApplicationDeviceGroupSettingsEnvironment',
+    components: {
+        ExclamationCircleIcon,
+        TemplateSettingsEnvironment
+    },
+    mixins: [permissionsMixin],
+    beforeRouteLeave: async function (_to, _from, next) {
+        if (this.unsavedChanges) {
+            const dialogOpts = {
+                header: 'Unsaved changes',
+                kind: 'danger',
+                text: 'You have unsaved changes. Are you sure you want to leave?',
+                confirmLabel: 'Yes, lose changes'
+            }
+            const answer = await dialog.showAsync(dialogOpts)
+            if (answer === 'confirm') {
+                next()
+            } else {
+                next(false)
+            }
+        } else {
+            next()
+        }
+    },
+    props: {
+        application: {
+            type: Object,
+            required: true
+        },
+        deviceGroup: {
+            type: Object,
+            required: true
+        }
+    },
+    emits: ['device-group-updated'],
+    data () {
+        return {
+            hasError: false,
+            editable: {
+                name: '',
+                settings: {
+                    /** @type {EnvVar[]} */ env: []
+                },
+                policy: {},
+                changed: {
+                    name: false,
+                    description: false,
+                    settings: {
+                        /** @type {EnvVar[]} */ env: []
+                    },
+                    env: false,
+                    policy: {}
+                },
+                errors: {}
+            },
+            original: {
+                settings: {
+                    /** @type {EnvVar[]} */ envMap: {}
+                }
+            },
+            templateEnvValues: {}
+        }
+    },
+    computed: {
+        ...mapState('account', ['teamMembership']),
+        unsavedChanges () {
+            return this.editable.changed.env
+        }
+    },
+    watch: {
+        deviceGroup: 'getSettings',
+        'editable.settings.env': {
+            deep: true,
+            handler (v) {
+                let changed = false
+                let error = false
+
+                this.editable.settings?.env.forEach(field => {
+                    // if we do not recognise the env var name from our original settings,
+                    // or if we do recognise it, but the value is different
+                    if (!this.original.settings.envMap[field.name] || field.value !== this.original.settings.envMap[field.name].value) {
+                        changed = true
+                    }
+                    // there is an issue with he key/value
+                    if (field.error) {
+                        error = true
+                    }
+                })
+
+                // some env vars have been deleted
+                if (this.editable.settings.env.length !== Object.keys(this.original.settings.envMap).length) {
+                    changed = true
+                }
+
+                this.hasError = error
+                this.editable.changed.env = changed
+            }
+        }
+    },
+    mounted () {
+        this.getSettings()
+    },
+    methods: {
+        getSettings: async function () {
+            if (this.deviceGroup) {
+                this.original.settings.envMap = {}
+                this.editable.settings.env = []
+                const settings = this.deviceGroup.settings
+                settings.env?.forEach(envVar => {
+                    this.editable.settings.env.push(Object.assign({}, envVar))
+                    // make a map of the key:value so it's easier to check for changes
+                    this.original.settings.envMap[envVar.name] = envVar
+                })
+            }
+        },
+        saveSettings: async function () {
+            const settings = {
+                env: []
+            }
+            this.editable.settings.env.forEach(field => {
+                settings.env.push({
+                    name: field.name,
+                    value: field.value
+                })
+            })
+            await applicationApi.updateDeviceGroupSettings(this.application.id, this.deviceGroup.id, settings)
+            this.$emit('device-group-updated')
+            alerts.emit('Device Group settings successfully updated. NOTE: changes will be applied to the devices in the group once they restart.', 'confirmation', 6000)
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/application/DeviceGroup/Settings/Environment.vue
+++ b/frontend/src/pages/application/DeviceGroup/Settings/Environment.vue
@@ -14,16 +14,16 @@
                 <p>Updating these environment variables will cause devices in the group to be restarted when a change is detected.</p>
             </template>
         </TemplateSettingsEnvironment>
-        <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
-            <ff-button size="small" :disabled="!unsavedChanges || hasError" @click="saveSettings()">Save Settings</ff-button>
-        </div>
-        <div class="ff-banner ff-banner-warning w-full max-w-5xl">
+        <div class="ff-banner ff-banner-info w-full max-w-5xl">
             <span>
                 <ExclamationCircleIcon class="ff-icon mr-2" />
                 <span class="relative top-0.5">Note: Updating environment variables can cause devices in the group to be restarted.</span>
             </span>
 
             <ChevronRightIcon class="ff-icon align-self-right" />
+        </div>
+        <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
+            <ff-button :disabled="!unsavedChanges || hasError" @click="saveSettings()">Save Settings</ff-button>
         </div>
     </form>
 </template>

--- a/frontend/src/pages/application/DeviceGroup/Settings/General.vue
+++ b/frontend/src/pages/application/DeviceGroup/Settings/General.vue
@@ -37,15 +37,15 @@
 <script>
 import { mapState } from 'vuex'
 
-import ApplicationApi from '../../../api/application.js'
-import FormHeading from '../../../components/FormHeading.vue'
-import FormRow from '../../../components/FormRow.vue'
-import permissionsMixin from '../../../mixins/Permissions.js'
-import Alerts from '../../../services/alerts.js'
-import Dialog from '../../../services/dialog.js'
+import ApplicationApi from '../../../../api/application.js'
+import FormHeading from '../../../../components/FormHeading.vue'
+import FormRow from '../../../../components/FormRow.vue'
+import permissionsMixin from '../../../../mixins/Permissions.js'
+import Alerts from '../../../../services/alerts.js'
+import Dialog from '../../../../services/dialog.js'
 
 export default {
-    name: 'ApplicationDeviceGroupSettings',
+    name: 'ApplicationDeviceGroupSettingsGeneral',
     components: {
         FormRow,
         FormHeading

--- a/frontend/src/pages/application/DeviceGroup/Settings/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/Settings/index.vue
@@ -1,0 +1,68 @@
+<template>
+    <div class="flex flex-col sm:flex-row">
+        <SectionSideMenu :options="sideNavigation" />
+        <div class="flex-grow">
+            <router-view :deviceGroup="deviceGroup" :application="application" @device-group-updated="onDeviceGroupUpdated" />
+        </div>
+    </div>
+</template>
+
+<script>
+import { useRouter } from 'vue-router'
+import { mapState } from 'vuex'
+
+import SectionSideMenu from '../../../../components/SectionSideMenu.vue'
+
+import permissionsMixin from '../../../../mixins/Permissions.js'
+
+export default {
+    name: 'DeviceGroupSettings',
+    components: {
+        SectionSideMenu
+    },
+    mixins: [permissionsMixin],
+    props: {
+        application: {
+            type: Object,
+            required: true
+        },
+        deviceGroup: {
+            type: Object,
+            required: true
+        }
+    },
+    emits: ['device-group-updated'],
+    data: function () {
+        return {
+            sideNavigation: []
+        }
+    },
+    computed: {
+        ...mapState('account', ['teamMembership', 'team'])
+    },
+    watch: {
+        deviceGroup: function (newVal, oldVal) {
+            this.checkAccess()
+        }
+    },
+    mounted () {
+        this.checkAccess()
+    },
+    methods: {
+        checkAccess: async function () {
+            if (!this.teamMembership) {
+                useRouter().push({ replace: true, path: 'overview' })
+                return false
+            }
+            this.sideNavigation = [
+                { name: 'General', path: './general' },
+                { name: 'Environment', path: './environment' }
+            ]
+            return true
+        },
+        onDeviceGroupUpdated: function () {
+            this.$emit('device-group-updated')
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -116,7 +116,7 @@ export default {
                 {
                     label: 'Settings',
                     to: {
-                        name: 'ApplicationDeviceGroupSettings',
+                        name: 'ApplicationDeviceGroupSettingsGeneral',
                         params: {
                             applicationId: this.application?.id,
                             deviceGroupId: this.deviceGroup?.id
@@ -154,7 +154,6 @@ export default {
     methods: {
         async load () {
             const applicationId = this.$route.params.applicationId
-
             // See https://github.com/FlowFuse/flowfuse/issues/2929
             if (!applicationId) {
                 return

--- a/frontend/src/pages/application/routes.js
+++ b/frontend/src/pages/application/routes.js
@@ -6,9 +6,11 @@
  */
 import ApplicationActivity from './Activity.vue'
 import Dependencies from './Dependencies/Dependencies.vue'
+import ApplicationDeviceGroupSettingsEnvironment from './DeviceGroup/Settings/Environment.vue'
+import ApplicationDeviceGroupSettingsGeneral from './DeviceGroup/Settings/General.vue'
+import ApplicationDeviceGroupSettings from './DeviceGroup/Settings/index.vue'
 import ApplicationDeviceGroupDevices from './DeviceGroup/devices.vue'
 import ApplicationDeviceGroupIndex from './DeviceGroup/index.vue'
-import ApplicationDeviceGroupSettings from './DeviceGroup/settings.vue'
 import ApplicationDeviceGroups from './DeviceGroups.vue'
 import ApplicationDevices from './Devices.vue'
 import ApplicationLogs from './Logs.vue'
@@ -183,7 +185,29 @@ export default [
                 component: ApplicationDeviceGroupSettings,
                 meta: {
                     title: 'Application - Device Group - Settings'
-                }
+                },
+                redirect: to => {
+                    return `/application/${to.params.applicationId}/device-group/${to.params.deviceGroupId}/settings/general`
+                },
+                children: [
+                    {
+                        path: 'general',
+                        name: 'ApplicationDeviceGroupSettingsGeneral',
+                        component: ApplicationDeviceGroupSettingsGeneral,
+                        meta: {
+                            title: 'Application - Device Group - Settings - General'
+                        }
+                    },
+                    {
+                        path: 'environment',
+                        name: 'ApplicationDeviceGroupSettingsEnvironment',
+                        component: ApplicationDeviceGroupSettingsEnvironment,
+                        meta: {
+                            title: 'Application - Device Group - Settings - Environment'
+                        }
+                    }
+
+                ]
             }
         ]
     }

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -125,7 +125,7 @@ export default {
                     value: field.value
                 })
             })
-            deviceApi.updateSettings(this.device.id, settings)
+            await deviceApi.updateSettings(this.device.id, settings)
             this.$emit('device-updated')
             alerts.emit('Device settings successfully updated. NOTE: changes will be applied once the device restarts.', 'confirmation', 6000)
         }


### PR DESCRIPTION
closes #4660 

## Description

* Re-arranges the Device Group settings into 2 sub-tabs of
  * General - this includes the original settings (like editing name/desc and deleting the device group)
  * Environment - this hosts the new Env Var editor for device groups
    * NOTE: As discussed in the issue, a warning was added near the save button to ensure users are aware that saving env changes could cause the member devices to restart
* Updates the `TemplateSettingsEnvironment` to permit `helptext` popup
  * The newly added `Environment.vue` uses this to explain the merge rules
* Updates audit log to properly render Device Group Settings Updated


### Screenshots

#### Original settings section moved to "general" in new tabbed layout
![image](https://github.com/user-attachments/assets/153ad3e3-c217-43b5-8882-0984764fb2b4)


#### New Environment Variables section in new tabbed layout
![image](https://github.com/user-attachments/assets/a2d53a68-5218-44f4-9c22-52afa61c01d9)


#### Info text
![image](https://github.com/user-attachments/assets/05e75d21-2bfc-4caa-8c07-8b64961a16a5)


#### Unsaved changes
Demonstrating what happens if you have edited env vars but forgotten to save
![image](https://github.com/user-attachments/assets/6c6e6b74-5b53-4bb0-aff0-21543ae80711)


## Related Issue(s)

Owner: #4660 
Parent:  #4538

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

