### PR TITLE
Fix applications page nested routes

### DIFF
--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -36,16 +36,19 @@ export default [
                 },
                 children: [
                     {
-                        name: 'Applications',
                         path: 'applications',
-                        component: TeamApplications,
-                        meta: {
-                            title: 'Team - Applications'
-                        },
                         children: [
                             {
-                                path: 'create',
+                                name: 'Applications',
+                                path: '',
+                                component: TeamApplications,
+                                meta: {
+                                    title: 'Team - Applications'
+                                }
+                            },
+                            {
                                 name: 'CreateTeamApplication',
+                                path: 'create',
                                 component: CreateApplication,
                                 meta: {
                                     title: 'Team - Create Application',


### PR DESCRIPTION
## Description

The applications create page was improperly nested causing the create form to be rendered at the bottom of the page instead of a new one.

Introduced by https://github.com/FlowFuse/flowfuse/pull/4744

## Related Issue(s)

tbd

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

