### PR TITLE
Allow env var values to be hidden in UI

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -166,7 +166,12 @@ module.exports = {
         result.push(makeVar('FF_SNAPSHOT_ID', snapshotId))
         result.push(makeVar('FF_SNAPSHOT_NAME', snapshotName))
         result.push(...app.db.controllers.Device.removePlatformSpecificEnvVars(envVars))
-        return result
+        return result.map((env) => {
+            if (Object.hasOwnProperty.call(env, 'hidden') && env.hidden === true) {
+                env.value = ''
+            }
+            return env
+        })
     },
 
     /**

--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -166,12 +166,8 @@ module.exports = {
         result.push(makeVar('FF_SNAPSHOT_ID', snapshotId))
         result.push(makeVar('FF_SNAPSHOT_NAME', snapshotName))
         result.push(...app.db.controllers.Device.removePlatformSpecificEnvVars(envVars))
-        return result.map((env) => {
-            if (Object.hasOwnProperty.call(env, 'hidden') && env.hidden === true) {
-                env.value = ''
-            }
-            return env
-        })
+
+        return result
     },
 
     /**

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -270,7 +270,13 @@ module.exports = {
         result.push(makeVar('FF_PROJECT_ID', project.id || '', true)) // deprecated as of V1.6.0
         result.push(makeVar('FF_PROJECT_NAME', project.name || '', true)) // deprecated as of V1.6.0
         result.push(...app.db.controllers.Project.removePlatformSpecificEnvVars(envVars))
-        return result
+
+        return result.map((env) => {
+            if (Object.hasOwnProperty.call(env, 'hidden') && env.hidden === true) {
+                env.value = ''
+            }
+            return env
+        })
     },
 
     /**

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -491,7 +491,8 @@ module.exports = {
             sourceProjectEnvVars.forEach(envVar => {
                 newProjectSettings.env.push({
                     name: envVar.name,
-                    value: options.envVars === 'keys' ? '' : envVar.value
+                    value: options.envVars === 'keys' ? '' : envVar.value,
+                    hidden: envVar.hidden ?? false
                 })
             })
         }

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -271,12 +271,7 @@ module.exports = {
         result.push(makeVar('FF_PROJECT_NAME', project.name || '', true)) // deprecated as of V1.6.0
         result.push(...app.db.controllers.Project.removePlatformSpecificEnvVars(envVars))
 
-        return result.map((env) => {
-            if (Object.hasOwnProperty.call(env, 'hidden') && env.hidden === true) {
-                env.value = ''
-            }
-            return env
-        })
+        return result
     },
 
     /**

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -82,7 +82,12 @@ module.exports = function (app) {
                 result.launcherSettings.disableAutoSafeMode = disableAutoSafeMode.value
             }
             // Environment
-            result.settings.env = app.db.controllers.Project.insertPlatformSpecificEnvVars(proj, result.settings.env)
+            result.settings.env = app.db.controllers.Project.insertPlatformSpecificEnvVars(proj, result.settings.env).map((env) => {
+                if (Object.hasOwnProperty.call(env, 'hidden') && env.hidden === true) {
+                    env.value = ''
+                }
+                return env
+            })
             if (!result.settings.palette?.modules) {
                 // If there are no modules listed in settings, check the StorageSettings
                 // for the project to see what Node-RED may already think is installed

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -718,6 +718,12 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const settings = await request.device.getAllSettings()
+        settings.env = settings.env.map((env) => {
+            if (Object.hasOwnProperty.call(env, 'hidden') && env.hidden === true) {
+                env.value = ''
+            }
+            return env
+        })
         if (request.teamMembership?.role === Roles.Owner) {
             reply.send(settings)
         } else {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -411,15 +411,17 @@ module.exports = async function (app) {
 
             // Merge the settings into the existing values
             const currentProjectSettings = await request.project.getSetting(KEY_SETTINGS) || {}
-            newSettings.env = newSettings.env.map(env => {
-                // hidden env vars are received as empty strings so we'll replace the empty string with the previous value,
-                // allowing them to be overwritten when needed
-                if (Object.prototype.hasOwnProperty.call(env, 'hidden') && env.hidden && !env.value.length) {
-                    const previousValue = currentProjectSettings.env.find(e => e.name === env.name)
-                    env.value = previousValue.value
-                }
-                return env
-            })
+            if (newSettings.env && Array.isArray(newSettings.env)) {
+                newSettings.env = newSettings.env.map(env => {
+                    // hidden env vars are received as empty strings so we'll replace the empty string with the previous value,
+                    // allowing them to be overwritten when needed
+                    if (Object.prototype.hasOwnProperty.call(env, 'hidden') && env.hidden && !env.value.length) {
+                        const previousValue = currentProjectSettings.env.find(e => e.name === env.name)
+                        env.value = previousValue.value
+                    }
+                    return env
+                })
+            }
             const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings)
 
             changesToPersist.settings = { from: currentProjectSettings, to: updatedSettings }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -411,6 +411,15 @@ module.exports = async function (app) {
 
             // Merge the settings into the existing values
             const currentProjectSettings = await request.project.getSetting(KEY_SETTINGS) || {}
+            newSettings.env = newSettings.env.map(env => {
+                // hidden env vars are received as empty strings so we'll replace the empty string with the previous value,
+                // allowing them to be overwritten when needed
+                if (Object.prototype.hasOwnProperty.call(env, 'hidden') && env.hidden && !env.value.length) {
+                    const previousValue = currentProjectSettings.env.find(e => e.name === env.name)
+                    env.value = previousValue.value
+                }
+                return env
+            })
             const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings)
 
             changesToPersist.settings = { from: currentProjectSettings, to: updatedSettings }

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -1,5 +1,5 @@
 <template>
-    <form class="space-y-4" @submit.prevent>
+    <form class="space-y-4 ff-environment" @submit.prevent>
         <FormHeading>
             <div class="flex">
                 <div class="mr-4">Environment Variables</div>
@@ -58,7 +58,7 @@
                                 :containerClass="'w-full' + (!readOnly && (editTemplate || item.policy === undefined)) ? ' env-cell-uneditable':''"
                                 :inputClass="item.deprecated ? 'w-full text-yellow-700 italic' : 'w-full'"
                                 :error="errors[item.index].error"
-                                :disabled="item.encrypted"
+                                :disabled="item.encrypted || (typeof item.index === 'number' && item.hidden)"
                                 value-empty-text=""
                                 :type="(!readOnly && (editTemplate || item.policy === undefined))?'text':'uneditable'"
                             />
@@ -412,5 +412,15 @@ export default {
 }
 .ff-data-table--cell div.uneditable {
     cursor: default;
+}
+</style>
+
+<style lang="scss">
+.ff-environment {
+    .ff-input.ff-text-input {
+        input:disabled {
+            color: $ff-grey-600
+        }
+    }
 }
 </style>

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -302,8 +302,13 @@ export default {
             }
         },
         removeEnv (index) {
-            const field = this.editable.settings.env[index]
-            delete this.envVarLookup[field.name]
+            if (typeof index === 'string' && index.startsWith('add-')) {
+                index = this.editable.settings.env.findIndex(env => env.index === index)
+            } else {
+                const field = this.editable.settings.env[index]
+                delete this.envVarLookup[field.name]
+            }
+
             this.editable.settings.env.splice(index, 1)
         },
         importEnv () {

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -60,7 +60,7 @@
                                 :containerClass="'w-full' + (!readOnly && (editTemplate || item.policy === undefined)) ? ' env-cell-uneditable':''"
                                 :inputClass="item.deprecated ? 'w-full text-yellow-700 italic' : 'w-full'"
                                 :error="errors[item.index].error"
-                                :disabled="item.encrypted || (typeof item.index === 'number' && item.hidden)"
+                                :disabled="isDisabledName(item)"
                                 value-empty-text=""
                                 data-el="var-name"
                                 :type="(!readOnly && (editTemplate || item.policy === undefined))?'text':'uneditable'"
@@ -386,6 +386,11 @@ export default {
             }
 
             field.hidden = !field.hidden
+        },
+        isDisabledName (item) {
+            if (item.encrypted) return true
+            const originalItem = this.originalEnvVars.find(env => env.index === item.index)
+            return typeof item.index === 'number' && item.hidden && originalItem?.hidden
         }
     }
 }

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -185,6 +185,10 @@ export default {
             // for the dialog that opens, e.g. "FlowFuse - Device Group Environment Variables"
             type: String,
             default: null
+        },
+        originalEnvVars: {
+            type: Array,
+            required: true
         }
     },
     emits: ['update:modelValue', 'validated'],
@@ -193,7 +197,6 @@ export default {
             addedCount: 0,
             input: {},
             envVarLookup: {},
-            originalEnvVars: null,
             search: '',
             pauseEnvWatch: false,
             errors: { }
@@ -227,15 +230,11 @@ export default {
         'editable.settings.env': {
             deep: true,
             handler: 'validate'
-        },
-        modelValue: {
-            handler (model) {
-                if (this.originalEnvVars === null || this.originalEnvVars.length === 0) {
-                    this.originalEnvVars = JSON.parse(JSON.stringify(model.settings?.env || [])) // make a copy for later comparison
-                }
-            },
-            immediate: true
         }
+        // modelValue: {
+        //     handler: 'setOriginalValues',
+        //     immediate: true
+        // }
     },
     mounted () {
         this.updateLookup()
@@ -382,6 +381,11 @@ export default {
 
             field.hidden = !field.hidden
         }
+        // setOriginalValues (model) {
+        //     if (this.originalEnvVars === null || this.originalEnvVars.length === 0) {
+        //         this.originalEnvVars = JSON.parse(JSON.stringify(model.settings?.env || [])) // make a copy for later comparison
+        //     }
+        // }
     }
 }
 </script>

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -99,7 +99,13 @@
                                     </template>
                                 </ff-button>
                                 <template v-if="typeof item.index === 'string' && item.index.startsWith('add-')">
-                                    <ff-button kind="tertiary" size="small" data-el="visibility" @click="setEnvHidden(item.index)">
+                                    <ff-button
+                                        v-ff-tooltip:left="'Setting visibility to hidden will lock the variable name and make the value hidden. To revert, you\'ll need to delete and recreate the variable.'"
+                                        kind="tertiary"
+                                        size="small"
+                                        data-el="visibility"
+                                        @click="setEnvHidden(item.index)"
+                                    >
                                         <template #icon>
                                             <EyeOffIcon v-if="item.hidden" />
                                             <EyeIcon v-else />
@@ -118,6 +124,7 @@
                                     </span>
                                     <ff-button
                                         v-else
+                                        v-ff-tooltip:left="'Setting visibility to hidden will lock the variable name and make the value hidden. To revert, you\'ll need to delete and recreate the variable.'"
                                         kind="tertiary" size="small" data-el="visibility"
                                         @click="setEnvHidden(item.index)"
                                     >

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -27,6 +27,7 @@
                 search-placeholder="Search environment variables..."
                 :columns="editTemplate ? [,,,,] : [,,,]"
                 :noDataMessage="noDataMessage"
+                data-el="env-vars-table"
             >
                 <template #actions>
                     <template v-if="!readOnly">
@@ -35,7 +36,7 @@
                             <template #icon><DocumentDownloadIcon /></template>
                             <span class="hidden sm:flex pl-1">Import .env</span>
                         </ff-button>
-                        <ff-button kind="primary" accesskey="a" @click="addVarHandler">
+                        <ff-button kind="primary" accesskey="a" data-el="add-variable" @click="addVarHandler">
                             <template #icon><PlusSmIcon /></template>
                             <span class="hidden sm:flex pl-1">Add variable</span>
                         </ff-button>
@@ -50,16 +51,18 @@
                     </ff-data-table-row>
                 </template>
                 <template #rows>
-                    <ff-data-table-row v-for="(item) in filteredRows" :key="item.index">
+                    <ff-data-table-row v-for="(item) in filteredRows" :key="item.index" :data-row="'row-' + item.name">
                         <td class="ff-data-table--cell !pl-1 !pr-0 !py-1 border min-w-max max-w-sm align-top">
                             <FormRow
                                 v-model="item.name"
+                                v-ff-tooltip:left="'Cannot be renamed'"
                                 class="font-mono"
                                 :containerClass="'w-full' + (!readOnly && (editTemplate || item.policy === undefined)) ? ' env-cell-uneditable':''"
                                 :inputClass="item.deprecated ? 'w-full text-yellow-700 italic' : 'w-full'"
                                 :error="errors[item.index].error"
                                 :disabled="item.encrypted || (typeof item.index === 'number' && item.hidden)"
                                 value-empty-text=""
+                                data-el="var-name"
                                 :type="(!readOnly && (editTemplate || item.policy === undefined))?'text':'uneditable'"
                             />
                         </td>
@@ -70,6 +73,7 @@
                                     <textarea
                                         v-model="item.value"
                                         :placeholder="item.hidden ? 'Value hidden' : ''"
+                                        data-el="var-value"
                                         :class="'w-full font-mono max-h-40' + ((item.value && item.value.split('\n').length > 1) ? ' h-20' : ' h-8') + (item.deprecated ? ' text-yellow-700 italic' : '')"
                                     />
                                 </template>
@@ -79,6 +83,7 @@
                                         class="font-mono"
                                         containerClass="w-full env-cell-uneditable"
                                         :inputClass="item.deprecated ? 'text-yellow-700 italic' : ''"
+                                        data-el="var-value"
                                         value-empty-text=""
                                         :type="'uneditable'"
                                     />
@@ -88,13 +93,13 @@
                         </td>
                         <td class="ff-data-table--cell !p-1 border w-16 align-top">
                             <div v-if="(!readOnly && (editTemplate|| item.policy === undefined))" class="flex justify-center mt-1 items-center gap-3">
-                                <ff-button kind="tertiary" size="small" @click="removeEnv(item.index)">
+                                <ff-button kind="tertiary" size="small" data-el="remove" @click="removeEnv(item.index)">
                                     <template #icon>
                                         <TrashIcon />
                                     </template>
                                 </ff-button>
                                 <template v-if="typeof item.index === 'string' && item.index.startsWith('add-')">
-                                    <ff-button kind="tertiary" size="small" @click="setEnvHidden(item.index)">
+                                    <ff-button kind="tertiary" size="small" data-el="visibility" @click="setEnvHidden(item.index)">
                                         <template #icon>
                                             <EyeOffIcon v-if="item.hidden" />
                                             <EyeIcon v-else />
@@ -106,13 +111,15 @@
                                         v-if="!!(originalEnvVars.find(v => v.index === item.index))?.hidden"
                                         :key="item.index"
                                         v-ff-tooltip:left="'Cannot be made public again, only overwritten'"
-                                        class="mx-2"
+                                        class="mx-2 disabled"
+                                        data-el="visibility"
                                     >
                                         <EyeOffIcon class="ff-icon-sm color-grey" />
                                     </span>
                                     <ff-button
                                         v-else
-                                        kind="tertiary" size="small" @click="setEnvHidden(item.index)"
+                                        kind="tertiary" size="small" data-el="visibility"
+                                        @click="setEnvHidden(item.index)"
                                     >
                                         <template #icon>
                                             <EyeOffIcon v-if="item.hidden" />
@@ -384,7 +391,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .ff-data-table--cell textarea {
     resize: vertical;
     max-height: 10rem; /* 160px approx ~8 lines, after which user will need to scroll */

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -231,10 +231,6 @@ export default {
             deep: true,
             handler: 'validate'
         }
