### PR TITLE
Update node-saml to 5

### DIFF
--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -13,6 +13,9 @@ module.exports.init = async function (app) {
         const provider = await app.db.models.SAMLProvider.byId(id)
         if (provider) {
             const result = { ...provider.getOptions() }
+            // @node-saml@4 renamed `cert` to `idpCert`
+            result.idpCert = result.cert
+            delete result.cert
             return result
         }
         return null

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@immobiliarelabs/fastify-sentry": "^8.0.0",
                 "@levminer/speakeasy": "^1.4.2",
                 "@node-red/util": "^4.0.2",
-                "@node-saml/passport-saml": "^4.0.4",
+                "@node-saml/passport-saml": "^5.0.0",
                 "@sentry/node": "^7.73.0",
                 "@sentry/profiling-node": "^1.2.1",
                 "@sentry/vue": "^7.91.0",
@@ -4999,40 +4999,58 @@
             }
         },
         "node_modules/@node-saml/node-saml": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@node-saml/node-saml/-/node-saml-4.0.5.tgz",
-            "integrity": "sha512-J5DglElbY1tjOuaR1NPtjOXkXY5bpUhDoKVoeucYN98A3w4fwgjIOPqIGcb6cQsqFq2zZ6vTCeKn5C/hvefSaw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@node-saml/node-saml/-/node-saml-5.0.0.tgz",
+            "integrity": "sha512-4JGubfHgL5egpXiuo9bupSGn6mgpfOQ/brZZvv2Qiho5aJmW7O1khbjdB7tsTsCvNFtLLjQqm3BmvcRicJyA2g==",
             "dependencies": {
-                "@types/debug": "^4.1.7",
-                "@types/passport": "^1.0.11",
-                "@types/xml-crypto": "^1.4.2",
-                "@types/xml-encryption": "^1.2.1",
-                "@types/xml2js": "^0.4.11",
-                "@xmldom/xmldom": "^0.8.6",
+                "@types/debug": "^4.1.12",
+                "@types/qs": "^6.9.11",
+                "@types/xml-encryption": "^1.2.4",
+                "@types/xml2js": "^0.4.14",
+                "@xmldom/is-dom-node": "^1.0.1",
+                "@xmldom/xmldom": "^0.8.10",
                 "debug": "^4.3.4",
-                "xml-crypto": "^3.0.1",
+                "xml-crypto": "^6.0.0",
                 "xml-encryption": "^3.0.2",
-                "xml2js": "^0.5.0",
-                "xmlbuilder": "^15.1.1"
+                "xml2js": "^0.6.2",
+                "xmlbuilder": "^15.1.1",
+                "xpath": "^0.0.34"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@node-saml/passport-saml": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@node-saml/passport-saml/-/passport-saml-4.0.4.tgz",
-            "integrity": "sha512-xFw3gw0yo+K1mzlkW15NeBF7cVpRHN/4vpjmBKzov5YFImCWh/G0LcTZ8krH3yk2/eRPc3Or8LRPudVJBjmYaw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@node-saml/passport-saml/-/passport-saml-5.0.0.tgz",
+            "integrity": "sha512-7miY7Id6UkP39+6HO68e3/V6eJwszytEQl+oCh0R/gbzp5nHA/WI1mvrI6NNUVq5gC5GEnDS8GTw7oj+Kx499w==",
             "dependencies": {
-                "@node-saml/node-saml": "^4.0.4",
-                "@types/express": "^4.17.14",
-                "@types/passport": "^1.0.11",
-                "@types/passport-strategy": "^0.2.35",
-                "passport": "^0.6.0",
+                "@node-saml/node-saml": "^5.0.0",
+                "@types/express": "^4.17.21",
+                "@types/passport": "^1.0.16",
+                "@types/passport-strategy": "^0.2.38",
+                "passport": "^0.7.0",
                 "passport-strategy": "^1.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
+            }
+        },
+        "node_modules/@node-saml/passport-saml/node_modules/passport": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+            "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+            "dependencies": {
+                "passport-strategy": "1.x.x",
+                "pause": "0.0.1",
+                "utils-merge": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/jaredhanson"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -6802,9 +6820,9 @@
             }
         },
         "node_modules/@types/debug": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-            "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+            "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "dependencies": {
                 "@types/ms": "*"
             }
@@ -6815,9 +6833,9 @@
             "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
         },
         "node_modules/@types/express": {
-            "version": "4.17.17",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-            "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -6925,26 +6943,26 @@
             "dev": true
         },
         "node_modules/@types/passport": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.12.tgz",
