### PR TITLE
Fix hidden env vars getting overwritten to blank value when updating other env-vars

### DIFF
--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -646,7 +646,17 @@ module.exports = async function (app) {
         const currentSettings = await request.device.getAllSettings()
         // remove any extra properties from env to ensure they match the format of the body data
         // and prevent updates from being logged for unchanged values
-        currentSettings.env = (currentSettings.env || []).map(e => ({ name: e.name, value: e.value }))
+        currentSettings.env = (currentSettings.env || []).map(e => ({ name: e.name, value: e.value, hidden: e.hidden ?? false }))
+        request.body.env.map(env => {
+            if (env.hidden === true && env.value === '') {
+                // we need to re-map the hidden value so it won't get overwritten
+                const existingVar = currentSettings.env.find(currentEnv => currentEnv.name === env.name)
+                if (existingVar) {
+                    env.value = existingVar.value
+                }
+            }
+            return env
+        })
         const captureUpdates = (key) => {
             if (key === 'env') {
                 // transform the env array to a map for better logging format

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -647,16 +647,18 @@ module.exports = async function (app) {
         // remove any extra properties from env to ensure they match the format of the body data
         // and prevent updates from being logged for unchanged values
         currentSettings.env = (currentSettings.env || []).map(e => ({ name: e.name, value: e.value, hidden: e.hidden ?? false }))
-        request.body.env.map(env => {
-            if (env.hidden === true && env.value === '') {
-                // we need to re-map the hidden value so it won't get overwritten
-                const existingVar = currentSettings.env.find(currentEnv => currentEnv.name === env.name)
-                if (existingVar) {
-                    env.value = existingVar.value
+        if (request.body.env) {
+            request.body.env.map(env => {
+                if (env.hidden === true && env.value === '') {
+                    // we need to re-map the hidden value so it won't get overwritten
+                    const existingVar = currentSettings.env.find(currentEnv => currentEnv.name === env.name)
+                    if (existingVar) {
+                        env.value = existingVar.value
+                    }
                 }
-            }
-            return env
-        })
+                return env
+            })
+        }
         const captureUpdates = (key) => {
             if (key === 'env') {
                 // transform the env array to a map for better logging format


### PR DESCRIPTION
## Description

Fixes device hidden env vars getting overwritten when altering other env vars.

Because we're sending hidden env vars as empty values to the frontend in order to mask their value, they need to get re-hydrated when attempting to update them so they won't get overwritten on subsequent updates

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5063

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

