### PR TITLE
Fixe the outline of the first search result title

### DIFF
--- a/frontend/src/components/global-search/GlobalSearch.vue
+++ b/frontend/src/components/global-search/GlobalSearch.vue
@@ -341,7 +341,7 @@ export default {
             background: $ff-white;
             min-width: 100%;
             z-index: 120;
-            padding: 0 5px 15px;
+            padding: 5px 5px 15px 5px;
 
             .result-badge {
                 padding: 0 5px;


### PR DESCRIPTION
## Description

Fixes the outline of the first result wrapper title when navigating the global search with keyboard

![Screenshot from 2024-12-05 12-44-38](https://github.com/user-attachments/assets/6ad439f7-df84-4ae3-86e0-3de6d4aecd41)


## Related Issue(s)

n/a

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

