### PR TITLE
Alter the destination of the applications more link for viewer role users

### DIFF
--- a/frontend/src/composables/Permissions.js
+++ b/frontend/src/composables/Permissions.js
@@ -56,13 +56,13 @@ export default function usePermissions () {
     }
 
     /**
-         * Check if the user has the minimum required role.
-         * @param {Role} role - The role to check against.
-         * @returns {boolean} True if the user has the minimum required role, otherwise false.
-         * @example
-         * // Check if the user has at least the 'Member' role
-         * const isMemberOrHigher = hasAMinimumTeamRoleOf(Roles.Member)
-         */
+     * Check if the user has the minimum required role.
+     * @param {Role} role - The role to check against.
+     * @returns {boolean} True if the user has the minimum required role, otherwise false.
+     * @example
+     * // Check if the user has at least the 'Member' role
+     * const isMemberOrHigher = hasAMinimumTeamRoleOf(Roles.Member)
+     */
     const hasAMinimumTeamRoleOf = (role) => {
         if (isVisitingAdmin()) {
             return true
@@ -72,13 +72,24 @@ export default function usePermissions () {
     }
 
     /**
-         * Check if the user has a lower role than given role.
-         * @param {Role} role - The role to check against.
-         * @returns {boolean} True if the user has a lower role than the given one, otherwise false.
-         * @example
-         * // Check if the user has role lower than 'Member' role
-         * const isMemberOrHigher = hasALowerTeamRoleThan(Roles.Member)
-         */
+     * Check if the user has the minimum Member role.
+     *
+     * wrapper for the hasAMinimumTeamRoleOf method
+     *
+     * @returns {boolean}
+     */
+    const hasAMinimumTeamRoleOfMember = () => {
+        return hasAMinimumTeamRoleOf(Roles.Member)
+    }
+
+    /**
+     * Check if the user has a lower role than given role.
+     * @param {Role} role - The role to check against.
+     * @returns {boolean} True if the user has a lower role than the given one, otherwise false.
+     * @example
+     * // Check if the user has role lower than 'Member' role
+     * const isMemberOrHigher = hasALowerTeamRoleThan(Roles.Member)
+     */
     const hasALowerOrEqualTeamRoleThan = (role) => {
         if (isVisitingAdmin()) {
             return true
@@ -91,6 +102,7 @@ export default function usePermissions () {
         isVisitingAdmin,
         hasPermission,
         hasAMinimumTeamRoleOf,
+        hasAMinimumTeamRoleOfMember,
         hasALowerOrEqualTeamRoleThan
     }
 }

--- a/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
@@ -28,7 +28,7 @@
             </div>
             <HasMoreTile
                 v-if="hasMoreDevices"
-                link-to="ApplicationDevices"
+                :link-to="hasMoreLink"
                 :remaining="remainingDevices"
                 :application="application"
                 :search-query="searchQuery"
@@ -68,7 +68,10 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import IconDeviceSolid from '../../../../../components/icons/DeviceSolid.js'
+import usePermissions from '../../../../../composables/Permissions.js'
 import deviceActionsMixin from '../../../../../mixins/DeviceActions.js'
 import DeviceCredentialsDialog from '../../../Devices/dialogs/DeviceCredentialsDialog.vue'
 import TeamDeviceCreateDialog from '../../../Devices/dialogs/TeamDeviceCreateDialog.vue'
@@ -93,12 +96,18 @@ export default {
         }
     },
     emits: ['delete-device'],
+    setup () {
+        const { hasAMinimumTeamRoleOfMember } = usePermissions()
+
+        return { hasAMinimumTeamRoleOfMember }
+    },
     data () {
         return {
             devices: this.application.devices
         }
     },
     computed: {
+        ...mapState('account', ['team']),
         hasMoreDevices () {
             return this.application.deviceCount > this.visibleDevices.length
         },
@@ -124,6 +133,18 @@ export default {
         },
         isSearching () {
             return this.searchQuery.length > 0
+        },
+        hasMoreLink () {
+            const query = { }
+
+            if (this.searchQuery) {
+                query.searchQuery = this.searchQuery
+            }
+            if (this.hasAMinimumTeamRoleOfMember()) {
+                return { name: 'ApplicationDevices', params: { id: this.application.id }, query }
+            }
+
+            return { name: 'TeamDevices', params: { team_slug: this.team.slug }, query }
         }
     },
     watch: {

--- a/frontend/src/pages/team/Applications/components/compact/HasMoreTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/HasMoreTile.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="has-more item-wrapper" data-el="has-more-tile">
-        <router-link :to="{name: linkTo, params: {id: application.id}, query: {searchQuery}}">
+        <router-link :to="linkTo">
             <span>
                 {{ remaining }}
                 More...
@@ -26,18 +26,9 @@ export default {
             required: true
         },
         linkTo: {
-            type: String,
+            type: Object,
             required: true
-        },
-        searchQuery: {
-            type: String,
-            required: false,
-            default: ''
         }
     }
 }
 </script>
-
-<style scoped lang="scss">
-
-</style>

--- a/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
@@ -29,7 +29,7 @@
             </div>
             <HasMoreTile
                 v-if="hasMoreInstances"
-                link-to="ApplicationInstances"
+                :link-to="hasMoreLink"
                 :remaining="remainingInstances"
                 :application="application"
                 :search-query="searchQuery"
@@ -39,7 +39,11 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import IconNodeRedSolid from '../../../../../components/icons/NodeRedSolid.js'
+
+import usePermissions from '../../../../../composables/Permissions.js'
 
 import HasMoreTile from './HasMoreTile.vue'
 
@@ -61,7 +65,13 @@ export default {
         }
     },
     emits: ['delete-instance'],
+    setup () {
+        const { hasAMinimumTeamRoleOfMember } = usePermissions()
+
+        return { hasAMinimumTeamRoleOfMember }
+    },
     computed: {
+        ...mapState('account', ['team']),
         instances () {
             return this.application.instances.slice(0, 3)
         },
@@ -90,6 +100,18 @@ export default {
         },
         isSearching () {
             return this.searchQuery.length > 0
+        },
+        hasMoreLink () {
+            const query = { }
+
+            if (this.searchQuery) {
+                query.searchQuery = this.searchQuery
+            }
+            if (this.hasAMinimumTeamRoleOfMember()) {
+                return { name: 'ApplicationInstances', params: { id: this.application.id }, query }
+            }
+
+            return { name: 'Instances', params: { team_slug: this.team.slug }, query }
         }
     }
 }


### PR DESCRIPTION
## Description

- viewer roles do not have access to team device-groups, which returned a 403 when viewer roles attempted to open the applications instances/devices page resulting in a 404 page
- also wrapped the hasAMinimumTeamRoleOf to verbosely check for member roles

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4821
closes https://github.com/FlowFuse/flowfuse/issues/4687

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

