### PR TITLE
Return error if broker client already exists for team

### DIFF
--- a/forge/ee/routes/teamBroker/index.js
+++ b/forge/ee/routes/teamBroker/index.js
@@ -123,7 +123,7 @@ module.exports = async function (app) {
         if (await app.db.models.TeamBrokerClient.byUsername(request.body.username, request.team.hashid)) {
             return reply
                 .code(409)
-                send({
+                .send({
                     code: 'client_already_exists',
                     err: 'Client Already exists with username'
                 })

--- a/forge/ee/routes/teamBroker/index.js
+++ b/forge/ee/routes/teamBroker/index.js
@@ -120,6 +120,14 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
+        if (await app.db.models.TeamBrokerClient.byUsername(request.body.username, request.team.hashid)) {
+            return reply
+                .code(409)
+                send({
+                    code: 'client_already_exists',
+                    err: 'Client Already exists with username'
+                })
+        }
         try {
             const newUser = request.body
             newUser.acls = JSON.stringify(newUser.acls)

--- a/forge/ee/routes/teamBroker/index.js
+++ b/forge/ee/routes/teamBroker/index.js
@@ -125,7 +125,7 @@ module.exports = async function (app) {
                 .code(409)
                 .send({
                     code: 'client_already_exists',
-                    err: 'Client Already exists with username'
+                    error: 'Client Already exists with username'
                 })
         }
         try {

--- a/test/unit/forge/ee/routes/teamBroker/index_spec.js
+++ b/test/unit/forge/ee/routes/teamBroker/index_spec.js
@@ -203,7 +203,7 @@ describe('Team Broker API', function () {
             response.statusCode.should.equal(409)
             const result = response.json()
             result.should.have.property('error')
-            result.should.have.property('code', 'user_already_exists')
+            result.should.have.property('code', 'client_already_exists')
         })
 
         it('Delete MQTT Broker User', async function () {

--- a/test/unit/forge/ee/routes/teamBroker/index_spec.js
+++ b/test/unit/forge/ee/routes/teamBroker/index_spec.js
@@ -203,7 +203,7 @@ describe('Team Broker API', function () {
             response.statusCode.should.equal(409)
             const result = response.json()
             result.should.have.property('err')
-            result.should.have.property('code','user_already_exists')
+            result.should.have.property('code', 'user_already_exists')
         })
 
         it('Delete MQTT Broker User', async function () {

--- a/test/unit/forge/ee/routes/teamBroker/index_spec.js
+++ b/test/unit/forge/ee/routes/teamBroker/index_spec.js
@@ -184,6 +184,28 @@ describe('Team Broker API', function () {
             result.should.have.property('code', 'broker_client_limit_reached')
         })
 
+        it('Fail to Create existing MQTT Broker User', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${app.team.hashid}/broker/client`,
+                cookies: { sid: TestObjects.tokens.alice },
+                body: {
+                    username: 'alice',
+                    password: 'aaPassword',
+                    acls: [
+                        {
+                            pattern: 'foo/#',
+                            action: 'both'
+                        }
+                    ]
+                }
+            })
+            response.statusCode.should.equal(409)
+            const result = response.json()
+            result.should.have.property('err')
+            result.should.have.property('code','user_already_exists')
+        })
+
         it('Delete MQTT Broker User', async function () {
             const response = await app.inject({
                 method: 'DELETE',

--- a/test/unit/forge/ee/routes/teamBroker/index_spec.js
+++ b/test/unit/forge/ee/routes/teamBroker/index_spec.js
@@ -202,7 +202,7 @@ describe('Team Broker API', function () {
             })
             response.statusCode.should.equal(409)
             const result = response.json()
-            result.should.have.property('err')
+            result.should.have.property('error')
             result.should.have.property('code', 'user_already_exists')
         })
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Add check for existing client with username

Will now return 409 rather than DB constraints error

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

