### PR TITLE
Re-order Join Reason options in Sign Up page

### DIFF
--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -113,9 +113,9 @@ export default {
                 general: ''
             },
             reasons: [
+                { label: 'Educational Use', value: 'education' },
                 { label: 'Business Needs', value: 'business' },
-                { label: 'Personal Use', value: 'personal' },
-                { label: 'Educational Use', value: 'education' }
+                { label: 'Personal Use', value: 'personal' }
             ]
         }
     },


### PR DESCRIPTION
## Description

As per title, new order:

<img width="432" alt="Screenshot 2024-10-29 at 17 56 07" src="https://github.com/user-attachments/assets/e8080d49-b448-46d0-998e-9cd364adf0b6">

## Related Issue(s)

Closes #4699