### PR TITLE
Remove the injected canonical link

### DIFF
--- a/forge/routes/ui/index.js
+++ b/forge/routes/ui/index.js
@@ -77,10 +77,6 @@ module.exports = async function (app) {
                 injection += `<script>window.sentryConfig = { dsn: "${telemetry.frontend.sentry.dsn}", production_mode: ${telemetry.frontend.sentry.production_mode ?? true}, version: "flowfuse@${config.version}", environment: "${process.env.SENTRY_ENV ?? (process.env.NODE_ENV ?? 'unknown')}" }</script>`
             }
 
-            if (config.base_url) {
-                injection += `<link rel="canonical" href="${config.base_url}" />`
-            }
-
             // inject into index.html
             cachedIndex = data.replace(/<script>\/\*inject-ff-scripts\*\/<\/script>/g, injection)
         }


### PR DESCRIPTION
## Description

This change aims to enhance the visibility of the sign-up page and other public pages to search crawlers by removing the statically injected canonical link from the page header.

## Related Issue(s)

part of https://github.com/FlowFuse/website/issues/491

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

