### PR TITLE
Fixes setMainNavBackButton race condition before a team is present after logging in

### DIFF
--- a/frontend/src/components/drawers/navigation/MainNav.vue
+++ b/frontend/src/components/drawers/navigation/MainNav.vue
@@ -76,7 +76,7 @@ export default {
         backToButton () {
             const defaultBackToRoute = {
                 label: 'Back to Dashboard',
-                to: { name: 'Applications', params: { team_slug: this.team.slug } },
+                to: { name: 'Applications', params: { team_slug: this.team?.slug } },
                 tag: 'back',
                 icon: ChevronLeftIcon
             }
@@ -93,7 +93,7 @@ export default {
                 return { ...defaultBackToRoute, ...this.nearestMetaMenu.backTo }
 
             case isNearestMenuAnObject && hasBackToProp && typeof this.nearestMetaMenu.backTo === 'function':
-                return { ...defaultBackToRoute, ...this.nearestMetaMenu.backTo({ team_slug: this.team.slug }) }
+                return { ...defaultBackToRoute, ...this.nearestMetaMenu.backTo({ team_slug: this.team?.slug }) }
 
             case typeof this.nearestMetaMenu === 'string':
             default:
@@ -112,21 +112,20 @@ export default {
             immediate: true
         },
         backToButton: {
-            handler: function (menu) {
-                if (this.team) {
-                    this.setMainNavBackButton(menu)
-                }
-            },
+            handler: 'setBackButton',
             immediate: true
         },
-        team () {
-            this.setMainNavBackButton(this.backToButton)
-        }
+        team: 'setBackButton'
     },
     methods: {
         ...mapActions('ux', ['setMainNavContext', 'setMainNavBackButton']),
         onMenuItemClick () {
             this.$store.dispatch('ux/closeLeftDrawer')
+        },
+        setBackButton () {
+            if (this.team) {
+                this.setMainNavBackButton(this.backToButton)
+            }
         }
     }
 }

--- a/frontend/src/components/drawers/navigation/MainNav.vue
+++ b/frontend/src/components/drawers/navigation/MainNav.vue
@@ -107,17 +107,20 @@ export default {
     watch: {
         nearestContextualMenu: {
             handler: function (menu) {
-                if (Object.keys(this.mainNavContexts).includes(menu)) {
-                    this.setMainNavContext(menu)
-                }
+                this.setMainNavContext(menu)
             },
             immediate: true
         },
         backToButton: {
             handler: function (menu) {
-                this.setMainNavBackButton(menu)
+                if (this.team) {
+                    this.setMainNavBackButton(menu)
+                }
             },
             immediate: true
+        },
+        team () {
+            this.setMainNavBackButton(this.backToButton)
         }
     },
     methods: {


### PR DESCRIPTION
## Description

After a consistent way of reproducing the bug was found in https://github.com/FlowFuse/flowfuse/pull/4937 I was able to poke around and find the culprit. 

The underlying problem is that the backToButton watcher in the mainNav component was triggered immediately when the component was mounted after login but prior of having a loaded team which caused the backButton computed prop to fail and pushing an undefined value in the ux store.

The fix is preventing the backButton to be pushed in an invalid state whilst reacting/setting the button upon team changes.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4797

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

