### PR TITLE
PostHog - New "team-type-changed" event & add team type on team-created event

### DIFF
--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -223,12 +223,14 @@ const create = async (options) => {
         // PostHog Event & Group Capture
         product.capture('$ff-team-created', {
             'team-name': options.name,
+            'team-type-id': options.type,
             'created-at': res.data.createdAt
         }, {
             team: res.data.id
         })
         const props = {
             'team-name': options.name,
+            'team-type-id': options.type,
             'created-at': res.data.createdAt,
             'count-applications': 0,
             'count-instances': 0,


### PR DESCRIPTION
## Description

- Add new `ff-team-type-changed` event
- Add `team-type-id` to the team group object & `team-created` event

## Related Issue(s)

Closes https://github.com/FlowFuse/customer/issues/286
Closes https://github.com/FlowFuse/customer/issues/285