### PR TITLE
Update 'both' MQTT ACL label to 'publish & subscribe'

### DIFF
--- a/frontend/src/pages/team/Broker/dialogs/AclItem.vue
+++ b/frontend/src/pages/team/Broker/dialogs/AclItem.vue
@@ -52,7 +52,7 @@ export default {
                 pattern: ''
             },
             actions: [
-                { label: 'Both', value: 'both' },
+                { label: 'Publish & Subscribe', value: 'both' },
                 { label: 'Subscribe', value: 'subscribe' },
                 { label: 'Publish', value: 'publish' }
             ]


### PR DESCRIPTION
The default value is "both" - but not clear what that means when first viewing the dialog.

This updates the label to 'publish & subscribe' to be more explicit on meaning.