-        // modelValue: {
-        //     handler: 'setOriginalValues',
-        //     immediate: true
-        // }
     },
     mounted () {
         this.updateLookup()
@@ -274,6 +270,9 @@ export default {
                     hasErrors = true
                 } else if (field.name.startsWith('FF_') && !field.platform) {
                     this.errors[field.index].error = 'Reserved name'
+                    hasErrors = true
+                } else if (!field.name.match(/^[a-zA-Z_]+[a-zA-Z0-9_]*$/)) {
+                    this.errors[field.index].error = 'Names must start with a character'
                     hasErrors = true
                 } else if (counts[field.name] > 1) {
                     this.errors[field.index].error = 'Duplicate name'
@@ -381,11 +380,6 @@ export default {
 
             field.hidden = !field.hidden
         }
-        // setOriginalValues (model) {
-        //     if (this.originalEnvVars === null || this.originalEnvVars.length === 0) {
-        //         this.originalEnvVars = JSON.parse(JSON.stringify(model.settings?.env || [])) // make a copy for later comparison
-        //     }
-        // }
     }
 }
 </script>

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -67,7 +67,11 @@
                             <div v-if="!item.encrypted" class="w-full">
                                 <template v-if="(!readOnly && (editTemplate || item.policy === undefined || item.policy))">
                                     <!-- editable -->
