### PR TITLE
Fix invalid check for billing enablement

### DIFF
--- a/frontend/src/components/TeamTypeTile.vue
+++ b/frontend/src/components/TeamTypeTile.vue
@@ -50,7 +50,7 @@ export default {
     computed: {
         ...mapState('account', ['user', 'teams']),
         pricing: function () {
-            const billing = this.teamType.properties?.billing.description?.split('/')
+            const billing = this.teamType.properties?.billing?.description?.split('/')
             const price = {}
             if (typeof billing !== 'undefined') {
                 price.value = billing[0]

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -434,7 +434,7 @@ const actions = {
                 return
             }
         } else {
-            if (!currentTeam || currentTeam.id === team?.id) {
+            if ((!currentTeam && !team) || currentTeam?.id === team?.id) {
                 state.commit('clearPendingTeamChange')
                 return
             }


### PR DESCRIPTION
Part of #5027 

The new 'Choose Team Type' selection page had a bad check for billing enablement that was throwing an undef error if billing wasn't enabled.