### PR TITLE
Update Team Device Groups routes to use hashid not slug

### DIFF
--- a/forge/ee/routes/teamDeviceGroups/index.js
+++ b/forge/ee/routes/teamDeviceGroups/index.js
@@ -20,7 +20,7 @@ module.exports = async function (app) {
         }
 
         try {
-            request.team = await app.db.models.Team.bySlug(request.params.teamId)
+            request.team = await app.db.models.Team.byId(request.params.teamId)
             if (!request.team) {
                 return reply.code(404).send({ code: 'not_found', error: 'Not Found' })
             }

--- a/test/unit/forge/ee/routes/api/team-device-groups_spec.js
+++ b/test/unit/forge/ee/routes/api/team-device-groups_spec.js
@@ -116,7 +116,7 @@ describe('Team Device Groups API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.ATeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/device-groups`,
                 cookies: { sid }
             })
 
@@ -127,7 +127,7 @@ describe('Team Device Groups API', function () {
             const sid = await login('bob', 'bbPassword')
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.BTeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/device-groups`,
                 cookies: { sid }
             })
             response.statusCode.should.equal(200)
@@ -138,7 +138,7 @@ describe('Team Device Groups API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.BTeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/device-groups`,
                 cookies: { sid }
             })
 
@@ -162,7 +162,7 @@ describe('Team Device Groups API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.BTeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/device-groups`,
                 cookies: { sid }
             })
 
@@ -199,7 +199,7 @@ describe('Team Device Groups API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.ATeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/device-groups`,
                 cookies: { sid }
             })
 
@@ -236,7 +236,7 @@ describe('Team Device Groups API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.CTeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.CTeam.hashid}/device-groups`,
                 cookies: { sid }
             })
 
@@ -254,7 +254,7 @@ describe('Team Device Groups API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.CTeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.CTeam.hashid}/device-groups`,
                 cookies: { sid }
             })
 
@@ -266,7 +266,7 @@ describe('Team Device Groups API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.CTeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.CTeam.hashid}/device-groups`,
                 cookies: { sid }
             })
 
@@ -278,7 +278,7 @@ describe('Team Device Groups API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.CTeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.CTeam.hashid}/device-groups`,
                 cookies: { sid }
             })
 
@@ -290,7 +290,7 @@ describe('Team Device Groups API', function () {
 
             const response = await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.CTeam.slug}/device-groups`,
+                url: `/api/v1/teams/${TestObjects.CTeam.hashid}/device-groups`,
                 cookies: { sid }
             })
 


### PR DESCRIPTION
Spotted moments after I approved and merged #5009 - the api urls should be using team hashid, not slug.

This PR fixes it.