### PR TITLE
Only hash httpNodeAuth Password if not already hashed

### DIFF
--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -196,7 +196,10 @@ module.exports = {
             }
         }
         if (typeof result.httpNodeAuth?.pass === 'string' && result.httpNodeAuth.pass.length > 0) {
-            result.httpNodeAuth.pass = hash(result.httpNodeAuth.pass)
+            if (result.httpNodeAuth.pass.length !== 42 && !result.httpNodeAuth.pass.startsWith('$2b$10$')) {
+                // only hash if not already hashed
+                result.httpNodeAuth.pass = hash(result.httpNodeAuth.pass)
+            }
         }
         if (result.apiMaxLength) {
             if (!/^\d+(?:kb|mb)$/.test(result.apiMaxLength)) {


### PR DESCRIPTION
fixes #4960

## Description

<!-- Describe your changes in detail -->
Settings verification code hashes httpNodeAuth password, but when doing a pipeline deploy the password is already hashed.

Added test to see if the supplied string is the same length as the hash and if it starts with the hash type markers.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#4960

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

