### PR TITLE
ci: Disable team broker for starter team type on pre-staging

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -207,7 +207,7 @@ curl -ks -w "\n" -XPOST \
                        "contextLimit": null,
                        "customHostnames":false,
                        "staticAssets":false,
-                       "teamBroker":true
+                       "teamBroker":false
                   },
                   "instances": {
                       "'"$projectTypeId"'": {


### PR DESCRIPTION
## Description

This pull request disables team broker feature for Starter team type on pre-staging environment.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/544

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

