### PR TITLE
Allow for prefix/suffix to SSO GroupNames

### DIFF
--- a/docs/admin/sso/ldap.md
+++ b/docs/admin/sso/ldap.md
@@ -112,12 +112,9 @@ the groups in the LDAP Provider - rather than using the team's id. However, a te
 by a team owner. Doing so will break the link between the group and the team membership - so should only
 be done with care.
 
-If group naming policy doesn't allow this exact format, a prefix and suffix can be applied and the length 
-of these additions can be added to the SSO configuration so they can be removed. e.g. with a prefix and 
-suffix length of 5 the following group name will work:
+An optional prefix and suffix can be include in the group name to support LDAP providers that have existing naming policies. The SSO configuration can be configured with the lengths of these values so they will be stripped off before the group name is validated.
 
-- `test_ff-development-owner_test`
-
+For example, if an organisation requires all groups to begin with `acme-org-`, a prefix length of `9` can be set and the group `acme-org-ff-development-owner` will be handled as `ff-development-owner`.
 ## Managing Admin users
 
 The SSO Configuration can be configured to manage the admin users of the platform by enabling the

--- a/docs/admin/sso/ldap.md
+++ b/docs/admin/sso/ldap.md
@@ -112,6 +112,12 @@ the groups in the LDAP Provider - rather than using the team's id. However, a te
 by a team owner. Doing so will break the link between the group and the team membership - so should only
 be done with care.
 
+If group naming policy doesn't allow this exact format, a prefix and suffix can be applied and the length 
+of these additions can be added to the SSO configuration so they can be removed. e.g. with a prefix and 
+suffix length of 5 the following group name will work:
+
+- `test_ff-development-owner_test`
+
 ## Managing Admin users
 
 The SSO Configuration can be configured to manage the admin users of the platform by enabling the

--- a/docs/admin/sso/saml.md
+++ b/docs/admin/sso/saml.md
@@ -128,6 +128,12 @@ the groups in the SAML Provider - rather than using the team's id. However, a te
 by a team owner. Doing so will break the link between the group and the team membership - so should only
 be done with care.
 
+If group naming policy doesn't allow this exact format, a prefix and suffix can be applied and the length 
+of these additions can be added to the SSO configuration so they can be removed. e.g. with a prefix and 
+suffix length of 5 the following group name will work:
+
+- `test_ff-development-owner_test`
+
 ## Managing Admin users
 
 The SSO Configuration can be configured to managed the admin users of the platform by enabling the

--- a/docs/admin/sso/saml.md
+++ b/docs/admin/sso/saml.md
@@ -128,12 +128,9 @@ the groups in the SAML Provider - rather than using the team's id. However, a te
 by a team owner. Doing so will break the link between the group and the team membership - so should only
 be done with care.
 
-If group naming policy doesn't allow this exact format, a prefix and suffix can be applied and the length 
-of these additions can be added to the SSO configuration so they can be removed. e.g. with a prefix and 
-suffix length of 5 the following group name will work:
+An optional prefix and suffix can be include in the group name to support SAML providers that have existing naming policies. The SSO configuration can be configured with the lengths of these values so they will be stripped off before the group name is validated.
 
-- `test_ff-development-owner_test`
-
+For example, if an organisation requires all groups to begin with `acme-org-`, a prefix length of `9` can be set and the group `acme-org-ff-development-owner` will be handled as `ff-development-owner`.
 ## Managing Admin users
 
 The SSO Configuration can be configured to managed the admin users of the platform by enabling the

--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -316,6 +316,7 @@ module.exports.init = async function (app) {
                     const start = providerOpts.groupPrefixLength || 0
                     const end = providerOpts.groupSuffixLength || 0
                     shortGA = ga.slice(start, (end * -1))
+                    app.log.debug(`Converting Group name ${ga} to ${shortGA}`)
                 }
                 // Parse the group name - format: 'ff-SLUG-ROLE'
                 // Generate a slug->role object (desiredTeamMemberships)

