### PR TITLE
Fix useStore composable losing reactivity when used in uxStore

### DIFF
--- a/frontend/src/composables/Permissions.js
+++ b/frontend/src/composables/Permissions.js
@@ -19,11 +19,15 @@ let teamMembership = { role: 0 }
  * @typedef {0 | 5 | 10 | 30 | 50 | 99} Role
  * Enum for roles with specific numeric values.
  */
-export default function usePermissions () {
-    const store = useStore()
+export default function usePermissions (store = null) {
+    if (store !== null) {
+        store = store.state
+    } else {
+        store = (useStore())?.state
+    }
 
-    if (store && store?.state?.account?.teamMembership) {
-        teamMembership = store?.state?.account?.teamMembership
+    if (store && store?.account?.teamMembership) {
+        teamMembership = store?.account?.teamMembership
     }
 
     /**

--- a/frontend/src/composables/Permissions.js
+++ b/frontend/src/composables/Permissions.js
@@ -20,14 +20,16 @@ let teamMembership = { role: 0 }
  * Enum for roles with specific numeric values.
  */
 export default function usePermissions (store = null) {
+    let state
+
     if (store !== null) {
-        store = store.state
+        state = store.state
     } else {
-        store = (useStore())?.state
+        state = (useStore())?.state
     }
 
-    if (store && store?.account?.teamMembership) {
-        teamMembership = store?.account?.teamMembership
+    if (state && state?.account?.teamMembership) {
+        teamMembership = state?.account?.teamMembership
     }
 
     /**

--- a/frontend/src/composables/Permissions.js
+++ b/frontend/src/composables/Permissions.js
@@ -19,11 +19,11 @@ let teamMembership = { role: 0 }
  * @typedef {0 | 5 | 10 | 30 | 50 | 99} Role
  * Enum for roles with specific numeric values.
  */
-export default function usePermissions (store = null) {
+export default function usePermissions (rootState = null) {
     let state
 
-    if (store !== null) {
-        state = store.state
+    if (rootState !== null) {
+        state = rootState.state
     } else {
         state = (useStore())?.state
     }

--- a/frontend/src/store/ux.js
+++ b/frontend/src/store/ux.js
@@ -37,7 +37,7 @@ const getters = {
         return state.tours.education
     },
     mainNavContexts: function (state, getters, rootState, rootGetters) {
-        const { hasALowerOrEqualTeamRoleThan, hasAMinimumTeamRoleOf, hasPermission } = usePermissions()
+        const { hasALowerOrEqualTeamRoleThan, hasAMinimumTeamRoleOf, hasPermission } = usePermissions(rootState)
         const team = rootState.account.team
         const accountFeatures = rootState.account.features
         const noBilling = rootGetters['account/noBilling']
@@ -308,8 +308,7 @@ const getters = {
             //  app and hydrates vuex stores before attempting to render any data
             return []
         }
-
-        const { hasPermission } = usePermissions()
+        const { hasPermission } = usePermissions(rootState)
 
         return getters.mainNavContexts[state.mainNav.context]
             .map(category => {


### PR DESCRIPTION
## Description

Main train of thought after reproducing the issue locally and noticing that the mainNavContexts was undefined which prevented the mainNav's nearestContextualMenu watcher to set the mainNavContext due to it's safeguard is that the useStore composable is losing store reactivity and causing the uxStore mainNavContexts getter to fail.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4797

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

