### PR TITLE
Allow branding settings to be cleared in the UI

### DIFF
--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -75,7 +75,7 @@ module.exports = async function (app) {
                     'branding:account:signUpLeftBanner'
                 ].forEach(prop => {
                     const value = app.settings.get(prop)
-                    if (value) {
+                    if (value !== null) {
                         response[prop] = value
                     }
                 })
@@ -109,7 +109,7 @@ module.exports = async function (app) {
                 'branding:account:signUpLeftBanner'
             ].forEach(prop => {
                 const value = app.settings.get(prop)
-                if (value) {
+                if (value != null) {
                     publicSettings[prop] = value
                 }
             })
@@ -121,7 +121,6 @@ module.exports = async function (app) {
                 }
                 publicSettings.adwords = adwords
             }
-
             reply.send(publicSettings)
         }
     })
@@ -129,7 +128,7 @@ module.exports = async function (app) {
     app.put('/', {
         preHandler: app.needsPermission('settings:edit'),
         schema: {
-            summary: 'Get platform settings',
+            summary: 'Update platform settings',
             tags: ['Platform'],
             body: { type: 'object' },
             response: {


### PR DESCRIPTION
Fixes #4831

The two branding settings `branding:account:signUpTopBanner` and `branding:account:signUpLeftBanner` can, for historic reasons, be set via the `.yml` or the admin UI.

If set in the `yml`, it can be overridden by the admin UI. However, if the admin UI sets it to a blank string, the value of yml is used again; there's no way for admin to override it to a blank string... until now.

Rather than just check the truthiness of these two settings, it now checks if they are not null (the default value).