### PR TITLE
Fix dashboard role users blank page

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -63,11 +63,11 @@ module.exports = async function (app) {
     })
 
     async function getTeamDetails (request, reply, team) {
-        // if (!request.session.User?.admin && request.teamMembership.role < Roles.Viewer) {
-        //     // Return summary details for any role less than Viewer (eg dashboard)
-        //     reply.send(app.db.views.Team.teamSummary(team))
-        //     return
-        // }
+        if (!request.session.User?.admin && request.teamMembership.role < Roles.Viewer) {
+            // Return summary details for any role less than Viewer (eg dashboard)
+            reply.send(app.db.views.Team.teamSummary(team))
+            return
+        }
         const result = app.db.views.Team.team(team)
         result.instanceCountByType = await team.instanceCountByType()
         if (app.license.active() && app.billing) {

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -63,11 +63,11 @@ module.exports = async function (app) {
     })
 
     async function getTeamDetails (request, reply, team) {
-        if (!request.session.User?.admin && request.teamMembership.role < Roles.Viewer) {
-            // Return summary details for any role less than Viewer (eg dashboard)
-            reply.send(app.db.views.Team.teamSummary(team))
-            return
-        }
+        // if (!request.session.User?.admin && request.teamMembership.role < Roles.Viewer) {
+        //     // Return summary details for any role less than Viewer (eg dashboard)
+        //     reply.send(app.db.views.Team.teamSummary(team))
+        //     return
+        // }
         const result = app.db.views.Team.team(team)
         result.instanceCountByType = await team.instanceCountByType()
         if (app.license.active() && app.billing) {

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -127,9 +127,9 @@ const getters = {
                 }
 
                 // // dashboard users don't receive the team.type in the response payload
-                // if (state.teamMembership?.role === 5 && !state.team?.type?.properties) {
-                //     return true
-                // }
+                if (state.teamMembership?.role === 5 && !state.team?.type?.properties) {
+                    return true
+                }
 
                 let available = false
 

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -126,6 +126,11 @@ const getters = {
                     return false
                 }
 
+                // // dashboard users don't receive the team.type in the response payload
+                // if (state.teamMembership?.role === 5 && !state.team?.type?.properties) {
+                //     return true
+                // }
+
                 let available = false
 
                 // loop over the different instance types

--- a/test/e2e/frontend/cypress/tests/team/instances.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/instances.spec.js
@@ -55,6 +55,14 @@ describe('Team - Instances', () => {
     })
 
     describe('Users with dashboard only permissions', () => {
+        beforeEach(() => {
+            // viewer roled users don't receive the teamType in the team payload
+            cy.intercept('get', '/api/*/teams/slug/bteam', req => req.reply(res => {
+                const { type, ...response } = res.body
+                res.send(response)
+            })).as('getTeam')
+        })
+
         it('are shown a static message if no dashboard instances are found', () => {
             cy.intercept('GET', '/api/*/teams/*/user',
                 req => req.reply(res => {
@@ -73,8 +81,9 @@ describe('Team - Instances', () => {
                 }).as('getDashboardInstances')
 
             cy.login('bob', 'bbPassword')
-            cy.visit('/')
+            cy.visit('/team/bteam')
 
+            cy.wait('@getTeam')
             cy.wait('@getUser')
             cy.wait('@getDashboardInstances')
 
@@ -130,8 +139,9 @@ describe('Team - Instances', () => {
                 }).as('getDashboardInstances')
 
             cy.login('bob', 'bbPassword')
-            cy.visit('/')
+            cy.visit('/team/bteam')
 
+            cy.wait('@getTeam')
             cy.wait('@getUser')
             cy.wait('@getDashboardInstances')
 


### PR DESCRIPTION
## Description

Dashboard role users receive the teamSummary payload which omits the team.type which is required in the featuresCheck getter to deduce the freemium tier causing the frontend to crash.

The fix can be sorted either by responding with the full team payload and allowing the FE to deduce the free tier and render the dashboard list based on team tier and role or adding an exclusion for dashboard roled users in the featuresCheck (but that could lead to mixed messaging for dashboard users on freemium tiered teams) 

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5038

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

