### PR TITLE
Add device agent docker timezone docs

### DIFF
--- a/docs/device-agent/install.md
+++ b/docs/device-agent/install.md
@@ -71,6 +71,14 @@ services:
       - /path/to/device.yml:/opt/flowfuse-device/device.yml
 ```
 
+#### Time Zone
+
+In order to ensure that the device agent runs with the correct timezone environment variable is set with the `-e` option
+
+```bash
+docker run -e TZ=Europe/London --mount type=bind,src=/path/to/device.yml,target=/opt/flowfuse-device/device.yml -p 1880:1880 flowfuse/device-agent:latest
+```
+
 ## Configuration
 
 The agent configuration is provided by a `device.yml` file within its working


### PR DESCRIPTION
fixes #4628

## Description

<!-- Describe your changes in detail -->
Adds description of how to set timezone in Device agent on Docker

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

