### PR TITLE
Fix main nav matching context order

### DIFF
--- a/frontend/src/components/drawers/navigation/MainNav.vue
+++ b/frontend/src/components/drawers/navigation/MainNav.vue
@@ -48,8 +48,14 @@ export default {
                 return this.$route.meta.menu
             }
 
+            // this.$route.matched includes all nested parent routes in the order they match, starting from the root parent
+            // down to the most specific child route. Reversing the order so we find the nearest top-level parent with a
+            // meta.menu attribute not the other way around
+            const matched = [...this.$route.matched]
+            matched.reverse()
+
             // find the nearest parent with the meta.menu entry
-            const parentRoute = this.$route.matched.find(route => route.meta && route.meta.menu)
+            const parentRoute = matched.find(route => route.meta && route.meta.menu)
             return parentRoute ? parentRoute.meta.menu : null
         },
         nearestContextualMenu () {


### PR DESCRIPTION
## Description

- reversing the order so we find the nearest top-level parent with a meta.menu attribute not the other way around

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4797

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