--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -310,9 +310,16 @@ module.exports.init = async function (app) {
             const desiredTeamMemberships = {}
             app.log.debug(`SAML Group Assertions for ${user.username} ${JSON.stringify(groupAssertions)}`)
             groupAssertions.forEach(ga => {
+                // Trim prefix/postfix from group name
+                let shortGA = ga
+                if (providerOpts.groupPrefixLength || providerOpts.groupSuffixLength) {
+                    const start = providerOpts.groupPrefixLength || 0
+                    const end = providerOpts.groupSuffixLength || 0
+                    shortGA = ga.slice(start, (end * -1))
+                }
                 // Parse the group name - format: 'ff-SLUG-ROLE'
                 // Generate a slug->role object (desiredTeamMemberships)
-                const match = /^ff-(.+)-([^-]+)$/.exec(ga)
+                const match = /^ff-(.+)-([^-]+)$/.exec(shortGA)
                 if (match) {
                     const teamSlug = match[1]
                     const teamRoleName = match[2]
@@ -444,7 +451,14 @@ module.exports.init = async function (app) {
         const desiredTeamMemberships = {}
         const groupRegEx = /^ff-(.+)-([^-]+)$/
         for (const i in searchEntries) {
-            const match = groupRegEx.exec(searchEntries[i].cn)
+            let shortCN = searchEntries[i].cn
+            if (providerOpts.groupPrefixLength || providerOpts.groupSuffixLength) {
+                // Trim prefix and postfix
+                const start = providerOpts.groupPrefixLength || 0
+                const end = providerOpts.groupSuffixLength || 0
+                shortCN = searchEntries[i].cn.slice(start, (end * -1))
+            }
+            const match = groupRegEx.exec(shortCN)
             if (match) {
                 app.log.debug(`Found group ${searchEntries[i].cn} for user ${user.username}`)
                 const teamSlug = match[1]

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -208,13 +208,13 @@ export default {
             return !this.isGroupsDNValid ? 'Group DN is required' : ''
         },
         groupPrefixLengthError () {
-            return this.input.options.groupPrefixLength < 0 ? 'Must be a greater or equal to 0' : '';
+            return this.input.options.groupPrefixLength < 0 ? 'Must be a greater or equal to 0' : ''
         },
         isGroupPrefixValid () {
             return this.input.options.groupPrefixLength >= 0
         },
         groupSuffixLengthError () {
-            return this.input.options.groupSuffixLength < 0 ? 'Must be a greater or equal to 0' : '';
+            return this.input.options.groupSuffixLength < 0 ? 'Must be a greater or equal to 0' : ''
         },
         isGroupSuffixValid () {
             return this.input.options.groupSuffixLength >= 0

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -103,7 +103,7 @@
                             </FormRow>
                         </div>
                         <FormRow v-model="input.options.groupPrefixLength" :error="groupPrefixLengthError" type="number">
-                            Group Name Postfix Length
+                            Group Name Prefix Length
                             <template #description>The length of any prefix added to the FlowFuse Group Name format</template>
                         </FormRow>
                         <FormRow v-model="input.options.groupSuffixLength" :error="groupSuffixLengthError" type="number">

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -102,6 +102,14 @@
                                 <template #description>The name of the base object to search for groups</template>
                             </FormRow>
                         </div>
+                        <FormRow v-model="input.options.groupPrefixLength" :error="groupPrefixLengthError" type="number">
+                            Group Name Postfix Length
+                            <template #description>The length of any prefix added to the FlowFuse Group Name format</template>
+                        </FormRow>
+                        <FormRow v-model="input.options.groupSuffixLength" :error="groupSuffixLengthError" type="number">
+                            Group Name Postfix Length
+                            <template #description>The length of any suffix added to the FlowFuse Group Name format</template>
+                        </FormRow>
                         <FormRow v-model="input.options.groupAllTeams" :options="[{ value:true, label: 'Apply to all teams' }, { value:false, label: 'Apply to selected teams' }]">
                             Team Scope
                             <template #description>Should this apply to all teams on the platform, or just a restricted list of teams</template>
@@ -164,7 +172,9 @@ export default {
                     groupAssertionName: '',
                     groupsDN: '',
                     groupMapping: false,
-                    groupAdminName: ''
+                    groupAdminName: '',
+                    groupPrefixLength: 0,
+                    groupSuffixLength: 0
                 }
             },
             errors: {},
@@ -182,7 +192,7 @@ export default {
         isGroupOptionsValid () {
             return !this.input.options.groupMapping || (
                 (this.input.type === 'saml' ? this.isGroupAssertionNameValid : this.isGroupsDNValid) &&
-                  this.isGroupAdminNameValid
+                  this.isGroupAdminNameValid && this.isGroupPrefixValid && this.isGroupSuffixValid
             )
         },
         isGroupAssertionNameValid () {
@@ -196,6 +206,18 @@ export default {
         },
         groupsDNError () {
             return !this.isGroupsDNValid ? 'Group DN is required' : ''
+        },
+        groupPrefixLengthError () {
+            return this.input.options.groupPrefixLength < 0 ? 'Must be a greater or equal to 0' : '';
+        },
+        isGroupPrefixValid () {
+            return this.input.options.groupPrefixLength >= 0
+        },
+        groupSuffixLengthError () {
+            return this.input.options.groupSuffixLength < 0 ? 'Must be a greater or equal to 0' : '';
+        },
+        isGroupSuffixValid () {
+            return this.input.options.groupSuffixLength >= 0
         },
         isGroupAdminNameValid () {
             return !this.input.options.groupAdmin || (this.input.options.groupAdminName && this.input.options.groupAdminName.length > 0)
@@ -303,7 +325,9 @@ export default {
                     groupOtherTeams: false,
                     groupAdmin: false,
                     groupAdminName: 'ff-admins',
-                    groupAssertionName: 'ff-roles'
+                    groupAssertionName: 'ff-roles',
+                    groupPrefixLength: 0,
+                    groupSuffixLength: 0
                 }
             } else {
                 this.loading = true
@@ -342,6 +366,12 @@ export default {
                     // Default to enabled
                     this.input.options.tlsVerifyServer = true
                 }
+            }
+            if (this.provider.options.groupPrefixLength === undefined) {
+                this.input.options.groupPrefixLength = 0
+            }
+            if (this.provider.options.groupSuffixLength === undefined) {
+                this.input.options.groupSuffixLength = 0
             }
             this.originalValues = JSON.stringify(this.input)
         },

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -107,7 +107,7 @@
                             <template #description>The length of any prefix added to the FlowFuse Group Name format</template>
                         </FormRow>
                         <FormRow v-model="input.options.groupSuffixLength" :error="groupSuffixLengthError" type="number">
-                            Group Name Postfix Length
+                            Group Name Suffix Length
                             <template #description>The length of any suffix added to the FlowFuse Group Name format</template>
                         </FormRow>
                         <FormRow v-model="input.options.groupAllTeams" :options="[{ value:true, label: 'Apply to all teams' }, { value:false, label: 'Apply to selected teams' }]">

--- a/test/unit/forge/ee/lib/sso/index_spec.js
+++ b/test/unit/forge/ee/lib/sso/index_spec.js
@@ -376,15 +376,15 @@ d
             await app.sso.updateTeamMembership({
                 'ff-roles': [
                     'test_ff-ateam-magician_err',
-                    'test_ff-ateam-member_test',
-                    'test_ff-bteam-owner_test',
-                    'ff-ateam-admin_test'
+                    'test_ff-ateam-member_test2',
+                    'test_ff-bteam-owner_test2',
+                    'ff-ateam-admin_test2'
                 ]
             }, app.user, {
                 groupAssertionName: 'ff-roles',
                 groupAllTeams: true,
                 groupPrefixLength: 5,
-                groupSuffixLength: 5
+                groupSuffixLength: 6
             })
             ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)).should.have.property('role', Roles.Member)
             ;(await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.BTeam.id)).should.have.property('role', Roles.Owner)

--- a/test/unit/forge/ee/lib/sso/index_spec.js
+++ b/test/unit/forge/ee/lib/sso/index_spec.js
@@ -5,7 +5,7 @@ const setup = require('../../setup')
 const FF_UTIL = require('flowforge-test-utils')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
 
-describe.only('SSO Providers', function () {
+describe('SSO Providers', function () {
     let app
 
     before(async function () {


### PR DESCRIPTION
fixes #4768

## Description

<!-- Describe your changes in detail -->
Allows a prefix and suffix length to be defined for SSO group names, this works for both SAML and LDAP.

e.g.

ff requires groupnames in the following format `ff-teamslug-role`, this allows an arbitrary number of characters to be before and after this format. e.g.

with prefix and suffix length set to 5 the following group would match

`test_ff-teamslug-role_test`

![image](https://github.com/user-attachments/assets/e78de00b-3170-45f5-aa0e-e728eec77ba7)


## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4768

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

