### PR TITLE
Fix oauth tests on node 20

### DIFF
--- a/test/unit/forge/routes/auth/oauth_spec.js
+++ b/test/unit/forge/routes/auth/oauth_spec.js
@@ -61,7 +61,7 @@ describe('OAuth', async function () {
             authURL.search = new URLSearchParams(params)
             return {
                 verifier,
-                authURL
+                authURL: `${authURL.pathname}${authURL.search}`
             }
         }
 


### PR DESCRIPTION
The Oauth tests were passing a `URL` object to the route.inject functions. This worked fine in Node 18, but broke in Node 20 - it was causing the request to be sent to `/` rather than the expected route.

I don't know *why* this broke in node 20; but there were some changes around the implementation of the URL object between 18 and 20.

The docs for inject say the parameter should be a String, so this tidies up the test to pass in the url as a string instead.