### PR TITLE
Add Open Schema button to Topic Hierarchy view

### DIFF
--- a/forge/ee/routes/teamBroker/schema.js
+++ b/forge/ee/routes/teamBroker/schema.js
@@ -24,7 +24,10 @@ module.exports = async function (app) {
             schema.servers = {
                 'team-broker': {
                     host: teamBrokerHost,
-                    protocol: 'mqtt'
+                    protocol: 'mqtt',
+                    security: [{
+                        type: 'userPassword'
+                    }]
                 }
             }
         }

--- a/frontend/src/pages/team/UNS/Hierarchy/index.vue
+++ b/frontend/src/pages/team/UNS/Hierarchy/index.vue
@@ -2,7 +2,11 @@
     <div class="unified-namespace-hierarchy">
         <div class="title mb-5 flex gap-3 items-center">
             <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
-            <h3 class="m-0" data-el="subtitle">Topic Hierarchy</h3>
+            <h3 class="m-0 flex-grow" data-el="subtitle">Topic Hierarchy</h3>
+            <ff-button v-if="featuresCheck.isMqttBrokerFeatureEnabled" @click="openSchema()">
+                <template #icon-right><ExternalLinkIcon /></template>
+                Open Schema
+            </ff-button>
         </div>
 
         <EmptyState
@@ -57,16 +61,21 @@
 
 <script>
 
+import { ExternalLinkIcon } from '@heroicons/vue/solid'
 import { mapGetters, mapState } from 'vuex'
 
 import brokerClient from '../../../../api/broker.js'
 import EmptyState from '../../../../components/EmptyState.vue'
 
+import { useNavigationHelper } from '../../../../composables/NavigationHelper.js'
+
 import TopicSegment from './components/TopicSegment.vue'
+
+const { openInANewTab } = useNavigationHelper()
 
 export default {
     name: 'UNSHierarchy',
-    components: { TopicSegment, EmptyState },
+    components: { TopicSegment, EmptyState, ExternalLinkIcon },
     data () {
         return {
             loading: false,
@@ -179,6 +188,9 @@ export default {
         toggleSegmentVisibility (segment) {
             // trigger's the hierarchy setter
             this.hierarchy = segment
+        },
+        openSchema () {
+            openInANewTab(`/api/v1/teams/${this.team.id}/broker/team-broker/schema.yml`, '_blank')
         }
     }
 }


### PR DESCRIPTION
Part of #4919 

Adds a button to the header of the Topic Hierarchy view to open the generated AsyncAPI in a new window.

<img width="814" alt="image" src="https://github.com/user-attachments/assets/a82456bf-6669-47d2-907d-6974aba17e56" />

Also noticed the generated schema ought to have a `security` section - so added.