-            "integrity": "sha512-QFdJ2TiAEoXfEQSNDISJR1Tm51I78CymqcBa8imbjo6dNNu+l2huDxxbDEIoFIwOSKMkOfHEikyDuZ38WwWsmw==",
+            "version": "1.0.17",
+            "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+            "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
             "dependencies": {
                 "@types/express": "*"
             }
         },
         "node_modules/@types/passport-strategy": {
-            "version": "0.2.35",
-            "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.35.tgz",
-            "integrity": "sha512-o5D19Jy2XPFoX2rKApykY15et3Apgax00RRLf0RUotPDUsYrQa7x4howLYr9El2mlUApHmCMv5CZ1IXqKFQ2+g==",
+            "version": "0.2.38",
+            "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+            "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
             "dependencies": {
                 "@types/express": "*",
                 "@types/passport": "*"
             }
         },
         "node_modules/@types/qs": {
-            "version": "6.9.7",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+            "version": "6.9.18",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+            "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA=="
         },
         "node_modules/@types/range-parser": {
             "version": "1.2.4",
@@ -7045,27 +7063,18 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/xml-crypto": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/@types/xml-crypto/-/xml-crypto-1.4.2.tgz",
-            "integrity": "sha512-1kT+3gVkeBDg7Ih8NefxGYfCApwZViMIs5IEs5AXF6Fpsrnf9CLAEIRh0DYb1mIcRcvysVbe27cHsJD6rJi36w==",
-            "dependencies": {
-                "@types/node": "*",
-                "xpath": "0.0.27"
-            }
-        },
         "node_modules/@types/xml-encryption": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.1.tgz",
-            "integrity": "sha512-UeyZkfZFZSa9XCGU5uGgUmsSLwQESDJvF076bJGyDf2gkXJjKvK8fW/x4ckvEHB2M/5RHJEkMc5xI+JrdmCTKA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.4.tgz",
+            "integrity": "sha512-I69K/WW1Dv7j6O3jh13z0X8sLWJRXbu5xnHDl9yHzUNDUBtUoBY058eb5s+x/WG6yZC1h8aKdI2EoyEPjyEh+Q==",
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/xml2js": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.11.tgz",
-            "integrity": "sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==",
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+            "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -7547,10 +7556,18 @@
                 }
             }
         },
+        "node_modules/@xmldom/is-dom-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+            "integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
+            "engines": {
+                "node": ">= 16"
+            }
+        },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.7",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
-            "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg==",
+            "version": "0.8.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+            "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -20324,9 +20341,9 @@
             }
         },
         "node_modules/sax": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
         },
         "node_modules/saxes": {
             "version": "6.0.0",
@@ -23762,21 +23779,22 @@
             }
         },
         "node_modules/xml-crypto": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.1.0.tgz",
-            "integrity": "sha512-GPDprzBeCvn2ByTzeX+DOXbQ7V2IHmE6H1WZkrR+5LPrRQrwwYC9RoCYZ2++y2yJTYzRre1qY4gqNjmJLKdQ6Q==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
+            "integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
             "dependencies": {
-                "@xmldom/xmldom": "0.8.7",
-                "xpath": "0.0.32"
+                "@xmldom/is-dom-node": "^1.0.1",
+                "@xmldom/xmldom": "^0.8.10",
+                "xpath": "^0.0.33"
             },
             "engines": {
-                "node": ">=4.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/xml-crypto/node_modules/xpath": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-            "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
+            "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
             "engines": {
                 "node": ">=0.6.0"
             }
@@ -23812,9 +23830,9 @@
             }
         },
         "node_modules/xml2js": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "dependencies": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -23846,9 +23864,9 @@
             "dev": true
         },
         "node_modules/xpath": {
-            "version": "0.0.27",
-            "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-            "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==",
+            "version": "0.0.34",
+            "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+            "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
             "engines": {
                 "node": ">=0.6.0"
             }
@@ -27210,34 +27228,47 @@
             }
         },
         "@node-saml/node-saml": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@node-saml/node-saml/-/node-saml-4.0.5.tgz",
