### PR TITLE
Add ACLS for project nodes to access team broker topic space

### DIFF
--- a/forge/comms/v2AuthRoutes.js
+++ b/forge/comms/v2AuthRoutes.js
@@ -110,6 +110,12 @@ module.exports = async function (app) {
             const acc = action === 'subscribe' ? 1 : 2
             const allowed = await app.comms.aclManager.verify(username, topic, acc)
             if (allowed) {
+                if (action === 'publish') {
+                    const m = /^ff\/v1\/([^/]+)\/c\/(.+)$/.exec(topic)
+                    if (m) {
+                        app.teamBroker.addUsedTopic(m[2], m[1])
+                    }
+                }
                 reply.send({ result: 'allow' })
             } else {
                 reply.send({ result: 'deny' })

--- a/forge/ee/lib/projectComms/index.js
+++ b/forge/ee/lib/projectComms/index.js
@@ -110,5 +110,11 @@ module.exports.init = function (app) {
             'pub',
             { topic: /^ff\/v1\/([^/]+)\/p\/(?!dev:)([^/]+)\/res\/[^/]+($|\/.*$)/, verify: 'checkDeviceCanAccessProject', deviceOwnerType: 'instance' }
         )
+
+        // Team Broker ACLS - pub/sub to common topic space
+        app.comms.aclManager.addACL('project', 'pub', { topic: /^ff\/v1\/([^/]+)\/c\/[^/]+($|\/.*$)/, verify: 'checkTeamId' })
+        app.comms.aclManager.addACL('project', 'sub', { topic: /^ff\/v1\/([^/]+)\/c\/[^/]+($|\/.*$)/, verify: 'checkTeamId' })
+        app.comms.aclManager.addACL('device', 'pub', { topic: /^ff\/v1\/([^/]+)\/c\/[^/]+($|\/.*$)/, verify: 'checkTeamId' })
+        app.comms.aclManager.addACL('device', 'sub', { topic: /^ff\/v1\/([^/]+)\/c\/[^/]+($|\/.*$)/, verify: 'checkTeamId' })
     }
 }

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -244,7 +244,8 @@ module.exports = async function (app) {
         const teamType = await request.device.Team.getTeamType()
         response.features = {
             'shared-library': !!(app.config.features.enabled('shared-library') && teamType.getFeatureProperty('shared-library', true)),
-            projectComms: !!(app.config.features.enabled('projectComms') && teamType.getFeatureProperty('projectComms', true))
+            projectComms: !!(app.config.features.enabled('projectComms') && teamType.getFeatureProperty('projectComms', true)),
+            teamBroker: !!(app.config.features.enabled('teamBroker') && teamType.getFeatureProperty('teamBroker', true))
         }
         response.assistant = {
             enabled: app.config.assistant?.enabled || false,

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -840,7 +840,8 @@ module.exports = async function (app) {
 
         settings.features = {
             'shared-library': app.config.features.enabled('shared-library') && teamType.getFeatureProperty('shared-library', true),
-            projectComms: app.config.features.enabled('projectComms') && teamType.getFeatureProperty('projectComms', true)
+            projectComms: app.config.features.enabled('projectComms') && teamType.getFeatureProperty('projectComms', true),
+            teamBroker: app.config.features.enabled('teamBroker') && teamType.getFeatureProperty('teamBroker', true)
         }
         reply.send(settings)
     })


### PR DESCRIPTION
Part of https://github.com/FlowFuse/nr-project-nodes/issues/114

## Description

 - Adds the `teamBroker` feature flag to the settings object passed to Instances and Devices
 - Adds ACL rules to allow project nodes to pub/sub from the team broker topic space
 - Adds topic usage tracking when the Project Nodes publish to the team broker

Keeping in draft whilst I assemble the other parts.