### PR TITLE
Do not add api-error:version_mismatch to audit log

### DIFF
--- a/forge/routes/logging/index.js
+++ b/forge/routes/logging/index.js
@@ -47,6 +47,13 @@ module.exports = async function (app) {
         const auditEvent = request.body
         const event = auditEvent.event
         const error = auditEvent.error
+
+        // Some node-red audit events are not useful to expose to the end user - filter them out here
+        // api.error:version_mismatch - normal part of collision detection when trying to deploy flows
+        if (event === 'api.error' && error === 'version_mismatch') {
+            response.status(200).send()
+        }
+
         let user = request.session?.User || null
         if (!user && auditEvent?.user && typeof auditEvent.user === 'string') {
             user = await app.db.models.User.byId(auditEvent.user) || null


### PR DESCRIPTION
Closes #4738 

## Description

The `api-error:version_mismatch` audit event from Node-RED occurs when a user tries to deploy changes but they don't have the latest flows loaded - it is part of the normal sequence that allows the editor to prompt the user to merge remote changes first and retry.

Node-RED emits it within its own audit log which we capture and put in the Instance audit log. However there is no real value in logging it - it displays as an error in the log but is not actionable. There is very little value knowing it happened as its a normal part of the deploy lifecycle.

This PR filters these events so they do not end up in the instance audit log.