-            "integrity": "sha512-J5DglElbY1tjOuaR1NPtjOXkXY5bpUhDoKVoeucYN98A3w4fwgjIOPqIGcb6cQsqFq2zZ6vTCeKn5C/hvefSaw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@node-saml/node-saml/-/node-saml-5.0.0.tgz",
+            "integrity": "sha512-4JGubfHgL5egpXiuo9bupSGn6mgpfOQ/brZZvv2Qiho5aJmW7O1khbjdB7tsTsCvNFtLLjQqm3BmvcRicJyA2g==",
             "requires": {
-                "@types/debug": "^4.1.7",
-                "@types/passport": "^1.0.11",
-                "@types/xml-crypto": "^1.4.2",
-                "@types/xml-encryption": "^1.2.1",
-                "@types/xml2js": "^0.4.11",
-                "@xmldom/xmldom": "^0.8.6",
+                "@types/debug": "^4.1.12",
+                "@types/qs": "^6.9.11",
+                "@types/xml-encryption": "^1.2.4",
+                "@types/xml2js": "^0.4.14",
+                "@xmldom/is-dom-node": "^1.0.1",
+                "@xmldom/xmldom": "^0.8.10",
                 "debug": "^4.3.4",
-                "xml-crypto": "^3.0.1",
+                "xml-crypto": "^6.0.0",
                 "xml-encryption": "^3.0.2",
-                "xml2js": "^0.5.0",
-                "xmlbuilder": "^15.1.1"
+                "xml2js": "^0.6.2",
+                "xmlbuilder": "^15.1.1",
+                "xpath": "^0.0.34"
             }
         },
         "@node-saml/passport-saml": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@node-saml/passport-saml/-/passport-saml-4.0.4.tgz",
-            "integrity": "sha512-xFw3gw0yo+K1mzlkW15NeBF7cVpRHN/4vpjmBKzov5YFImCWh/G0LcTZ8krH3yk2/eRPc3Or8LRPudVJBjmYaw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@node-saml/passport-saml/-/passport-saml-5.0.0.tgz",
+            "integrity": "sha512-7miY7Id6UkP39+6HO68e3/V6eJwszytEQl+oCh0R/gbzp5nHA/WI1mvrI6NNUVq5gC5GEnDS8GTw7oj+Kx499w==",
             "requires": {
-                "@node-saml/node-saml": "^4.0.4",
-                "@types/express": "^4.17.14",
-                "@types/passport": "^1.0.11",
-                "@types/passport-strategy": "^0.2.35",
-                "passport": "^0.6.0",
+                "@node-saml/node-saml": "^5.0.0",
+                "@types/express": "^4.17.21",
+                "@types/passport": "^1.0.16",
+                "@types/passport-strategy": "^0.2.38",
+                "passport": "^0.7.0",
                 "passport-strategy": "^1.0.0"
+            },
+            "dependencies": {
+                "passport": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+                    "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+                    "requires": {
+                        "passport-strategy": "1.x.x",
+                        "pause": "0.0.1",
+                        "utils-merge": "^1.0.1"
+                    }
+                }
             }
         },
         "@nodelib/fs.scandir": {
@@ -28519,9 +28550,9 @@
             }
         },
         "@types/debug": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-            "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+            "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "requires": {
                 "@types/ms": "*"
             }
@@ -28532,9 +28563,9 @@
             "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
         },
         "@types/express": {
-            "version": "4.17.17",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-            "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
             "requires": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -28642,26 +28673,26 @@
             "dev": true
         },
         "@types/passport": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.12.tgz",
-            "integrity": "sha512-QFdJ2TiAEoXfEQSNDISJR1Tm51I78CymqcBa8imbjo6dNNu+l2huDxxbDEIoFIwOSKMkOfHEikyDuZ38WwWsmw==",
+            "version": "1.0.17",
+            "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+            "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
             "requires": {
                 "@types/express": "*"
             }
         },
         "@types/passport-strategy": {
-            "version": "0.2.35",
-            "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.35.tgz",
-            "integrity": "sha512-o5D19Jy2XPFoX2rKApykY15et3Apgax00RRLf0RUotPDUsYrQa7x4howLYr9El2mlUApHmCMv5CZ1IXqKFQ2+g==",
+            "version": "0.2.38",
+            "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+            "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
             "requires": {
                 "@types/express": "*",
                 "@types/passport": "*"
             }
         },
         "@types/qs": {
-            "version": "6.9.7",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+            "version": "6.9.18",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+            "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA=="
         },
         "@types/range-parser": {
             "version": "1.2.4",
@@ -28764,27 +28795,18 @@
                 "@types/node": "*"
             }
         },
-        "@types/xml-crypto": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/@types/xml-crypto/-/xml-crypto-1.4.2.tgz",
-            "integrity": "sha512-1kT+3gVkeBDg7Ih8NefxGYfCApwZViMIs5IEs5AXF6Fpsrnf9CLAEIRh0DYb1mIcRcvysVbe27cHsJD6rJi36w==",
-            "requires": {
-                "@types/node": "*",
-                "xpath": "0.0.27"
-            }
-        },
         "@types/xml-encryption": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.1.tgz",
