### PR TITLE
Respect CTRL/CMD+Click for opening instance editor in new tab

### DIFF
--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -89,7 +89,15 @@ export default {
             if (this.disabled) {
                 return false
             }
-            window.open(this.url, !this.isImmersiveEditor ? '_blank' : '_self')
+            let href = this.url
+            let target = !this.isImmersiveEditor ? '_blank' : '_self'
+            // On Mac Keyboard, ⌘ + click opens in new tab (⌘ is `metaKey`)
+            // Otherwise Ctrl + click opens in new tab (Ctrl is `ctrlKey`)
+            if (evt.ctrlKey || evt.metaKey) {
+                target = '_blank'
+                href = this.editorURL
+            }
+            window.open(href, target)
             return false
         }
     }


### PR DESCRIPTION
## Description

Opens the instance editor in a new tab when CTRL/CMD is held
This is not as straight forward as setting target since the URL for immersive is different to the URL for standalone (thought that is something that could potentially be handled with more effort)
For now, this is a simple mod that adds to the current working logic. i.e.  currently, we do already support middle mouse button click, this PR builds on that to check the key held and opens in a new tab if it is. 

Very much a nice to have but worth the 20 mins

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

