### PR TITLE
Fix multiple non-authenticated page layouts

### DIFF
--- a/frontend/src/components/auth/UpdateExpiredPassword.vue
+++ b/frontend/src/components/auth/UpdateExpiredPassword.vue
@@ -1,9 +1,36 @@
 <template>
     <form class="space-y-6" ref="password_form" @submit.prevent>
         <div>You must set a new password before continuing</div>
-        <FormRow type="password" @enter="focusPassword" :error="errors.old_password" v-model="input.old_password" ref="row-old">Old Password</FormRow>
-        <FormRow type="password" @enter="focusConfirmPassword" :error="errors.password" v-model="input.password" ref="row-new">New Password</FormRow>
-        <FormRow type="password" @enter="changePassword" :error="errors.password_confirm" v-model="input.password_confirm" ref="row-confirm">Confirm</FormRow>
+        <FormRow
+            type="password"
+            @enter="focusPassword"
+            :error="errors.old_password"
+            v-model="input.old_password"
+            ref="row-old"
+            container-class="max-w-full"
+        >
+            Old Password
+        </FormRow>
+        <FormRow
+            type="password"
+            @enter="focusConfirmPassword"
+            :error="errors.password"
+            v-model="input.password"
+            ref="row-new"
+            container-class="max-w-full"
+        >
+            New Password
+        </FormRow>
+        <FormRow
+            type="password"
+            @enter="changePassword"
+            :error="errors.password_confirm"
+            v-model="input.password_confirm"
+            ref="row-confirm"
+            container-class="max-w-full"
+        >
+            Confirm
+        </FormRow>
         <ff-button @click="changePassword" type="submit">
             Change Password
         </ff-button>

--- a/frontend/src/pages/PasswordExpired.vue
+++ b/frontend/src/pages/PasswordExpired.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-layout-box class="ff-password-expired">
+    <ff-layout-box class="ff-password-expired ff--center-box">
         <form class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
             <UpdateExpiredPassword />
         </form>
@@ -24,23 +24,3 @@ export default {
     }
 }
 </script>
-
-<style lang="scss">
-.ff-layout--box.ff-password-expired {
-    flex-direction: column;
-    min-height: fit-content;
-    overflow: auto;
-
-    .ff-layout--box--wrapper {
-        display: flex;
-        width: 100%;
-        max-height: fit-content;
-        height: fit-content;
-
-        .ff-layout--box--left,
-        .ff-layout--box--right {
-            width: 100%;
-        }
-    }
-}
-</style>

--- a/frontend/src/pages/PasswordExpired.vue
+++ b/frontend/src/pages/PasswordExpired.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-layout-box>
+    <ff-layout-box class="ff-password-expired">
         <form class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
             <UpdateExpiredPassword />
         </form>
@@ -24,3 +24,23 @@ export default {
     }
 }
 </script>
+
+<style lang="scss">
+.ff-layout--box.ff-password-expired {
+    flex-direction: column;
+    min-height: fit-content;
+    overflow: auto;
+
+    .ff-layout--box--wrapper {
+        display: flex;
+        width: 100%;
+        max-height: fit-content;
+        height: fit-content;
+
+        .ff-layout--box--left,
+        .ff-layout--box--right {
+            width: 100%;
+        }
+    }
+}
+</style>

--- a/frontend/src/pages/TermsAndConditions.vue
+++ b/frontend/src/pages/TermsAndConditions.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-layout-box class="ff-terms-and-conditions">
+    <ff-layout-box class="ff-terms-and-conditions ff--center-box">
         <form class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6" @submit.prevent>
             <p>
                 Welcome {{ user.name }}, the <a target="_blank" :href="settings['user:tcs-url']">FlowFuse Terms &amp; Conditions</a> have been updated.
@@ -55,23 +55,3 @@ export default {
     }
 }
 </script>
-
-<style lang="scss">
-.ff-layout--box.ff-terms-and-conditions {
-    flex-direction: column;
-    min-height: fit-content;
-    overflow: auto;
-
-    .ff-layout--box--wrapper {
-        display: flex;
-        width: 100%;
-        max-height: fit-content;
-        height: fit-content;
-
-        .ff-layout--box--left,
-        .ff-layout--box--right {
-            width: 100%;
-        }
-    }
-}
-</style>

--- a/frontend/src/pages/TermsAndConditions.vue
+++ b/frontend/src/pages/TermsAndConditions.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-layout-box>
+    <ff-layout-box class="ff-terms-and-conditions">
         <form class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6" @submit.prevent>
             <p>
                 Welcome {{ user.name }}, the <a target="_blank" :href="settings['user:tcs-url']">FlowFuse Terms &amp; Conditions</a> have been updated.
