### PR TITLE
Prevent viewer role users from getting 404 when accesing applications

### DIFF
--- a/frontend/src/mixins/Application.js
+++ b/frontend/src/mixins/Application.js
@@ -5,8 +5,6 @@ export default {
     data () {
         return {
             application: {},
-            applicationDevices: [],
-            deviceGroups: [],
             applicationInstances: new Map(),
             loading: {
                 deleting: false,
@@ -23,12 +21,6 @@ export default {
                 return []
             }
             return Array.from(this.applicationInstances.values()).filter(el => el)
-        },
-        devicesArray () {
-            return this.applicationDevices
-        },
-        deviceGroupsArray () {
-            return this.deviceGroups || []
         }
     },
     watch: {
@@ -51,16 +43,7 @@ export default {
                     await this.$store.dispatch('account/setTeam', this.application.team.slug)
                 }
                 const instancesPromise = ApplicationApi.getApplicationInstances(applicationId) // To-do needs to be enriched with instance state
-                const devicesPromise = ApplicationApi.getApplicationDevices(applicationId)
-                const deviceData = await devicesPromise
-                this.applicationDevices = deviceData?.devices
                 const applicationInstances = await instancesPromise
-                if (this.features?.deviceGroups && this.team.type.properties.features?.deviceGroups) {
-                    const deviceGroupsData = await ApplicationApi.getDeviceGroups(applicationId)
-                    this.deviceGroups = deviceGroupsData?.groups || []
-                } else {
-                    this.deviceGroups = []
-                }
 
                 this.applicationInstances = new Map()
                 applicationInstances.forEach(instance => {

--- a/frontend/src/pages/application/DeviceGroups.vue
+++ b/frontend/src/pages/application/DeviceGroups.vue
@@ -72,6 +72,7 @@ import ApplicationAPI from '../../api/application.js'
 import EmptyState from '../../components/EmptyState.vue'
 import FormRow from '../../components/FormRow.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
+import usePermissions from '../../composables/Permissions.js'
 
 import Alerts from '../../services/alerts.js'
 
@@ -98,6 +99,10 @@ export default {
             type: Object,
             required: true
         }
+    },
+    setup () {
+        const { hasPermission } = usePermissions()
+        return { hasPermission }
     },
     data () {
         return {
@@ -138,7 +143,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['features', 'team']),
+        ...mapState('account', ['features', 'team', 'teamMembership']),
         featureEnabledForTeam () {
             return !!this.team?.type?.properties?.features?.deviceGroups
         },
@@ -152,6 +157,11 @@ export default {
     watch: {
         featureEnabled: function (v) {
             this.loadDeviceGroups()
+        },
+        teamMembership () {
+            if (!this.hasPermission('application:device-group:list')) {
+                return this.$router.push({ name: 'Application', params: this.$route.params })
+            }
         }
     },
     mounted () {
@@ -191,22 +201,24 @@ export default {
             this.$router.push(route)
         },
         async loadDeviceGroups () {
-            this.loading = true
-            ApplicationAPI.getDeviceGroups(this.application.id)
-                .then((groups) => {
-                    this.deviceGroups = groups.groups
-                    if (this.deviceGroups?.length > 0) {
+            if (this.hasPermission('application:device-group:list')) {
+                this.loading = true
+                ApplicationAPI.getDeviceGroups(this.application.id)
+                    .then((groups) => {
+                        this.deviceGroups = groups.groups
+                        if (this.deviceGroups?.length > 0) {
                         // if there is no target snapshot set, set it to an empty object so that the `markRaw` function renders _something_ in the table cell
-                        this.deviceGroups.forEach((group) => {
-                            group.targetSnapshot = group.targetSnapshot || {}
-                        })
-                    }
-                })
-                .catch((err) => {
-                    console.error(err)
-                }).finally(() => {
-                    this.loading = false
-                })
+                            this.deviceGroups.forEach((group) => {
+                                group.targetSnapshot = group.targetSnapshot || {}
+                            })
+                        }
+                    })
+                    .catch((err) => {
+                        console.error(err)
+                    }).finally(() => {
+                        this.loading = false
+                    })
+            }
         }
     }
 }

--- a/frontend/src/pages/application/Pipeline/index.vue
+++ b/frontend/src/pages/application/Pipeline/index.vue
@@ -27,55 +27,52 @@ export default {
         instances: {
             type: Object,
             required: true
-        },
-        devices: {
-            type: Array,
-            required: true
-        },
-        deviceGroups: {
-            type: Array,
-            required: true
         }
     },
     data: function () {
         return {
-            pipeline: null
+            pipeline: null,
+            devices: [],
+            deviceGroups: []
         }
     },
     watch: {
-        'application.id': 'loadPipeline'
+        'application.id': 'fetchData',
+        '$route.params.pipelineId': 'fetchData'
     },
-    created () {
-        this.loadPipeline()
-
-        this.$watch(
-            () => this.$route.params.pipelineId,
-            () => {
-                if (!this.$route.params.pipelineId) {
-                    return
-                }
-
-                this.loadPipeline()
-            }
-        )
+    async created () {
+        await this.fetchData()
     },
     methods: {
         async loadPipeline () {
             if (!this.application.id) {
-                return
+                return Promise.resolve()
             }
 
-            try {
-                this.pipeline = await ApplicationApi.getPipeline(this.application.id, this.$route.params.pipelineId)
-            } catch (err) {
-                this.$router.push({
-                    name: 'page-not-found',
-                    params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
-                    // preserve existing query and hash if any
-                    query: this.$router.currentRoute.value.query,
-                    hash: this.$router.currentRoute.value.hash
+            return ApplicationApi.getPipeline(this.application.id, this.$route.params.pipelineId)
+                .then(res => {
+                    this.pipeline = res
                 })
-            }
+        },
+        async fetchData () {
+            return this.loadPipeline()
+                .then(() => ApplicationApi.getApplicationDevices(this.application.id))
+                .then(res => {
+                    this.devices = res.devices
+                })
+                .then(() => ApplicationApi.getDeviceGroups(this.application.id))
+                .then((res) => {
+                    this.deviceGroups = res.groups
+                })
+                .catch(() => {
+                    this.$router.push({
+                        name: 'page-not-found',
+                        params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
+                        // preserve existing query and hash if any
+                        query: this.$router.currentRoute.value.query,
+                        hash: this.$router.currentRoute.value.hash
+                    })
+                })
         }
     }
 }

--- a/frontend/src/pages/application/Snapshots.vue
+++ b/frontend/src/pages/application/Snapshots.vue
@@ -87,6 +87,7 @@ export default {
         EmptyState
     },
     mixins: [permissionsMixin],
+    inheritAttrs: false,
     props: {
         application: {
             type: Object,

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -25,8 +25,6 @@
             <router-view
                 :application="application"
                 :instances="instancesArray"
-                :devices="devicesArray"
-                :deviceGroups="deviceGroupsArray"
                 :is-visiting-admin="isVisitingAdmin"
                 @application-updated="updateApplication"
                 @application-delete="showConfirmDeleteApplicationDialog"
@@ -79,28 +77,36 @@ export default {
         ...mapState('account', ['features']),
         navigation () {
             const routes = [
-                { label: 'Instances', to: `/application/${this.application.id}/instances`, tag: 'application-overview', icon: ProjectsIcon },
-                { label: 'Devices', to: `/application/${this.application.id}/devices`, tag: 'application-devices-overview', icon: ChipIcon },
+                { label: 'Instances', to: { name: 'ApplicationInstances' }, tag: 'application-overview', icon: ProjectsIcon },
+                { label: 'Devices', to: { name: 'ApplicationDevices' }, tag: 'application-devices-overview', icon: ChipIcon },
                 {
                     label: 'Devices Groups',
-                    to: `/application/${this.application.id}/device-groups`,
+                    to: { name: 'ApplicationDeviceGroups' },
                     tag: 'application-devices-groups-overview',
                     icon: ChipIcon,
+                    hidden: !this.hasPermission('application:device-group:list'),
                     featureUnavailable: !this.features?.deviceGroups
                 },
-                { label: 'Snapshots', to: `/application/${this.application.id}/snapshots`, tag: 'application-snapshots', icon: ClockIcon },
+                { label: 'Snapshots', to: { name: 'ApplicationSnapshots' }, tag: 'application-snapshots', icon: ClockIcon },
                 {
                     label: 'DevOps Pipelines',
-                    to: `/application/${this.application.id}/pipelines`,
+                    to: { name: 'ApplicationPipelines' },
                     tag: 'application-pipelines',
                     icon: PipelinesIcon,
+                    hidden: !this.hasPermission('application:pipeline:list'),
                     featureUnavailable: !this.features?.['devops-pipelines']
                 },
-                { label: 'Logs', to: `/application/${this.application.id}/logs`, tag: 'application-logs', icon: TerminalIcon },
-                { label: 'Audit Log', to: `/application/${this.application.id}/activity`, tag: 'application-activity', icon: ViewListIcon },
+                { label: 'Logs', to: { name: 'application-logs' }, tag: 'application-logs', icon: TerminalIcon },
+                {
+                    label: 'Audit Log',
+                    to: { name: 'application-activity' },
+                    tag: 'application-activity',
+                    icon: ViewListIcon,
+                    hidden: !this.hasPermission('application:audit-log')
+                },
                 {
                     label: 'Dependencies',
-                    to: `/application/${this.application.id}/dependencies`,
+                    to: { name: 'application-dependencies' },
                     tag: 'application-dependencies',
                     icon: CogIcon,
                     hidden: !this.hasPermission('application:bom')

--- a/frontend/src/pages/application/routes.js
+++ b/frontend/src/pages/application/routes.js
@@ -87,6 +87,7 @@ export default [
             {
                 path: 'logs',
                 component: ApplicationLogs,
+                name: 'application-logs',
                 meta: {
                     title: 'Application - Logs',
                     shouldPoll: true
@@ -94,6 +95,7 @@ export default [
             },
             {
                 path: 'activity',
+                name: 'application-activity',
                 component: ApplicationActivity,
                 meta: {
                     title: 'Application - Activity'
@@ -141,7 +143,7 @@ export default [
             },
             {
                 path: 'dependencies',
-                name: 'Dependencies',
+                name: 'application-dependencies',
                 component: Dependencies,
                 meta: {
                     title: 'Dependencies'

--- a/test/e2e/frontend/cypress/tests-ee/applications/device-groups.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/device-groups.spec.js
@@ -56,6 +56,26 @@ describe('FlowForge - Application - Device Groups', () => {
         it.skip('can create device-group', () => {
             // TODO
         })
+
+        it('should hide the device groups tab from users with viewer roles', () => {
+            cy.intercept('GET', '/api/v1/teams/*/user', { role: 10 }).as('getTeamRole')
+
+            cy.visit(`/application/${application.id}`)
+
+            cy.get('[data-nav="application-devices-groups-overview"]').should('not.exist')
+        })
+
+        it('should redirect users to the instances overview when accessing the device groups page', () => {
+            cy.intercept('GET', '/api/v1/teams/*/user', { role: 10 }).as('getTeamRole')
+
+            cy.visit(`/application/${application.id}/devices`)
+
+            cy.url().should('include', '/devices')
+
+            cy.visit(`/application/${application.id}/device-groups`)
+
+            cy.url().should('include', '/instances')
+        })
     })
 
     describe('Device Group', () => {

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -734,7 +734,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         // Protect Instance
         cy.visit(`/application/${application.id}`)
         cy.get('[data-el="cloud-instances"] table tbody tr:nth-of-type(2)').click()
-        cy.get('[data-nav="instance-settings"').click()
+        cy.get('[data-nav="instance-settings"]').click()
         cy.get('[data-el="section-side-menu"] li:nth-of-type(4)').click()
         cy.get('[data-nav="enable-protect"]').click()
 

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -838,4 +838,24 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         cy.get('[data-el="section-side-menu"] li:nth-of-type(4)').click()
         cy.get('[data-nav="disable-protect"]').click()
     })
+
+    it('should hide the pipelines tab from users with viewer roles', () => {
+        cy.intercept('GET', '/api/v1/teams/*/user', { role: 10 }).as('getTeamRole')
+
+        cy.visit(`/application/${application.id}`)
+
+        cy.get('[data-nav="application-pipelines"]').should('not.exist')
+    })
+
+    it('should redirect users to the instances overview when accessing the applications pipelines page', () => {
+        cy.intercept('GET', '/api/v1/teams/*/user', { role: 10 }).as('getTeamRole')
+
+        cy.visit(`/application/${application.id}/devices`)
+
+        cy.url().should('include', '/devices')
+
+        cy.visit(`/application/${application.id}/pipelines`)
+
+        cy.url().should('include', '/instances')
+    })
 })


### PR DESCRIPTION
## Description

- removed the 403 triggering api calls from the application page/mixin (alongside the devices api call) and stopped passing the devices & deviceGroups as props to the router in order to leave the components that actually need that data to get it themselves
- hid and added 'route guards' to the device groups, application pipelines, and audit log tabs
- altered the navigation routes to use named routes instead of hardcoded ones
- prevented the audit log, device groups and pipelines pages from calling api endpoints when the user accessing them doesn't have sufficient premissions
- had to load deviceGroups and devices on the pipelines page after removing them from their parent

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4821
closes https://github.com/FlowFuse/flowfuse/issues/4687

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

