### PR TITLE
Add connection test button to LDAP SSO page

### DIFF
--- a/forge/ee/routes/sso/index.js
+++ b/forge/ee/routes/sso/index.js
@@ -1,5 +1,7 @@
 const fp = require('fastify-plugin')
 
+const { Client, InvalidCredentialsError } = require('ldapts')
+
 module.exports = fp(async function (app, opts) {
     // Get all
     app.get('/ee/sso/providers', {
@@ -83,6 +85,65 @@ module.exports = fp(async function (app, opts) {
             reply.send(app.db.views.SAMLProvider.provider(updatedProvider))
         } else {
             reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+        }
+    })
+
+    /**
+     * Test SSO creds, LDAP only at first
+     */
+    app.post('/ee/sso/providers/test', {
+        preHandler: app.needsPermission('saml-provider:edit')
+    }, async (request, reply) => {
+        let url = request.body.options.server
+        if (!/^ldaps?:\/\//.test(url)) {
+            if (request.body.options.tls) {
+                url = 'ldaps://' + url
+            } else {
+                url = 'ldap://' + url
+            }
+        }
+
+        const clientOptions = { url }
+        if (request.body.options.tls) {
+            if (!request.body.options.tlsVerifyServer) {
+                clientOptions.tlsOptions = {
+                    rejectUnauthorized: false
+                }
+            }
+        }
+
+        if (request.body.options.password === '__PLACEHOLDER__' && request.body.id) {
+            const provider = await app.db.models.SAMLProvider.byId(request.body.id)
+            request.body.options.password = provider.getOptions().password
+        }
+
+        let adminClient
+        try {
+            adminClient = new Client(clientOptions)
+            await adminClient.bind(request.body.options.username, request.body.options.password)
+            reply.send({})
+        } catch (err) {
+            const response = {}
+            if (err instanceof InvalidCredentialsError) {
+                response.code = 'incorrect_credentials'
+                response.error = 'Incorrect Credentials'
+            } else if (err.code === 'ECONNREFUSED') {
+                response.code = 'connection_refused'
+                response.error = 'Connection Refused'
+            } else if (err.code === 'ERR_INVALID_URL') {
+                response.code = 'invalid_url'
+                response.message = `${err.input} not valid LDAP URL`
+            } else {
+                response.code = 'unexpected_error'
+                response.error = err.toString()
+            }
+            reply.code(400).send(response)
+        } finally {
+            try {
+                if (adminClient) {
+                    await adminClient.unbind()
+                }
+            } catch (err) {}
         }
     })
 

--- a/forge/ee/routes/sso/index.js
+++ b/forge/ee/routes/sso/index.js
@@ -132,7 +132,7 @@ module.exports = fp(async function (app, opts) {
                 response.error = 'Connection Refused'
             } else if (err.code === 'ERR_INVALID_URL') {
                 response.code = 'invalid_url'
-                response.message = `${err.input} not valid LDAP URL`
+                response.error = `${err.input} not valid LDAP URL`
             } else {
                 response.code = 'unexpected_error'
                 response.error = err.toString()

--- a/frontend/src/api/sso.js
+++ b/frontend/src/api/sso.js
@@ -24,10 +24,16 @@ const updateProvider = async (id, options) => {
 const deleteProvider = async (id) => {
     return await client.delete(`/ee/sso/providers/${id}`)
 }
+const testProvider = async (id, options) => {
+    return client.post('/ee/sso/providers/test', { id, ...options }).then(res => {
+        return res.data
+    })
+}
 export default {
     createProvider,
     updateProvider,
     getProvider,
     deleteProvider,
-    getProviders
+    getProviders,
+    testProvider
 }

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -359,8 +359,8 @@ export default {
                     await ssoApi.testProvider(this.provider.id, opts)
                     Alerts.emit('Connection succeeded', 'confirmation')
                 } catch (err) {
-                    const message = err.response.data.message
-                    Alerts.emit(`Connection failed, ${message}`, 'warning')
+                    const message = err.response.data.error
+                    Alerts.emit(`Connection failed: ${error}`, 'warning')
                 }
             }
         }

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -360,7 +360,7 @@ export default {
                     Alerts.emit('Connection succeeded', 'confirmation')
                 } catch (err) {
                     const message = err.response.data.error
-                    Alerts.emit(`Connection failed: ${error}`, 'warning')
+                    Alerts.emit(`Connection failed: ${message}`, 'warning')
                 }
             }
         }

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -72,7 +72,7 @@
                             Password
                             <template #description>The password to access the server</template>
                         </FormRow>
-                        <ff-button :disabled="!allowTest" kind="secondary" @click="testProvider()">
+                        <ff-button :disabled="!allowTest" size="small" kind="secondary" @click="testProvider()">
                             Test Connection
                         </ff-button>
                         <FormRow v-model="input.options.baseDN">


### PR DESCRIPTION
fixes #4782

## Description

<!-- Describe your changes in detail -->

Adds ability to test SSO LDAP credentials

This adds 1 new API endpoint and a minor change to the LDAP SSO config page to add test button.

- POST `/ee/sso/providers/test` takes the same payload as the update provider, and needs same permissions

Returns 200 and empty json for success or 400 and standard error json for failure, with messages to suite the type of failure.

feedback is via Alerts, success

![image](https://github.com/user-attachments/assets/ab7d05cf-1a06-4294-a9a1-c3a310c47b02)

or for failure

![image](https://github.com/user-attachments/assets/bfedf140-d3e6-48a3-9d23-cab920bf31b3)

Note, button is secondary, only showing blue here because mouse is over it in the screenshot

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

