### PR TITLE
Use default behavior for platform wide anchors (part I)

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -46,7 +46,7 @@
         <div class="hidden lg:flex ff-desktop-navigation-right" data-el="desktop-nav-right">
             <ff-team-selection data-action="team-selection" />
             <div class="px-4 flex flex-col justify-center" v-if="showInviteButton">
-                <ff-button kind="secondary" @click="inviteTeamMembers">
+                <ff-button kind="secondary" type="anchor" :to="{ name: 'team-members', params: { team_slug: team.slug }, query: { action: 'invite' } }">
                     <template #icon-left><UserAddIcon /></template>
                     Invite Members
                 </ff-button>
@@ -123,7 +123,7 @@ export default {
                     label: 'Documentation',
                     icon: QuestionMarkCircleIcon,
                     tag: 'documentation',
-                    onclick: this.to,
+                    onclick: (route) => window.open(route.url, '_blank'),
                     onclickparams: { url: 'https://flowfuse.com/docs/' }
                 },
                 this.isTrialAccount
@@ -178,20 +178,6 @@ export default {
     },
     methods: {
         ...mapActions('ux', ['toggleLeftDrawer']),
-        to (route) {
-            window.open(route.url, '_blank')
-        },
-        inviteTeamMembers () {
-            this.$router.push({
-                name: 'team-members',
-                params: {
-                    team_slug: this.team.slug
-                },
-                query: {
-                    action: 'invite'
-                }
-            })
-        },
         ...mapActions('ux', ['activateTour']),
         openEducationModal () {
             this.activateTour('education')

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -8,7 +8,9 @@
             </transition>
         </i>
         <!-- FlowFuse Logo -->
-        <img class="ff-logo" src="/ff-logo--wordmark-caps--dark.png" @click="home()">
+        <router-link :to="homeLink">
+            <img class="ff-logo" src="/ff-logo--wordmark-caps--dark.png">
+        </router-link>
         <global-search v-if="hasAMinimumTeamRoleOf(Roles.Viewer)" />
         <!-- Mobile: Toggle(User Options) -->
         <div class="flex ff-mobile-navigation-right" data-el="mobile-nav-right">
@@ -89,7 +91,7 @@ import TeamSelection from './TeamSelection.vue'
 import GlobalSearch from './global-search/GlobalSearch.vue'
 
 export default {
-    name: 'NavBar',
+    name: 'PageHeader',
     mixins: [navigationMixin, permissionsMixin],
     computed: {
         Roles () {

--- a/frontend/src/composables/NavigationHelper.js
+++ b/frontend/src/composables/NavigationHelper.js
@@ -4,21 +4,53 @@ export function useNavigationHelper () {
     const _router = useRouter()
 
     const openInANewTab = (href) => {
-        window.open(href, '_blank')
+        return new Promise(resolve => {
+            window.open(href, '_blank')
+            resolve()
+        })
+    }
+
+    const _isExternalLink = (href) => {
+        try {
+            const link = new URL(href, window.location.origin)
+
+            return link.origin !== window.location.origin
+        } catch {
+            return false
+        }
     }
 
     const navigateTo = (to, $event = null) => {
+        const internalHref = _router.resolve(to).href
         const isMiddleButtonClick = $event?.button === 1
+        const newTabKeyCombination = $event && ($event?.ctrlKey || $event.metaKey || isMiddleButtonClick)
+        const isExternalLink = _isExternalLink(to)
 
-        if ($event && ($event?.ctrlKey || isMiddleButtonClick)) {
-            openInANewTab(_router.resolve(to).href)
-        } else {
-            _router.push(to)
+        switch (true) {
+        case isExternalLink && newTabKeyCombination:
+            return openInANewTab(to)
+
+        case isExternalLink:
+            return navigateToExternal(to)
+
+        case newTabKeyCombination:
+            return openInANewTab(internalHref)
+
+        default:
+            return _router.push(to)
         }
+    }
+
+    const navigateToExternal = (href) => {
+        return new Promise(resolve => {
+            window.location.href = href
+            resolve()
+        })
     }
 
     return {
         openInANewTab,
-        navigateTo
+        navigateTo,
+        navigateToExternal
     }
 }

--- a/frontend/src/composables/NavigationHelper.js
+++ b/frontend/src/composables/NavigationHelper.js
@@ -1,0 +1,19 @@
+import { useRouter } from 'vue-router'
+
+export function useNavigationHelper () {
+    const _router = useRouter()
+
+    const navigateTo = (to, $event = null) => {
+        const isMiddleButtonClick = $event?.button === 1
+
+        if ($event && ($event?.ctrlKey || isMiddleButtonClick)) {
+            window.open(_router.resolve(to).href, '_blank')
+        } else {
+            _router.push(to)
+        }
+    }
+
+    return {
+        navigateTo
+    }
+}

--- a/frontend/src/composables/NavigationHelper.js
+++ b/frontend/src/composables/NavigationHelper.js
@@ -3,17 +3,22 @@ import { useRouter } from 'vue-router'
 export function useNavigationHelper () {
     const _router = useRouter()
 
+    const openInANewTab = (href) => {
+        window.open(href, '_blank')
+    }
+
     const navigateTo = (to, $event = null) => {
         const isMiddleButtonClick = $event?.button === 1
 
         if ($event && ($event?.ctrlKey || isMiddleButtonClick)) {
-            window.open(_router.resolve(to).href, '_blank')
+            openInANewTab(_router.resolve(to).href)
         } else {
             _router.push(to)
         }
     }
 
     return {
+        openInANewTab,
         navigateTo
     }
 }

--- a/frontend/src/mixins/Navigation.js
+++ b/frontend/src/mixins/Navigation.js
@@ -2,9 +2,7 @@ import { mapState } from 'vuex'
 
 export default {
     computed: {
-        ...mapState('account', ['team', 'defaultUserTeam'])
-    },
-    methods: {
+        ...mapState('account', ['team', 'defaultUserTeam']),
         homeLink () {
             if (this.team?.slug) {
                 return { name: 'Team', params: { team_slug: this.team.slug } }
@@ -13,7 +11,9 @@ export default {
             } else {
                 return { name: 'Home' }
             }
-        },
+        }
+    },
+    methods: {
         signOut () {
             this.$router.push({ name: 'Sign out' })
         }

--- a/frontend/src/mixins/Navigation.js
+++ b/frontend/src/mixins/Navigation.js
@@ -5,13 +5,13 @@ export default {
         ...mapState('account', ['team', 'defaultUserTeam'])
     },
     methods: {
-        home () {
+        homeLink () {
             if (this.team?.slug) {
-                this.$router.push({ name: 'Team', params: { team_slug: this.team.slug } })
+                return { name: 'Team', params: { team_slug: this.team.slug } }
             } else if (this.defaultUserTeam?.slug) {
-                this.$router.push({ name: 'Team', params: { team_slug: this.defaultUserTeam?.slug } })
+                return { name: 'Team', params: { team_slug: this.defaultUserTeam?.slug } }
             } else {
-                this.$router.push({ name: 'Home' })
+                return { name: 'Home' }
             }
         },
         signOut () {

--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -14,6 +14,7 @@
                     v-if="hasPermission('project:create')"
                     data-action="create-instance"
                     :to="{ name: 'ApplicationCreateInstance' }"
+                    type="anchor"
                 >
                     <template #icon-left><PlusSmIcon /></template>
                     Add Instance
@@ -79,6 +80,7 @@
                     <ff-button
                         v-if="hasPermission('project:create')"
                         :to="{ name: 'ApplicationCreateInstance' }"
+                        type="anchor"
                     >
                         <template #icon-left><PlusSmIcon /></template>
                         Add Instance
@@ -104,6 +106,7 @@ import { mapState } from 'vuex'
 
 import EmptyState from '../../components/EmptyState.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
+import { useNavigationHelper } from '../../composables/NavigationHelper.js'
 
 import permissionsMixin from '../../mixins/Permissions.js'
 import { Roles } from '../../utils/roles.js'
@@ -134,6 +137,13 @@ export default {
         }
     },
     emits: ['instance-delete', 'instance-suspend', 'instance-restart', 'instance-start'],
+    setup () {
+        const { navigateTo } = useNavigationHelper()
+
+        return {
+            navigateTo
+        }
+    },
     data () {
         return {
             searchTerm: ''
@@ -180,13 +190,13 @@ export default {
         }
     },
     methods: {
-        selectedCloudRow (cloudInstance) {
-            this.$router.push({
+        selectedCloudRow (cloudInstance, event) {
+            this.navigateTo({
                 name: 'Instance',
                 params: {
                     id: cloudInstance.id
                 }
-            })
+            }, event)
         },
         updateSearch (searchTerm) {
             this.searchTerm = searchTerm

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -61,7 +61,7 @@ import ConfirmInstanceDeleteDialog from '../instance/Settings/dialogs/ConfirmIns
 import ConfirmApplicationDeleteDialog from './Settings/dialogs/ConfirmApplicationDeleteDialog.vue'
 
 export default {
-    name: 'ProjectPage',
+    name: 'ApplicationPage',
     components: {
         ConfirmApplicationDeleteDialog,
         ConfirmInstanceDeleteDialog,

--- a/frontend/src/pages/instance/components/DashboardLink.vue
+++ b/frontend/src/pages/instance/components/DashboardLink.vue
@@ -7,6 +7,8 @@
         :target="target"
         :disabled="buttonDisabled"
         class="whitespace-nowrap"
+        @click.stop.prevent
+        @mouseup.stop.prevent
     >
         <template v-if="showText" #icon-left>
             <ChartPieIcon />

--- a/frontend/src/pages/instance/components/DashboardLink.vue
+++ b/frontend/src/pages/instance/components/DashboardLink.vue
@@ -1,7 +1,6 @@
 <template>
     <ff-button
         v-if="!hidden"
-        type="anchor"
         kind="secondary"
         data-action="open-dashboard"
         :to="dashboardURL"

--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -1,15 +1,15 @@
 <template>
-    <div :data-type="`${isImmersiveEditor ? 'immersive' : 'standard'}-editor`" @click.stop="openEditor()">
+    <div :data-type="`${isImmersiveEditor ? 'immersive' : 'standard'}-editor`" @mouseup.stop.prevent="openEditor">
         <slot name="default">
             <ff-button
                 v-ff-tooltip:left="(editorDisabled || disabled) ? disabledReason : undefined"
-                type="anchor"
                 :to="editorURL"
                 kind="secondary"
                 data-action="open-editor"
                 :disabled="buttonDisabled"
                 class="whitespace-nowrap"
-                @click.stop="openEditor"
+                :emit-instead-of-navigate="true"
+                @click.stop.prevent="openEditor"
             >
                 <template v-if="showText" #icon-left>
                     <ProjectIcon />
@@ -32,6 +32,7 @@ import SemVer from 'semver'
 import { mapState } from 'vuex'
 
 import ProjectIcon from '../../../components/icons/Projects.js'
+import { useNavigationHelper } from '../../../composables/NavigationHelper.js'
 
 export default {
     name: 'InstanceEditorLink',
@@ -57,6 +58,13 @@ export default {
         showText: {
             default: true,
             type: Boolean
+        }
+    },
+    setup () {
+        const { openInANewTab } = useNavigationHelper()
+
+        return {
+            openInANewTab
         }
     },
     computed: {
@@ -85,20 +93,21 @@ export default {
     },
     methods: {
         openEditor (evt) {
-            evt.preventDefault()
             if (this.disabled) {
                 return false
             }
-            let href = this.url
-            let target = !this.isImmersiveEditor ? '_blank' : '_self'
-            // On Mac Keyboard, ⌘ + click opens in new tab (⌘ is `metaKey`)
-            // Otherwise Ctrl + click opens in new tab (Ctrl is `ctrlKey`)
-            if (evt.ctrlKey || evt.metaKey) {
-                target = '_blank'
-                href = this.editorURL
+
+            switch (true) {
+            case !this.isImmersiveEditor:
+                return this.openInANewTab(this.editorURL)
+            case evt.ctrlKey || evt.metaKey || evt.button === 1:
+                // On Mac Keyboard, ⌘ + click opens in new tab (⌘ is `metaKey`)
+                // Otherwise Ctrl + click opens in new tab (Ctrl is `ctrlKey`)
+                // Middle mouse button click opens in a new tab (button === 1)
+                return this.openInANewTab(this.url)
+            default:
+                return this.$router.push(this.url)
             }
-            window.open(href, target)
-            return false
         }
     }
 }

--- a/frontend/src/pages/instance/components/EditorLink.vue
+++ b/frontend/src/pages/instance/components/EditorLink.vue
@@ -3,13 +3,12 @@
         <slot name="default">
             <ff-button
                 v-ff-tooltip:left="(editorDisabled || disabled) ? disabledReason : undefined"
-                :to="editorURL"
                 kind="secondary"
                 data-action="open-editor"
                 :disabled="buttonDisabled"
                 class="whitespace-nowrap"
                 :emit-instead-of-navigate="true"
-                @click.stop.prevent="openEditor"
+                @select="openEditor"
             >
                 <template v-if="showText" #icon-left>
                     <ProjectIcon />

--- a/frontend/src/pages/team/Applications/components/ApplicationHeader.vue
+++ b/frontend/src/pages/team/Applications/components/ApplicationHeader.vue
@@ -1,11 +1,20 @@
 <template>
-    <div class="ff-application-list--app gap-x-4 flex flex-col gap-2 sm:gap-0 justify-between sm:flex-row sm:items-center" data-action="view-application" @click="openApplication(application)">
+    <router-link
+        :to="{ name: 'Application', params: { id: application.id } }"
+        data-action="view-application"
+        class="ff-application-list--app gap-x-4 flex flex-col gap-2 sm:gap-0 justify-between sm:flex-row sm:items-center"
+    >
         <div class="flex items-cente flex-wrap">
-            <span class="ff-application-list--icon flex flex-shrink-0 flex-grow-0 whitespace-nowrap gap-2 w-full"><TemplateIcon class="ff-icon text-gray-600" />{{ application.name }}</span>
-            <span class="!inline-block !flex-shrink !flex-grow italic text-gray-500 dark:text-gray-400 truncate"> {{ application.description }} </span>
+            <span class="ff-application-list--icon flex flex-shrink-0 flex-grow-0 whitespace-nowrap gap-2 w-full">
+                <TemplateIcon class="ff-icon text-gray-600" />
+                {{ application.name }}
+            </span>
+            <span class="!inline-block !flex-shrink !flex-grow italic text-gray-500 dark:text-gray-400 truncate">
+                {{ application.description }}
+            </span>
         </div>
         <ApplicationSummaryLabel :application="application" />
-    </div>
+    </router-link>
 </template>
 
 <script>
@@ -24,16 +33,6 @@ export default {
             type: Object,
             required: true,
             default: null
-        }
-    },
-    methods: {
-        openApplication (application) {
-            this.$router.push({
-                name: 'Application',
-                params: {
-                    id: application.id
-                }
-            })
         }
     }
 }

--- a/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
@@ -5,7 +5,9 @@
         </div>
         <div class="details">
             <div class="detail-wrapper">
-                <span class="cursor-pointer name" @click="openDevice(device)">{{ device.name }}</span>
+                <router-link :to="{ name: 'Device', params: { id: device.id } }" class="name" :title="device.name">
+                    {{ device.name }}
+                </router-link>
             </div>
             <div class="detail-wrapper">
                 <span class="detail">
@@ -69,17 +71,7 @@ export default {
             type: Object
         }
     },
-    emits: ['device-action'],
-    methods: {
-        openDevice (device) {
-            this.$router.push({
-                name: 'Device',
-                params: {
-                    id: device.id
-                }
-            })
-        }
-    }
+    emits: ['device-action']
 }
 </script>
 

--- a/frontend/src/pages/team/Applications/components/compact/InstanceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstanceTile.vue
@@ -10,14 +10,14 @@
         </div>
         <div class="details">
             <div class="detail-wrapper">
-                <span
+                <router-link
+                    :to="{ name: 'Instance', params: { id: localInstance.id } }"
                     :title="localInstance.name"
-                    class="cursor-pointer name"
+                    class="name"
                     :class="{'no-highlight': isHoveringInstanceUrl}"
-                    @click="openInstance"
                 >
                     {{ localInstance.name }}
-                </span>
+                </router-link>
             </div>
             <div class="detail-wrapper detail">
                 <a
@@ -154,14 +154,6 @@ export default {
             mutator.clearState()
 
             this.localInstance = { ...this.localInstance, ...instanceData }
-        },
-        openInstance () {
-            this.$router.push({
-                name: 'Instance',
-                params: {
-                    id: this.localInstance.id
-                }
-            })
         }
     }
 }

--- a/frontend/src/pages/team/Applications/index.vue
+++ b/frontend/src/pages/team/Applications/index.vue
@@ -23,6 +23,7 @@
                         data-action="create-application"
                         kind="primary"
                         :to="{name: 'CreateTeamApplication'}"
+                        type="anchor"
                     >
                         <template #icon-left>
                             <PlusSmIcon />
@@ -77,6 +78,7 @@
                         v-if="hasPermission('project:create')"
                         data-action="create-application"
                         kind="primary"
+                        type="anchor"
                         :to="{name: 'CreateTeamApplication'}"
                     >
                         <template #icon-left>

--- a/frontend/src/ui-components/components/Button.vue
+++ b/frontend/src/ui-components/components/Button.vue
@@ -1,5 +1,13 @@
 <template>
-    <a v-if="type==='anchor'" ref="input" class="ff-btn transition-fade--color" :target="target" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :href="(!to || disabled) ? null : to" :aria-disabled="disabled===true?'true':null" :disabled="disabled===true?'true':null">
+    <router-link v-if="type==='anchor'"
+                 ref="input"
+                 class="ff-btn transition-fade--color"
+                 :target="target"
+                 :class="computedClass"
+                 to="#"
+                 :aria-disabled="htmlDisabled"
+                 :disabled="htmlDisabled"
+    >
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
         </span>
@@ -10,8 +18,15 @@
         <span v-if="hasIconRight" class="ff-btn--icon ff-btn--icon-right">
             <slot name="icon-right"></slot>
         </span>
-    </a>
-    <button v-else ref="input" class="ff-btn transition-fade--color" :type="type" :class="'ff-btn--' + kind + (hasIcon ? ' ff-btn-icon' : '') + (size === 'small' ? ' ff-btn-small' : '') + (size === 'full-width' ? ' ff-btn-fwidth' : '')" :disabled="disabled===true?'true':null" @click="go()">
+    </router-link>
+
+    <button v-else ref="input"
+            class="ff-btn transition-fade--color"
+            :type="type"
+            :class="computedClass"
+            :disabled="htmlDisabled"
+            @click="go()"
+    >
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
         </span>
@@ -75,6 +90,17 @@ export default {
         },
         isIconOnly: function () {
             return this.$slots.icon
+        },
+        computedClass () {
+            return {
+                ['ff-btn--' + this.kind]: true,
+                'ff-btn-icon': this.hasIcon,
+                'ff-btn-small': this.size === 'small',
+                'ff-btn-fwidth': this.size === 'full-width'
+            }
+        },
+        htmlDisabled () {
+            return this.disabled === true ? 'true' : null
         }
     },
     methods: {

--- a/frontend/src/ui-components/components/Button.vue
+++ b/frontend/src/ui-components/components/Button.vue
@@ -4,7 +4,7 @@
                  class="ff-btn transition-fade--color"
                  :target="target"
                  :class="computedClass"
-                 :to="to"
+                 :to="to ?? '#'"
                  :aria-disabled="htmlDisabled"
                  :disabled="htmlDisabled"
     >

--- a/frontend/src/ui-components/components/Button.vue
+++ b/frontend/src/ui-components/components/Button.vue
@@ -25,7 +25,7 @@
             :type="type"
             :class="computedClass"
             :disabled="htmlDisabled"
-            @click="go()"
+            @mouseup="go()"
     >
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
@@ -41,6 +41,8 @@
 </template>
 
 <script>
+import { useNavigationHelper } from '../../composables/NavigationHelper.js'
+
 export default {
     name: 'ff-button',
     props: {
@@ -76,6 +78,17 @@ export default {
         disabled: {
             default: null,
             type: Boolean
+        },
+        emitInsteadOfNavigate: {
+            default: false,
+            type: Boolean
+        }
+    },
+    emits: ['click'],
+    setup () {
+        const { navigateTo } = useNavigationHelper()
+        return {
+            navigateTo
         }
     },
     computed: {
@@ -104,9 +117,13 @@ export default {
         }
     },
     methods: {
-        go: function () {
+        go: function (event) {
             if (!this.disabled && this.to) {
-                this.$router.push(this.to)
+                if (this.emitInsteadOfNavigate) {
+                    this.$emit('click')
+                } else {
+                    this.navigateTo(this.to, event)
+                }
             }
         },
         focus () {

--- a/frontend/src/ui-components/components/Button.vue
+++ b/frontend/src/ui-components/components/Button.vue
@@ -25,7 +25,7 @@
             :type="type"
             :class="computedClass"
             :disabled="htmlDisabled"
-            @mouseup="go()"
+            @mouseup="go"
     >
         <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
             <slot name="icon-left"></slot>
@@ -117,13 +117,14 @@ export default {
         }
     },
     methods: {
-        go: function (event) {
-            if (!this.disabled && this.to) {
-                if (this.emitInsteadOfNavigate) {
-                    this.$emit('click')
-                } else {
-                    this.navigateTo(this.to, event)
-                }
+        go (event) {
+            switch (true) {
+            case this.disabled:
+                return
+            case !!this.to:
+                return this.navigateTo(this.to, event)
+            default:
+                return this.$emit('click', event)
             }
         },
         focus () {

--- a/frontend/src/ui-components/components/Button.vue
+++ b/frontend/src/ui-components/components/Button.vue
@@ -4,7 +4,7 @@
                  class="ff-btn transition-fade--color"
                  :target="target"
                  :class="computedClass"
-                 to="#"
+                 :to="to"
                  :aria-disabled="htmlDisabled"
                  :disabled="htmlDisabled"
     >

--- a/frontend/src/ui-components/components/data-table/DataTable.vue
+++ b/frontend/src/ui-components/components/data-table/DataTable.vue
@@ -50,7 +50,7 @@
                         <template v-if="!loading">
                             <ff-data-table-row
                                 v-for="(r, $index) in filteredRows" :key="$index" :data="r" :columns="columns"
-                                :selectable="rowsSelectable" :highlight-cell="sort.highlightColumn" @selected="rowClick(r)"
+                                :selectable="rowsSelectable" :highlight-cell="sort.highlightColumn" @selected="rowClick(r, $event)"
                             >
                                 <template v-if="showRowCheckboxes" #row-prepend="{row}">
                                     <ff-checkbox v-model="checks[row[checkKeyProp]]" />
@@ -326,9 +326,9 @@ export default {
                 return searchObjectProps(row, search.toLowerCase(), this.searchFields)
             })
         },
-        rowClick (row) {
+        rowClick (row, $event) {
             if (this.rowsSelectable) {
-                this.$emit('row-selected', row)
+                this.$emit('row-selected', row, $event._event)
             }
         },
         sortBy (col, colIndex) {

--- a/frontend/src/ui-components/components/data-table/DataTableRow.vue
+++ b/frontend/src/ui-components/components/data-table/DataTableRow.vue
@@ -4,7 +4,13 @@
             <slot name="row-prepend" :row="data" />
         </ff-data-table-cell>
         <slot>
-            <ff-data-table-cell v-for="(col, $column) in columns" :key="col.label" :class="col.class" :style="col.style" :highlight="highlightCell === $column" @click="$emit('selected', data)">
+            <ff-data-table-cell v-for="(col, $column) in columns"
+                                :key="col.label"
+                                :class="col.class"
+                                :style="col.style"
+                                :highlight="highlightCell === $column"
+                                @mouseup.self="handleMouseUp"
+            >
                 <template v-if="col.component">
                     <component :is="col.component.is" v-bind="{...col.component.extraProps ?? {}, ...getCellData(data, col)}" />
                 </template>
@@ -98,6 +104,9 @@ export default {
                 }
             }
             return obj
+        },
+        handleMouseUp (event) {
+            this.$emit('selected', { ...this.data, _event: event })
         }
     }
 }

--- a/frontend/src/ui-components/components/data-table/DataTableRow.vue
+++ b/frontend/src/ui-components/components/data-table/DataTableRow.vue
@@ -9,7 +9,7 @@
                                 :class="col.class"
                                 :style="col.style"
                                 :highlight="highlightCell === $column"
-                                @mouseup.self="handleMouseUp"
+                                @mouseup="handleMouseUp"
             >
                 <template v-if="col.component">
                     <component :is="col.component.is" v-bind="{...col.component.extraProps ?? {}, ...getCellData(data, col)}" />

--- a/test/e2e/frontend/cypress/tests/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications.spec.js
@@ -60,8 +60,8 @@ describe('FlowForge - Applications', () => {
                 // now navigate to the Applications view and check the description is present alongside the application name
                 cy.visit(`/team/${team.slug}/applications`)
                 // div.ff-application-list--app should have the app name and description
-                cy.get('div.ff-application-list--app').contains(APPLICATION_NAME)
-                cy.get('div.ff-application-list--app').contains(APPLICATION_DESCRIPTION)
+                cy.get('[data-action="view-application"]').contains(APPLICATION_NAME)
+                cy.get('[data-action="view-application"]').contains(APPLICATION_DESCRIPTION)
             })
         })
 
@@ -239,8 +239,8 @@ describe('FlowForge - Applications', () => {
                 // now navigate to the Applications view and check the UPDATED description is present alongside the application name
                 cy.visit(`/team/${team.slug}/applications`)
                 // div.ff-application-list--app should have the app name and description
-                cy.get('div.ff-application-list--app').contains(UPDATED_APPLICATION_NAME)
-                cy.get('div.ff-application-list--app').contains(UPDATED_APPLICATION_DESCRIPTION)
+                cy.get('[data-action="view-application"]').contains(UPDATED_APPLICATION_NAME)
+                cy.get('[data-action="view-application"]').contains(UPDATED_APPLICATION_DESCRIPTION)
             })
     })
 

--- a/test/e2e/frontend/cypress/tests/team/instances.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/instances.spec.js
@@ -43,16 +43,14 @@ describe('Team - Instances', () => {
             .parent()
             .parent()
             .within(() => {
-                // checking for ara-disabled because somehow should.be.enabled always returns true no matter the btn state
-                cy.get('[data-action="open-dashboard"]').should('not.have.attr', 'aria-disabled')
+                cy.get('[data-action="open-dashboard"]').should('not.be.disabled')
             })
         cy.contains('instance-1-2')
             .parent()
             .parent()
             .parent()
             .within(() => {
-                // checking for ara-disabled because somehow should.be.enabled always returns true no matter the btn state
-                cy.get('[data-action="open-dashboard"]').should('have.attr', 'aria-disabled', 'true')
+                cy.get('[data-action="open-dashboard"]').should('be.disabled')
             })
     })
 
@@ -142,7 +140,7 @@ describe('Team - Instances', () => {
                 .parent()
                 .parent()
                 .within(() => {
-                    cy.get('[data-action="open-dashboard"]').should('have.attr', 'aria-disabled', 'true')
+                    cy.get('[data-action="open-dashboard"]').should('be.disabled')
                 })
 
             cy.contains('death-start-ac')
@@ -150,7 +148,7 @@ describe('Team - Instances', () => {
                 .parent()
                 .parent()
                 .within(() => {
-                    cy.get('[data-action="open-dashboard"]').should('not.have.attr', 'aria-disabled')
+                    cy.get('[data-action="open-dashboard"]').should('not.be.disabled')
                 })
         })
     })

--- a/test/e2e/frontend/cypress/tests/team/instances.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/instances.spec.js
@@ -9,16 +9,14 @@ describe('Team - Instances', () => {
             .parent()
             .parent()
             .within(() => {
-                // checking for ara-disabled because somehow should.be.enabled always returns true no matter the btn state
-                cy.get('[data-action="open-editor"]').should('not.have.attr', 'aria-disabled')
+                cy.get('[data-action="open-editor"]').should('not.be.disabled')
             })
         cy.contains('instance-1-2')
             .parent()
             .parent()
             .parent()
             .within(() => {
-                // checking for ara-disabled because somehow should.be.enabled always returns true no matter the btn state
-                cy.get('[data-action="open-editor"]').should('have.attr', 'aria-disabled', 'true')
+                cy.get('[data-action="open-editor"]').should('be.disabled')
             })
     })
 


### PR DESCRIPTION
## Description

First iteration to correct platform wide link interaction to allow mouse+keyboard combinations.

- Fixes inconsistencies when opening the immersive editor from  different places using  key + mouse click
  - for example the applications instances open editor button was opening the regular editor when ctrl+clicking even though the immersive one was available
- added middle mouse click support
- restores default anchor behavior to links on the page header (except team selector), applications overview page, application instances and application devices pages
- links can be opened via cmd/ctrl + click or middle mouse button click
- had to alter the datatable components to trickle-up the click event in order to be able to decide in we open in a new tab or current one
- in order to identify middle mouse button clicks I had to replace the @click event handler to @mouseup which includes it
- simplified the open editor method while fixing aforementioned bugs
- used the vue router where possible to preserve navigation integrity
- added cmd/ctrl+click and middle mouse button interactivity to the open dashboard

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4837
closes https://github.com/FlowFuse/flowfuse/issues/4838

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

