### PR TITLE
Make email matching case insensitive for external invites

### DIFF
--- a/forge/db/controllers/Invitation.js
+++ b/forge/db/controllers/Invitation.js
@@ -93,7 +93,7 @@ module.exports = {
         if (!invitedUser && invitation.external) {
             // This won't have a full user object attached as they had not registered
             // when the invitation was created.
-            if (user.email === invitation.email) {
+            if (user.email.toLowerCase() === invitation.email.toLowerCase()) {
                 invitedUser = user
             }
         }
@@ -144,7 +144,7 @@ module.exports = {
         if (!invitedUser && invitation.external) {
             // This won't have a full user object attached as they had not registered
             // when the invitation was created.
-            if (user.email === invitation.email) {
+            if (user.email.toLowerCase() === invitation.email.toLowerCase()) {
                 invitedUser = user
             }
         }

--- a/forge/db/models/Invitation.js
+++ b/forge/db/models/Invitation.js
@@ -1,4 +1,4 @@
-const { DataTypes } = require('sequelize')
+const { DataTypes, fn, col, Op, where } = require('sequelize')
 
 const { generateToken } = require('../utils')
 
@@ -120,8 +120,13 @@ module.exports = {
                 forExternalEmail: async (email) => {
                     return this.findAll({
                         where: {
-                            external: true,
-                            email
+                            [Op.and]: [
+                                { external: true },
+                                where(
+                                    fn('lower', col('Invitation.email')),
+                                    email.toLowerCase()
+                                )
+                            ]
                         },
                         include: [
                             { model: M.Team, as: 'team' },

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -454,14 +454,14 @@ describe('Accounts API', async function () {
                 // Create existing team
                 const existingTeam = await app.factory.createTeam({ name: 'ExistingTeam' })
                 await existingTeam.addUser(app.adminUser, { through: { role: app.factory.Roles.Roles.Owner } })
-                // Alice invite External User to ExistingTeam
+                // Alice invite External User to ExistingTeam - note mixed case of email to ensure we match case-insensitive
                 await login('alice', 'aaPassword')
                 const inviteResponse = await app.inject({
                     method: 'POST',
                     url: `/api/v1/teams/${existingTeam.hashid}/invitations`,
                     cookies: { sid: TestObjects.tokens.alice },
                     payload: {
-                        user: 'user6@example.com',
+                        user: 'user6@EXAMPLE.com',
                         role: app.factory.Roles.Roles.Owner
                     }
                 })


### PR DESCRIPTION
Fixes #4781 

This updates how we lookup invites for external users to be case insensitive on email.

Existing test updated to cover the scenario.

