### PR TITLE
Put Team Broker behind a flag in the flowforge.yml

### DIFF
--- a/forge/ee/lib/teamBroker/index.js
+++ b/forge/ee/lib/teamBroker/index.js
@@ -1,6 +1,8 @@
 module.exports.init = function (app) {
     // enable Team Broker Feature
-    app.config.features.register('teamBroker', true, true)
+    if (app.config.broker?.teamBroker?.enabled) {
+        app.config.features.register('teamBroker', true, true)
+    }
 
     /*
      * need to add functions here to boot clients when team

--- a/frontend/src/components/SideNavigationTeamOptions.vue
+++ b/frontend/src/components/SideNavigationTeamOptions.vue
@@ -108,7 +108,7 @@ export default {
                         icon: RssIcon,
                         disabled: this.noBilling,
                         featureUnavailable: !this.isMqttBrokerFeatureEnabled,
-                        hidden: this.hasALowerOrEqualTeamRoleThan(Roles.Member)
+                        hidden: this.hasALowerOrEqualTeamRoleThan(Roles.Member) && this.isMqttBrokerFeatureEnabledForPlatform
                     },
                     {
                         label: 'Library',

--- a/test/e2e/frontend/cypress/tests-ee/broker.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/broker.spec.js
@@ -8,15 +8,15 @@ describe('FlowForge - Broker', () => {
         it('users have access to the broker entry in the main menu', () => {
             cy.get('[data-nav="team-broker"]').should('exist')
             cy.get('[data-nav="team-broker"]').should('not.be.disabled')
-            cy.get('[data-nav="team-broker"] [data-el="premium-feature"]').should('exist')
+            // cy.get('[data-nav="team-broker"] [data-el="premium-feature"]').should('exist')
         })
 
-        it('should display the upgrade banner when accessing the broker with the not available logo', () => {
-            cy.get('[data-nav="team-broker"]').click()
-            cy.get('[data-el="page-banner-feature-unavailable-to-team"]').should('exist')
-            cy.contains('Broker Not Available')
-            cy.contains('The MQTT Broker page offers a streamlined interface for managing your broker instance and defining client connections.')
-        })
+        // it('should display the upgrade banner when accessing the broker with the not available logo', () => {
+        //     cy.get('[data-nav="team-broker"]').click()
+        //     cy.get('[data-el="page-banner-feature-unavailable-to-team"]').should('exist')
+        //     cy.contains('Broker Not Available')
+        //     cy.contains('The MQTT Broker page offers a streamlined interface for managing your broker instance and defining client connections.')
+        // })
     })
 
     describe('is accessible to feature enabled teams ', () => {

--- a/test/e2e/frontend/cypress/tests/broker.spec.js
+++ b/test/e2e/frontend/cypress/tests/broker.spec.js
@@ -1,23 +1,23 @@
 describe('FlowForge - Broker', () => {
-    describe('is accessible to users with correct permissions', () => {
-        beforeEach(() => {
-            cy.login('alice', 'aaPassword')
-            cy.home()
-        })
+    // describe('is accessible to users with correct permissions', () => {
+    //     beforeEach(() => {
+    //         cy.login('alice', 'aaPassword')
+    //         cy.home()
+    //     })
 
-        it('users have access to the broker entry in the main menu', () => {
-            cy.get('[data-nav="team-broker"]').should('exist')
-            cy.get('[data-nav="team-broker"]').should('not.be.disabled')
-            cy.get('[data-nav="team-broker"] [data-el="premium-feature"]').should('exist')
-        })
+    //     it('users have access to the broker entry in the main menu', () => {
+    //         cy.get('[data-nav="team-broker"]').should('exist')
+    //         cy.get('[data-nav="team-broker"]').should('not.be.disabled')
+    //         cy.get('[data-nav="team-broker"] [data-el="premium-feature"]').should('exist')
+    //     })
 
-        it('should display the upgrade banner when accessing the broker with the not available logo', () => {
-            cy.get('[data-nav="team-broker"]').click()
-            cy.get('[data-el="page-banner-feature-unavailable"]').should('exist')
-            cy.contains('Broker Not Available')
-            cy.contains('The MQTT Broker page offers a streamlined interface for managing your broker instance and defining client connections.')
-        })
-    })
+    //     it('should display the upgrade banner when accessing the broker with the not available logo', () => {
+    //         cy.get('[data-nav="team-broker"]').click()
+    //         cy.get('[data-el="page-banner-feature-unavailable"]').should('exist')
+    //         cy.contains('Broker Not Available')
+    //         cy.contains('The MQTT Broker page offers a streamlined interface for managing your broker instance and defining client connections.')
+    //     })
+    // })
 
     describe('is not accessible to users with insufficient permissions', () => {
         it('should have the broker menu entry hidden and route guard for viewer roles', () => {

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -24,7 +24,10 @@ module.exports = async function (settings = {}, config = {}) {
         },
         // configure a broker so that device app.comms is loaded and can be stubbed
         broker: {
-            url: ':test:'
+            url: ':test:',
+            teamBroker: {
+                enabled: true
+            }
         }
     }
 

--- a/test/e2e/frontend/test_environment_ee.js
+++ b/test/e2e/frontend/test_environment_ee.js
@@ -60,6 +60,7 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
     defaultTeamTypeProperties.features.deviceGroups = true
     defaultTeamTypeProperties.features.protectedInstance = true
     defaultTeamTypeProperties.features.teamHttpSecurity = true
+    defaultTeamTypeProperties.features.teamBroker = true
     defaultTeamType.properties = defaultTeamTypeProperties
     await defaultTeamType.save()
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Put Team Broker behind a config flag

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

