### PR TITLE
Fix silently failing featuresCheck due to missing team

### DIFF
--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -122,7 +122,12 @@ const getters = {
         const preCheck = {
             // Instances
             isHostedInstancesEnabledForTeam: ((state) => {
+                if (!state.team) {
+                    return false
+                }
+
                 let available = false
+
                 // loop over the different instance types
                 for (const instanceType of Object.keys(state.team.type.properties?.instances) || []) {
                     if (state.team.type.properties?.instances[instanceType].active) {


### PR DESCRIPTION
## Description

Added an early return in the featuresCheck getter when no team is present  because it was causing the instance page to silently fail when opening it directly.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5004

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

