### PR TITLE
Fix broken anchor links in docs

### DIFF
--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -285,7 +285,9 @@ Restart the core application to apply the changes:
 docker compose restart forge
 ```
 
-### After starting the platform, I can't access it in the browser - I see Connection Refused error
+### Connection Refused error
+
+After starting the platform, I can't access it in the browser - I see "Connection Refused error"
 
 If you are using the Digital Ocean Docker Droplet to host FlowFuse you will need to ensure that port 80 & 443 are opened in the UFW firewall before starting.
 
@@ -318,7 +320,7 @@ New-NetFireWallRule -DisplayName 'WSL 8080TCP' -Direction Outbound -LocalPort 80
 
 ### I installed FlowFuse on Windows with WSL2, application is running but I can't access it in the browser
 
-Next to [opening the ports in the firewall](#after-starting-the-platform-i-cant-access-it-in-the-browser---i-see-connection-refused-error), 
+Next to [opening the ports in the firewall](#connection-refused-error), 
 you need to configure port forwarding from Windows host to WSL2 server.
 
 To forward traffic from an external IP to your container, run the following PowerShell command (administrator privileges required):

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -95,7 +95,7 @@ Before you begin, ensure you have the following:
 
 For a production-ready environment, we also recommend: 
 * **Database:** Prepare dedicated database on a external database server (see [FAQ](#how-to-use-external-database-server%3F) for more details)
-* **TLS Certificate:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](#enable-https-optional))
+* **TLS Certificate:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](../docker/README.md#enable-https-optional)) 
 
 ### DNS
 

--- a/docs/user/snapshots.md
+++ b/docs/user/snapshots.md
@@ -25,7 +25,7 @@ A Snapshot is a point-in-time backup of a Node-RED instance. It captures:
 - [Upload a snapshot](#upload-a-snapshot) - Upload a snapshot to a device or an instance
 - [Download a snapshot](#download-a-snapshot) - Download a snapshot to your local machine
 - [Delete a snapshot](#delete-a-snapshot) - Delete a snapshot
-- [Set Device Target (instance)](#Instance-owned-devices) - Set a snapshot as the target for all devices belonging to an instance
+- [Set Device Target (instance)](#instance-owned-devices) - Set a snapshot as the target for all devices belonging to an instance
 - [Creating a Snapshot from a device](#creating-a-snapshot-from-a-device) - Create a snapshot from the device overview page
 - [Creating a Snapshot from within a device](#creating-a-snapshot-locally) - Create a snapshot from within Node-RED
 - [Auto Snapshots](#auto-snapshots) - Automatically create snapshots when flows are deployed
@@ -41,7 +41,7 @@ All snapshots belonging to the instances and devices of an application are gathe
 
 - [Edit a snapshot](#edit-a-snapshot) - Edit the name and description of a snapshot
 - [View Snapshot](#previewing-snapshots) - Preview the flows of a snapshot
-- [Compare Snapshot](#compare-snapshots) - Compare the snapshot with another snapshot
+- [Compare Snapshot](#comparing-snapshots) - Compare the snapshot with another snapshot
 - [Download Snapshot](#download-a-snapshot) - Download the snapshot to your local machine
 - [Delete Snapshot](#delete-a-snapshot) - Delete the snapshot
 
@@ -60,7 +60,7 @@ Snapshots belonging to an instance are gathered and presented in a single list w
 - [Restore Snapshot](#setting-a-device-target-snapshot) - Restore the snapshot to the instance
 - [Edit Snapshot](#edit-a-snapshot) - Edit the snapshot name and description
 - [View Snapshot](#previewing-snapshots) - Preview the snapshot flows
-- [Compare Snapshot](#compare-snapshots) - Compare the snapshot with another snapshot
+- [Compare Snapshot](#comparing-snapshots) - Compare the snapshot with another snapshot
 - [Download Snapshot](#download-a-snapshot) - Download the snapshot to your local machine
 - [Set as Device Target](#setting-a-device-target-snapshot) - Set the snapshot as the device target snapshot
 - [Delete Snapshot](#delete-a-snapshot) - Delete the snapshot
@@ -87,7 +87,7 @@ Snapshots belonging to a device are presented in a single list where you can per
 - [Restore Snapshot](#setting-a-device-target-snapshot) - Set the snapshot as the devices target snapshot
 - [Edit Snapshot](#edit-a-snapshot) - Edit the snapshot name and description
 - [View Snapshot](#previewing-snapshots) - Preview the snapshot flows
-- [Compare Snapshot](#compare-snapshots) - Compare the snapshot with another snapshot
+- [Compare Snapshot](#comparing-snapshots) - Compare the snapshot with another snapshot
 - [Download Snapshot](#download-a-snapshot) - Download the snapshot to your local machine
 - [Delete Snapshot](#delete-a-snapshot) - Delete the snapshot
 


### PR DESCRIPTION
## Description

Addresses snapshots link issue
- `#compare-snapshots`
  - updated the links to recently renamed section title
- `#Instance-owned-devices`
  - capital letter in section link

Addresses  docker/kubernetes broken link
- `#enable-https-optional`
  - I am not sure where this originally linked to but I have pointed the link in `docs/install/kubernetes/README.md` to the existing section in the docker.md - not 100% sure if that was the intention - please check.
- `#after-starting-the-platform-i-cant-access-it-in-the-browser---i-see-connection-refused-error`
  - This link was working in editor. suspect the punctuation of length of the section title is not playing nicely with the link checker. I simplified the title of this one.


Regarding the docker broken link, 


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