-                                    <textarea v-model="item.value" :class="'w-full font-mono max-h-40' + ((item.value && item.value.split('\n').length > 1) ? ' h-20' : ' h-8') + (item.deprecated ? ' text-yellow-700 italic' : '')" />
+                                    <textarea
+                                        v-model="item.value"
+                                        :placeholder="item.hidden ? 'Value hidden' : ''"
+                                        :class="'w-full font-mono max-h-40' + ((item.value && item.value.split('\n').length > 1) ? ' h-20' : ' h-8') + (item.deprecated ? ' text-yellow-700 italic' : '')"
+                                    />
                                 </template>
                                 <template v-else>
                                     <FormRow

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -103,7 +103,7 @@
                                 </template>
                                 <template v-else>
                                     <span
-                                        v-if="!!(originalEnvVars.find(v => v.index === item.index)).hidden"
+                                        v-if="!!(originalEnvVars.find(v => v.index === item.index))?.hidden"
                                         :key="item.index"
                                         v-ff-tooltip:left="'Cannot be made public again, only overwritten'"
                                         class="mx-2"

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -1,6 +1,11 @@
 <template>
     <form class="space-y-6">
-        <TemplateSettingsEnvironment :readOnly="!hasPermission('device:edit-env')" v-model="editable" :editTemplate="false" />
+        <TemplateSettingsEnvironment
+            :readOnly="!hasPermission('device:edit-env')"
+            v-model="editable"
+            :original-env-vars="original.settings.env"
+            :editTemplate="false"
+        />
         <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
             <ff-button size="small" :disabled="!unsavedChanges || hasError" @click="saveSettings()">Save Settings</ff-button>
         </div>
