### PR TITLE
Decrease device auto timeout to 15 seconds from 30

### DIFF
--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -74,14 +74,14 @@ class DeviceCommsHandler {
         this.deviceLogHeartbeatInterval = setInterval(() => {
             const now = Date.now()
             for (const [key, value] of Object.entries(this.deviceLogHeartbeats)) {
-                if (now - value > 25000) {
+                if (now - value > 12500) {
                     const parts = key.split(':')
                     this.sendCommand(parts[0], parts[1], 'stopLog', '')
                     this.app.log.info(`Disable device logging ${parts[1]} in team ${parts[0]}`)
                     delete this.deviceLogHeartbeats[key]
                 }
             }
-        }, 30000)
+        }, 15000)
     }
 
     async handleStatus (status) {

--- a/frontend/src/pages/device/components/DeviceLog.vue
+++ b/frontend/src/pages/device/components/DeviceLog.vue
@@ -71,7 +71,7 @@ export default {
                 this.client.publish(`${topic}/heartbeat`, 'alive')
                 this.keepAliveInterval = setInterval(() => {
                     this.client.publish(`${topic}/heartbeat`, 'alive')
-                }, 20000)
+                }, 10000)
             })
 
             this.client.on('offline', () => {


### PR DESCRIPTION
part of #4832

## Description

<!-- Describe your changes in detail -->
reduces the time the device agent will continue to send logs in the background if a single user navigates away from the logs page. This should make for a better experience of returning to the page and seeing log history.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

