### PR TITLE
ci: Create `check-tests-status` job summary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,17 +59,30 @@ jobs:
             const failedJobs = relevantJobs.filter(job => job.conclusion === 'failure');
             const allSkippedJobs = relevantJobs.every(job => job.conclusion === 'skipped');
             
+            const { summary } = require('@actions/core');
+
             if (failedJobs.length > 0) {
               console.log('🚨 The following tests failed:');
+              await summary.addHeading('Failed Tests 🚨');
+              let failedList = '';
               failedJobs.forEach(job => {
                 console.log(`❌ ${job.name}`);
+                failedList += `- ❌ ${job.name}\n`;
               });
+              await summary.addRaw(failedList);
+              await summary.write();
               core.setOutput('jobs_status', 'failure');
             } else if (allSkippedJobs) {
               console.log('⏩ All tests were skipped ⏩');
+              await summary.addHeading('Test Status ⏩');
+              await summary.addRaw('All tests were skipped');
+              await summary.write();
               core.setOutput('jobs_status', 'skipped');
             } else {
               console.log('✅ Required tests passed successfully ✅');
+              await summary.addHeading('Test Status ✅');
+              await summary.addRaw('All required tests passed successfully');
+              await summary.write();
               core.setOutput('jobs_status', 'success');
             }
 


### PR DESCRIPTION
## Description

This pull request improves the visibility of `check-tests-status` job by adding a job summary to the workflow. In result, instead of digging to the exact step result, tests workflow status will be visible on the workflow run summary page.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/4977

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

