### PR TITLE
Fix race condition when changing teams while on the application page

### DIFF
--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -51,12 +51,14 @@ export default {
     methods: {
         selectTeam (team) {
             if (team) {
-                this.$router.push({
-                    name: 'Team',
-                    params: {
-                        team_slug: team.slug
-                    }
-                })
+                this.$store.dispatch('account/setTeam', team.slug)
+                    .then(() => this.$router.push({
+                        name: 'Team',
+                        params: {
+                            team_slug: team.slug
+                        }
+                    }))
+                    .catch(e => console.warn(e))
             }
         },
         createTeam () {

--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -51,14 +51,12 @@ export default {
     methods: {
         selectTeam (team) {
             if (team) {
-                this.$store.dispatch('account/setTeam', team.slug)
-                    .then(() => this.$router.push({
-                        name: 'Team',
-                        params: {
-                            team_slug: team.slug
-                        }
-                    }))
-                    .catch(e => console.warn(e))
+                this.$router.push({
+                    name: 'Team',
+                    params: {
+                        team_slug: team.slug
+                    }
+                })
             }
         },
         createTeam () {

--- a/frontend/src/mixins/Application.js
+++ b/frontend/src/mixins/Application.js
@@ -39,8 +39,7 @@ export default {
                 this.application = await ApplicationApi.getApplication(applicationId)
                 // Check to see if we have the right team loaded
                 if (this.team?.slug !== this.application.team.slug) {
-                    // Load the team for this application
-                    await this.$store.dispatch('account/setTeam', this.application.team.slug)
+                    return
                 }
                 const instancesPromise = ApplicationApi.getApplicationInstances(applicationId) // To-do needs to be enriched with instance state
                 const applicationInstances = await instancesPromise

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -53,12 +53,14 @@ export default {
             await this.$store.dispatch('account/refreshTeams')
             Alerts.emit(`Invite to "${invite.team.name}" has been accepted.`, 'confirmation')
             // navigate to team dashboad once invite accepted
-            this.$router.push({
-                name: 'Team',
-                params: {
-                    team_slug: invite.team.slug
-                }
-            })
+            this.$store.dispatch('account/setTeam', invite.team.slug)
+                .then(() => this.$router.push({
+                    name: 'Team',
+                    params: {
+                        team_slug: invite.team.slug
+                    }
+                }))
+                .catch(e => console.warn(e))
         },
         async rejectInvite (invite) {
             await userApi.rejectTeamInvitation(invite.id, invite.team.id)

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -53,14 +53,12 @@ export default {
             await this.$store.dispatch('account/refreshTeams')
             Alerts.emit(`Invite to "${invite.team.name}" has been accepted.`, 'confirmation')
             // navigate to team dashboad once invite accepted
-            this.$store.dispatch('account/setTeam', invite.team.slug)
-                .then(() => this.$router.push({
-                    name: 'Team',
-                    params: {
-                        team_slug: invite.team.slug
-                    }
-                }))
-                .catch(e => console.warn(e))
+            this.$router.push({
+                name: 'Team',
+                params: {
+                    team_slug: invite.team.slug
+                }
+            })
         },
         async rejectInvite (invite) {
             await userApi.rejectTeamInvitation(invite.id, invite.team.id)

--- a/frontend/src/pages/admin/Teams.vue
+++ b/frontend/src/pages/admin/Teams.vue
@@ -221,14 +221,12 @@ export default {
             this.loading = false
         },
         viewTeam (row) {
-            this.$store.dispatch('account/setTeam', row.slug)
-                .then(() => this.$router.push({
-                    name: 'Team',
-                    params: {
-                        team_slug: row.slug
-                    }
-                }))
-                .catch(e => console.warn(e))
+            this.$router.push({
+                name: 'Team',
+                params: {
+                    team_slug: row.slug
+                }
+            })
         }
     }
 }

--- a/frontend/src/pages/admin/Teams.vue
+++ b/frontend/src/pages/admin/Teams.vue
@@ -221,12 +221,14 @@ export default {
             this.loading = false
         },
         viewTeam (row) {
-            this.$router.push({
-                name: 'Team',
-                params: {
-                    team_slug: row.slug
-                }
-            })
+            this.$store.dispatch('account/setTeam', row.slug)
+                .then(() => this.$router.push({
+                    name: 'Team',
+                    params: {
+                        team_slug: row.slug
+                    }
+                }))
+                .catch(e => console.warn(e))
         }
     }
 }

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -57,11 +57,6 @@ export default {
         InstanceStatusPolling
     },
     mixins: [permissionsMixin, applicationMixin, instanceActionsMixin],
-    data: function () {
-        return {
-            mounted: false
-        }
-    },
     computed: {
         ...mapState('account', ['features']),
         navigation () {
@@ -106,20 +101,11 @@ export default {
             return routes
         }
     },
-    async created () {
-        await this.updateApplication()
-
-        this.$watch(
-            () => this.$route.params.id,
-            async () => {
-                await this.updateApplication()
-            }
-        )
-    },
-    mounted () {
-        this.mounted = true
-    },
-    methods: {
+    watch: {
+        'team.name': {
+            handler: 'updateApplication',
+            immediate: true
+        }
     }
 }
 </script>

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -66,6 +66,11 @@ export default {
             return this.isAdminUser || this.teamMembership?.role >= Roles.Viewer
         }
     },
+    watch: {
+        '$route.params.team_slug' (slug) {
+            this.$store.dispatch('account/setTeam', slug)
+        }
+    },
     mounted () {
         this.mounted = true
     },

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -19,7 +19,6 @@
 </template>
 
 <script>
-import { useRoute } from 'vue-router'
 import { mapGetters, mapState } from 'vuex'
 
 import Loading from '../../components/Loading.vue'
@@ -40,7 +39,6 @@ export default {
         TeamTrialBanner
     },
     async beforeRouteUpdate (to, from, next) {
-        await this.$store.dispatch('account/setTeam', to.params.team_slug)
         // even if billing is not yet enabled, users should be able to see these screens,
         // in order to delete the project, or setup billing
         await this.checkRoute(to)
@@ -72,17 +70,16 @@ export default {
         this.mounted = true
     },
     async beforeMount () {
-        await this.$store.dispatch('account/setTeam', useRoute().params.team_slug)
         this.checkRoute(this.$route)
     },
     methods: {
         checkRoute: async function (route) {
             const allowedRoutes = [
-                '/team/' + this.team.slug + '/billing',
-                '/team/' + this.team.slug + '/settings',
-                '/team/' + this.team.slug + '/settings/general',
-                '/team/' + this.team.slug + '/settings/danger',
-                '/team/' + this.team.slug + '/settings/change-type'
+                '/team/' + this.team?.slug + '/billing',
+                '/team/' + this.team?.slug + '/settings',
+                '/team/' + this.team?.slug + '/settings/general',
+                '/team/' + this.team?.slug + '/settings/danger',
+                '/team/' + this.team?.slug + '/settings/change-type'
             ]
             if (allowedRoutes.indexOf(route.path) === -1) {
                 // if we're on a path that requires billing


### PR DESCRIPTION
Issue caused by setting team sequentially while on the application page. This did not pose a problem until nesting the application pages under the team namespace

## Description

- removed the team dispatch on beforeMount and beforeRouteEnter causing the issue
- update how we change the team, updating the team is more than enough while pushing a new route for browser history consistency
- a bit of code cleanup on the application page

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4950
introduced by https://github.com/FlowFuse/flowfuse/pull/4885

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

