### PR TITLE
Updated Onboarding Tours

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -173,7 +173,7 @@
                                 <template #icon-left>
                                     <PlusSmIcon />
                                 </template>
-                                Add Device
+                                Add Remote Instance
                             </ff-button>
                         </template>
                     </EmptyState>
@@ -212,7 +212,7 @@
                                 <template #icon-left>
                                     <PlusSmIcon />
                                 </template>
-                                Add Device
+                                Add Remote Instance
                             </ff-button>
                         </template>
                     </EmptyState>

--- a/frontend/src/pages/application/Devices.vue
+++ b/frontend/src/pages/application/Devices.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div data-el="application-devices">
         <SectionTopMenu hero="Remote Instances" help-header="Remote Instances - Registered to FlowFuse" info="Manage remote instances of Node-RED running on your own hardware, managed with the FlowFuse Device Agent.">
             <template #pictogram>
                 <img src="../../images/pictograms/devices_red.png">
@@ -16,8 +16,13 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import DevicesBrowser from '../../components/DevicesBrowser.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
+import Tours from '../../tours/Tours.js'
+
+import TourFirstDevice from '../../tours/tour-first-device.json'
 
 export default {
     name: 'ApplicationDevices',
@@ -29,6 +34,15 @@ export default {
         application: {
             type: Object,
             required: true
+        }
+    },
+    computed: {
+        ...mapState('ux', ['tours'])
+    },
+    mounted () {
+        if (this.tours['first-device']) {
+            const tour = Tours.create('first-device', TourFirstDevice, this.$store)
+            tour.start()
         }
     }
 }

--- a/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
@@ -1,7 +1,7 @@
 <template>
-    <section v-if="hasNoInstances" class="ff-no-data--boxed">
+    <section v-if="hasNoInstances" class="ff-no-data--boxed" data-el="application-instances-none">
         <label class="delimiter">
-            <IconNodeRedSolid class="ff-icon ff-icon-sm text-red-800" /> Instances
+            <IconNodeRedSolid class="ff-icon ff-icon-sm text-red-800" /> Hosted Instances
         </label>
         <span v-if="!isSearching" class="message">
             This Application currently has no
@@ -11,11 +11,11 @@
             No instance matches your criteria.
         </span>
     </section>
-    <section v-else class="ff-applications-list-instances--compact">
+    <section v-else class="ff-applications-list-instances--compact" data-el="application-instances">
         <label class="delimiter">
-            <IconNodeRedSolid class="ff-icon ff-icon-sm text-red-800" /> Instances
+            <IconNodeRedSolid class="ff-icon ff-icon-sm text-red-800" /> Hosted Instances
         </label>
-        <div class="items-wrapper" :class="{one: singleInstance, two: twoInstances, three: threeInstances}" data-el="application-instances">
+        <div class="items-wrapper" :class="{one: singleInstance, two: twoInstances, three: threeInstances}">
             <div
                 v-for="instance in instances"
                 :key="instance.id"

--- a/frontend/src/pages/team/Applications/index.vue
+++ b/frontend/src/pages/team/Applications/index.vue
@@ -222,6 +222,11 @@ export default {
             count += app.instances.length
             return count
         }, 0)
