### PR TITLE
Update text on create button for trial teams

### DIFF
--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -53,7 +53,7 @@
                         </ff-button>
                     </template>
                     <ff-button v-else :disabled="!formValid" @click="createTeam()">
-                        <template v-if="billingEnabled && isSelectionTrial">Start trial</template>
+                        <template v-if="billingEnabled && isSelectionTrial">Start Free Trial</template>
                         <template v-else>Create team</template>
                     </ff-button>
                 </div>

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -42,14 +42,17 @@
                         </template>
                     </FormRow>
 
-                    <template v-if="billingEnabled && !isSelectionTrial">
+                    <template v-if="billingEnabled">
                         <div class="mb-8 text-sm text-gray-500 space-y-2">
                             <p v-if="!presetTeamType || (!isSelectionTrial && !presetTeamType.isFree)">To create the team we need to setup payment details via Stripe, our secure payment provider.</p>
-                            <p v-else>Please note that, whilst we do require credit card details, this Team is free of charge, and no charges will be made.</p>
+                            <p v-else-if="!isSelectionTrial">Please note that, whilst we do require credit card details, this Team is free of charge, and no charges will be made.</p>
                         </div>
-                        <ff-button :disabled="!formValid" @click="createTeam()">
+                        <ff-button v-if="!isSelectionTrial" :disabled="!formValid" @click="createTeam()">
                             <template #icon-right><ExternalLinkIcon /></template>
                             Create team and setup payment details
+                        </ff-button>
+                        <ff-button v-else :disabled="!formValid" @click="createTeam()">
+                            Start Free Trial
                         </ff-button>
                     </template>
                     <ff-button v-else :disabled="!formValid" @click="createTeam()">


### PR DESCRIPTION
## Description

When opting to create a Trial team, the final create button and text talks about sending the user to stripe. This is not the case for trial teams - clicking the button takes them straight to their team.

<img width="493" alt="image" src="https://github.com/user-attachments/assets/d39d1ed2-0041-4761-84f3-c1cb984f20f2" />


With this PR, when creating a trial team, the text/button have been updated as:

<img width="418" alt="image" src="https://github.com/user-attachments/assets/b1165fbb-caa6-47d9-9529-227037e60573" />

