### PR TITLE
Ensure Device Provisioning tokens removed with Team

### DIFF
--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -73,7 +73,7 @@ module.exports = {
                 await M.AccessToken.destroy({
                     where: {
                         ownerType: 'team',
-                        ownerId: team.id
+                        ownerId: team.id.toString()
                     }
                 })
             }

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -69,6 +69,13 @@ module.exports = {
                         TeamId: team.id
                     }
                 })
+                // Remove Team's device provisioning tokens
+                await M.AccessToken.destroy({
+                    where: {
+                        ownerType: 'team',
+                        ownerId: team.id
+                    }
+                })
             }
         }
     },


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This removes Team Device Provisioning tokens when team is deleted

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

