### PR TITLE
Make sure the Team Types are ordered correctly when changing team type

### DIFF
--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -254,7 +254,7 @@ export default {
                 teamType.name = `${teamType.name} (current)`
             }
             return teamType
-        })
+        }).sort((a, b) => a.order - b.order)
         this.input.teamTypeId = this.team.type.id
 
         const instanceTypes = (await instanceTypesApi.getInstanceTypes()).types


### PR DESCRIPTION
## Description

Team Selection on the "Change Team Type" is rendering the team types are rendered in the order the team type was created, rather than using the defined `order` field.