### PR TITLE
Ensure Pipelines don't fall over if Device Groups are unavailable

### DIFF
--- a/frontend/src/api/application.js
+++ b/frontend/src/api/application.js
@@ -285,8 +285,14 @@ const getDeviceGroup = async (applicationId, groupId) => {
  */
 const getDeviceGroups = async (applicationId, cursor, limit, query, extraParams = {}) => {
     const url = paginateUrl(`/api/v1/applications/${applicationId}/device-groups`, cursor, limit, query, extraParams)
-    const res = await client.get(url)
-    return res.data
+    try {
+        const res = await client.get(url)
+        return res.data
+    } catch (e) {
+        return {
+            groups: []
+        }
+    }
 }
 
 /**

--- a/frontend/src/pages/application/Pipeline/index.vue
+++ b/frontend/src/pages/application/Pipeline/index.vue
@@ -55,24 +55,31 @@ export default {
                 })
         },
         async fetchData () {
-            return this.loadPipeline()
-                .then(() => ApplicationApi.getApplicationDevices(this.application.id))
-                .then(res => {
-                    this.devices = res.devices
-                })
-                .then(() => ApplicationApi.getDeviceGroups(this.application.id))
-                .then((res) => {
-                    this.deviceGroups = res.groups
-                })
-                .catch(() => {
-                    this.$router.push({
-                        name: 'page-not-found',
-                        params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
-                        // preserve existing query and hash if any
-                        query: this.$router.currentRoute.value.query,
-                        hash: this.$router.currentRoute.value.hash
-                    })
-                })
+            try {
+                await this.loadPipeline()
+            } catch (err) {
+                this.notFound()
+            }
+
+            try {
+                this.devices = (await ApplicationApi.getApplicationDevices(this.application.id)).devices
+            } catch (err) {
+                this.devices = []
+            }
+            try {
+                this.deviceGroups = (await ApplicationApi.getDeviceGroups(this.application.id)).groups
+            } catch (err) {
+                this.deviceGroups = []
+            }
+        },
+        notFound () {
+            this.$router.push({
+                name: 'page-not-found',
+                params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
+                // preserve existing query and hash if any
+                query: this.$router.currentRoute.value.query,
+                hash: this.$router.currentRoute.value.hash
+            })
         }
     }
 }

--- a/frontend/src/pages/application/PipelineStage/create.vue
+++ b/frontend/src/pages/application/PipelineStage/create.vue
@@ -43,7 +43,7 @@ export default {
         },
         deviceGroups: {
             type: Array,
-            required: true
+            default: () => []
         },
         pipeline: {
             type: Object,


### PR DESCRIPTION
## Description

If Device Groups are not available to a Team, then the API returns a `404`, in turn, this was causing the Pipelines (Create) page to fall over when trying to load the list of available Device Groups.