### PR TITLE
Add initial schema generation for team-broker topics

### DIFF
--- a/forge/ee/routes/teamBroker/index.js
+++ b/forge/ee/routes/teamBroker/index.js
@@ -1,3 +1,5 @@
+const schemaApi = require('./schema')
+
 module.exports = async function (app) {
     app.addHook('preHandler', app.verifySession)
 
@@ -34,6 +36,8 @@ module.exports = async function (app) {
             request.teamMembership = await request.session.User.getTeamMembership(request.team.id)
         }
     })
+
+    await schemaApi(app)
 
     /**
      * Get the Teams MQTT Clients

--- a/forge/ee/routes/teamBroker/schema.js
+++ b/forge/ee/routes/teamBroker/schema.js
@@ -1,0 +1,42 @@
+const YAML = require('yaml')
+module.exports = async function (app) {
+    app.get('/team-broker/schema.yml', async (request, reply) => {
+        const list = await app.teamBroker.getUsedTopics(request.team.hashid)
+        const schema = {
+            asyncapi: '3.0.0',
+            info: {
+                version: '1.0.0',
+                title: `${request.team.name} Team Broker`,
+                description: 'An auto-generated schema of the topics being used on the team broker'
+            }
+        }
+        // Add the team-broker details
+
+        // Figure out the hostname for the team broker
+        let teamBrokerHost = app.config.broker?.teamBroker?.host
+        if (!teamBrokerHost) {
+            // No explict value set, default to broker.${domain}
+            if (app.config.domain) {
+                teamBrokerHost = `broker.${app.config.domain}`
+            }
+        }
+        if (teamBrokerHost) {
+            schema.servers = {
+                'team-broker': {
+                    host: teamBrokerHost,
+                    protocol: 'mqtt'
+                }
+            }
+        }
+
+        if (list.length > 0) {
+            schema.channels = {}
+            list.forEach(topic => {
+                schema.channels[topic] = {
+                    address: topic
+                }
+            })
+        }
+        reply.send(YAML.stringify(schema))
+    })
+}


### PR DESCRIPTION
Part of #4919

## Description

Initial implementation of schema generation based on the observed team broker topics.

See #4919 for details on the schema and url used to expose.