@@ -90,7 +95,8 @@ export default {
             },
             original: {
                 settings: {
-                    envMap: {}
+                    envMap: {},
+                    env: []
                 }
             },
             templateEnvValues: {}
@@ -112,6 +118,13 @@ export default {
                     this.editable.settings.env.push(Object.assign({}, envVar))
                     // make a map of the key:value so it's easier to check for changes
                     this.original.settings.envMap[envVar.name] = envVar
+                })
+                Object.keys(this.original.settings.envMap).forEach((key, i) => {
+                    this.original.settings.env.push({
+                        key: i,
+                        hidden: false,
+                        ...this.original.settings.envMap[key]
+                    })
                 })
             }
         },

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -3,7 +3,7 @@
         <TemplateSettingsEnvironment
             :readOnly="!hasPermission('device:edit-env')"
             v-model="editable"
-            :original-env-vars="original.settings.env"
+            :original-env-vars="original?.settings?.env ?? []"
             :editTemplate="false"
             @validated="onFormValidated"
         />

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -5,9 +5,10 @@
             v-model="editable"
             :original-env-vars="original.settings.env"
             :editTemplate="false"
+            @validated="onFormValidated"
         />
         <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
-            <ff-button size="small" :disabled="!unsavedChanges || hasError" @click="saveSettings()">Save Settings</ff-button>
+            <ff-button size="small" :disabled="isUpdateButtonDisabled" @click="saveSettings()">Save Settings</ff-button>
         </div>
     </form>
 </template>
