### PR TITLE
Fix device log race condition between publish and disconnect

### DIFF
--- a/frontend/src/pages/device/components/DeviceLog.vue
+++ b/frontend/src/pages/device/components/DeviceLog.vue
@@ -52,7 +52,7 @@ export default {
         // need to unsubscribe here
         const topic = `ff/v1/${this.device.team.id}/d/${this.device.id}/logs`
         this.client.publish(`${topic}/heartbeat`, 'leaving')
-        this.disconnectMQTT()
+        setTimeout(() => this.disconnectMQTT())
         clearInterval(this.keepAliveInterval)
     },
     methods: {


### PR DESCRIPTION
## Description

Fix device log race condition between publish and disconnect

## Related Issue(s)

missed out of https://github.com/FlowFuse/flowfuse/pull/4893

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

