### PR TITLE
Improve feedback when Hosted Instances are not available to a team

### DIFF
--- a/frontend/src/pages/application/Devices.vue
+++ b/frontend/src/pages/application/Devices.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <SectionTopMenu hero="Edge Devices" help-header="Node-RED Edge Devices - Registered to FlowFuse" info="Edge Devices belonging to this application.">
+        <SectionTopMenu hero="Edge Devices" help-header="Node-RED Edge Devices - Registered to FlowFuse" info="Manage remote instances of Node-RED running on your own hardware.">
             <template #pictogram>
                 <img src="../../images/pictograms/devices_red.png">
             </template>

--- a/frontend/src/pages/application/routes.js
+++ b/frontend/src/pages/application/routes.js
@@ -1,9 +1,5 @@
-/**
- * WARNING: There is ongoing work to move Application functionality up into applications
- * or down into instances.
- *
- * No new functionality should be added here.
- */
+import store from '../../store/index.js'
+
 import ApplicationActivity from './Activity.vue'
 import Dependencies from './Dependencies/Dependencies.vue'
 import ApplicationDeviceGroupSettingsEnvironment from './DeviceGroup/Settings/Environment.vue'
@@ -25,10 +21,19 @@ import ApplicationSnapshots from './Snapshots.vue'
 import ApplicationCreateInstance from './createInstance.vue'
 import ApplicationIndex from './index.vue'
 