@@ -105,7 +106,11 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership'])
+        ...mapState('account', ['teamMembership']),
+        isUpdateButtonDisabled () {
+            if (this.hasError) return true
+            return !this.unsavedChanges
+        }
     },
     mounted () {
         this.getSettings()
@@ -148,6 +153,9 @@ export default {
             await deviceApi.updateSettings(this.device.id, settings)
             this.$emit('device-updated')
             alerts.emit('Device settings successfully updated. NOTE: changes will be applied once the device restarts.', 'confirmation', 6000)
+        },
+        onFormValidated (hasErrors) {
+            this.hasError = hasErrors
         }
     }
 }

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -57,6 +57,8 @@ export default {
                     // or if we do recognise it, but the value is different
                     if (!this.original.settings.envMap[field.name] || field.value !== this.original.settings.envMap[field.name].value) {
                         changed = true
+                    } else if (field.hidden !== this.original.settings.envMap[field.name].hidden) {
+                        changed = true
                     }
                     // there is an issue with he key/value
                     if (field.error) {
@@ -115,13 +117,17 @@ export default {
                 this.editable.settings.env = []
                 const settings = await deviceApi.getSettings(this.device.id)
                 settings.env?.forEach(envVar => {
+                    envVar = {
+                        hidden: false,
+                        ...envVar
+                    }
                     this.editable.settings.env.push(Object.assign({}, envVar))
                     // make a map of the key:value so it's easier to check for changes
                     this.original.settings.envMap[envVar.name] = envVar
                 })
                 Object.keys(this.original.settings.envMap).forEach((key, i) => {
                     this.original.settings.env.push({
-                        key: i,
+                        index: i,
                         hidden: false,
                         ...this.original.settings.envMap[key]
                     })
@@ -135,7 +141,8 @@ export default {
             this.editable.settings.env.forEach(field => {
                 settings.env.push({
                     name: field.name,
-                    value: field.value
+                    value: field.value,
+                    hidden: field.hidden
                 })
             })
             await deviceApi.updateSettings(this.device.id, settings)

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -8,7 +8,9 @@
             @validated="onFormValidated"
         />
         <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
-            <ff-button size="small" :disabled="isUpdateButtonDisabled" @click="saveSettings()">Save Settings</ff-button>
+            <ff-button size="small" :disabled="isUpdateButtonDisabled" @click="saveSettings()" data-el="submit">
+                Save Settings
+            </ff-button>
         </div>
     </form>
 </template>

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -130,6 +130,8 @@ export default {
                     // make a map of the key:value so it's easier to check for changes
                     this.original.settings.envMap[envVar.name] = envVar
                 })
+
+                this.original.settings.env = []
                 Object.keys(this.original.settings.envMap).forEach((key, i) => {
                     this.original.settings.env.push({
                         index: i,

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -4,6 +4,7 @@
             v-model="editable"
             :readOnly="!hasPermission('device:edit-env')"
             :editTemplate="false"
+            :original-env-vars="original.settings.env"
             @validated="onFormValidated"
         />
         <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -92,16 +92,6 @@ export default {
                             originalCount++
                             if (this.original.settings.envMap[field.name]) {
                                 const original = this.original.settings.envMap[field.name]
-
-                                // original = {
-                                //     hidden: false,
-                                //     ...original
-                                // }
-                                // field = {
-                                //     hidden: false,
-                                //     ...field
-                                // }
-
                                 if (original.index !== field.index) {
                                     changed = true
                                 } else if (original.name !== field.name) {

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -179,9 +179,13 @@ export default {
                     hidden: field.hidden
                 })
             })
-            await InstanceApi.updateInstance(this.project.id, { settings })
-            this.$emit('instance-updated')
-            alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
+            InstanceApi.updateInstance(this.project.id, { settings })
+                .then(() => {
+                    // wait before we reload the instance so we don't get a blip by returning the old values
+                    setTimeout(() => this.$emit('instance-updated'), 1000)
+                })
+                .then(() => alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000))
+                .catch(e => e)
         },
         onFormValidated (hasErrors) {
             this.hasErrors = hasErrors

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -1,8 +1,15 @@
 <template>
     <form class="space-y-6">
-        <TemplateSettingsEnvironment v-model="editable" :readOnly="!hasPermission('device:edit-env')" :editTemplate="false" />
+        <TemplateSettingsEnvironment
+            v-model="editable"
+            :readOnly="!hasPermission('device:edit-env')"
+            :editTemplate="false"
+            @validated="onFormValidated"
+        />
         <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
-            <ff-button size="small" :disabled="!unsavedChanges || hasErrors" @click="saveSettings()">Save settings</ff-button>
+            <ff-button size="small" :disabled="!unsavedChanges || hasErrors" @click="saveSettings()">
+                Save settings
+            </ff-button>
         </div>
     </form>
 </template>
@@ -64,8 +71,7 @@ export default {
                     description: false,
                     settings: {},
                     policy: {}
-                },
-                errors: {}
+                }
             },
             original: {},
             templateEnvValues: {}
@@ -81,11 +87,9 @@ export default {
             handler (v) {
                 if (this.project.template) {
                     let changed = false
-                    let errors = false
 
                     let originalCount = 0
                     this.editable.settings.env.forEach(field => {
-                        errors = errors || !!field.error
                         if (/^add/.test(field.index)) {
                             changed = true
                         } else {
@@ -110,7 +114,6 @@ export default {
                         changed = true
                     }
                     this.unsavedChanges = changed
-                    this.hasErrors = errors
                 }
             }
         }
@@ -179,6 +182,9 @@ export default {
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
             alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
+        },
+        onFormValidated (hasErrors) {
+            this.hasErrors = hasErrors
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -92,11 +92,23 @@ export default {
                             originalCount++
                             if (this.original.settings.envMap[field.name]) {
                                 const original = this.original.settings.envMap[field.name]
+
+                                // original = {
+                                //     hidden: false,
+                                //     ...original
+                                // }
+                                // field = {
+                                //     hidden: false,
+                                //     ...field
+                                // }
+
                                 if (original.index !== field.index) {
                                     changed = true
                                 } else if (original.name !== field.name) {
                                     changed = true
                                 } else if (original.value !== field.value) {
+                                    changed = true
+                                } else if (original.hidden !== field.hidden) {
                                     changed = true
                                 }
                             } else {
@@ -131,6 +143,11 @@ export default {
                 })
                 if (this.project.settings.env) {
                     this.project.settings.env.forEach((envVar) => {
+                        // hidden key backwards compatability
+                        envVar = {
+                            hidden: false,
+                            ...envVar
+                        }
                         envVar.index = this.editable.settings.env.length // ensure all env vars have an index
                         if (templateEnvMap[envVar.name]) {
                             if (templateEnvMap[envVar.name].policy) {
@@ -165,7 +182,8 @@ export default {
                 }
                 settings.env.push({
                     name: field.name,
-                    value: field.value
+                    value: field.value,
+                    hidden: field.hidden
                 })
             })
             await InstanceApi.updateInstance(this.project.id, { settings })

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -4,11 +4,11 @@
             v-model="editable"
             :readOnly="!hasPermission('device:edit-env')"
             :editTemplate="false"
-            :original-env-vars="original.settings.env"
+            :original-env-vars="original?.settings?.env ?? []"
             @validated="onFormValidated"
         />
         <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
-            <ff-button size="small" :disabled="!unsavedChanges || hasErrors" @click="saveSettings()">
+            <ff-button size="small" :disabled="!unsavedChanges || hasErrors" data-el="submit" @click="saveSettings()">
                 Save settings
             </ff-button>
         </div>

--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -965,6 +965,7 @@ li.ff-list-item {
     cursor: pointer;
     position: relative;
     display: flex;
+    max-height: 20px;
     svg {
       position: relative;
       z-index: 2;

--- a/test/e2e/frontend/cypress/tests/devices/settings/environment.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/settings/environment.spec.js
@@ -1,0 +1,95 @@
+describe('FlowForge - Device - Settings Environment', () => {
+    beforeEach(() => {
+        cy.login('bob', 'bbPassword')
+        cy.visit('/team/bteam/devices')
+        cy.get('[data-el="devices-browser"] tbody [data-el="ff-data-cell"] a').first().click()
+        cy.get('[data-nav="device-settings"]').click()
+        cy.get('[data-nav="environment"]').click()
+    })
+
+    it('can add, remove mark as hidden instance environment variables', () => {
+        cy.intercept('PUT', '/api/*/devices/*/settings').as('updateSettings')
+
+        cy.get('[data-el="env-vars-table"]').should('exist')
+        cy.get('[data-el="env-vars-table"]').should('be.visible')
+        cy.get('[data-el="env-vars-table"] tbody tr').should('have.length', 5)
+
+        cy.get('[data-el="submit"]').should('be.disabled')
+
+        cy.get('[data-el="add-variable"]').click()
+
+        cy.get('[data-el="submit"]').should('not.be.disabled')
+
+        cy.get('[data-el="env-vars-table"] tbody tr').should('have.length', 6)
+
+        // can remove an unsaved variable
+        cy.get('[data-el="env-vars-table"] [data-row="row-NEW"]').within(() => {
+            cy.get('[data-el="remove"]').click()
+        })
+
+        cy.get('[data-el="env-vars-table"] tbody tr').should('have.length', 5)
+
+        // can add a visible environment variable
+        cy.get('[data-el="add-variable"]').click()
+        cy.get('[data-el="submit"]').should('not.be.disabled')
+
+        cy.get('[data-el="env-vars-table"] [data-row="row-NEW"]').within(() => {
+            cy.get('[data-el="visibility"]').should('exist')
+            // filling in value first because changing the name will also change the selector
+            cy.get('[data-el="var-value"]').type('value')
+            cy.get('[data-el="var-name"]').type('new_var')
+        })
+
+        // can add a hidden environment variable
+        cy.get('[data-el="add-variable"]').click()
+        // previous entry changed name so new entry is the new row-NEW
+        cy.get('[data-el="env-vars-table"] [data-row="row-NEW"]').within(() => {
+            // filling in value first because changing the name will also change the selector
+            cy.get('[data-el="var-value"]').type('secret')
+            cy.get('[data-el="var-name"]').type('new_password')
+        })
+
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_password"]').within(() => {
+            cy.get('[data-el="visibility"]').click()
+        })
+
+        cy.get('[data-el="submit"]').click()
+        cy.wait('@updateSettings')
+
+        cy.get('[data-el="submit"]').should('be.disabled')
+
+        // check that the hidden var name and visibility can't be changed
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_password"]').within(() => {
+            cy.get('[data-el="var-name"] input').should('be.disabled')
+            cy.get('[data-el="var-value"]').should('have.value', '')
+            cy.get('[data-el="visibility"]').should('have.class', 'disabled')
+        })
+
+        // can mark an existing env var as hidden
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_var"]').within(() => {
+            cy.get('[data-el="visibility"]').should('not.have.class', 'disabled')
+            cy.get('[data-el="visibility"]').should('not.be.disabled')
+            cy.get('[data-el="visibility"]').click()
+        })
+        cy.get('[data-el="submit"]').should('not.be.disabled')
+        cy.get('[data-el="submit"]').click()
+        cy.wait('@updateSettings')
+
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_var"]').within(() => {
+            cy.get('[data-el="var-name"] input').should('be.disabled')
+            cy.get('[data-el="var-value"]').should('be.empty')
+            cy.get('[data-el="visibility"]').should('have.class', 'disabled')
+        })
+
+        // cleanup, can remove vars
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_var"] [data-el="remove"]').click()
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_password"] [data-el="remove"]').click()
+
+        cy.get('[data-el="submit"]').should('not.be.disabled')
+
+        cy.get('[data-el="submit"]').click()
+        cy.wait('@updateSettings')
+
+        cy.get('[data-el="submit"]').should('be.disabled')
+    })
+})

--- a/test/e2e/frontend/cypress/tests/instances/settings/environment.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances/settings/environment.spec.js
@@ -1,0 +1,101 @@
+describe('FlowForge - Instance - Settings Environment', () => {
+    let instanceId
+    beforeEach(() => {
+        cy.login('alice', 'aaPassword')
+        cy.home()
+
+        cy.request('GET', '/api/v1/teams/')
+            .then((response) => {
+                const team = response.body.teams[0]
+                return cy.request('GET', `/api/v1/teams/${team.id}/projects`)
+            })
+            .then((response) => {
+                instanceId = response.body.projects[0].id
+                cy.visit(`/instance/${instanceId}/settings/environment`)
+            })
+    })
+
+    it('can add, remove mark as hidden instance environment variables', () => {
+        cy.get('[data-el="env-vars-table"]').should('exist')
+        cy.get('[data-el="env-vars-table"]').should('be.visible')
+        cy.get('[data-el="env-vars-table"] tbody tr').should('have.length', 2)
+
+        cy.get('[data-el="submit"]').should('be.disabled')
+
+        cy.get('[data-el="add-variable"]').click()
+
+        cy.get('[data-el="submit"]').should('not.be.disabled')
+
+        cy.get('[data-el="env-vars-table"] tbody tr').should('have.length', 3)
+
+        // can remove an unsaved variable
+        cy.get('[data-el="env-vars-table"] [data-row="row-NEW"]').within(() => {
+            cy.get('[data-el="remove"]').click()
+        })
+
+        cy.get('[data-el="env-vars-table"] tbody tr').should('have.length', 2)
+
+        // can add a visible environment variable
+        cy.get('[data-el="add-variable"]').click()
+        cy.get('[data-el="submit"]').should('not.be.disabled')
+
+        cy.get('[data-el="env-vars-table"] [data-row="row-NEW"]').within(() => {
+            cy.get('[data-el="visibility"]').should('exist')
+            // filling in value first because changing the name will also change the selector
+            cy.get('[data-el="var-value"]').type('value')
+            cy.get('[data-el="var-name"]').type('new_var')
+        })
+
+        // can add a hidden environment variable
+        cy.get('[data-el="add-variable"]').click()
+        // previous entry changed name so new entry is the new row-NEW
+        cy.get('[data-el="env-vars-table"] [data-row="row-NEW"]').within(() => {
+            // filling in value first because changing the name will also change the selector
+            cy.get('[data-el="var-value"]').type('secret')
+            cy.get('[data-el="var-name"]').type('new_password')
+        })
+
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_password"]').within(() => {
+            cy.get('[data-el="visibility"]').click()
+        })
+        cy.intercept('PUT', '/api/*/projects/*').as('updateSettings')
+        cy.get('[data-el="submit"]').click()
+        cy.wait('@updateSettings')
+
+        cy.get('[data-el="submit"]').should('be.disabled')
+
+        // check that the hidden var name and visibility can't be changed
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_password"]').within(() => {
+            cy.get('[data-el="var-name"] input').should('be.disabled')
+            cy.get('[data-el="var-value"]').should('have.value', '')
+            cy.get('[data-el="visibility"]').should('have.class', 'disabled')
+        })
+
+        // can mark an existing env var as hidden
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_var"]').within(() => {
+            cy.get('[data-el="visibility"]').should('not.have.class', 'disabled')
+            cy.get('[data-el="visibility"]').should('not.be.disabled')
+            cy.get('[data-el="visibility"]').click()
+        })
+        cy.get('[data-el="submit"]').should('not.be.disabled')
+        cy.get('[data-el="submit"]').click()
+        cy.wait('@updateSettings')
+
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_var"]').within(() => {
+            cy.get('[data-el="var-name"] input').should('be.disabled')
+            cy.get('[data-el="var-value"]').should('be.empty')
+            cy.get('[data-el="visibility"]').should('have.class', 'disabled')
+        })
+
+        // cleanup, can remove vars
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_var"] [data-el="remove"]').click()
+        cy.get('[data-el="env-vars-table"] [data-row="row-new_password"] [data-el="remove"]').click()
+
+        cy.get('[data-el="submit"]').should('not.be.disabled')
+
+        cy.get('[data-el="submit"]').click()
+        cy.wait('@updateSettings')
+
+        cy.get('[data-el="submit"]').should('be.disabled')
+    })
+})

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -498,7 +498,8 @@ describe('Project API', function () {
                         dashboardUI: '/test-dash',
                         env: [
                             { name: 'one', value: 'a' },
-                            { name: 'two', value: 'b' }
+                            { name: 'two', value: 'b' },
+                            { name: 'three', value: 'c', hidden: true }
                         ]
                     }
                 )
