### PR TITLE
ci: Fix prestaging slack notification conditional

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -413,9 +413,7 @@ jobs:
     needs: 
       - deploy
       - create-custom-stack
-    if: |
-      always() &&
-      github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number == '' && inputs.pr_number || github.event.number }}

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -413,7 +413,9 @@ jobs:
     needs: 
       - deploy
       - create-custom-stack
-    if: github.actor != 'dependabot[bot]'
+    if: |
+      always() &&
+      (needs.deploy.result != 'skipped' || needs.create-custom-stack.result != 'skipped')
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number == '' && inputs.pr_number || github.event.number }}


### PR DESCRIPTION
## Description

This pull request fixes the conditions needed to send a notification on Slack about the success/failure of pre-staging environment deployment. It also ensures, that no notification will be sent on the tear down of the pre-staging environment.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/389

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

