### PR TITLE
Add tooltips to "Open Editor" button for Devices

### DIFF
--- a/frontend/src/pages/device/components/DeviceModeBadge.vue
+++ b/frontend/src/pages/device/components/DeviceModeBadge.vue
@@ -8,7 +8,7 @@
         }"
         :data-el="`${isBadge ? 'badge' : 'text'}-${mode === 'developer' ? 'dev' : 'fleet'}mode`"
     >
-        <span v-ff-tooltip="isIcon ? (isDevMode ? 'Developer Mode' : 'Fleet Mode') : undefined" class="inline-flex space-x-2 items-center">
+        <span v-ff-tooltip="isIcon ? (isDevMode ? 'Developer Mode' : 'Fleet Mode') : (isDevMode ? 'make changes to the Instance Editor directly' : 'Deploy changes to this Instance via Pipelines')" class="inline-flex space-x-2 items-center">
             <template v-if="isDevMode">
                 <BeakerIcon :class="`text-purple-600 w-${size} h-${size}`" />
                 <span v-if="!isIcon" class="ml-1"> Developer Mode</span>

--- a/frontend/src/pages/device/components/DeviceModeBadge.vue
+++ b/frontend/src/pages/device/components/DeviceModeBadge.vue
@@ -8,7 +8,7 @@
         }"
         :data-el="`${isBadge ? 'badge' : 'text'}-${mode === 'developer' ? 'dev' : 'fleet'}mode`"
     >
-        <span v-ff-tooltip="isIcon ? (isDevMode ? 'Developer Mode' : 'Fleet Mode') : (isDevMode ? 'make changes to the Instance Editor directly' : 'Deploy changes to this Instance via Pipelines')" class="inline-flex space-x-2 items-center">
+        <span v-ff-tooltip="isIcon ? (isDevMode ? 'Developer Mode' : 'Fleet Mode') : (isDevMode ? 'Make changes to the Instance Editor directly' : 'Deploy changes to this Instance via Pipelines')" class="inline-flex space-x-2 items-center">
             <template v-if="isDevMode">
                 <BeakerIcon :class="`text-purple-600 w-${size} h-${size}`" />
                 <span v-if="!isIcon" class="ml-1"> Developer Mode</span>

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -38,7 +38,7 @@
                     -->
                     <div class="space-x-2 flex align-center" style="height: 34px;">
                         <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" :disabled="disableModeToggle" :disabledReason="disableModeToggleReason" @mode-change="setDeviceMode" />
-                        <button v-if="!isVisitingAdmin" v-ff-tooltip:left="!editorAvailable ? 'You can edit flows directly when Developer Mode is enabled, and your Remote Instance is connected.' : 'Open Remote Instance Editor'" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">
+                        <button v-if="!isVisitingAdmin" v-ff-tooltip:left="!editorAvailable ? 'You can edit flows directly when Developer Mode is enabled, and your Edge Instance is connected.' : 'Open Edge Instance Editor'" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">
                             Open Editor
                             <span class="ff-btn--icon ff-btn--icon-right">
                                 <ExternalLinkIcon />

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -38,8 +38,8 @@
                     -->
                     <div class="space-x-2 flex align-center" style="height: 34px;">
                         <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" :disabled="disableModeToggle" :disabledReason="disableModeToggleReason" @mode-change="setDeviceMode" />
-                        <button v-if="!isVisitingAdmin" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">
-                            Device Editor
+                        <button v-if="!isVisitingAdmin" v-ff-tooltip:left="!editorAvailable ? 'You can edit flows directly when Developer Mode is enabled, and your Remote Instance is connected.' : 'Open Remote Instance Editor'" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">
+                            Open Editor
                             <span class="ff-btn--icon ff-btn--icon-right">
                                 <ExternalLinkIcon />
                             </span>


### PR DESCRIPTION
## Description

Add tooltip to the "Open Editor" button for devices, especially important when this button is disabled, as we're seeing [support tickets](https://app-eu1.hubspot.com/help-desk/26586079/view/233410279/ticket/63094537444/thread/9496840410#live-chat) and account deletion over the fact this isn't clear.