### PR TITLE
Fix failing feature checks when the features state hasn't been hydrated

### DIFF
--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -125,24 +125,24 @@ const getters = {
                 const flag = state.team?.type?.properties?.features?.['shared-library']
                 return flag === undefined || flag
             })(state),
-            isSharedLibraryFeatureEnabledForPlatform: state.features['shared-library'],
+            isSharedLibraryFeatureEnabledForPlatform: state.features?.['shared-library'],
 
             // Blueprints
             isBlueprintsFeatureEnabledForTeam: ((state) => {
                 const flag = state.team?.type?.properties?.features?.flowBlueprints
                 return flag === undefined || flag
             })(state),
-            isBlueprintsFeatureEnabledForPlatform: !!state.features.flowBlueprints,
+            isBlueprintsFeatureEnabledForPlatform: !!state.features?.flowBlueprints,
 
             // Custom Catalogs
-            isCustomCatalogsFeatureEnabledForPlatform: !!state.features.customCatalogs,
+            isCustomCatalogsFeatureEnabledForPlatform: !!state.features?.customCatalogs,
             isCustomCatalogsFeatureEnabledForTeam: ((state) => {
-                const flag = state.team.type.properties.features?.customCatalogs
+                const flag = state.team?.type.properties.features?.customCatalogs
                 return flag === undefined || flag
             })(state),
 
             // Static Assets
-            isStaticAssetFeatureEnabledForPlatform: !!state.features.staticAssets,
+            isStaticAssetFeatureEnabledForPlatform: !!state.features?.staticAssets,
             isStaticAssetsFeatureEnabledForTeam: !!state.team?.type?.properties?.features?.staticAssets,
 
             // HTTP BearerTokens
@@ -150,15 +150,15 @@ const getters = {
             isHTTPBearerTokensFeatureEnabledForTeam: !!state.team?.type.properties.features.teamHttpSecurity,
 
             // BOM
-            isBOMFeatureEnabledForPlatform: !!state.features.bom,
+            isBOMFeatureEnabledForPlatform: !!state.features?.bom,
             isBOMFeatureEnabledForTeam: !!state.team?.type?.properties?.features?.bom,
 
             // Timeline
-            isTimelineFeatureEnabledForPlatform: !!state.features.projectHistory,
+            isTimelineFeatureEnabledForPlatform: !!state.features?.projectHistory,
             isTimelineFeatureEnabledForTeam: !!state.team?.type?.properties?.features?.projectHistory,
 
             // Mqtt Broker
-            isMqttBrokerFeatureEnabledForPlatform: !!state.features.teamBroker,
+            isMqttBrokerFeatureEnabledForPlatform: !!state.features?.teamBroker,
             isMqttBrokerFeatureEnabledForTeam: !!state.team?.type?.properties?.features?.teamBroker
         }
         return {


### PR DESCRIPTION
## Description

Added a safeguard in the account store's featuresCheck getter to stop the vuex store from silently failing.

This is merely a patchwork, the true fix would require the implementation of an application service that would make sure that the application & store is hydrated accordingly in a particular order and with the minimal viable set of data required for the application to be rendered.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4758

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

