### PR TITLE
Change external domain used in offboarding test to be more reliable

### DIFF
--- a/test/e2e/frontend/cypress/tests/admin/offboarding.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin/offboarding.spec.js
@@ -69,7 +69,7 @@ describe('FlowForge - Team Membership', () => {
                 ...res.body,
                 ...{
                     'user:offboarding-required': true,
-                    'user:offboarding-url': 'https://www.google.com/search?q=rick+astley'
+                    'user:offboarding-url': 'https://nodered.org/about/?search=rick'
                 }
             }
             return res
@@ -86,8 +86,8 @@ describe('FlowForge - Team Membership', () => {
         cy.get('[data-action="delete-account"]').click()
         cy.get('[data-action="dialog-confirm"]').click()
 
-        cy.origin('https://www.google.com', () => {
-            cy.url().should('to.match', /^https:\/\/www\.google\.com\/search\?q=rick\+astley/)
+        cy.origin('https://nodered.org', () => {
+            cy.url().should('to.match', /^https:\/\/nodered\.org\/about\/\?search=rick/)
         })
     })
 })


### PR DESCRIPTION
Fixes #5019

The offboarding test that verifies the user gets redirected to the configured URL is a bit flaky as it redirects to Google which sometimes returns something unexpected.

This changes the test to redirect to nodered.org and far more predictable.