@@ -55,3 +55,23 @@ export default {
     }
 }
 </script>
+
+<style lang="scss">
+.ff-layout--box.ff-terms-and-conditions {
+    flex-direction: column;
+    min-height: fit-content;
+    overflow: auto;
+
+    .ff-layout--box--wrapper {
+        display: flex;
+        width: 100%;
+        max-height: fit-content;
+        height: fit-content;
+
+        .ff-layout--box--left,
+        .ff-layout--box--right {
+            width: 100%;
+        }
+    }
+}
+</style>

--- a/frontend/src/pages/UnverifiedEmail.vue
+++ b/frontend/src/pages/UnverifiedEmail.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-layout-box>
+    <ff-layout-box class="ff-unverified-email">
         <form class="px-4 sm:px-6 lg:px-8 mt-8 mx-auto space-y-6 max-w-md" @submit.prevent>
             <p>
                 Before you can access the platform, we need to verify your email
@@ -87,3 +87,23 @@ export default {
     }
 }
 </script>
+
+<style lang="scss">
+.ff-layout--box.ff-unverified-email {
+    flex-direction: column;
+    min-height: fit-content;
+    overflow: auto;
+
+    .ff-layout--box--wrapper {
+        display: flex;
+        width: 100%;
+        max-height: fit-content;
+        height: fit-content;
+
+        .ff-layout--box--left,
+        .ff-layout--box--right {
+            width: 100%;
+        }
+    }
+}
+</style>

--- a/frontend/src/pages/UnverifiedEmail.vue
+++ b/frontend/src/pages/UnverifiedEmail.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-layout-box class="ff-unverified-email">
+    <ff-layout-box class="ff-unverified-email ff--center-box">
         <form class="px-4 sm:px-6 lg:px-8 mt-8 mx-auto space-y-6 max-w-md" @submit.prevent>
             <p>
                 Before you can access the platform, we need to verify your email
@@ -87,23 +87,3 @@ export default {
     }
 }
 </script>
-
-<style lang="scss">
-.ff-layout--box.ff-unverified-email {
-    flex-direction: column;
-    min-height: fit-content;
-    overflow: auto;
-
-    .ff-layout--box--wrapper {
-        display: flex;
-        width: 100%;
-        max-height: fit-content;
-        height: fit-content;
-
-        .ff-layout--box--left,
-        .ff-layout--box--right {
-            width: 100%;
-        }
-    }
-}
-</style>

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/no-v-html -->
 
 <template>
-    <ff-layout-box class="ff-signup">
+    <ff-layout-box class="ff-signup ff--center-box">
         <template v-if="splash" #splash-content>
             <div data-el="splash" v-html="splash" />
         </template>
@@ -285,23 +285,3 @@ export default {
     }
 }
 </script>
-
-<style lang="scss">
-.ff-layout--box.ff-signup {
-    flex-direction: column;
-    min-height: fit-content;
-    overflow: auto;
-
-    .ff-layout--box--wrapper {
-        display: flex;
-        width: 100%;
-        max-height: fit-content;
-        height: fit-content;
-
-        .ff-layout--box--left,
-        .ff-layout--box--right {
-            width: 100%;
-        }
-    }
-}
-</style>

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -285,3 +285,23 @@ export default {
     }
 }
 </script>
+
+<style lang="scss">
+.ff-layout--box.ff-signup {
+    flex-direction: column;
+    min-height: fit-content;
+    overflow: auto;
+
+    .ff-layout--box--wrapper {
+        display: flex;
+        width: 100%;
+        max-height: fit-content;
+        height: fit-content;
+
+        .ff-layout--box--left,
+        .ff-layout--box--right {
+            width: 100%;
+        }
+    }
+}
+</style>

--- a/frontend/src/pages/account/ForgotPassword.vue
+++ b/frontend/src/pages/account/ForgotPassword.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-layout-box>
+    <ff-layout-box class="ff-forgot-password">
         <form v-if="!pending" class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
             <div v-if="flash" class="font-medium" v-text="flash" />
             <template v-else>
@@ -74,3 +74,23 @@ export default {
     }
 }
 </script>
+
+<style lang="scss">
+.ff-layout--box.ff-forgot-password {
+    flex-direction: column;
+    min-height: fit-content;
+    overflow: auto;
+
+    .ff-layout--box--wrapper {
+        display: flex;
+        width: 100%;
+        max-height: fit-content;
+        height: fit-content;
+
+        .ff-layout--box--left,
+        .ff-layout--box--right {
+            width: 100%;
+        }
+    }
+}
+</style>

