### PR TITLE
docs: fix failing anchors on kubernetes and docker docs

### DIFF
--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -91,7 +91,7 @@ Before you begin, ensure you have the following:
 
 For a production-ready environment, we also recommend: 
 * **Database:** Prepare dedicated database on a external database server (see [FAQ](#how-to-use-external-database-server%3F) for more details)
-* **TLS Certification:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](#enable-https-optional))
+* **TLS Certification:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](#enable-https-(optional)))
 
 ### DNS
 
@@ -266,7 +266,7 @@ Once ready, [start the application](#start-flowfuse-platform) .
 
 ### How can I provide my own TLS certificate?
 
-If you have your own TLS certificate, you can use it in FlowFuse platform installation as well. See [Enable HTTPS](#enable-https-optional) section for more details.
+If you have your own TLS certificate, you can use it in FlowFuse platform installation as well. See [Enable HTTPS](#enable-https-(optional)) section for more details.
 
 ### I would like to invite my team members to the platform with e-mail, how can I do that?
 

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -95,7 +95,7 @@ Before you begin, ensure you have the following:
 
 For a production-ready environment, we also recommend: 
 * **Database:** Prepare dedicated database on a external database server (see [FAQ](#how-to-use-external-database-server%3F) for more details)
-* **TLS Certificate:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](#i-would-like-to-secure-the-platform-with-https-how-can-i-do-that)) 
+* **TLS Certificate:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](#i-would-like-to-secure-the-platform-with-https%2C-how-can-i-do-that%3F)) 
 
 ### DNS
 

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -95,7 +95,7 @@ Before you begin, ensure you have the following:
 
 For a production-ready environment, we also recommend: 
 * **Database:** Prepare dedicated database on a external database server (see [FAQ](#how-to-use-external-database-server%3F) for more details)
-* **TLS Certificate:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](../docker/README.md#enable-https-optional)) 
+* **TLS Certificate:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](#i-would-like-to-secure-the-platform-with-https-how-can-i-do-that)) 
 
 ### DNS
 

--- a/docs/install/kubernetes/aws_terraform.md
+++ b/docs/install/kubernetes/aws_terraform.md
@@ -191,7 +191,7 @@ Apply the SES module using the shared variables file:
 terraform -chdir=ses apply -var-file=../terraform.tfvars
 ```
 
-To get the IAM role ARN created by the SES module and required during [FlowFuse platform configuration](./README.md#configure-flowfuse), run the following command:
+To get the IAM role ARN created by the SES module and required during [FlowFuse platform configuration](/docs/install/configuration.md#aws-ses-email), run the following command:
 
 ```bash
 terraform -chdir=ses output flowfuse_ses_role_arn


### PR DESCRIPTION
## Description

This pull request fixes failing hyperlink validation executed against the whole flowfuse website build.
A successful links validation test with changes from this PR: https://github.com/FlowFuse/website/actions/runs/11955879818/job/33329770167

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

