### PR TITLE
ci: Add `nr-assistant` package build step to a pre-staging deployment

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -22,6 +22,10 @@ on:
         description: 'flowfuse/nr-file-nodes branch name'
         required: true
         default: 'main'
+      nr_assistant_branch:
+        description: 'flowfuse/nr-assistant branch name'
+        required: true
+        default: 'main'
   pull_request:
     types: 
       - opened
@@ -120,16 +124,34 @@ jobs:
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
+  publish_nr_assistant:
+    name: Build and publish nr-assistant package
+    needs: validate-user
+    if: |
+      needs.validate-user.outputs.is_org_member == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.nr_assistant_branch != 'main'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
+    with:
+      package_name: nr-assistant
+      publish_package: true
+      repository_name: 'FlowFuse/nr-assistant'
+      branch_name: ${{ inputs.nr_assistant_branch }}
+      release_name: "pre-staging-${{ inputs.nr_assistant_branch }}"
+    secrets:
+      npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
   publish_nr_launcher:
     name: Build and publish nr-launcher package
     needs: 
       - validate-user
       - publish_nr_project_nodes
       - publish_nr_file_nodes
+      - publish_nr_assistant
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      (always() && inputs.nr_launcher_branch != 'main') || needs.publish_nr_project_nodes.result == 'success' || needs.publish_nr_file_nodes.result == 'success'
+      (always() && inputs.nr_launcher_branch != 'main') || needs.publish_nr_project_nodes.result == 'success' || needs.publish_nr_file_nodes.result == 'success' || needs.publish_nr_assistant.result == 'success'
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.38.0'
     with:
       package_name: flowfuse-nr-launcher
@@ -140,7 +162,7 @@ jobs:
       package_dependencies: |
         @flowfuse/nr-project-nodes=${{ inputs.nr_project_nodes_branch != 'main' && needs.publish_nr_project_nodes.outputs.release_name || 'nightly' }}
         @flowfuse/nr-file-nodes=${{ inputs.nr_file_nodes_branch != 'main' && needs.publish_nr_file_nodes.outputs.release_name || 'nightly' }}
-        @flowfuse/nr-assistant=nightly
+        @flowfuse/nr-assistant=${{ inputs.nr_assistant_branch != 'main' && needs.publish_nr_assistant.outputs.release_name || 'nightly' }}
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 


### PR DESCRIPTION
.## Description

This pull request includes changes to the `.github/workflows/branch-deploy.yaml` file to add support for building and publishing the `nr-assistant` package and using this package on a pre-staging environment. 
The most important changes include adding a new input parameter for the `nr-assistant` branch, creating a new job to publish the `nr-assistant` package, and updating dependencies to include the `nr-assistant` package.

Improvements to the workflow:

* Added a new input parameter `nr_assistant_branch` to specify the branch name for the `nr-assistant` package.
* Created a new job `publish_nr_assistant` to build and publish the `nr-assistant` package if certain conditions are met.
* Updated the `publish_nr_launcher` job to include a dependency on the `publish_nr_assistant` job and to check the result of the `publish_nr_assistant` job.
* Updated the `package_dependencies` to include the `nr-assistant` package with the appropriate release name based on the branch

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/596

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

