### PR TITLE
Ensure Instance suspended on expired license

### DIFF
--- a/forge/housekeeper/tasks/licenseCheck.js
+++ b/forge/housekeeper/tasks/licenseCheck.js
@@ -36,7 +36,8 @@ module.exports = {
                     'id',
                     'state',
                     'ProjectStackId',
-                    'TeamId'
+                    'TeamId',
+                    'safeName'
                 ],
                 where: {
                     state: {


### PR DESCRIPTION
fixes #4772 
## Description

<!-- Describe your changes in detail -->
k8s driver needs the safeName to suspend and instance and it was missing from the fields return in the projectList

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4772 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