+        // Do we have an Instance already? Tells us which tour to run
+        const deviceCount = this.applicationsList.reduce((count, app) => {
+            count += app.devices.length
+            return count
+        }, 0)
 
         // First time here?
         if (this.tours.welcome) {
@@ -233,8 +238,10 @@ export default {
                 })
             } else {
                 // Free Tier Tour (No Instances)
-                tour = Tours.create('welcome-free', TourWelcomeFree, this.$store, () => {
-                    this.$store.dispatch('ux/activateTour', 'first-device')
+                tour = Tours.create('welcome', TourWelcomeFree, this.$store, () => {
+                    if (deviceCount === 0) {
+                        this.$store.dispatch('ux/activateTour', 'first-device')
+                    }
                 })
             }
             tour.start()

--- a/frontend/src/store/ux.js
+++ b/frontend/src/store/ux.js
@@ -21,7 +21,8 @@ const state = () => ({
     },
     tours: {
         welcome: false,
-        education: false
+        education: false,
+        'first-device': false
     },
     mainNav: {
         context: 'team',
@@ -402,9 +403,6 @@ const actions = {
         commit('activateTour', tour)
     },
     deactivateTour ({ commit, state }, tour) {
-        if (tour === 'welcome') {
-            commit('activateTour', 'education')
-        }
         commit('deactivateTour', tour)
     }
 }

--- a/frontend/src/tours/Tours.js
+++ b/frontend/src/tours/Tours.js
@@ -10,8 +10,10 @@ import Product from '../services/product.js'
 import 'shepherd.js/dist/css/shepherd.css'
 import './tour-theme.scss'
 
-function create (id, tourJson) {
-    const store = useStore()
+function create (id, tourJson, store, onCloseHook) {
+    if (!store) {
+        store = useStore()
+    }
     Product.capture('ff-tour-start', {
         tour_id: id
     })
@@ -37,6 +39,9 @@ function create (id, tourJson) {
             tour_id: id,
             tour_step: index
         })
+        if (onCloseHook) {
+            onCloseHook()
+        }
     }
 
     function onComplete () {
@@ -44,6 +49,9 @@ function create (id, tourJson) {
         Product.capture('ff-tour-complete', {
             tour_id: id
         })
+        if (onCloseHook) {
+            onCloseHook()
+        }
     }
 
     function onBack () {
@@ -73,32 +81,35 @@ function create (id, tourJson) {
     tourJson.forEach((step, i) => {
         const buttons = []
 
-        // which secondary button do we need?
-        if (i === 0) {
-            buttons.push({
-                text: 'Exit',
-                action: tour.cancel,
-                secondary: true
-            })
-        } else {
-            buttons.push({
-                text: 'Back',
-                action: onBack,
-                secondary: true
-            })
-        }
+        // if the step requires an interaction with the UI, don't add our own buttons
+        if (!step.advanceOn) {
+            // which secondary button do we need?
+            if (i === 0) {
+                buttons.push({
+                    text: 'Exit',
+                    action: tour.cancel,
+                    secondary: true
+                })
+            } else {
+                buttons.push({
+                    text: 'Back',
+                    action: onBack,
+                    secondary: true
+                })
+            }
 
-        // which primary button do we need?
-        if (i !== steps - 1) {
-            buttons.push({
-                text: 'Next',
-                action: onNext
-            })
-        } else {
-            buttons.push({
-                text: 'Finish',
-                action: tour.complete
-            })
+            // which primary button do we need?
+            if (i !== steps - 1) {
+                buttons.push({
+                    text: 'Next',
+                    action: onNext
+                })
+            } else {
+                buttons.push({
+                    text: 'Finish',
+                    action: tour.complete
+                })
+            }
         }
 
         tour.addStep({

--- a/frontend/src/tours/tour-first-device.json
+++ b/frontend/src/tours/tour-first-device.json
@@ -1,0 +1,41 @@
+[{
+    "title": "Application: Remote Instances",
+    "text": "<p>Here we can manage the <b>Remote Instances</b> managed by our Application.</p>",
+    "attachTo": {
+        "element": "a[data-nav=\"application-devices-overview\"]",
+        "on": "bottom"
+    },
+    "modalOverlayOpeningPadding": 12
+}, {
+    "title": "Add Remote Instance",
+    "text": "<p>Let's add our first Remote Instance to FlowFuse.</p><p>We have two steps to complete here:</p><ol class=\"list-disc pl-4 space-y-2 mb-2\"><li>Add your <b>Remote Instance</b> to FlowFuse.</li><li>Install and run the <b>FlowFuse Device Agent</b> on the hardware where you want the Instance to run.</li></ol><p>After this, you'll be able to update and deploy flows to your hardware from anywhere in the world.",
+    "attachTo": {
+        "element": "button[data-action=\"register-device\"]",
+        "on": "top"
+    },
+    "modalOverlayOpeningPadding": 6,
+    "modalOverlayOpeningRadius": 6,
+    "noActions": true,
+    "advanceOn": {
+        "selector": "button[data-action=\"register-device\"]",
+        "event": "click"
+    }
+}, {
+    "title": "Add Details",
+    "text": "<p>Define a name and type for your new <b>Remote Instance</b>.</p><ul class=\"list-disc pl-4 space-y-2\"><li><b>Name:</b> A Unique identifier for your Remote Instance</li><li><b>Type:</b> Use this field to make your Instance more easily identifiable, and group together similar Instances.</li></ul>",
+    "attachTo": {
+        "element": "div[data-el=\"team-device-create-dialog\"] .ff-dialog-box",
+        "on": "bottom"
+    },
+    "advanceOn": {
+        "selector": "div[data-el=\"team-device-create-dialog\"] .ff-dialog-box button[data-action=\"dialog-confirm\"]",
+        "event": "click"
+    }
+}, {
+    "title": "Connect Your Remote Instance",
+    "text": "<p>Now you can install the FlowFuse Device Agent onto your hardware, e.g. your own laptop, Raspberry Pi or PLC. Use this command to connect the Device Agent to FlowFuse.</p><p>Once you've done this, you'll have a remotely managed Node-RED Instance all setup and running!</p>",
+    "attachTo": {
+        "element": "div[data-el=\"team-device-config-dialog\"] .ff-dialog-box",
+        "on": "bottom"
+    }
+}]

--- a/frontend/src/tours/tour-welcome-free.json
+++ b/frontend/src/tours/tour-welcome-free.json
@@ -1,0 +1,65 @@
+[{
+    "title": "Welcome to FlowFuse!",
+    "text": "<p>Welcome to FlowFuse, the complete platform for building, managing and deploying your Node-RED applications.</p><p><b>Let's take a quick tour to get you started.</b></p>"
+}, {
+    "title": "Concept: Applications",
+    "text": "<p><b>This is your first Application in FlowFuse.</b></p><p>Applications help to organize your Node-RED Instances and other resources.</p>",
+    "attachTo": {
+        "element": "li[data-el=\"application-item\"]",
+        "on": "bottom"
+    },
+    "modalOverlayOpeningXOffset": 12
+}, {
+    "title": "Concept: Hosted Instances",
+    "text": "<p><b>Instances</b> refer to instances of Node-RED, managed through FlowFuse.</p><p><b>Hosted Instances</b> run in the same environment as FlowFuse.</p>",
+    "attachTo": {
+        "element": "section[data-el=\"application-instances-none\"]",
+        "on": "bottom"
+    }
+}, {
+    "title": "Concept: Remote Instances",
+    "text": "<p><b>Remote Instances</b> are Node-RED instances that are managed and deployed onto your own hardware.</p><p>This could be Instances running in factories or on a Raspberry Pi on your desk.</p>",
+    "attachTo": {
+        "element": "section[data-el=\"application-devices-none\"]",
+        "on": "bottom"
+    }
+}, {
+    "title": "Navigation: Application Summary",
+    "text": "<p>Here you can see a summary of the resources within your Application.</p><p>We've already had a quick look at the first two, but let's quickly scan over the others.</p>",
+    "attachTo": {
+        "element": "div[data-el=\"application-summary\"]",
+        "on": "left"
+    }
+}, {
+    "title": "Concept: Pipelines",
+    "text": "<p><b>DevOps Pipelines</b> help you push flows and configuration from one running Node-RED Instance to another.</p></p>This could be from a testing Instance to a production Instance, or from a single (test) Remote Instance out to thousands of (production) Remote Instances in your factory.</p>",
+    "attachTo": {
+        "element": "a[data-nav=\"application-pipelines\"] ",
+        "on": "left"
+    }
+}, {
+    "title": "Concept: Snapshots",
+    "text": "<p><b>Snapshots</b> are a point-in-time backup of a Node-RED Instance. They capture the flows, credentials and runtime settings.</p><p>Snapshots are used mostly for <b>Version Control</b> and in <b>Pipelines</b> where you can choose to roll out a <b>Snapshot</b> to <b>Instances</b> or <b>Device Group</b>.</p>",
+    "attachTo": {
+        "element": "a[data-nav=\"application-snapshots\"] ",
+        "on": "left"
+    }
+}, {
+    "title": "Concept: Device Groups",
+    "text": "<p><b>Device Groups</b> are collections of <b>Remote Instances</b> that can be used in <b>Pipelines</b> in order to deploy the same Node-RED flows out to multiple pieces of hardware in one-click.</p>",
+    "attachTo": {
+        "element": "a[data-nav=\"application-device-groups\"] ",
+        "on": "left"
+    }
+}, {
+    "title": "Setup Your First Remote Instance",
+    "text": "To get started, let's select your Application.</p>",
+    "attachTo": {
+        "element": "a[data-action=\"view-application\"]",
+        "on": "bottom"
+    },
+    "advanceOn": {
+        "selector": "a[data-action=\"view-application\"]",
+        "event": "click"
+    }
+}]

--- a/frontend/src/tours/tour-welcome.json
+++ b/frontend/src/tours/tour-welcome.json
@@ -3,7 +3,7 @@
     "text": "<p>Welcome to FlowFuse, the complete platform for building, managing and deploying your Node-RED applications.</p><p><b>Let's take a quick tour to get you started.</b></p>"
 }, {
     "title": "Concept: Applications",
-    "text": "<p><b>This is your first Application in FlowFuse.</b></p><p>Applications are the top level container for your Node-RED Instances, Edge Devices and other resources.</p>",
+    "text": "<p><b>This is your first Application in FlowFuse.</b></p><p>Applications help to organize your Node-RED Instances and other resources.</p>",
     "attachTo": {
         "element": "li[data-el=\"application-item\"]",
         "on": "bottom"


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/011f7d47-f691-440a-9223-4d0a0aa4e883

Our existing onboarding tour doesn't align very well to the new new FlowFuse Cloud Free Tier, as it assumes an Instance has been setup for you - not the case.

This PR adds two new tours. One as an alternative introduction to the concepts of FlowFuse, but knowing there is no existing Instance to highlight. Then, the second starts when a user selects "Add Remote Instance" (the last stage of Tour 1) which then directs the user through the stages of adding their first Remote Instance

### TODO

- Reliant upon https://github.com/FlowFuse/flowfuse/pull/4985