### PR TITLE
Add support for httpNodeAuth settings on devices

### DIFF
--- a/forge/db/controllers/AuthClient.js
+++ b/forge/db/controllers/AuthClient.js
@@ -23,6 +23,21 @@ module.exports = {
         return client
     },
 
+    createClientForDevice: async function (app, device) {
+        const existingAuthClient = await device.getAuthClient()
+        if (existingAuthClient) {
+            // TODO: are there sessions to expire as well?
+            await existingAuthClient.destroy()
+        }
+
+        const client = {
+            clientID: generateToken(32, 'ffd'),
+            clientSecret: generateToken(48)
+        }
+        await device.createAuthClient(client)
+        return client
+    },
+
     getAuthClient: async function (app, clientID, clientSecret) {
         const client = await app.db.models.AuthClient.findOne({
             where: { clientID }

--- a/forge/db/controllers/AuthClient.js
+++ b/forge/db/controllers/AuthClient.js
@@ -34,7 +34,11 @@ module.exports = {
             clientID: generateToken(32, 'ffd'),
             clientSecret: generateToken(48)
         }
-        await device.createAuthClient(client)
+        await app.db.models.AuthClient.create({
+            ownerType: 'device',
+            ownerId: '' + device.id,
+            ...client
+        })
         return client
     },
 

--- a/forge/db/controllers/AuthClient.js
+++ b/forge/db/controllers/AuthClient.js
@@ -38,6 +38,13 @@ module.exports = {
         return client
     },
 
+    removeClientForDevice: async function (app, device) {
+        const existingAuthClient = await device.getAuthClient()
+        if (existingAuthClient) {
+            await existingAuthClient.destroy()
+        }
+    },
+
     getAuthClient: async function (app, clientID, clientSecret) {
         const client = await app.db.models.AuthClient.findOne({
             where: { clientID }

--- a/forge/db/models/AuthClient.js
+++ b/forge/db/models/AuthClient.js
@@ -22,6 +22,9 @@ module.exports = {
     },
     associations: function (M) {
         this.belongsTo(M.Project, { foreignKey: 'ownerId', constraints: false })
+        // Also belongsTo Device - but not adding the association as we don't
+        // want the sequelize mixins to be added to the Device model - they don't
+        // handle the casting from int to string for the deviceId/ownerId
     },
     finders: function (M) {
         return {

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -15,7 +15,8 @@ const ALLOWED_SETTINGS = {
     autoSnapshot: 1,
     editor: 1,
     env: 1,
-    palette: 1
+    palette: 1,
+    security: 1
 }
 
 const DEFAULT_SETTINGS = {
@@ -70,6 +71,13 @@ module.exports = {
         this.hasMany(M.DeviceSettings)
         this.hasMany(M.ProjectSnapshot) // associate device at application level with snapshots
         this.belongsTo(M.DeviceGroup, { foreignKey: { allowNull: true } }) // SEE: forge/db/models/DeviceGroup.js for the other side of this relationship
+        this.hasOne(M.AuthClient, {
+            foreignKey: 'ownerId',
+            constraints: false,
+            scope: {
+                ownerType: 'device'
+            }
+        })
     },
     hooks: function (M, app) {
         return {
@@ -135,6 +143,12 @@ module.exports = {
                     }
                 })
                 await M.BrokerClient.destroy({
+                    where: {
+                        ownerType: 'device',
+                        ownerId: '' + device.id
+                    }
+                })
+                await M.AuthClient.destroy({
                     where: {
                         ownerType: 'device',
                         ownerId: '' + device.id

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -71,13 +71,10 @@ module.exports = {
         this.hasMany(M.DeviceSettings)
         this.hasMany(M.ProjectSnapshot) // associate device at application level with snapshots
         this.belongsTo(M.DeviceGroup, { foreignKey: { allowNull: true } }) // SEE: forge/db/models/DeviceGroup.js for the other side of this relationship
-        this.hasOne(M.AuthClient, {
-            foreignKey: 'ownerId',
-            constraints: false,
-            scope: {
-                ownerType: 'device'
-            }
-        })
+
+        // Also hasOne AuthClient (for ff-auth) - but not adding the association as we don't
+        // want the sequelize mixins to be added to the Device model - they don't
+        // handle the casting from int to string for the deviceId/ownerId
     },
     hooks: function (M, app) {
         return {
@@ -182,6 +179,13 @@ module.exports = {
                 async getAccessToken () {
                     return M.AccessToken.findOne({
                         where: { ownerId: '' + this.id, ownerType: 'device', scope: 'device' }
+                    })
+                },
+                async getAuthClient () {
+                    // Cannot use a hasOne association as the resulting getAuthClient
+                    // mixin doesn't know to cast this.id to a string
+                    return M.AuthClient.findOne({
+                        where: { ownerId: '' + this.id, ownerType: 'device' }
                     })
                 },
                 async updateSettingsHash (settings) {

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -692,6 +692,9 @@ module.exports = async function (app) {
                         request.body.security.httpNodeAuth.pass = hash(request.body.security.httpNodeAuth.pass)
                     }
                 }
+                if (request.body.security.httpNodeAuth.type !== 'flowforge-user') {
+                    await app.db.controllers.AuthClient.removeClientForDevice(request.device)
+                }
             }
             await request.device.updateSettings(request.body)
             const keys = Object.keys(request.body)

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -251,6 +251,18 @@ module.exports = async function (app) {
             enabled: app.config.assistant?.enabled || false,
             requestTimeout: app.config.assistant?.requestTimeout || 60000
         }
+
+        if (settings.security?.httpNodeAuth?.type) {
+            response.security = settings.security
+            if (response.security.httpNodeAuth.type === 'flowforge-user') {
+                // Convert the old 'flowforge-user' type to 'ff-user'
+                response.security.httpNodeAuth.type = 'ff-user'
+                // Regenerate the auth client for this device
+                const authClient = await app.db.controllers.AuthClient.createClientForDevice(request.device)
+                response.security.httpNodeAuth.clientID = authClient.clientID
+                response.security.httpNodeAuth.clientSecret = authClient.clientSecret
+            }
+        }
         reply.send(response)
     })
 }

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -183,8 +183,13 @@ module.exports = async function (app) {
                     if (!authClient) {
                         return badRequest(reply, 'invalid_request', 'Invalid client_id')
                     }
-                    const project = await app.db.models.Project.byId(authClient.ownerId)
-                    const teamMembership = await request.session.User.getTeamMembership(project.TeamId)
+                    let owner = null
+                    if (authClient.ownerType === 'project') {
+                        owner = await app.db.models.Project.byId(authClient.ownerId)
+                    } else if (authClient.ownerType === 'device') {
+                        owner = await app.db.models.Device.byId(parseInt(authClient.ownerId))
+                    }
+                    const teamMembership = await request.session.User.getTeamMembership(owner.TeamId)
                     if (!teamMembership && !request.session.User.admin) {
                         // This user is neither a team member, nor an admin - reject
                         return redirectInvalidRequest(reply, requestObject.redirect_uri, 'access_denied', 'Access Denied', requestObject.state)
@@ -192,7 +197,7 @@ module.exports = async function (app) {
                     const isEditor = /^editor($|-)/.test(requestObject.scope)
                     if (isEditor) {
                         // Allow admin users to have read-access to flows
-                        const protectedInstance = await project.getSetting(KEY_PROTECTED)
+                        const protectedInstance = await owner.getSetting(KEY_PROTECTED)
                         const canReadFlows = request.session.User.admin || app.hasPermission(teamMembership, 'project:flows:view')
                         const canWriteFlows = app.hasPermission(teamMembership, 'project:flows:edit') && !protectedInstance?.enabled
                         const canReadHTTP = app.hasPermission(teamMembership, 'project:flows:http')
@@ -332,11 +337,20 @@ module.exports = async function (app) {
                     return badRequest(reply, 'invalid_request', 'Invalid client_id')
                 }
 
-                const project = await app.db.models.Project.byId(authClient.ownerId)
-                const teamMembership = await app.db.models.TeamMember.findOne({ where: { TeamId: project.TeamId, UserId: requestObject.userId } })
+                let owner = null
+                if (authClient.ownerType === 'project') {
+                    owner = await app.db.models.Project.byId(authClient.ownerId)
+                } else if (authClient.ownerType === 'device') {
+                    owner = await app.db.models.Device.byId(parseInt(authClient.ownerId))
+                }
+
+                const teamMembership = await app.db.models.TeamMember.findOne({ where: { TeamId: owner.TeamId, UserId: requestObject.userId } })
                 const user = await app.db.models.User.findOne({ where: { id: requestObject.userId }, attributes: ['admin'] })
                 const canReadFlows = user.admin || app.hasPermission(teamMembership, 'project:flows:view')
-                const protectedInstance = await project.getSetting(KEY_PROTECTED)
+                let protectedInstance = null
+                if (authClient.ownerType === 'project') {
+                    protectedInstance = await owner.getSetting(KEY_PROTECTED)
+                }
                 const canWriteFlows = app.hasPermission(teamMembership, 'project:flows:edit') && !protectedInstance?.enabled
                 const canReadHTTP = app.hasPermission(teamMembership, 'project:flows:http')
                 const isEditor = /^editor($|-)/.test(requestObject.scope)
@@ -408,9 +422,14 @@ module.exports = async function (app) {
 
                 // Check the owner of the existing session still has access to the project
                 // this client is owned by
-                const project = await app.db.models.Project.byId(authClient.ownerId)
+                let owner = null
+                if (authClient.ownerType === 'project') {
+                    owner = await app.db.models.Project.byId(authClient.ownerId)
+                } else if (authClient.ownerType === 'device') {
+                    owner = await app.db.models.Device.byId(parseInt(authClient.ownerId))
+                }
                 const user = await app.db.models.User.findOne({ where: { id: parseInt(existingToken.ownerId) }, attributes: ['admin'] })
-                const teamMembership = await app.db.models.TeamMember.findOne({ where: { TeamId: project.TeamId, UserId: parseInt(existingToken.ownerId) } })
+                const teamMembership = await app.db.models.TeamMember.findOne({ where: { TeamId: owner.TeamId, UserId: parseInt(existingToken.ownerId) } })
                 const canReadFlows = user.admin || app.hasPermission(teamMembership, 'project:flows:view')
                 const canWriteFlows = app.hasPermission(teamMembership, 'project:flows:edit')
 

--- a/frontend/src/pages/device/Settings/Security.vue
+++ b/frontend/src/pages/device/Settings/Security.vue
@@ -1,0 +1,148 @@
+<template>
+    <form class="space-y-6">
+        <div
+            v-if="!securityOptionsSupported"
+            class="ff-page-banner my-4"
+            data-el="settings-banner-feature-unavailable"
+        >
+            These options require Device Agent v3.1 or later to take effect.
+        </div>
+        <TemplateSettingsSecurity
+            v-model="editable"
+            :editTemplate="false"
+            :team="team"
+        />
+        <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
+            <div v-if="!securityOptionsSupported" class="ff-description italic mb-2">
+                These options require Device Agent v3.1 or later to take effect.
+            </div>
+            <ff-button data-el="submit" size="small" :disabled="!unsavedChanges" @click="saveSettings()">
+                Save Settings
+            </ff-button>
+        </div>
+    </form>
+</template>
+
+<script>
+import semver from 'semver'
+import { mapState } from 'vuex'
+
+import deviceApi from '../../../api/devices.js'
+
+import permissionsMixin from '../../../mixins/Permissions.js'
+import Alerts from '../../../services/alerts.js'
+
+import TemplateSettingsSecurity from '../../admin/Template/sections/Security.vue'
+
+export default {
+    name: 'DeviceSettingsSecurity',
+    components: {
+        TemplateSettingsSecurity
+    },
+    mixins: [permissionsMixin],
+    props: {
+        device: { type: Object, default: null }
+    },
+    emits: ['device-updated', 'assign-device'],
+    data () {
+        return {
+            editable: {
+                settings: {
+                    httpNodeAuth_type: '',
+                    httpNodeAuth_user: '',
+                    httpNodeAuth_pass: ''
+                },
+                policy: {
+                    httpNodeAuth_type: true,
+                    httpNodeAuth_user: true,
+                    httpNodeAuth_pass: true
+                },
+                changed: {
+                    settings: {},
+                    policy: { }
+                },
+                errors: {}
+            },
+            original: {
+                httpNodeAuth_type: '',
+                httpNodeAuth_user: '',
+                httpNodeAuth_pass: ''
+            }
+        }
+    },
+    computed: {
+        ...mapState('account', ['teamMembership']),
+        securityOptionsSupported () {
+            if (!this.device.agentVersion) {
+                // Device has not called home yet - so we don't know what agent
+                // version it is running.
+                return false
+            }
+            return semver.gte(this.device.agentVersion, '3.1.0')
+        },
+        unsavedChanges () {
+            if (this.editable.settings.httpNodeAuth_type !== this.original.httpNodeAuth_type) {
+                return true
+            }
+            if (this.editable.settings.httpNodeAuth_type === 'basic') {
+                if (this.editable.settings.httpNodeAuth_user !== this.original.httpNodeAuth_user) {
+                    return true
+                }
+                if (this.editable.settings.httpNodeAuth_pass !== this.original.httpNodeAuth_pass) {
+                    return true
+                }
+            }
+            return false
+        }
+    },
+    watch: {
+        device: {
+            handler () {
+                this.getSettings()
+            },
+            deep: true
+        }
+    },
+    mounted () {
+        this.getSettings()
+    },
+    methods: {
+        async updateDevice () {
+            await deviceApi.updateDevice(this.device.id, { name: this.input.deviceName })
+            this.$emit('device-updated')
+        },
+        getSettings: async function () {
+            if (this.device) {
+                const settings = await deviceApi.getSettings(this.device.id)
+                this.editable.settings.httpNodeAuth_type = settings.security?.httpNodeAuth?.type || 'none'
+                this.editable.settings.httpNodeAuth_user = settings.security?.httpNodeAuth?.user || ''
+                this.editable.settings.httpNodeAuth_pass = settings.security?.httpNodeAuth?.pass || ''
+                if (this.editable.settings.httpNodeAuth_pass === true) {
+                    this.editable.settings.httpNodeAuth_pass = '_PLACEHOLDER_'
+                }
+
+                this.original.httpNodeAuth_type = this.editable.settings.httpNodeAuth_type
+                this.original.httpNodeAuth_user = this.editable.settings.httpNodeAuth_user
+                this.original.httpNodeAuth_pass = this.editable.settings.httpNodeAuth_pass
+            }
+        },
+        saveSettings: async function () {
+            const settings = { security: { } }
+            if (this.editable.settings.httpNodeAuth_type !== 'none') {
+                settings.security.httpNodeAuth = {
+                    type: this.editable.settings.httpNodeAuth_type
+                }
+                if (this.editable.settings.httpNodeAuth_type === 'basic') {
+                    settings.security.httpNodeAuth.user = this.editable.settings.httpNodeAuth_user
+                    if (this.editable.settings.httpNodeAuth_pass !== '_PLACEHOLDER_') {
+                        settings.security.httpNodeAuth.pass = this.editable.settings.httpNodeAuth_pass
+                    }
+                }
+            }
+            await deviceApi.updateSettings(this.device.id, settings)
+            this.$emit('device-updated')
+            Alerts.emit('Device settings successfully updated. NOTE: changes will be applied once the device restarts.', 'confirmation', 6000)
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/device/Settings/index.vue
+++ b/frontend/src/pages/device/Settings/index.vue
@@ -47,6 +47,7 @@ export default {
             ]
             if (this.device.ownerType === 'application' && this.hasPermission('device:edit')) {
                 this.sideNavigation.push({ name: 'Editor', path: './editor' })
+                this.sideNavigation.push({ name: 'Security', path: './security' })
                 this.sideNavigation.push({ name: 'Palette', path: './palette' })
             }
             if (this.hasPermission('device:edit')) {

--- a/frontend/src/pages/device/routes.js
+++ b/frontend/src/pages/device/routes.js
@@ -7,6 +7,7 @@ import DeviceSettingsEditor from './Settings/Editor.vue'
 import DeviceSettingsEnvironment from './Settings/Environment.vue'
 import DeviceSettingsGeneral from './Settings/General.vue'
 import DeviceSettingsPalette from './Settings/Palette.vue'
+import DeviceSettingsSecurity from './Settings/Security.vue'
 import DeviceSettings from './Settings/index.vue'
 import DeviceSnapshots from './Snapshots/index.vue'
 
@@ -38,6 +39,7 @@ export default [
                     { path: 'general', component: DeviceSettingsGeneral },
                     { path: 'environment', component: DeviceSettingsEnvironment },
                     { path: 'editor', component: DeviceSettingsEditor },
+                    { path: 'security', component: DeviceSettingsSecurity },
                     { path: 'palette', component: DeviceSettingsPalette },
                     { path: 'danger', component: DeviceSettingsDanger }
                 ]

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -1,7 +1,7 @@
 const should = require('should') // eslint-disable-line
 const sinon = require('sinon')
 
-const { sha256 } = require('../../../../../forge/db/utils')
+const { sha256, compareHash } = require('../../../../../forge/db/utils')
 const setup = require('../setup')
 
 const FF_UTIL = require('flowforge-test-utils')
@@ -152,6 +152,37 @@ describe('Device API', async function () {
             },
             cookies: { sid: token }
         })
+    }
+    async function getLiveSettings (device) {
+        const response = await app.inject({
+            method: 'GET',
+            url: `/api/v1/devices/${device.id}/live/settings`,
+            headers: {
+                authorization: `Bearer ${device.credentials.token}`
+            }
+        })
+        response.statusCode.should.equal(200)
+        return response.json()
+    }
+    async function getSettings (device, token) {
+        const response = await app.inject({
+            method: 'GET',
+            url: `/api/v1/devices/${device.id}/settings`,
+            cookies: { sid: token }
+        })
+        response.statusCode.should.equal(200)
+        return response.json()
+    }
+
+    async function updateSettings (device, token, settings) {
+        const response = await app.inject({
+            method: 'PUT',
+            url: `/api/v1/devices/${device.id}/settings`,
+            body: settings,
+            cookies: { sid: token }
+        })
+        response.statusCode.should.equal(200)
+        response.json().should.have.property('status', 'okay')
     }
 
     describe('Create device', async function () {
@@ -1118,24 +1149,10 @@ describe('Device API', async function () {
         describe('edit device settings', function () {
             it('can set env vars for the device', async function () {
                 const device = await createDevice({ name: 'Ad1', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
-                const response = await app.inject({
-                    method: 'PUT',
-                    url: `/api/v1/devices/${device.id}/settings`,
-                    body: {
-                        env: [{ name: 'a', value: 'foo' }]
-                    },
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
-                response.statusCode.should.equal(200)
-                response.json().should.have.property('status', 'okay')
 
-                const settingsResponse = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/devices/${device.id}/settings`,
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
+                await updateSettings(device, TestObjects.tokens.alice, { env: [{ name: 'a', value: 'foo' }] })
 
-                const settings = settingsResponse.json()
+                const settings = await getSettings(device, TestObjects.tokens.alice)
                 settings.should.have.property('env')
                 const nonPlatformVars = settings.env.filter(e => !e.name.startsWith('FF_')) // ignore platform defined vars
                 nonPlatformVars.should.have.length(1)
@@ -1145,24 +1162,10 @@ describe('Device API', async function () {
             })
             it('can set hidden env vars for the device', async function () {
                 const device = await createDevice({ name: 'Ad1', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
-                const response = await app.inject({
-                    method: 'PUT',
-                    url: `/api/v1/devices/${device.id}/settings`,
-                    body: {
-                        env: [{ name: 'a', value: 'foo' }, { name: 'b', value: 'bar', hidden: true }]
-                    },
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
-                response.statusCode.should.equal(200)
-                response.json().should.have.property('status', 'okay')
 
-                const settingsResponse = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/devices/${device.id}/settings`,
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
+                await updateSettings(device, TestObjects.tokens.alice, { env: [{ name: 'a', value: 'foo' }, { name: 'b', value: 'bar', hidden: true }] })
 
-                const settings = settingsResponse.json()
+                const settings = await getSettings(device, TestObjects.tokens.alice)
                 settings.should.have.property('env')
                 const nonPlatformVars = settings.env.filter(e => !e.name.startsWith('FF_')) // ignore platform defined vars
                 nonPlatformVars.should.have.length(2)
@@ -1176,24 +1179,10 @@ describe('Device API', async function () {
 
             it('non team owner can set env vars for the device', async function () {
                 const device = await createDevice({ name: 'Ad1', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
-                const response = await app.inject({
-                    method: 'PUT',
-                    url: `/api/v1/devices/${device.id}/settings`,
-                    body: {
-                        env: [{ name: 'a', value: 'foo' }]
-                    },
-                    cookies: { sid: TestObjects.tokens.chris }
-                })
-                response.statusCode.should.equal(200)
-                response.json().should.have.property('status', 'okay')
 
-                const settingsResponse = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/devices/${device.id}/settings`,
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
+                await updateSettings(device, TestObjects.tokens.chris, { env: [{ name: 'a', value: 'foo' }] })
 
-                const settings = settingsResponse.json()
+                const settings = await getSettings(device, TestObjects.tokens.alice)
                 settings.should.have.property('env')
                 const nonPlatformVars = settings.env.filter(e => !e.name.startsWith('FF_')) // ignore platform defined vars
                 nonPlatformVars.should.have.length(1)
@@ -1203,32 +1192,126 @@ describe('Device API', async function () {
             })
             it('owner set .npmrc', async function () {
                 const device = await createDevice({ name: 'Ad2', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
-                const response = await app.inject({
-                    method: 'PUT',
-                    url: `/api/v1/devices/${device.id}/settings`,
-                    body: {
-                        palette: {
-                            npmrc: '; testing',
-                            catalogues: ['http://example.com/catalog.json']
-                        }
-                    },
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
-                response.statusCode.should.equal(200)
-                response.json().should.have.property('status', 'okay')
 
-                const settingsResponse = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/devices/${device.id}/settings`,
-                    cookies: { sid: TestObjects.tokens.alice }
+                await updateSettings(device, TestObjects.tokens.alice, {
+                    palette: {
+                        npmrc: '; testing',
+                        catalogues: ['http://example.com/catalog.json']
+                    }
                 })
 
-                const settings = settingsResponse.json()
+                const settings = await getSettings(device, TestObjects.tokens.alice)
                 settings.should.have.property('palette')
                 settings.palette.should.have.property('npmrc', '; testing')
                 settings.palette.should.have.property('catalogues')
                 settings.palette.catalogues.should.have.length(1)
                 settings.palette.catalogues[0].should.equal('http://example.com/catalog.json')
+            })
+
+            it('can set httpNodeAuth to basic', async function () {
+                const device = await createDevice({ name: 'AuthSettingsD1', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
+
+                await updateSettings(device, TestObjects.tokens.alice, {
+                    security: {
+                        httpNodeAuth: {
+                            type: 'basic',
+                            user: 'userName',
+                            pass: 'passWord'
+                        }
+                    }
+                })
+
+                const settings = await getSettings(device, TestObjects.tokens.alice)
+
+                settings.should.have.property('security')
+                settings.security.should.have.property('httpNodeAuth')
+                settings.security.httpNodeAuth.should.have.property('type', 'basic')
+                settings.security.httpNodeAuth.should.have.property('user', 'userName')
+                // Verify password isn't returned
+                settings.security.httpNodeAuth.should.have.property('pass', true)
+
+                // Verify the live settings include the hashed credentials
+                let liveSettings = await getLiveSettings(device)
+                liveSettings.should.have.property('security')
+                liveSettings.security.should.have.property('httpNodeAuth')
+                liveSettings.security.httpNodeAuth.should.have.property('type', 'basic')
+                liveSettings.security.httpNodeAuth.should.have.property('user', 'userName')
+                liveSettings.security.httpNodeAuth.should.have.property('pass')
+                compareHash('passWord', liveSettings.security.httpNodeAuth.pass).should.be.true()
+
+                // Verify that updating the username does not clear the password
+                await updateSettings(device, TestObjects.tokens.alice, {
+                    security: {
+                        httpNodeAuth: {
+                            type: 'basic',
+                            user: 'newUserName'
+                        }
+                    }
+                })
+                liveSettings = await getLiveSettings(device)
+                liveSettings.should.have.property('security')
+                liveSettings.security.should.have.property('httpNodeAuth')
+                liveSettings.security.httpNodeAuth.should.have.property('type', 'basic')
+                liveSettings.security.httpNodeAuth.should.have.property('user', 'newUserName')
+                liveSettings.security.httpNodeAuth.should.have.property('pass')
+                compareHash('passWord', liveSettings.security.httpNodeAuth.pass).should.be.true()
+
+                // Verify that changing to none clears out the credentials information
+                await updateSettings(device, TestObjects.tokens.alice, { security: { httpNodeAuth: { } } })
+
+                liveSettings = await getLiveSettings(device)
+                liveSettings.should.have.property('security')
+                liveSettings.security.should.have.property('httpNodeAuth', {})
+            })
+            it('can set httpNodeAuth to flowforge-user', async function () {
+                const device = await createDevice({ name: 'AuthSettingsD2', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
+                await updateSettings(device, TestObjects.tokens.alice, {
+                    security: {
+                        httpNodeAuth: {
+                            type: 'flowforge-user'
+                        }
+                    }
+                })
+
+                const settings = await getSettings(device, TestObjects.tokens.alice)
+                settings.should.have.property('security')
+                settings.security.should.have.property('httpNodeAuth')
+                settings.security.httpNodeAuth.should.have.property('type', 'flowforge-user')
+
+                // Verify the deviceLive settings are updated
+                let liveSettings = await getLiveSettings(device)
+                liveSettings.should.have.property('security')
+                liveSettings.security.should.have.property('httpNodeAuth')
+                // Note: we map 'flowforge-user' to 'ff-user' for devices
+                liveSettings.security.httpNodeAuth.should.have.property('type', 'ff-user')
+                liveSettings.security.httpNodeAuth.should.have.property('clientID')
+                liveSettings.security.httpNodeAuth.should.have.property('clientSecret')
+
+                // Store the current values
+                const { clientID, clientSecret } = liveSettings.security.httpNodeAuth
+
+                const [deviceId] = app.db.models.Device.decodeHashid(device.id)
+                let authClient = await app.db.models.AuthClient.findOne({ where: { ownerType: 'device', ownerId: '' + deviceId } })
+                authClient.clientID.should.equal(clientID)
+                compareHash(clientSecret, authClient.clientSecret).should.be.true()
+
+                // Get the live settings again - verify the client credentials have been refreshed
+                liveSettings = await getLiveSettings(device)
+                liveSettings.security.httpNodeAuth.should.have.property('clientID')
+                liveSettings.security.httpNodeAuth.should.have.property('clientSecret')
+                liveSettings.security.httpNodeAuth.clientID.should.not.equal(clientID)
+                liveSettings.security.httpNodeAuth.clientSecret.should.not.equal(clientSecret)
+
+                // Verify that changing to none clears out the credentials information
+                await updateSettings(device, TestObjects.tokens.alice, { security: { httpNodeAuth: { } } })
+
+                liveSettings = await getLiveSettings(device)
+                liveSettings.should.have.property('security')
+                liveSettings.security.should.have.property('httpNodeAuth', {})
+
+                // Verify the AuthClient has been removed
+                authClient = await app.db.models.AuthClient.findOne({ where: { ownerType: 'device', ownerId: '' + deviceId } })
+                should.not.exist(authClient)
             })
         })
 
@@ -2017,16 +2100,7 @@ describe('Device API', async function () {
             const deviceSettings = await TestObjects.deviceProject.getSetting('deviceSettings')
             dbDevice.targetSnapshotId = deviceSettings?.targetSnapshot
             await dbDevice.save()
-            const response = await app.inject({
-                method: 'GET',
-                url: `/api/v1/devices/${device.id}/live/settings`,
-                headers: {
-                    authorization: `Bearer ${device.credentials.token}`,
-                    'content-type': 'application/json'
-                }
-            })
-            const body = JSON.parse(response.body)
-            response.statusCode.should.equal(200)
+            const body = await getLiveSettings(device)
             body.should.have.property('hash').which.equal(dbDevice.settingsHash)
             body.should.have.property('env').which.have.property('FOO')
             body.should.have.property('env').which.have.property('FF_DEVICE_ID', device.id)
@@ -2049,16 +2123,7 @@ describe('Device API', async function () {
             await dbDevice.save()
             app.config.features.register('projectComms', true, true)
             app.config.features.register('shared-library', true, true)
-            const response = await app.inject({
-                method: 'GET',
-                url: `/api/v1/devices/${device.id}/live/settings`,
-                headers: {
-                    authorization: `Bearer ${device.credentials.token}`,
-                    'content-type': 'application/json'
-                }
-            })
-            const body = JSON.parse(response.body)
-            response.statusCode.should.equal(200)
+            const body = await getLiveSettings(device)
             body.should.have.property('features').and.be.an.Object()
             body.features.should.have.property('projectComms', true)
             body.features.should.have.property('shared-library', true)
@@ -2070,16 +2135,7 @@ describe('Device API', async function () {
             dbDevice.setApplication(TestObjects.Application1)
             await dbDevice.save()
 
-            const response = await app.inject({
-                method: 'GET',
-                url: `/api/v1/devices/${device.id}/live/settings`,
-                headers: {
-                    authorization: `Bearer ${device.credentials.token}`,
-                    'content-type': 'application/json'
-                }
-            })
-            const body = JSON.parse(response.body)
-            response.statusCode.should.equal(200)
+            const body = await getLiveSettings(device)
             body.should.have.property('editor').and.be.an.Object()
             body.editor.should.have.property('nodeRedVersion', 'next')
         })


### PR DESCRIPTION
Part of #5014 

**Note: do not merge until Device Agent 3.1 has been published**

## Description

Adds the HTTP Node security settings to the Device settings page.

This reuses the Instance template page for node security.

Includes a banner warning if the Device Agent version is unknown, or too old to support the settings. However, I did chose to allow the settings to be saved in those cases. (Note banner at top, which is repeated above the Save button, just to be sure).

<img width="600" alt="image" src="https://github.com/user-attachments/assets/dae38bcd-e82c-408e-86af-396278cac336" />

---

To support FF Auth on devices, we now generate an AuthClient whenever the device calls home to get its settings. That happens whenever the device is notified the settings have been changed. The auth client details are only needed when establishing a login session - changing the client details doesn't invalidate existing sessions.

I did have to update `oauth.js` which assumed the AuthClient owner was an Instance - but it can now be a device.

Will link to the companion Device Agent PR once it is available.

---

 - [x] Add some tests