@@ -560,6 +561,7 @@ describe('Project API', function () {
                 runtimeSettings.should.have.property('env')
                 runtimeSettings.env.should.have.property('one', 'a')
                 runtimeSettings.env.should.have.property('two', 'b')
+                runtimeSettings.env.should.have.property('three', '')
             })
 
             it('Create a project cloned from existing one - env-var keys only', async function () {
@@ -1621,7 +1623,8 @@ describe('Project API', function () {
                     codeEditor: 'monaco',
                     env: [
                         { name: 'one', value: 'a' },
-                        { name: 'two', value: 'b' }
+                        { name: 'two', value: 'b' },
+                        { name: 'three', value: 'c', hidden: true }
                     ]
                 }
             )
@@ -1633,7 +1636,8 @@ describe('Project API', function () {
                     settings: {
                         env: [
                             { name: 'one', value: '1' },
-                            { name: 'two', value: '2' }
+                            { name: 'two', value: '2' },
+                            { name: 'three', value: '3', hidden: true }
                         ]
                     }
                 },
@@ -1646,7 +1650,8 @@ describe('Project API', function () {
             newSettings.should.have.property('httpAdminRoot', '/test-red') // should be unchanged
             newSettings.should.have.property('env', [
                 { name: 'one', value: '1' },
-                { name: 'two', value: '2' }
+                { name: 'two', value: '2' },
+                { name: 'three', value: '3', hidden: true }
             ]) // should be unchanged
         })
         it('Change project env vars - member', async function () {
@@ -2612,6 +2617,52 @@ describe('Project API', function () {
             })
             response.should.have.property('statusCode')
             response.statusCode.should.eqls(400)
+        })
+        it('should return empty values for hidden env vars', async () => {
+            const projectSettings = await TestObjects.project1.getSetting('settings')
+            projectSettings.env = [{ name: 'hidden_var', value: 'hidden-content', hidden: true }]
+            await TestObjects.project1.updateSetting('settings', projectSettings)
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/projects/${app.project.id}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.should.have.property('statusCode')
+            response.statusCode.should.eqls(200)
+
+            const json = response.json()
+            json.settings.env[4].should.have.property('name', 'hidden_var')
+            json.settings.env[4].should.have.property('value', '')
+            json.settings.env[4].should.have.property('hidden', true)
+        })
+        it('should store hidden env vars', async () => {
+            const projectSettings = await TestObjects.project1.getSetting('settings')
+            projectSettings.env = [{ name: 'hidden_var', value: 'initial-content', hidden: true }]
+            await TestObjects.project1.updateSetting('settings', projectSettings)
+
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/projects/${app.project.id}`,
+                body: {
+                    settings: {
+                        env: [
+                            { name: 'hidden_var', value: 'updated-content', hidden: true }
+                        ]
+                    }
+                },
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            const json = response.json()
+
+            json.settings.env[4].should.have.property('name', 'hidden_var')
+            json.settings.env[4].should.have.property('value', '')
+            json.settings.env[4].should.have.property('hidden', true)
+
+            const updatedProjectSettings = await TestObjects.project1.getSetting('settings')
+            updatedProjectSettings.env[0].should.have.property('name', 'hidden_var')
+            updatedProjectSettings.env[0].should.have.property('value', 'updated-content')
+            updatedProjectSettings.env[0].should.have.property('hidden', true)
         })
         // it('Reject Illegal names', async function () {
         //     const response = await app.inject({

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -561,7 +561,7 @@ describe('Project API', function () {
                 runtimeSettings.should.have.property('env')
                 runtimeSettings.env.should.have.property('one', 'a')
                 runtimeSettings.env.should.have.property('two', 'b')
-                runtimeSettings.env.should.have.property('three', '')
+                runtimeSettings.env.should.have.property('three', 'c')
             })
 
             it('Create a project cloned from existing one - env-var keys only', async function () {


### PR DESCRIPTION
## Description

Allows setting of hidden env vars, once set they can only be updated or removed
- applies to both remote and hosted instances
- duplicating hosted instances preserves varhidden state
- other limitations described in closes https://github.com/FlowFuse/flowfuse/issues/4835
- updated error logging and validation to include env vars names starting with numbers
- fixes validation recursion
- fixes removal of unsaved vars

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4835

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

