### PR TITLE
Docs: Clearer DNS instructions and cross-linking

### DIFF
--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -28,14 +28,17 @@ For a full installation guide, including how to setup FlowFuse in a production e
 
 ## Prerequisites
 
-Before you begin, ensure you have the following:
+Before you begin, ensure you have [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) installed on your system (either as a standalone binary or as docker plugin)
 
-1. A domain name that you own and can configure DNS settings for (explained in step 1)
-2. Docker and Docker Compose installed on your system (either as a standalone binary or as docker plugin)
+## Step 1: Configure Domain
 
-## Step 1: Configure DNS
+### No DNS Server
 
-Before running FlowFuse, you need to configure your fully qualified domain name settings:
+If you're just looking to test FlowFuse locally, and do not have a local DNS server, then we recommend [setting up an alternative to DNS](../install/dns-setup.md#no-local-dns-server). 
+
+### DNS Server
+
+Otherwise, before running FlowFuse, you need to configure your fully qualified domain name settings, and will need a domain name that you own and can configure DNS settings for:
 
 1. Set up an A record for your domain (e.g., `example.com`) to your server's IP address (this works with subdomain as well e.g. `flowfuse.example.com`). FlowFuse will run here.
 2. In the same manner, set up a wildcard DNS record (e.g., `*.example.com`, `*.flowfuse.example.com`) to point to your server's IP address. Any Node-RED instances setup by FlowFuse will run here.


### PR DESCRIPTION
## Description

We're losing an estimated 93% of traffic to the first step in our self-hosted install instructions for our "Quick Start" guide. This attempts to remedy the step/intimidation of setting up a DNS server in Step 1, which will hopefully improve conversion here.