-            "integrity": "sha512-UeyZkfZFZSa9XCGU5uGgUmsSLwQESDJvF076bJGyDf2gkXJjKvK8fW/x4ckvEHB2M/5RHJEkMc5xI+JrdmCTKA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.4.tgz",
+            "integrity": "sha512-I69K/WW1Dv7j6O3jh13z0X8sLWJRXbu5xnHDl9yHzUNDUBtUoBY058eb5s+x/WG6yZC1h8aKdI2EoyEPjyEh+Q==",
             "requires": {
                 "@types/node": "*"
             }
         },
         "@types/xml2js": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.11.tgz",
-            "integrity": "sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==",
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+            "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
             "requires": {
                 "@types/node": "*"
             }
@@ -29192,10 +29214,15 @@
             "dev": true,
             "requires": {}
         },
+        "@xmldom/is-dom-node": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+            "integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q=="
+        },
         "@xmldom/xmldom": {
-            "version": "0.8.7",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
-            "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg=="
+            "version": "0.8.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+            "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -38450,9 +38477,9 @@
             }
         },
         "sax": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
         },
         "saxes": {
             "version": "6.0.0",
@@ -40950,18 +40977,19 @@
             "requires": {}
         },
         "xml-crypto": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.1.0.tgz",
-            "integrity": "sha512-GPDprzBeCvn2ByTzeX+DOXbQ7V2IHmE6H1WZkrR+5LPrRQrwwYC9RoCYZ2++y2yJTYzRre1qY4gqNjmJLKdQ6Q==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.0.0.tgz",
+            "integrity": "sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==",
             "requires": {
-                "@xmldom/xmldom": "0.8.7",
-                "xpath": "0.0.32"
+                "@xmldom/is-dom-node": "^1.0.1",
+                "@xmldom/xmldom": "^0.8.10",
+                "xpath": "^0.0.33"
             },
             "dependencies": {
                 "xpath": {
-                    "version": "0.0.32",
-                    "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-                    "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
+                    "version": "0.0.33",
+                    "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
+                    "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA=="
                 }
             }
         },
@@ -40989,9 +41017,9 @@
             "dev": true
         },
         "xml2js": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "requires": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -41016,9 +41044,9 @@
             "dev": true
         },
         "xpath": {
-            "version": "0.0.27",
-            "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-            "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
+            "version": "0.0.34",
+            "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+            "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA=="
         },
         "xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "@immobiliarelabs/fastify-sentry": "^8.0.0",
         "@levminer/speakeasy": "^1.4.2",
         "@node-red/util": "^4.0.2",
-        "@node-saml/passport-saml": "^4.0.4",
+        "@node-saml/passport-saml": "^5.0.0",
         "@sentry/node": "^7.73.0",
         "@sentry/profiling-node": "^1.2.1",
         "@sentry/vue": "^7.91.0",

--- a/test/unit/forge/ee/lib/sso/index_spec.js
+++ b/test/unit/forge/ee/lib/sso/index_spec.js
@@ -97,10 +97,10 @@ d
     describe('getProviderOptions', async function () {
         it('gets provider options for known provider', async function () {
             const result = await app.sso.getProviderOptions(app.samlProviders.provider1.hashid)
-            result.should.have.only.keys('issuer', 'callbackUrl', 'cert', 'entryPoint')
+            result.should.have.only.keys('issuer', 'callbackUrl', 'idpCert', 'entryPoint')
             result.issuer.should.equal(`http://localhost:3000/ee/sso/entity/${app.samlProviders.provider1.hashid}`)
             result.callbackUrl.should.equal('http://localhost:3000/ee/sso/login/callback')
-            result.cert.should.equal('abcde')
+            result.idpCert.should.equal('abcde')
             result.entryPoint.should.equal('https://sso.example.com/entry')
         })
         it('returns null for unknown provider', async function () {
@@ -109,11 +109,11 @@ d
         })
         it('handles multi-line cert', async function () {
             const result = await app.sso.getProviderOptions(app.samlProviders.provider3.hashid)
-            result.cert.should.equal('abcde')
+            result.idpCert.should.equal('abcde')
         })
         it('handles multi-line cert without header/footer', async function () {
             const result = await app.sso.getProviderOptions(app.samlProviders.provider4.hashid)
-            result.cert.should.equal('abcde')
+            result.idpCert.should.equal('abcde')
         })
     })
 


### PR DESCRIPTION
Replaces https://github.com/FlowFuse/flowfuse/pull/4734

The bump to node-saml@5 includes a breaking change on its options object - `cert` is now `idpCert`.

This PR updates to node-saml@5 and maps the old property to the new name. Tested locally against azure SSO.