### PR TITLE
Disable caching of index.html when in dev mode

### DIFF
--- a/forge/routes/ui/index.js
+++ b/forge/routes/ui/index.js
@@ -27,7 +27,7 @@ module.exports = async function (app) {
      * feConfig - the 'frontend' portion of our flowforge.yml
      */
     async function injectAnalytics (config) {
-        if (!cachedIndex) {
+        if (process.env.NODE_ENV === 'development' || !cachedIndex) {
             const telemetry = config.telemetry
             const support = config.support
             const filepath = path.join(frontendAssetsDir, 'index.html')

--- a/test/e2e/frontend/cypress/tests/admin/offboarding.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin/offboarding.spec.js
@@ -87,7 +87,7 @@ describe('FlowForge - Team Membership', () => {
         cy.get('[data-action="dialog-confirm"]').click()
 
         cy.origin('https://www.google.com', () => {
-            cy.url().should('eq', 'https://www.google.com/search?q=rick+astley')
+            cy.url().should('to.match', /^https:\/\/www\.google\.com\/search\?q=rick\+astley/)
         })
     })
 })


### PR DESCRIPTION
When telemetry (ie sentry) is enabled, the app loads `index.html` and injects the necessary scripts - and then caches the result for subsequent requests.

When running in dev mode (ie `npm run serve`), webpack rewrites index.html with the new content hashes applied. However, the forge app still serves the cached version - causing errors.

This fix disables the caching of index.html when telemetry is enabled *and* we're running in development mode. We know we're dev mode as `NODE_ENV` is set to `development` by the npm scripts.