### PR TITLE
docs: Change links to Docker Compose files

### DIFF
--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -112,7 +112,7 @@ Notes on how to setup DNS can be found [here](../dns-setup.md).
 Download the latest version of the FlowFuse Docker Compose file and example `.env` file used for installation configuration:
 
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/FlowFuse/docker-compose/refs/heads/main/docker-compose.yml
+curl -L -o docker-compose.yml https://github.com/FlowFuse/docker-compose/releases/latest/download/docker-compose.yml
 curl -o .env https://raw.githubusercontent.com/FlowFuse/docker-compose/refs/heads/main/.env.example
 ```
 
@@ -236,7 +236,7 @@ Once you have finished setting up the admin user there are some Docker specific 
    ```
 3. Download the latest Docker Compose files:
     ```bash
-    curl -o docker-compose.yml https://raw.githubusercontent.com/FlowFuse/docker-compose/refs/heads/main/docker-compose.yml
+    curl -L -o docker-compose.yml https://github.com/FlowFuse/docker-compose/releases/latest/download/docker-compose.yml
     ```
 4. Make sure the `.env` file is present and contains your installaction-specific configuration. Download an example `.env` file if needed:
     ```bash

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -45,7 +45,7 @@ This step is crucial for the proper functioning of the application. FlowFuse wil
 ## Step 2: Download Compose file
 
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/FlowFuse/docker-compose/refs/heads/main/docker-compose-quick-start.yml
+curl -L -o docker-compose.yml https://github.com/FlowFuse/docker-compose/releases/latest/download/docker-compose-quick-start.yml
 ```
 
 ## Step 3: Start the Application


### PR DESCRIPTION
## Description

This pull request changes links to Docker Compose files. Instad of using direct links to raw files within a repository, we point to compose files attached to the latest release.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

