### PR TITLE
Ensure existing http auth tokens shown

### DIFF
--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -153,6 +153,13 @@ export default {
                     this.hasErrors = errors
                 }
             }
+        },
+        'editable.settings.httpNodeAuth_type': {
+            handler (v) {
+                if (v === 'flowforge-user') {
+                    this.getTokens()
+                }
+            }
         }
     },
     mounted () {


### PR DESCRIPTION
fixes #4860

## Description

<!-- Describe your changes in detail -->
If there existing Instance HTTP Auth tokens, but FlowFuse auth is not enabled, when enabling the tokens were not shown.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4860

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

