### PR TITLE
Fix immersive editor not displaying due to parent container height

### DIFF
--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -186,6 +186,7 @@ $nav_height: 60px;
 .ff-layout--platform,
 .ff-layout--plain {
     min-height: inherit;
+    flex: 1;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
## Description

makes the ff-layout-plain stretch to max available space

## Related Issue(s)

introduced by https://github.com/FlowFuse/flowfuse/pull/4763

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