--- a/frontend/src/pages/account/ForgotPassword.vue
+++ b/frontend/src/pages/account/ForgotPassword.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-layout-box class="ff-forgot-password">
+    <ff-layout-box class="ff-forgot-password ff--center-box">
         <form v-if="!pending" class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
             <div v-if="flash" class="font-medium" v-text="flash" />
             <template v-else>
@@ -74,23 +74,3 @@ export default {
     }
 }
 </script>
-
-<style lang="scss">
-.ff-layout--box.ff-forgot-password {
-    flex-direction: column;
-    min-height: fit-content;
-    overflow: auto;
-
-    .ff-layout--box--wrapper {
-        display: flex;
-        width: 100%;
-        max-height: fit-content;
-        height: fit-content;
-
-        .ff-layout--box--left,
-        .ff-layout--box--right {
-            width: 100%;
-        }
-    }
-}
-</style>

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -137,7 +137,7 @@ const getters = {
             // Custom Catalogs
             isCustomCatalogsFeatureEnabledForPlatform: !!state.features?.customCatalogs,
             isCustomCatalogsFeatureEnabledForTeam: ((state) => {
-                const flag = state.team?.type.properties.features?.customCatalogs
+                const flag = state.team?.type?.properties.features?.customCatalogs
                 return flag === undefined || flag
             })(state),
 
@@ -147,7 +147,7 @@ const getters = {
 
             // HTTP BearerTokens
             isHTTPBearerTokensFeatureEnabledForPlatform: !!state.settings?.features.httpBearerTokens,
-            isHTTPBearerTokensFeatureEnabledForTeam: !!state.team?.type.properties.features.teamHttpSecurity,
+            isHTTPBearerTokensFeatureEnabledForTeam: !!state.team?.type?.properties.features.teamHttpSecurity,
 
             // BOM
             isBOMFeatureEnabledForPlatform: !!state.features?.bom,

--- a/frontend/src/stylesheets/common.scss
+++ b/frontend/src/stylesheets/common.scss
@@ -7,10 +7,13 @@
 
 html, body, #app {
     height: 100%;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
 }
 
 #ff-app {
-    height: 100%;
+    flex: 1;
     background-color: $ff-grey-300;
 }
 
@@ -104,10 +107,10 @@ html, body, #app {
     &.ff-no-data-large {
         padding: 64px 12px;
     }
-    
+
     &--boxed {
         @extend .ff-no-data;
-        
+
        .message {
            display: block;
            text-align: center;
@@ -180,7 +183,7 @@ label {
     align-items: center;
     justify-content: center;
     padding: 8px 16px;
-    
+
     &.minimal {
         background: none;
         border: none;

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -33,6 +33,24 @@ $nav_height: 60px;
         margin-top: 0.25rem;
         color: $ff-red-200;
     }
+
+    &.ff--center-box {
+        flex-direction: column;
+        min-height: fit-content;
+        overflow: auto;
+
+        .ff-layout--box--wrapper {
+            display: flex;
+            width: 100%;
+            max-height: fit-content;
+            height: fit-content;
+
+            .ff-layout--box--left,
+            .ff-layout--box--right {
+                width: 100%;
+            }
+        }
+    }
 }
 
 .ff-layout--box--wrapper {

--- a/frontend/src/stylesheets/pages/login.scss
+++ b/frontend/src/stylesheets/pages/login.scss
@@ -1,9 +1,19 @@
-.ff-login {
+.ff-layout--box.ff-login {
+    flex-direction: column;
+    min-height: 660px;
+    overflow: auto;
+
     .ff-layout--box--wrapper {
-        width: 75%;
         max-width: 1048px;
+        min-height: 660px;
+        min-width: 400px;
+
         .ff-layout--box--right {
-            padding: 128px 48px;
+            padding: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
         }
         .ff-layout--box--content {
             max-width: 380px;


### PR DESCRIPTION
## Description

Addresses some ui issues caused by the removal of referencing the viewport height.

- forced the `html`, `body`, `#app` and `#ff-app` containers to to full height by using flex in order to preserve scroll functionality
- fixed the layouts for the following pages:
 - updateExpiredPassword
 - PasswordExpired
 - TermsAndConditions
 - UnverifiedEmail
 - Create (signup)
 - ForgotPassword
 - Login
- also fixed a minor snag in the account store where state.team.types were not loaded causing the menu to rendered empty for users with lesser permissions


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

