### PR TITLE
Change team before switching route when accessing team link from the admin page

### DIFF
--- a/frontend/src/components/tables/cells/TeamCell.vue
+++ b/frontend/src/components/tables/cells/TeamCell.vue
@@ -14,7 +14,14 @@ export default {
     methods: {
         goToTeam () {
             if (this.slug) {
-                this.$router.push({ name: 'Team', params: { team_slug: this.slug } })
+                this.$store.dispatch('account/setTeam', this.slug)
+                    .then(() => this.$router.push({
+                        name: 'Team',
+                        params: {
+                            team_slug: this.slug
+                        }
+                    }))
+                    .catch(e => console.warn(e))
             }
         }
     }


### PR DESCRIPTION
## Description

Added a missing team dispatch action when accessing a user's team from the admin menu

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4981

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

