### PR TITLE
Ensure Downgraded Teams can't authenticate MQTT Clients

### DIFF
--- a/forge/db/controllers/TeamBrokerClient.js
+++ b/forge/db/controllers/TeamBrokerClient.js
@@ -15,7 +15,6 @@ module.exports = {
             }
 
             const properties = user.Team.TeamType.properties
-            console.log(properties)
             if (!properties?.features?.teamBroker) {
                 return false
             }

--- a/forge/db/controllers/TeamBrokerClient.js
+++ b/forge/db/controllers/TeamBrokerClient.js
@@ -10,6 +10,16 @@ module.exports = {
                 return false
             }
 
+            if (user.Team.suspended) {
+                return false
+            }
+
+            const properties = user.Team.TeamType.properties
+            console.log(properties)
+            if (!properties?.features?.teamBroker) {
+                return false
+            }
+
             if (!password || password.length > 128) {
                 return false
             }

--- a/forge/db/models/TeamBrokerClient.js
+++ b/forge/db/models/TeamBrokerClient.js
@@ -49,7 +49,13 @@ module.exports = {
                         teamId = M.Team.decodeHashid(teamHashId)
                     }
                     return this.findOne({
-                        where: { username, TeamId: teamId }
+                        where: { username, TeamId: teamId },
+                        include: {
+                            model: M.Team,
+                            include: {
+                                model: M.TeamType
+                            }
+                        }
                     })
                 },
                 byTeam: async (teamHashId, pagination = {}, where = {}) => {

--- a/test/unit/forge/ee/routes/teamBroker/index_spec.js
+++ b/test/unit/forge/ee/routes/teamBroker/index_spec.js
@@ -439,7 +439,6 @@ describe('Team Broker API', function () {
                 result.should.have.property('result', 'deny')
             })
             it('Test Authentication fail suspended team', async function () {
-
                 app.team.suspended = true
                 await app.team.save()
 

--- a/test/unit/forge/ee/routes/teamBroker/index_spec.js
+++ b/test/unit/forge/ee/routes/teamBroker/index_spec.js
@@ -438,6 +438,28 @@ describe('Team Broker API', function () {
                 const result = response.json()
                 result.should.have.property('result', 'deny')
             })
+            it('Test Authentication fail suspended team', async function () {
+
+                app.team.suspended = true
+                await app.team.save()
+
+                const response = await app.inject({
+                    method: 'POST',
+                    url: '/api/comms/v2/auth',
+                    cookies: { sid: TestObjects.tokens.bob },
+                    body: {
+                        username: `bob@${app.team.hashid}`,
+                        password: 'bbPassword',
+                        clientId: `bob@${app.team.hashid}`
+                    }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('result', 'deny')
+
+                app.team.suspended = false
+                await app.team.save()
+            })
             it('Test subscribe allowed', async function () {
                 const response = await app.inject({
                     method: 'POST',


### PR DESCRIPTION
part of #4474

## Description

<!-- Describe your changes in detail -->
Adds checks for if the Team is suspended and that the team still has the `teamBroker` feature enabled.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4474 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

