### PR TITLE
Remove the term "Free Trial" from the welcome dialog

### DIFF
--- a/frontend/src/components/dialogs/EducationModal.vue
+++ b/frontend/src/components/dialogs/EducationModal.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="isOpen" class="ff-dialog-box education-modal">
         <div class="ff-dialog-header text-center" data-sentry-unmask>
-            Welcome to your free trial of FlowFuse!
+            Welcome to FlowFuse!
         </div>
         <div class="ff-dialog-content">
             <template v-if="!isClosing">


### PR DESCRIPTION
## Description

As part of the onboarding product tour, we assume that the user is on a free trial, this caused confusion for at least 2 users I've seen where they've signed up for the Free tier, and then spent 5 minutes trying to delete their team and confirm whether they're on a trial or free tier.
