### PR TITLE
ci: Add `nr-project-nodes` package build step to the pre-staging deployment pipeline

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -140,8 +140,6 @@ jobs:
       image_name: 'node-red'
       dockerfile_path: Dockerfile
       image_tag_prefix: '4.0.x-'
-      package_dependencies: |
-        @flowforge/nr-project-nodes=nightly
       build_context: './ci/node-red'
       build_arguments: |
         BUILD_TAG=${{ needs.publish_nr_launcher.outputs.release_name }}

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -14,6 +14,10 @@ on:
         description: 'flowfuse/nr-launcher branch name'
         required: true
         default: 'main'
+      nr_project_nodes_branch:
+        description: 'flowfuse/nr-project-nodes branch name'
+        required: true
+        default: 'main'
   pull_request:
     types: 
       - opened
@@ -79,14 +83,34 @@ jobs:
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
-  publish_nr_launcher:
-    name: Build and publish Node-RED launcher package
+  publish_nr_project_nodes:
+    name: Build and publish nr-project-nodes package
     needs: validate-user
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
       github.event.action != 'closed' &&
-      inputs.nr_launcher_branch != 'main'
+      inputs.nr_project_nodes_branch != 'main'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
+    with:
+      package_name: nr-project-nodes
+      publish_package: true
+      repository_name: 'FlowFuse/nr-project-nodes'
+      branch_name: ${{ inputs.nr_project_nodes_branch }}
+      release_name: "pre-staging-${{ inputs.nr_project_nodes_branch }}"
+    secrets:
+      npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+  publish_nr_launcher:
+    name: Build and publish Node-RED launcher package
+    needs: 
+      - validate-user
+      - publish_nr_project_nodes
+    if: |
+      needs.validate-user.outputs.is_org_member == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.action != 'closed' &&
+      (inputs.nr_launcher_branch != 'main' || needs.publish_nr_project_nodes.result != 'failure')
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
     with:
       package_name: flowfuse-nr-launcher
@@ -94,6 +118,10 @@ jobs:
       repository_name: 'FlowFuse/nr-launcher'
       branch_name: ${{ inputs.nr_launcher_branch }}
       release_name: "pre-staging-${{ inputs.nr_launcher_branch }}"
+      package_dependencies: |
+        @flowfuse/nr-project-nodes=${{ inputs.nr_project_nodes_branch != 'main' && format('pre-staging-{0}', inputs.nr_project_nodes_branch ) || 'nightly' }}
+        @flowfuse/nr-file-nodes=nightly
+        @flowfuse/nr-assistant=nightly
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
@@ -413,9 +441,10 @@ jobs:
     needs: 
       - deploy
       - create-custom-stack
-    if: |
-      always() &&
-      (needs.deploy.result != 'skipped' || needs.create-custom-stack.result != 'skipped')
+    if: false
+    # if: |
+    #   always() &&
+    #   (needs.deploy.result != 'skipped' || needs.create-custom-stack.result != 'skipped')
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number == '' && inputs.pr_number || github.event.number }}

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -117,9 +117,9 @@ jobs:
       publish_package: true
       repository_name: 'FlowFuse/nr-launcher'
       branch_name: ${{ inputs.nr_launcher_branch }}
-      release_name: "pre-staging-${{ inputs.nr_launcher_branch }}"
+      release_name: "pre-staging-${{ inputs.nr_launcher_branch == 'main' && github.sha || inputs.nr_launcher_branch }}"
       package_dependencies: |
-        @flowfuse/nr-project-nodes=${{ inputs.nr_project_nodes_branch != 'main' && format('pre-staging-{0}', inputs.nr_project_nodes_branch ) || 'nightly' }}
+        @flowfuse/nr-project-nodes=${{ inputs.nr_project_nodes_branch != 'main' && needs.publish_nr_project_nodes.outputs.release_name || 'nightly' }}
         @flowfuse/nr-file-nodes=nightly
         @flowfuse/nr-assistant=nightly
     secrets:

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -109,7 +109,7 @@ jobs:
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      ((always() && inputs.nr_launcher_branch != 'main') || needs.publish_nr_project_nodes.result != 'failure')
+      ((always() && inputs.nr_launcher_branch != 'main') || needs.publish_nr_project_nodes.result == 'success')
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
     with:
       package_name: flowfuse-nr-launcher
@@ -133,7 +133,7 @@ jobs:
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
       github.event.action != 'closed' &&
-      (always() && needs.publish_nr_launcher.result != 'failure')
+      (always() && needs.publish_nr_launcher.result == 'success')
     uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.38.0
     with:
       image_name: 'node-red'
@@ -156,7 +156,7 @@ jobs:
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
       github.event.action != 'closed' &&
-      (always() && needs.build-node-red.result != 'failure')
+      (always() && needs.build-node-red.result == 'success')
     runs-on: ubuntu-latest
     environment: staging
     env:

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -439,10 +439,9 @@ jobs:
     needs: 
       - deploy
       - create-custom-stack
-    if: false
-    # if: |
-    #   always() &&
-    #   (needs.deploy.result != 'skipped' || needs.create-custom-stack.result != 'skipped')
+    if: |
+      always() &&
+      (needs.deploy.result != 'skipped' || needs.create-custom-stack.result != 'skipped')
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number == '' && inputs.pr_number || github.event.number }}

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -102,7 +102,7 @@ jobs:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   publish_nr_launcher:
-    name: Build and publish Node-RED launcher package
+    name: Build and publish nr-launcher package
     needs: 
       - validate-user
       - publish_nr_project_nodes

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -109,8 +109,7 @@ jobs:
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      github.event.action != 'closed' &&
-      (inputs.nr_launcher_branch != 'main' || needs.publish_nr_project_nodes.result != 'failure')
+      ((always() && inputs.nr_launcher_branch != 'main') || needs.publish_nr_project_nodes.result != 'failure')
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
     with:
       package_name: flowfuse-nr-launcher

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -155,7 +155,8 @@ jobs:
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      github.event.action != 'closed'
+      github.event.action != 'closed' &&
+      (always() && needs.build-node-red.result != 'failure')
     runs-on: ubuntu-latest
     environment: staging
     env:


### PR DESCRIPTION
## Description

This pull request extends existing `Create pre-staging environment` workflow by adding a possibility to test `flowfuse/nr-project-nodes` package on pre-staging environment.

Introduced changes:
* Added a new input `nr_project_nodes_branch` to specify the branch name for `flowfuse/nr-project-nodes`.
* Modified the `publish_nr_launcher` job to depend on the success of the `publish_nr_project_nodes` job and updated the release name and package dependencies accordingly.
* Updated the condition for the `build_container_image` job to ensure it only runs if the `publish_nr_launcher` job is successful.
* Added a condition to the final job to ensure it only runs if the `build-node-red` job is successful.

## Related Issue(s)

closes https://github.com/FlowFuse/CloudProject/issues/598

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

