### PR TITLE
Ensure device logs always shown

### DIFF
--- a/forge/comms/commsClient.js
+++ b/forge/comms/commsClient.js
@@ -59,11 +59,18 @@ class CommsClient extends EventEmitter {
                         })
                     } else if (messageType === 'logs') {
                         if (topicParts[6] && topicParts[6] === 'heartbeat') {
-                            // track frontends
-                            this.emit('logs/heartbeat', {
-                                id: `${topicParts[2]}:${ownerId}`,
-                                timestamp: Date.now()
-                            })
+                            const payload = message.toString()
+                            if (payload === 'alive') {
+                                // track frontends
+                                this.emit('logs/heartbeat', {
+                                    id: `${topicParts[2]}:${ownerId}`,
+                                    timestamp: Date.now()
+                                })
+                            } else if (payload === 'leaving') {
+                                this.emit('logs/disconnect', {
+                                    id: `${topicParts[2]}:${ownerId}`
+                                })
+                            }
                         }
                     } else if (messageType === 'response') {
                         const response = {

--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -64,6 +64,12 @@ class DeviceCommsHandler {
         client.on('logs/heartbeat', (beat) => {
             this.deviceLogHeartbeats[beat.id] = beat.timestamp
         })
+        client.on('logs/disconnect', (beat) => {
+            const parts = beat.id.split(':')
+            this.sendCommand(parts[0], parts[1], 'stopLog', '')
+            this.app.log.info(`Disable device logging ${parts[1]} in team ${parts[0]}`)
+            delete this.deviceLogHeartbeats[beat.id]
+        })
 
         this.deviceLogHeartbeatInterval = setInterval(() => {
             const now = Date.now()

--- a/frontend/src/pages/device/components/DeviceLog.vue
+++ b/frontend/src/pages/device/components/DeviceLog.vue
@@ -49,7 +49,9 @@ export default {
         this.connectMQTT()
     },
     unmounted () {
-    // need to unsubscribe here
+        // need to unsubscribe here
+        const topic = `ff/v1/${this.device.team.id}/d/${this.device.id}/logs`
+        this.client.publish(`${topic}/heartbeat`, 'leaving')
         this.disconnectMQTT()
         clearInterval(this.keepAliveInterval)
     },


### PR DESCRIPTION
fixes #4832

## Description

<!-- Describe your changes in detail -->
This triggers a publish of the logs history every time the tab is opened. It does this by explicitly telling the device agent it has disconnected when navigating away from the tab.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4832

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

