### PR TITLE
Remove platform banners from the applications page

### DIFF
--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -7,13 +7,6 @@
     <main v-else class="ff-with-status-header">
         <ConfirmApplicationDeleteDialog ref="confirmApplicationDeleteDialog" @confirm="deleteApplication" />
         <ConfirmInstanceDeleteDialog ref="confirmInstanceDeleteDialog" @confirm="onInstanceDeleted" />
-        <Teleport v-if="mounted" to="#platform-banner">
-            <div v-if="isVisitingAdmin" class="ff-banner" data-el="banner-project-as-admin">
-                You are viewing this application as an Administrator
-            </div>
-            <SubscriptionExpiredBanner v-if="team" :team="team" />
-            <TeamTrialBanner v-if="team && team.billing?.trial" :team="team" />
-        </Teleport>
         <div class="ff-instance-header">
             <ff-page-header :title="application.name" :tabs="navigation">
                 <template #breadcrumbs>
@@ -45,8 +38,6 @@ import { ChipIcon, ClockIcon, CogIcon, TerminalIcon, ViewListIcon } from '@heroi
 import { mapState } from 'vuex'
 
 import InstanceStatusPolling from '../../components/InstanceStatusPolling.vue'
-import SubscriptionExpiredBanner from '../../components/banners/SubscriptionExpired.vue'
-import TeamTrialBanner from '../../components/banners/TeamTrial.vue'
 import PipelinesIcon from '../../components/icons/Pipelines.js'
 import ProjectsIcon from '../../components/icons/Projects.js'
 
@@ -63,9 +54,7 @@ export default {
     components: {
         ConfirmApplicationDeleteDialog,
         ConfirmInstanceDeleteDialog,
-        InstanceStatusPolling,
-        SubscriptionExpiredBanner,
-        TeamTrialBanner
+        InstanceStatusPolling
     },
     mixins: [permissionsMixin, applicationMixin, instanceActionsMixin],
     data: function () {


### PR DESCRIPTION
## Description

https://github.com/FlowFuse/flowfuse/pull/4885#event-15700596492 nested application pages under team pages, and both injected platform banners.

Removed the application platform-banners and left only the team ones.

## Related Issue(s)

introduced by https://github.com/FlowFuse/flowfuse/pull/4885#event-15700596492

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