+// import account vuex store
+
 export default [
     {
         path: ':id',
-        redirect: { name: 'ApplicationInstances' },
+        redirect: function () {
+            const features = store.getters['account/featuresCheck']
+            if (features.isHostedInstancesEnabledForTeam) {
+                return { name: 'ApplicationInstances' }
+            } else {
+                return { name: 'ApplicationDevices' }
+            }
+        },
         name: 'Application',
         component: ApplicationIndex,
         meta: {

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -57,14 +57,14 @@
             </FormRow>
         </div>
 
-        <FormRow v-if="creatingApplication" v-model="input.createInstance" type="checkbox" data-form="create-instance">
+        <FormRow v-if="creatingApplication && instancesAvailable" v-model="input.createInstance" type="checkbox" data-form="create-instance">
             Create Node-RED Instance
             <template #description>
                 This will create an instance of Node-RED that will be managed in your new Application.
             </template>
         </FormRow>
 
-        <div v-if="!creatingApplication || input.createInstance" :class="creatingApplication ? 'ml-6' : ''" class="space-y-6">
+        <div v-if="instancesAvailable && (!creatingApplication || input.createInstance)" :class="creatingApplication ? 'ml-6' : ''" class="space-y-6">
             <FeatureUnavailableToTeam v-if="teamRuntimeLimitReached" fullMessage="You have reached the runtime limit for this team." />
             <FeatureUnavailableToTeam v-else-if="teamInstanceLimitReached" fullMessage="You have reached the instance limit for this team." />
             <!-- Instance Name -->
@@ -212,7 +212,7 @@
                 type="submit"
             >
                 <template v-if="creatingNew">
-                    <span v-if="applicationFieldsVisible">Create Application<span v-if="input.createInstance"> &amp; Instance</span></span>
+                    <span v-if="applicationFieldsVisible">Create Application<span v-if="input.createInstance && instancesAvailable"> &amp; Instance</span></span>
                     <span v-else>Create Instance</span>
                 </template>
                 <template v-else>
@@ -384,7 +384,7 @@ export default {
     },
     computed: {
         ...mapState('account', ['settings']),
-        ...mapGetters('account', ['blueprints', 'defaultBlueprint']),
+        ...mapGetters('account', ['blueprints', 'defaultBlueprint', 'featuresCheck']),
         creatingApplication () {
             return (this.applicationSelection && !this.applications.length) || (this.creatingNew && this.applicationFieldsVisible)
         },
@@ -457,6 +457,9 @@ export default {
             //                               taking into account their limits
             // Hence, if activeProjectTypeCount === 0, then they are at their limit of usage
             return this.projectTypes.length > 0 && this.activeProjectTypeCount === 0
+        },
+        instancesAvailable () {
+            return this.featuresCheck?.isHostedInstancesEnabledForTeam
         },
         atLeastOneFlowBlueprint () {
             return this.blueprints.length > 0

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -655,7 +655,7 @@ export default {
                 ...this.preDefinedInputs
             }
         }
-        if (this.teamInstanceLimitReached || this.teamRuntimeLimitReached) {
+        if (this.teamInstanceLimitReached || this.teamRuntimeLimitReached || !this.instancesAvailable) {
             this.input.createInstance = false
         }
     },

--- a/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
@@ -6,7 +6,7 @@
         </label>
         <span v-if="!isSearching" class="message">
             This Application currently has no
-            <router-link :to="`/application/${application.id}/devices`" class="ff-link">attached devices</router-link>
+            <router-link :to="{name: 'ApplicationDevices', params: {team_slug: team.slug, id: application.id}}" class="ff-link">attached devices</router-link>
             .
         </span>
         <span v-else class="message">
@@ -68,6 +68,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import IconDeviceSolid from '../../../../../components/icons/DeviceSolid.js'
 import deviceActionsMixin from '../../../../../mixins/DeviceActions.js'
 import DeviceCredentialsDialog from '../../../Devices/dialogs/DeviceCredentialsDialog.vue'
@@ -99,6 +101,7 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['team']),
         hasMoreDevices () {
             return this.application.deviceCount > this.visibleDevices.length
         },

--- a/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
@@ -5,7 +5,7 @@
         </label>
         <span v-if="!isSearching" class="message">
             This Application currently has no
-            <router-link :to="`/application/${application.id}/instances`" class="ff-link">
+            <router-link :to="{name: 'ApplicationInstances', params: {team_slug: team.slug, id: application.id}}" class="ff-link">
                 attached Node-RED Instances
             </router-link>
             .
@@ -39,6 +39,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import IconNodeRedSolid from '../../../../../components/icons/NodeRedSolid.js'
 
 import HasMoreTile from './HasMoreTile.vue'
@@ -62,6 +64,7 @@ export default {
     },
     emits: ['delete-instance'],
     computed: {
+        ...mapState('account', ['team']),
         instances () {
             return this.application.instances.slice(0, 3)
         },

--- a/frontend/src/pages/team/Instances.vue
+++ b/frontend/src/pages/team/Instances.vue
@@ -29,8 +29,11 @@
             </ff-page-header>
         </template>
         <div class="space-y-6">
+            <div class="banner-wrapper">
+                <FeatureUnavailableToTeam v-if="!instancesAvailable" />
+            </div>
             <ff-loading v-if="loading" message="Loading Instances..." />
-            <template v-else>
+            <template v-else-if="instancesAvailable">
                 <ff-data-table
                     v-if="instances.length > 0"
                     data-el="instances-table" :columns="columns" :rows="instances" :show-search="true" search-placeholder="Search Instances..."
@@ -98,6 +101,19 @@
                     <template #header>There are no dashboards in this team.</template>
                 </EmptyState>
             </template>
+            <template v-else>
+                <EmptyState>
+                    <template #img>
+                        <img src="../../images/empty-states/team-instances.png">
+                    </template>
+                    <template #header>Hosted Instances Not Available</template>
+                    <template #message>
+                        <p>
+                            Hosted Node-RED Instances are not available on your Team Tier. Please explore upgrade options to enable it.
+                        </p>
+                    </template>
+                </EmptyState>
+            </template>
         </div>
     </ff-page>
 </template>
@@ -105,9 +121,11 @@
 <script>
 import { PlusSmIcon } from '@heroicons/vue/outline'
 import { markRaw } from 'vue'
+import { mapGetters } from 'vuex'
 
 import teamApi from '../../api/team.js'
 import EmptyState from '../../components/EmptyState.vue'
+import FeatureUnavailableToTeam from '../../components/banners/FeatureUnavailableToTeam.vue'
 import permissionsMixin from '../../mixins/Permissions.js'
 import DeploymentName from '../application/components/cells/DeploymentName.vue'
 import SimpleTextCell from '../application/components/cells/SimpleTextCell.vue'
@@ -121,7 +139,8 @@ export default {
         InstanceEditorLink,
         DashboardLink,
         PlusSmIcon,
-        EmptyState
+        EmptyState,
+        FeatureUnavailableToTeam
     },
     mixins: [permissionsMixin],
     props: {
@@ -152,6 +171,12 @@ export default {
             ]
         }
     },
+    computed: {
+        ...mapGetters('account', ['featuresCheck']),
+        instancesAvailable () {
+            return this.featuresCheck?.isHostedInstancesEnabledForTeam
+        }
+    },
     watch: {
         team: 'fetchData'
     },
@@ -159,9 +184,9 @@ export default {
         this.fetchData()
     },
     methods: {
-        fetchData: async function (newVal) {
+        fetchData: async function () {
             this.loading = true
-            if (this.team.id) {
+            if (this.team.id && this.instancesAvailable) {
                 if (this.hasPermission('team:projects:list')) {
                     this.instances = (await teamApi.getTeamInstances(this.team.id)).projects
                 } else if (this.hasPermission('team:read')) {

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -120,6 +120,19 @@ const getters = {
 
     featuresCheck: (state) => {
         const preCheck = {
+            // Instances
+            isHostedInstancesEnabledForTeam: ((state) => {
+                let available = false
+                // loop over the different instance types
+                for (const instanceType of Object.keys(state.team.type.properties?.instances) || []) {
+                    if (state.team.type.properties?.instances[instanceType].active) {
+                        available = true
+                        break
+                    }
+                }
+                return available
+            })(state),
+
             // Shared Library
             isSharedLibraryFeatureEnabledForTeam: ((state) => {
                 const flag = state.team?.type?.properties?.features?.['shared-library']

--- a/frontend/src/store/ux.js
+++ b/frontend/src/store/ux.js
@@ -66,6 +66,7 @@ const getters = {
                             to: { name: 'Instances', params: { team_slug: team.slug } },
                             tag: 'team-instances',
                             icon: ProjectsIcon,
+                            featureUnavailable: !features.isHostedInstancesEnabledForTeam,
                             disabled: noBilling
                         },
                         {

--- a/frontend/src/ui-components/components/tabs/Tabs.vue
+++ b/frontend/src/ui-components/components/tabs/Tabs.vue
@@ -11,14 +11,21 @@
                 @click="selectTab($index)"
             >
                 {{ tab.label }}
+                <span v-if="tab.featureUnavailable" v-ff-tooltip="'Not available in this Team Tier'" data-el="premium-feature">
+                    <SparklesIcon class="ff-icon transition-fade--color hollow" style="stroke-width: 1;" />
+                </span>
             </router-link>
         </ul>
     </div>
 </template>
 
 <script>
+import { SparklesIcon } from '@heroicons/vue/outline'
 export default {
     name: 'ff-tabs',
+    components: {
+        SparklesIcon
+    },
     props: {
         orientation: {
             default: 'horizontal',

--- a/test/e2e/frontend/cypress/tests-ee/free-tier/free-tier.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/free-tier/free-tier.spec.js
@@ -1,0 +1,22 @@
+describe('FlowFuse EE - Free Tier', () => {
+    beforeEach(() => {
+        cy.login('freddie', 'ffPassword')
+        cy.home()
+    })
+
+    it('shows that Hosted Instances are a premium feature in the side navigation', () => {
+        cy.get('[data-nav="team-instances"]').get('[data-el="premium-feature"]').should('exist')
+    })
+
+    it('shows that Hosted Instances are a premium feature when on the /team/<teamId>/instances page', () => {
+        cy.get('[data-nav="team-instances"]').click()
+        cy.get('[data-el="page-banner-feature-unavailable-to-team"]').should('exist')
+    })
+
+    it('redirects to /application/devices after creating an Application when Hosted Instances are not enabled', () => {
+        cy.get('[data-el="empty-state"] [data-action="create-application"]').click()
+        cy.get('[data-form="application-name"] input[type="text"]').type('My Application')
+        cy.get('[data-action="create-project"]').click()
+        cy.url().should('include', '/devices')
+    })
+})

--- a/test/e2e/frontend/test_environment_ee.js
+++ b/test/e2e/frontend/test_environment_ee.js
@@ -102,6 +102,27 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
         }
     })
 
+    // Mimic the FF Cloud "Free" Team Type
+    const userFreddie = await factory.createUser({ username: 'freddie', name: 'Freddie Fett', email: 'freddie@example.com', password: 'ffPassword', email_verified: true, password_expired: false })
+    const freeTeamType = await factory.createTeamType({
+        name: 'Free Team',
+        description: 'team type description',
+        active: true,
+        order: 4,
+        properties: {
+            instances: { [flowforge.projectTypes[0].hashid]: { active: false } },
+            devices: {},
+            users: {},
+            features: {}
+        }
+    })
+    const freeTeam = await factory.createTeam({
+        name: 'FFeam',
+        TeamTypeId: freeTeamType.id
+    })
+    await factory.createSubscription(freeTeam)
+    await freeTeam.addUser(userFreddie, { through: { role: Roles.Owner } })
+
     // create a snapshot on DeviceB
     const deviceB = flowforge.applicationDevices.find((device) => device.name === 'application-device-b')
     await factory.createDeviceSnapshot({ name: 'application-device-b snapshot 1' }, deviceB, userTerry)


### PR DESCRIPTION
## Description

Improves communication to user that Hosted Instances are unavailable on their Free Tier, as well as refining the UX path to Devices when a new Application is created and prevent the current confusion caused by users being redirected to `/instances` when it's not something they're able to use.

- Shows a "Premium" flag for "Hosted Instances" in the side navigation when 0 instances are permitted on tat given Team Type
- Auto-redirects to the `ApplicationDevices` screen when navigating to the base page for an Application, if no Instances are allowed to be created. This includes newly created applications on the Free Tier.
- Ensure we show the "Feature Unavailable" banner on the Application - Instances page if a user does navigate there
- Fix the `router-link` `:to` fields for the Instance and Device empty state placeholders on the Applications home page
- Prevent the option for "Create Node-RED Instance" when creating a new application in a team that isn't permitted to create an instance
- Prevent option to "Create Instance with Application" if the Team Tier does not permit it
- Improve language in the help text

### Screenshots

<img width="1212" alt="Screenshot 2024-12-23 at 12 47 19" src="https://github.com/user-attachments/assets/e8db2f68-7dbe-4ab7-9a4a-18f5b8947f1e" />

<img width="1211" alt="Screenshot 2024-12-23 at 12 47 37" src="https://github.com/user-attachments/assets/bf65afd0-c2a0-42f1-81b9-53e1cdc7626c" />

## Related Issue(s)

Closes #4955 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

