### PR TITLE
Replace the team selection drowpdown with the listbox component

### DIFF
--- a/frontend/src/ui-components/components/form/ListBox.vue
+++ b/frontend/src/ui-components/components/form/ListBox.vue
@@ -20,7 +20,7 @@
                 leave-to-class="opacity-0"
             >
                 <ListboxOptions class="absolute w-full overflow-auto bg-white py-1 ff-options">
-                    <slot name="options">
+                    <slot name="options" :options="options">
                         <ListboxOption
                             v-for="option in options"
                             v-slot="{ active, selected }"


### PR DESCRIPTION
## Description

Replace the team selection drowpdown with the listbox component

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/4475

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

