### PR TITLE
Show "Expired" for expired licenses

### DIFF
--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -120,9 +120,7 @@ export default {
         try {
             this.stats = await adminApi.getStats()
             this.license = await adminApi.getLicenseDetails()
-            if (this.license?.expiresAt && (Date.parse(this.license.expiresAt) - Date.now()) < 0) {
-                this.expired = true
-            }
+            this.expired = this.license?.expiresAt && (Date.parse(this.license.expiresAt) - Date.now()) < 0
         } catch (err) {
             if (err.response?.status === 403 || !err.response) {
                 this.$router.push('/')

--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -120,7 +120,7 @@ export default {
         try {
             this.stats = await adminApi.getStats()
             this.license = await adminApi.getLicenseDetails()
-            if ((Date.parse(this.license.expiresAt) - Date.now()) < 0) {
+            if (this.license?.expiresAt && (Date.parse(this.license.expiresAt) - Date.now()) < 0) {
                 this.expired = true
             }
         } catch (err) {

--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -50,7 +50,7 @@
                 <template v-if="license">
                     <tr><td class="w-40 font-medium">Organisation</td><td>{{ license.organisation }}</td></tr>
                     <tr><td class="w-40 font-medium">Tier</td><td>{{ license.tier }}</td></tr>
-                    <tr><td>Expires</td><td>{{ license.expires }}<br><span class="text-xs">{{ license.expiresAt }}</span></td></tr>
+                    <tr><td>{{ expired ? 'Expired' : 'Expires' }}</td><td>{{ license.expires }}<br><span class="text-xs">{{ license.expiresAt }}</span></td></tr>
                 </template>
                 <tr>
                     <td class="w-40">Users</td>
@@ -112,13 +112,17 @@ export default {
         return {
             license: {},
             stats: {},
-            settings: {}
+            settings: {},
+            expired: false
         }
     },
     async mounted () {
         try {
             this.stats = await adminApi.getStats()
             this.license = await adminApi.getLicenseDetails()
+            if ((Date.parse(this.license.expiresAt) - Date.now()) < 0) {
+                this.expired = true
+            }
         } catch (err) {
             if (err.response?.status === 403 || !err.response) {
                 this.$router.push('/')


### PR DESCRIPTION
fixes #4889

## Description

<!-- Describe your changes in detail -->
Admin overview showed "Expires: 2025-01-01" even when license has already expired, implying there was time left.

Now shows "Expied: 2024-01-01" after license has expired.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
 #4889

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

