### PR TITLE
ci: Add `nr-file-nodes` package build step to the pre-staging deployment

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -75,7 +75,6 @@ jobs:
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      github.event.action != 'closed' &&
       inputs.driver_k8s_branch != 'main'
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
     with:
@@ -93,7 +92,6 @@ jobs:
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      github.event.action != 'closed' &&
       inputs.nr_project_nodes_branch != 'main'
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
     with:
@@ -111,7 +109,6 @@ jobs:
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      github.event.action != 'closed' &&
       inputs.nr_file_nodes_branch != 'main'
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
     with:
@@ -155,7 +152,6 @@ jobs:
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      github.event.action != 'closed' &&
       (always() && needs.publish_nr_launcher.result == 'success')
     uses: flowfuse/github-actions-workflows/.github/workflows/build_container_image.yml@v0.38.0
     with:
@@ -178,7 +174,6 @@ jobs:
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      github.event.action != 'closed' &&
       (always() && needs.build-node-red.result == 'success')
     runs-on: ubuntu-latest
     environment: staging

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -142,7 +142,7 @@ jobs:
       release_name: "pre-staging-${{ inputs.nr_launcher_branch == 'main' && github.sha || inputs.nr_launcher_branch }}"
       package_dependencies: |
         @flowfuse/nr-project-nodes=${{ inputs.nr_project_nodes_branch != 'main' && needs.publish_nr_project_nodes.outputs.release_name || 'nightly' }}
-        @flowfuse/nr-file-nodes=nightly
+        @flowfuse/nr-file-nodes=${{ inputs.nr_file_nodes_branch != 'main' && needs.publish_nr_file_nodes.outputs.release_name || 'nightly' }}
         @flowfuse/nr-assistant=nightly
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -462,10 +462,9 @@ jobs:
     needs: 
       - deploy
       - create-custom-stack
-    if: false
-    # if: |
-    #   always() &&
-    #   (needs.deploy.result != 'skipped' || needs.create-custom-stack.result != 'skipped')
+    if: |
+      always() &&
+      (needs.deploy.result != 'skipped' || needs.create-custom-stack.result != 'skipped')
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number == '' && inputs.pr_number || github.event.number }}

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -18,6 +18,10 @@ on:
         description: 'flowfuse/nr-project-nodes branch name'
         required: true
         default: 'main'
+      nr_file_nodes_branch:
+        description: 'flowfuse/nr-file-nodes branch name'
+        required: true
+        default: 'main'
   pull_request:
     types: 
       - opened
@@ -101,15 +105,34 @@ jobs:
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
+  publish_nr_file_nodes:
+    name: Build and publish nr-file-nodes package
+    needs: validate-user
+    if: |
+      needs.validate-user.outputs.is_org_member == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.action != 'closed' &&
+      inputs.nr_file_nodes_branch != 'main'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
+    with:
+      package_name: nr-file-nodes
+      publish_package: true
+      repository_name: 'FlowFuse/nr-file-nodes'
+      branch_name: ${{ inputs.nr_file_nodes_branch }}
+      release_name: "pre-staging-${{ inputs.nr_file_nodes_branch }}"
+    secrets:
+      npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
   publish_nr_launcher:
     name: Build and publish nr-launcher package
     needs: 
       - validate-user
       - publish_nr_project_nodes
+      - publish_nr_file_nodes
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      ((always() && inputs.nr_launcher_branch != 'main') || needs.publish_nr_project_nodes.result == 'success')
+      (always() && inputs.nr_launcher_branch != 'main') || needs.publish_nr_project_nodes.result == 'success' || needs.publish_nr_file_nodes.result == 'success'
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
     with:
       package_name: flowfuse-nr-launcher

--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -462,9 +462,10 @@ jobs:
     needs: 
       - deploy
       - create-custom-stack
-    if: |
-      always() &&
-      (needs.deploy.result != 'skipped' || needs.create-custom-stack.result != 'skipped')
+    if: false
+    # if: |
+    #   always() &&
+    #   (needs.deploy.result != 'skipped' || needs.create-custom-stack.result != 'skipped')
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number == '' && inputs.pr_number || github.event.number }}


### PR DESCRIPTION
## Description

This pull request includes updates to the GitHub Actions workflow configuration to support the `nr-file-nodes` package and makes adjustments to the deployment conditions. The most important changes include adding a new branch input, defining a job for publishing the `nr-file-nodes` package, updating dependencies, and modifying deployment conditions.

Improvements to workflow configuration:

* Added a new input `nr_file_nodes_branch` to specify the branch name for `flowfuse/nr-file-nodes`.
* Defined a new job `publish_nr_file_nodes` to build and publish the `nr-file-nodes` package if certain conditions are met.
* Updated the `publish_nr_launcher` job to include a dependency on the `publish_nr_file_nodes` job and adjusted the conditions for running the job.
* Changed the dependency version for `@flowfuse/nr-file-nodes` to use the release name from the `publish_nr_file_nodes` job if the branch is not `main`.

## Related Issue(s)

closes https://github.com/FlowFuse/CloudProject/issues/597

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

