### PR TITLE
Set pending state when loggin in to prevent no team limbo

### DIFF
--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -205,6 +205,9 @@ const mutations = {
     clearPending (state) {
         state.pending = false
     },
+    setPending (state, pending) {
+        state.pending = pending
+    },
     setLoginInflight (state) {
         state.loginInflight = true
     },
@@ -397,6 +400,7 @@ const actions = {
             } else if (credentials.token) {
                 await userApi.verifyMFAToken(credentials.token)
             }
+            state.commit('setPending', true)
             state.dispatch('checkState', state.getters.redirectUrlAfterLogin)
         } catch (err) {
             if (err.response?.status >= 401) {


### PR DESCRIPTION
## Description

After login, users are redirected to the home component which has a loading screen present (if account.pending e true) and a team type selector present (if account.teams.length === 0). The purpose of this page is to redirect users to their respective team page after their team/teams are loaded via the two watchers (frontend/src/pages/Home.vue:45)

The account store checkState method is the default method that get's called to hydrate the application and among other things, clears pending state. By setting the pending state to true when logging in, I was able to trick the Home page to not show the team type selector but keep the loading screen present until either the component redirects due to the team/teams being loaded or the checkState method clearing the pending state.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4970

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

