### PR TITLE
Add option to auto-create team application

### DIFF
--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -56,6 +56,7 @@ module.exports = async function (app) {
                 response['user:team:auto-create'] = app.settings.get('user:team:auto-create')
                 response['user:team:auto-create:teamType'] = app.settings.get('user:team:auto-create:teamType')
                 response['user:team:auto-create:instanceType'] = app.settings.get('user:team:auto-create:instanceType')
+                response['user:team:auto-create:application'] = app.settings.get('user:team:auto-create:application')
                 response.email = app.postoffice.exportSettings(true)
                 response['version:forge'] = app.settings.get('version:forge')
                 response['version:node'] = app.settings.get('version:node')

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -47,6 +47,8 @@ module.exports = {
     'user:team:auto-create:teamType': null,
     // The type of instance to auto-create when an account signs up, defaults to none.
     'user:team:auto-create:instanceType': null,
+    // Auto-create a default application whenever a team is created
+    'user:team:auto-create:application': false,
 
     // Can external users be invited to join teams
     'team:user:invite:external': false,

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -93,6 +93,16 @@
                 <p>Administrators can always create teams.</p>
             </template>
         </FormRow>
+        <template v-if="input['team:create']">
+            <FormRow v-model="input['user:team:auto-create:application']" type="checkbox" containerClass="max-w-sm ml-9">
+                Create a default application in the team
+                <template #description>
+                    <p>
+                        Whenever a team is created, this will create a default application within that team.
+                    </p>
+                </template>
+            </FormRow>
+        </template>
         <FormRow v-model="input['team:user:invite:external']" type="checkbox" :disabled="!!errors.requiresEmail" :error="errors.requiresEmail">
             Allow users to invite external users to teams
             <template #description>
@@ -187,6 +197,7 @@ const validSettings = [
     'user:team:auto-create',
     'user:team:auto-create:teamType',
     'user:team:auto-create:instanceType',
+    'user:team:auto-create:application',
     'user:tcs-required',
     'user:tcs-url',
     'user:tcs-date',


### PR DESCRIPTION
Closes #4978

Adds an admin setting to enable auto-creation of a default application whenever a team is created.

By enabling this option it removes one piece of setup friction for new teams.