### PR TITLE
Add links to MQTT docs

### DIFF
--- a/docs/user/introduction.md
+++ b/docs/user/introduction.md
@@ -80,3 +80,6 @@ FlowFuse supports reading and writing persistent files and persistent context.
  - [High Availability mode](/docs/user/high-availability.md) - Run multiple copies of your instance for scaling and availability.
  - [FlowFuse Assistant](/docs/user/assistant.md) - A plugin for Node-RED that helps you code faster.
  
+ ## Working with MQTT
+
+ - [Team Broker](/docs/users/teambroker.md) - Working with the FlowFuse bundled MQTT Broker

--- a/docs/user/introduction.md
+++ b/docs/user/introduction.md
@@ -82,4 +82,4 @@ FlowFuse supports reading and writing persistent files and persistent context.
  
  ## Working with MQTT
 
- - [Team Broker](/docs/users/teambroker.md) - Working with the FlowFuse bundled MQTT Broker
+ - [Team Broker](/docs/user/teambroker.md) - Working with the FlowFuse bundled MQTT Broker

--- a/docs/user/team/README.md
+++ b/docs/user/team/README.md
@@ -78,6 +78,10 @@ table summaries what actions are available to the different roles.
 | • Add an item                        | ✓     | ✓      | -      | -              |
 | • Modify an item                     | ✓     | ✓      | -      | -              |
 | • Delete an item                     | ✓     | ✓      | -      | -              |
+| **Team Broker**                      |       |        |        |                |
+| • Create Client                      | ✓     | ✓      | -      | -              |
+| • Delete Client                      | ✓     | ✓      | -      | -              |
+| • List Clients                       | ✓     | ✓      | -      | -              |
 
 Notes:
  - **§1** A user in any role can remove themselves from a team

--- a/docs/user/teambroker.md
+++ b/docs/user/teambroker.md
@@ -1,0 +1,39 @@
+---
+navTitle: Team Broker
+---
+
+# Getting Started with Team Broker
+
+When FlowFuse is deployed with an Enterprise license from v2.11.0 onwards comes with the option to enable a MQTT broker for each Team.
+
+This is a single shared MQTT broker, but each team has their own separate topic space and the ability to provision credentials for clients.
+
+## Creating Clients
+
+When creating clients you can specify a username, it will prepended to the the Team's id e.g.  `alice` will become `alice@32E4NEO5pY`.
+
+This username should also be used as the MQTT Client ID in order to connect to the broker. Examples of how to do this are in the [next section](#connecting-to-the-broker).
+
+![Create Broker Client](../cloud/images/create-broker-client.png)
+
+## Connecting to the Broker
+
+The broker for FlowFuse Cloud is available on `broker.flowfuse.cloud` and supports the following connection types:
+
+ - MQTT on port `1883`
+ - MQTT over TLS on port `8883`
+ - MQTT over secure WebSockets on port `443`
+
+ For Self Hosted instances, please ask your Administrator for hostname and ports.
+
+ You can connect to the broker using any MQTT client, for example `mosquitto_sub`
+
+ ```
+ mosquitto_sub -u "alice@32E4NEO5pY" -i "alice@32E4NEO5pY" -P "password" -h broker.flowfuse.cloud -t "#"
+ ```
+
+ Or in Node-RED as follows
+
+ ![Node-RED MQTT Client Connection](../cloud/images/node-red-mqtt-connection.png)
+ 
+ ![Node-RED MQTT Client Security](../cloud/images/node-red-mqtt-security.png)

--- a/frontend/src/pages/team/Broker/index.vue
+++ b/frontend/src/pages/team/Broker/index.vue
@@ -12,6 +12,7 @@
                     <p>The <b>MQTT Broker</b> page offers a streamlined interface for managing your broker instance and defining client connections.</p>
                     <p>You can create and manage MQTT clients, each with customizable Access Control List (ACL) rules to ensure secure and controlled communication. The ACL rules allow for fine-grained control over each client’s access to specific topics, supporting both publishing and subscribing actions.</p>
                     <p>This overview provides a clear and organized view of your broker’s configuration, helping you manage client connections, security settings, and message flow efficiently.</p>
+                    <p>Documentation <a href="https://flowfuse.com/docs/user/teambroker" target="_blank" >here</a></p>
                 </template>
             </ff-page-header>
         </template>

--- a/frontend/src/pages/team/Broker/index.vue
+++ b/frontend/src/pages/team/Broker/index.vue
@@ -12,7 +12,7 @@
                     <p>The <b>MQTT Broker</b> page offers a streamlined interface for managing your broker instance and defining client connections.</p>
                     <p>You can create and manage MQTT clients, each with customizable Access Control List (ACL) rules to ensure secure and controlled communication. The ACL rules allow for fine-grained control over each client’s access to specific topics, supporting both publishing and subscribing actions.</p>
                     <p>This overview provides a clear and organized view of your broker’s configuration, helping you manage client connections, security settings, and message flow efficiently.</p>
-                    <p>Documentation <a href="https://flowfuse.com/docs/user/teambroker" target="_blank" >here</a></p>
+                    <p>Documentation <a href="https://flowfuse.com/docs/user/teambroker" target="_blank">here</a></p>
                 </template>
             </ff-page-header>
         </template>


### PR DESCRIPTION
part of #4707
## Description

<!-- Describe your changes in detail -->
This adds some links to the MQTT docs for the Team Broker.

Also includes new user docs section to cover self hosted rather than just FFC

## Related Issue(s)
Closes #4707 

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

