### PR TITLE
Allow topic metadata to be viewed and edited

### DIFF
--- a/forge/db/models/MQTTTopicSchema.js
+++ b/forge/db/models/MQTTTopicSchema.js
@@ -68,6 +68,27 @@ module.exports = {
                         topics: rows
                     }
                 },
+                /**
+                 * Get a single topic based on team/broker/topic
+                 */
+                get: async (teamId, brokerId, topicId) => {
+                    if (typeof topicId === 'string') {
+                        topicId = M.MQTTTopicSchema.decodeHashid(topicId)
+                    }
+                    if (typeof teamId === 'string') {
+                        teamId = M.Team.decodeHashid(teamId)
+                    }
+                    if (typeof brokerId === 'string') {
+                        brokerId = M.BrokerCredentials.decodeHashid(brokerId)
+                    }
+                    return this.findOne({
+                        where: {
+                            id: topicId,
+                            TeamId: teamId,
+                            BrokerCredentialsId: brokerId
+                        }
+                    })
+                },
                 getTeamBroker: async (teamId, pagination = {}, where = {}) => {
                     if (typeof teamId === 'string') {
                         teamId = M.Team.decodeHashid(teamId)

--- a/forge/db/models/MQTTTopicSchema.js
+++ b/forge/db/models/MQTTTopicSchema.js
@@ -10,7 +10,20 @@ module.exports = {
     name: 'MQTTTopicSchema',
     schema: {
         topic: { type: DataTypes.STRING, allowNull: false },
-        metadata: { type: DataTypes.TEXT, allowNull: true },
+        metadata: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+            get () {
+                const rawValue = this.getDataValue('metadata')
+                if (rawValue === undefined || rawValue === null) {
+                    return rawValue
+                }
+                return JSON.parse(rawValue)
+            },
+            set (value) {
+                this.setDataValue('metadata', JSON.stringify(value))
+            }
+        },
         inferredSchema: { type: DataTypes.TEXT, allowNull: true }
     },
     indexes: [

--- a/forge/db/views/MQTTTopicSchema.js
+++ b/forge/db/views/MQTTTopicSchema.js
@@ -4,7 +4,7 @@ module.exports = {
         const cleaned = {
             id: result.hashid,
             topic: result.topic,
-            metadata: result.metadata ? JSON.parse(result.metadata) : { },
+            metadata: result.metadata || { },
             inferredSchema: result.inferredSchema ? JSON.parse(result.inferredSchema) : undefined
         }
         return cleaned

--- a/forge/db/views/MQTTTopicSchema.js
+++ b/forge/db/views/MQTTTopicSchema.js
@@ -4,7 +4,7 @@ module.exports = {
         const cleaned = {
             id: result.hashid,
             topic: result.topic,
-            metadata: result.metadata ? JSON.parse(result.metadata) : undefined,
+            metadata: result.metadata ? JSON.parse(result.metadata) : { },
             inferredSchema: result.inferredSchema ? JSON.parse(result.inferredSchema) : undefined
         }
         return cleaned

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -1,6 +1,4 @@
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifySession)
-
     app.addHook('preHandler', async (request, reply) => {
         if (request.params.teamId !== undefined || request.params.teamSlug !== undefined) {
             // let teamId = request.params.teamId
@@ -465,7 +463,7 @@ module.exports = async function (app) {
                     topicObj.inferredSchema = JSON.stringify(topicInfo.type)
                 }
                 if (Object.hasOwn(topicInfo, 'metadata')) {
-                    topicObj.metadata = JSON.stringify(topicInfo.metadata)
+                    topicObj.metadata = topicInfo.metadata
                 }
                 try {
                     await app.db.models.MQTTTopicSchema.upsert(topicObj, {
@@ -524,7 +522,7 @@ module.exports = async function (app) {
         const topic = await app.db.models.MQTTTopicSchema.get(request.params.teamId, brokerId, request.params.topicId)
         if (topic) {
             if (request.body.metadata) {
-                topic.metadata = JSON.stringify(request.body.metadata)
+                topic.metadata = request.body.metadata
                 await topic.save()
             }
             reply.status(201).send(app.db.views.MQTTTopicSchema.clean(topic))

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -462,7 +462,7 @@ module.exports = async function (app) {
                     TeamId: teamId
                 }
                 if (Object.hasOwn(topicInfo, 'type')) {
-                    topicObj.type = JSON.stringify(topicInfo.type)
+                    topicObj.inferredSchema = JSON.stringify(topicInfo.type)
                 }
                 if (Object.hasOwn(topicInfo, 'metadata')) {
                     topicObj.metadata = JSON.stringify(topicInfo.metadata)

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -455,25 +455,27 @@ module.exports = async function (app) {
             body = [body]
         }
         body.forEach(async topicInfo => {
-            const topicObj = {
-                topic: topicInfo.topic,
-                BrokerCredentialsId: brokerId,
-                TeamId: teamId
-            }
-            if (Object.hasOwn(topicInfo, 'type')) {
-                topicObj.type = JSON.stringify(topicInfo.type)
-            }
-            if (Object.hasOwn(topicInfo, 'metadata')) {
-                topicObj.metadata = JSON.stringify(topicInfo.metadata)
-            }
-            try {
-                await app.db.models.MQTTTopicSchema.upsert(topicObj, {
-                    fields: ['inferredSchema', 'metadata'],
-                    conflictFields: ['topic', 'TeamId', 'BrokerCredentialsId']
-                })
-            } catch (err) {
-                // reply.status(500).send({ error: 'unknown_erorr', message: err.toString() })
-                // return
+            if (topicInfo.topic) {
+                const topicObj = {
+                    topic: topicInfo.topic,
+                    BrokerCredentialsId: brokerId,
+                    TeamId: teamId
+                }
+                if (Object.hasOwn(topicInfo, 'type')) {
+                    topicObj.type = JSON.stringify(topicInfo.type)
+                }
+                if (Object.hasOwn(topicInfo, 'metadata')) {
+                    topicObj.metadata = JSON.stringify(topicInfo.metadata)
+                }
+                try {
+                    await app.db.models.MQTTTopicSchema.upsert(topicObj, {
+                        fields: ['inferredSchema', 'metadata'],
+                        conflictFields: ['topic', 'TeamId', 'BrokerCredentialsId']
+                    })
+                } catch (err) {
+                    // reply.status(500).send({ error: 'unknown_erorr', message: err.toString() })
+                    // return
+                }
             }
         })
         reply.status(201).send({})

--- a/forge/ee/routes/teamBroker/index.js
+++ b/forge/ee/routes/teamBroker/index.js
@@ -1,8 +1,6 @@
 const schemaApi = require('./schema')
 
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifySession)
-
     app.addHook('preHandler', async (request, reply) => {
         if (request.params.teamId !== undefined || request.params.teamSlug !== undefined) {
             // let teamId = request.params.teamId

--- a/forge/ee/routes/teamBroker/schema.js
+++ b/forge/ee/routes/teamBroker/schema.js
@@ -1,9 +1,50 @@
 const YAML = require('yaml')
 module.exports = async function (app) {
-    app.get('/team-broker/schema.yml', async (request, reply) => {
-        const topics = await app.db.models.MQTTTopicSchema.getTeamBroker(request.team.hashid)
-        const list = topics.topics.map(t => t.topic)
-        list.sort()
+    app.addHook('preHandler', async (request, reply) => {
+        if (request.params.teamId !== undefined || request.params.teamSlug !== undefined) {
+            // let teamId = request.params.teamId
+            if (request.params.teamSlug) {
+                // If :teamSlug is provided, need to lookup the team to get
+                // its id for subsequent checks
+                request.team = await app.db.models.Team.bySlug(request.params.teamSlug)
+                if (!request.team) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                    return
+                }
+                // teamId = request.team.hashid
+            }
+
+            if (!request.team) {
+                // For a :teamId route, we can now lookup the full team object
+                request.team = await app.db.models.Team.byId(request.params.teamId)
+                if (!request.team) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                    return
+                }
+
+                const teamType = await request.team.getTeamType()
+                if (!teamType.getFeatureProperty('teamBroker', false)) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                    return // eslint-disable-line no-useless-return
+                }
+            }
+
+            if (request.params.brokerId && request.params.brokerId !== 'team-broker') {
+                request.broker = await app.db.models.BrokerCredentials.byId(request.params.brokerId)
+                if (!request.broker) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                    return // eslint-disable-line no-useless-return
+                }
+            }
+        }
+        if (!request.teamMembership && request.session.User) {
+            request.teamMembership = await request.session.User.getTeamMembership(request.team.id)
+        }
+    })
+
+    app.get('/:brokerId/schema.yml', {
+        preHandler: app.needsPermission('broker:topics:list')
+    }, async (request, reply) => {
         const schema = {
             asyncapi: '3.0.0',
             info: {
@@ -12,33 +53,63 @@ module.exports = async function (app) {
                 description: 'An auto-generated schema of the topics being used on the team broker'
             }
         }
-        // Add the team-broker details
 
-        // Figure out the hostname for the team broker
-        let teamBrokerHost = app.config.broker?.teamBroker?.host
-        if (!teamBrokerHost) {
-            // No explict value set, default to broker.${domain}
-            if (app.config.domain) {
-                teamBrokerHost = `broker.${app.config.domain}`
+        let topics
+        const isTeamBroker = request.params.brokerId === 'team-broker'
+        if (isTeamBroker) {
+            schema.info.title = `${request.team.name} Team Broker`
+            schema.info.description = 'An auto-generated schema of the topics being used on the team broker'
+            topics = await app.db.models.MQTTTopicSchema.getTeamBroker(request.team.hashid)
+            // Figure out the hostname for the team broker
+            let teamBrokerHost = app.config.broker?.teamBroker?.host
+            if (!teamBrokerHost) {
+                // No explict value set, default to broker.${domain}
+                if (app.config.domain) {
+                    teamBrokerHost = `broker.${app.config.domain}`
+                }
             }
-        }
-        if (teamBrokerHost) {
+            if (teamBrokerHost) {
+                schema.servers = {
+                    'team-broker': {
+                        host: teamBrokerHost,
+                        protocol: 'mqtt',
+                        security: [{
+                            type: 'userPassword'
+                        }]
+                    }
+                }
+            }
+        } else {
+            schema.info.title = `${request.broker.name}`
+            schema.info.description = `An auto-generated schema of the topics being used on the '${request.broker.name}' broker`
+            topics = await app.db.models.MQTTTopicSchema.byBroker(request.broker.id)
+
             schema.servers = {
-                'team-broker': {
-                    host: teamBrokerHost,
-                    protocol: 'mqtt',
-                    security: [{
+                [request.broker.name]: {
+                    host: request.broker.host + ':' + request.broker.port,
+                    protocol: 'mqtt'
+                }
+            }
+            if (request.broker.credentials) {
+                const creds = JSON.parse(request.broker.credentials)
+                if (creds.username && creds.password) {
+                    schema.servers[request.broker.name].security = [{
                         type: 'userPassword'
                     }]
                 }
             }
         }
 
-        if (list.length > 0) {
+        const topicList = topics.topics
+        topicList.sort((A, B) => A.topic.localeCompare(B.topic))
+        if (topicList.length > 0) {
             schema.channels = {}
-            list.forEach(topic => {
-                schema.channels[topic] = {
-                    address: topic
+            topicList.forEach(topicObj => {
+                schema.channels[topicObj.topic] = {
+                    address: topicObj.topic
+                }
+                if (topicObj.metadata?.description) {
+                    schema.channels[topicObj.topic].description = topicObj.metadata?.description
                 }
             })
         }

--- a/frontend/src/api/broker.js
+++ b/frontend/src/api/broker.js
@@ -59,6 +59,15 @@ const getBrokerTopics = (teamId, brokerId) => {
         .then(res => res.data)
 }
 
+const addBrokerTopic = (teamId, brokerId, payload) => {
+    return client.post(`/api/v1/teams/${teamId}/brokers/${brokerId}/topics`, payload)
+        .then(res => res.data)
+}
+const updateBrokerTopic = (teamId, brokerId, topicId, payload) => {
+    return client.put(`/api/v1/teams/${teamId}/brokers/${brokerId}/topics/${topicId}`, payload)
+        .then(res => res.data)
+}
+
 export default {
     getClients,
     getClient,
@@ -69,5 +78,7 @@ export default {
     createBroker,
     updateBroker,
     deleteBroker,
-    getBrokerTopics
+    getBrokerTopics,
+    addBrokerTopic,
+    updateBrokerTopic
 }

--- a/frontend/src/components/TextCopier.vue
+++ b/frontend/src/components/TextCopier.vue
@@ -6,7 +6,7 @@
             </slot>
         </span>
         <DuplicateIcon v-if="text.length" class="ff-icon" @click="copyPath" @click.prevent.stop />
-        <span ref="copied" class="ff-copied">Copied!</span>
+        <span ref="copied" class="ff-copied" :class="{ 'ff-copied-left': promptPosition === 'left'}">Copied!</span>
     </span>
 </template>
 
@@ -35,6 +35,14 @@ export default {
             required: false,
             type: Boolean,
             default: true
+        },
+        promptPosition: {
+            required: false,
+            type: String,
+            default: 'right',
+            validator: (value) => {
+                return ['left', 'right'].includes(value)
+            }
         }
     },
     emits: ['copied'],
@@ -78,6 +86,10 @@ export default {
     display: none;
     z-index: 100;
     left: 100%;
+  }
+  .ff-copied-left {
+    left: inherit;
+    right: 100%;
   }
 }
 </style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSegment.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSegment.vue
@@ -1,11 +1,11 @@
 <template>
-    <div class="segment-wrapper" :class="{open: isSegmentOpen, empty: isEmpty}" data-el="segment-wrapper" :data-value="segment.name">
+    <div class="segment-wrapper" :class="{open: isSegmentOpen, empty: isEmpty, selected: isSegmentSelected}" data-el="segment-wrapper" :data-value="segment.name">
         <div class="segment flex" @click="toggleChildren();rowClick(segment)">
             <div class="diagram">
                 <span v-if="!isRoot" class="connector-elbow" />
                 <span v-if="shouldShowTrunk" class="connector-trunk" />
             </div>
-            <div class="content flex gap-1.5 items-center font-bold" :class="{'cursor-pointer': hasChildren, 'cursor-default': !hasChildren, 'pl-10': !isRoot}">
+            <div class="content flex gap-1.5 items-center font-bold cursor-pointer" :class="{'pl-10': !isRoot}">
                 <ChevronRightIcon v-if="hasChildren" class="chevron ff-icon-sm" />
                 <p class="flex gap-2.5 items-end" :class="{'ml-2': !hasChildren}">
                     <span class="title">
@@ -19,7 +19,7 @@
                         </span>
                     </span>
                     <span v-if="hasChildren" class="font-normal opacity-50 text-xs">{{ topicsCounterLabel }}</span>
-                    <text-copier :text="isRoot ? segment.name : (`${segment.path}/${segment.name}`)" :show-text="false" class="ff-text-copier" />
+                    <text-copier :text="segment.topic" :show-text="false" class="ff-text-copier" />
                 </p>
             </div>
         </div>
@@ -32,6 +32,7 @@
                 :has-siblings="Object.keys(children).length > 1"
                 :is-last-sibling="key === Object.keys(children).length - 1"
                 :class="{'pl-10': !isRoot}"
+                :selected-segment="selectedSegment"
                 @segment-selected="rowClick"
                 @segment-state-changed="$emit('segment-state-changed', $event)"
             />
@@ -68,6 +69,11 @@ export default {
         isLastSibling: {
             required: true,
             type: Boolean
+        },
+        selectedSegment: {
+            required: false,
+            type: Object,
+            default: null
         }
     },
     emits: ['segment-selected', 'segment-state-changed'],
@@ -98,6 +104,9 @@ export default {
         },
         shouldShowTrunk () {
             return !this.isRoot && this.hasSiblings && this.isLastSibling
+        },
+        isSegmentSelected () {
+            return this.segment?.topic === this.selectedSegment?.topic
         }
     },
     watch: {
@@ -193,11 +202,13 @@ export default {
     .children {
         overflow: hidden;
     }
-
-    &.open > {
+    &.selected > {
         .segment {
             background: $ff-indigo-50;
-
+        }
+    }
+    &.open > {
+        .segment {
             .content {
                 .title {
                     color: $ff-indigo-700;

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSegment.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSegment.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="segment-wrapper" :class="{open: isSegmentOpen, empty: isEmpty}" data-el="segment-wrapper" :data-value="segment.name">
-        <div class="segment flex" @click="toggleChildren">
+        <div class="segment flex" @click="toggleChildren();rowClick(segment)">
             <div class="diagram">
                 <span v-if="!isRoot" class="connector-elbow" />
                 <span v-if="shouldShowTrunk" class="connector-trunk" />
@@ -32,6 +32,7 @@
                 :has-siblings="Object.keys(children).length > 1"
                 :is-last-sibling="key === Object.keys(children).length - 1"
                 :class="{'pl-10': !isRoot}"
+                @segment-selected="rowClick"
                 @segment-state-changed="$emit('segment-state-changed', $event)"
             />
         </div>
@@ -69,7 +70,7 @@ export default {
             type: Boolean
         }
     },
-    emits: ['segment-state-changed'],
+    emits: ['segment-selected', 'segment-state-changed'],
     data () {
         return {
             isSegmentOpen: false
@@ -114,6 +115,9 @@ export default {
         this.isSegmentOpen = this.segment.open
     },
     methods: {
+        rowClick (segment) {
+            this.$emit('segment-selected', segment)
+        },
         toggleChildren () {
             if (this.hasChildren) {
                 this.isSegmentOpen = !this.isSegmentOpen

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -1,42 +1,64 @@
 <template>
-    <div class="unified-namespace-hierarchy">
-        <div class="title mb-5 flex gap-3 items-center">
-            <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
-            <h3 class="my-2 flex-grow" data-el="subtitle">Topic Hierarchy</h3>
-            <ff-button v-if="shouldDisplaySchemaButton" @click="openSchema()">
-                <template #icon-right><ExternalLinkIcon /></template>
-                Open Schema
-            </ff-button>
+    <div class="ff-broker-hierarchy">
+        <div class="unified-namespace-hierarchy">
+            <div class="title mb-5 flex gap-3 items-center">
+                <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
+                <h3 class="my-2 flex-grow" data-el="subtitle">Topic Hierarchy</h3>
+                <ff-button v-if="shouldDisplaySchemaButton" @click="openSchema()">
+                    <template #icon-right><ExternalLinkIcon /></template>
+                    Open Schema
+                </ff-button>
+            </div>
+
+            <div class="space-y-6">
+                <ff-loading v-if="loading" message="Loading Topics..." />
+
+                <template v-else>
+                    <section v-if="topics.length > 0" class="topics">
+                        <topic-segment
+                            v-for="(segment, key) in hierarchySegments"
+                            :key="segment"
+                            :segment="hierarchy[segment]"
+                            :children="hierarchy[segment].children"
+                            :has-siblings="Object.keys(hierarchy).length > 1"
+                            :is-last-sibling="key === Object.keys(hierarchy).length-1"
+                            :is-root="true"
+                            @segment-selected="segmentSelected"
+                            @segment-state-changed="toggleSegmentVisibility"
+                        />
+                    </section>
+
+                    <EmptyState v-else>
+                        <template #img>
+                            <img src="../../../../images/empty-states/mqtt-empty.png" alt="logo">
+                        </template>
+                        <template #header>Start Building Your Topic Hierarchy</template>
+                        <template #message>
+                            <p>It looks like no topics have been created yet.</p>
+                            <p>Topics are automatically generated as your MQTT clients publish events to the broker. Get started by connecting a client and publishing your first message.</p>
+                        </template>
+                    </EmptyState>
+                </template>
+            </div>
         </div>
-
-        <div class="space-y-6">
-            <ff-loading v-if="loading" message="Loading Topics..." />
-
-            <template v-else>
-                <section v-if="topics.length > 0" class="topics">
-                    <topic-segment
-                        v-for="(segment, key) in hierarchySegments"
-                        :key="segment"
-                        :segment="hierarchy[segment]"
-                        :children="hierarchy[segment].children"
-                        :has-siblings="Object.keys(hierarchy).length > 1"
-                        :is-last-sibling="key === Object.keys(hierarchy).length-1"
-                        :is-root="true"
-                        @segment-state-changed="toggleSegmentVisibility"
-                    />
-                </section>
-
-                <EmptyState v-else>
-                    <template #img>
-                        <img src="../../../../images/empty-states/mqtt-empty.png" alt="logo">
-                    </template>
-                    <template #header>Start Building Your Topic Hierarchy</template>
-                    <template #message>
-                        <p>It looks like no topics have been created yet.</p>
-                        <p>Topics are automatically generated as your MQTT clients publish events to the broker. Get started by connecting a client and publishing your first message.</p>
-                    </template>
-                </EmptyState>
-            </template>
+        <div class="ff-topic-inspector" :style="{'width': inspecting ? '50%' : '0'}">
+            <div class="title mb-5 flex gap-3 items-center">
+                <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
+                <h3 class="my-2 flex-grow" data-el="subtitle">Topic Inspector</h3>
+                <div class="flex items-center gap-4">
+                    <ff-button kind="secondary" @click="clearTopicMetaChanges()">
+                        Cancel
+                    </ff-button>
+                    <ff-button @click="saveTopicMeta()">
+                        Save
+                    </ff-button>
+                </div>
+            </div>
+            <div v-if="inspecting" class="ff-topic-inspecting">
+                <label class="ff-topic-path">{{ inspecting?.path === inspecting?.name ? '' : inspecting?.path + '/' }}{{ inspecting?.name }}</label>
+                <ff-divider />
+                <FormRow v-model="inspecting.description" containerClass="max-w-full">Description</FormRow>
+            </div>
         </div>
     </div>
 </template>
@@ -49,6 +71,7 @@ import { mapGetters, mapState } from 'vuex'
 import brokerClient from '../../../../api/broker.js'
 import EmptyState from '../../../../components/EmptyState.vue'
 
+import FormRow from '../../../../components/FormRow.vue'
 import { useNavigationHelper } from '../../../../composables/NavigationHelper.js'
 
 import TopicSegment from './components/TopicSegment.vue'
@@ -57,11 +80,12 @@ const { openInANewTab } = useNavigationHelper()
 
 export default {
     name: 'BrokerHierarchy',
-    components: { TopicSegment, EmptyState, ExternalLinkIcon },
+    components: { TopicSegment, EmptyState, ExternalLinkIcon, FormRow },
     data () {
         return {
             loading: false,
-            topics: []
+            topics: [],
+            inspecting: null
         }
     },
     computed: {
@@ -182,6 +206,14 @@ export default {
             // trigger's the hierarchy setter
             this.hierarchy = segment
         },
+        segmentSelected (segment) {
+            console.log('segmentSelected', segment)
+            if (this.inspecting?.name === segment.name) {
+                this.inspecting = null
+                return
+            }
+            this.inspecting = segment
+        },
         openSchema () {
             openInANewTab(`/api/v1/teams/${this.team.id}/broker/team-broker/schema.yml`, '_blank')
         }
@@ -189,12 +221,46 @@ export default {
 }
 </script>
 <style scoped lang="scss">
+.ff-broker-hierarchy {
+    display: flex;
+    flex-direction: row;
+    gap: 12px;
+}
+
+.ff-topic-inspector {
+    transition: width 0.3s;
+    overflow: hidden;
+}
+
+.ff-topic-inspecting {
+    background: $ff-white;
+    padding: 10px;
+    border-radius: 6px;
+    border: 1px solid $ff-grey-100;
+}
+
+.ff-topic-path {
+    display: block;
+    background-color: $ff-indigo-50;
+    color: $ff-indigo-600;
+    border-radius: 6px;
+    border: 1px solid $ff-indigo-100;
+    padding: 6px;
+    font-weight: 600;
+}
+
 .unified-namespace-hierarchy {
+    flex-grow: 1;
+    min-width: 50%;
     .topics {
         background: $ff-white;
         padding: 10px;
-        border-radius: 5px;
+        border-radius: 6px;
         border: 1px solid $ff-grey-100;
     }
+}
+
+.title {
+    height: 34px;
 }
 </style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -42,7 +42,7 @@
                 </template>
             </div>
         </div>
-        <div class="ff-topic-inspector" style="width: 50%;">
+        <div v-if="!loading && topics.length > 0" class="ff-topic-inspector" style="width: 50%;">
             <div class="title mb-5 flex gap-3 items-center">
                 <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
                 <h3 class="my-2 flex-grow" data-el="subtitle">Topic Inspector</h3>
@@ -206,7 +206,7 @@ export default {
         shouldDisplaySchemaButton () {
             // For now, only show schema on Team Broker. This will need to be extended for 3rd party
             // brokers later
-            return this.featuresCheck.isMqttBrokerFeatureEnabled && this.$route.params.brokerId === 'team-broker'
+            return this.featuresCheck.isMqttBrokerFeatureEnabled
         },
         selectedTopic () {
             if (!this.inspecting) {
@@ -248,7 +248,7 @@ export default {
             this.inspecting = segment
         },
         openSchema () {
-            openInANewTab(`/api/v1/teams/${this.team.id}/broker/team-broker/schema.yml`, '_blank')
+            openInANewTab(`/api/v1/teams/${this.team.id}/broker/${this.$route.params.brokerId}/schema.yml`, '_blank')
         },
         async saveTopicMeta () {
             if (this.inspecting.id) {

--- a/frontend/src/ui-components/components.js
+++ b/frontend/src/ui-components/components.js
@@ -2,6 +2,7 @@ import FFNavBreadcrumb from './components/Breadcrumb.vue'
 import FFButton from './components/Button.vue'
 import FFCheck from './components/Check.vue'
 import FFDialogBox from './components/DialogBox.vue'
+import FFDivider from './components/Divider.vue'
 import FFHelpTooltip from './components/Help.vue'
 import FFKebabMenu from './components/KebabMenu.vue'
 
@@ -39,6 +40,7 @@ export default {
     FFKebabMenu,
     FFNavBreadcrumb,
     FFDialogBox,
+    FFDivider,
     FFHelpTooltip,
     FFListItem,
     FFCheck,

--- a/frontend/src/ui-components/components/Divider.vue
+++ b/frontend/src/ui-components/components/Divider.vue
@@ -1,0 +1,19 @@
+<template>
+    <div class="ff-divider"></div>
+</template>
+
+<script>
+export default {
+    name: 'ff-divider'
+}
+</script>
+
+<style lang="scss" scoped>
+.ff-divider {
+    width: 100%;
+    height: 1px;
+    background-color: $ff-grey-200;
+    margin-top: 12px;
+    margin-bottom: 12px;
+}
+</style>

--- a/test/unit/forge/ee/routes/teamBroker/3rdPartyBroker_spec.js
+++ b/test/unit/forge/ee/routes/teamBroker/3rdPartyBroker_spec.js
@@ -17,6 +17,7 @@ describe('3rd Party Broker API', function () {
         await login('alice', 'aaPassword')
 
         const userBob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+        app.userBob = userBob
         await app.team.addUser(userBob, { through: { role: Roles.Owner } })
         // Run all the tests with bob - non-admin Team Owner
         await login('bob', 'bbPassword')
@@ -238,20 +239,6 @@ describe('3rd Party Broker API', function () {
             const res = await creds.refreshAuthTokens()
             agentToken = res.token
         })
-        // it('Store Topic for a broker as a team owner', async function () {
-        //     const response = await app.inject({
-        //         method: 'POST',
-        //         url: `/api/v1/teams/${app.team.hashid}/brokers/${brokerCredentialId}/topics`,
-        //         cookies: { sid: TestObjects.tokens.bob },
-        //         body: {
-        //             topic: 'foo/bar/baz'
-        //         }
-        //     })
-        //     response.statusCode.should.equal(201)
-        //     const result = response.json()
-        //     result.should.have.property('id')
-        //     result.should.have.property('topic', 'foo/bar/baz')
-        // })
         it('Store Topic for a broker as a agent', async function () {
             let response = await app.inject({
                 method: 'POST',
@@ -419,6 +406,102 @@ describe('3rd Party Broker API', function () {
             response.statusCode.should.equal(200)
             result = response.json()
             result.count.should.equal(2)
+        })
+        describe('Team Broker', function () {
+            before(async function () {
+                app.team2 = await app.factory.createTeam({ name: 'BTeam' })
+                await app.team2.addUser(app.userBob, { through: { role: Roles.Owner } })
+            })
+            it('Store Topic for a team-broker as a team owner', async function () {
+                // Add to ATeam
+                let response = await app.inject({
+                    method: 'POST',
+                    url: `/api/v1/teams/${app.team.hashid}/brokers/team-broker/topics`,
+                    cookies: { sid: TestObjects.tokens.bob },
+                    body: [
+                        {
+                            topic: 'bar/baz/qux',
+                            metadata: { description: 'a topic' }
+                        }
+                    ]
+                })
+                response.statusCode.should.equal(201)
+
+                // Add to BTeam
+                response = await app.inject({
+                    method: 'POST',
+                    url: `/api/v1/teams/${app.team2.hashid}/brokers/team-broker/topics`,
+                    cookies: { sid: TestObjects.tokens.bob },
+                    body: [
+                        {
+                            topic: 'bar/baz/qux',
+                            metadata: { description: 'another topic' }
+                        }
+                    ]
+                })
+                response.statusCode.should.equal(201)
+            })
+            it('Get Topics for team-broker as a Team Owner', async function () {
+                // Check no cross-pollution between ATeam and BTeam
+                let response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${app.team.hashid}/brokers/team-broker/topics`,
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(200)
+                let result = response.json()
+                result.topics.should.have.a.lengthOf(1)
+                result.topics[0].should.have.property('topic', 'bar/baz/qux')
+                result.topics[0].should.have.property('metadata', { description: 'a topic' })
+
+                response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${app.team2.hashid}/brokers/team-broker/topics`,
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(200)
+                result = response.json()
+                result.topics.should.have.a.lengthOf(1)
+                result.topics[0].should.have.property('topic', 'bar/baz/qux')
+                result.topics[0].should.have.property('metadata', { description: 'another topic' })
+            })
+
+            it('Delete Topic', async function () {
+                let response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${app.team.hashid}/brokers/team-broker/topics`,
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(200)
+                let result = response.json()
+                result.topics.should.have.a.lengthOf(1)
+                const topicId = result.topics[0].id
+
+                // Verify delete against wrong team fails
+                response = await app.inject({
+                    method: 'DELETE',
+                    url: `/api/v1/teams/${app.team2.hashid}/brokers/team-broker/topics/${topicId}`,
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(404)
+
+                // Verify we can delete against the right team
+                response = await app.inject({
+                    method: 'DELETE',
+                    url: `/api/v1/teams/${app.team.hashid}/brokers/team-broker/topics/${topicId}`,
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(201)
+
+                response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${app.team.hashid}/brokers/team-broker/topics`,
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(200)
+                result = response.json()
+                result.count.should.equal(0)
+            })
         })
     })
 })


### PR DESCRIPTION
Closes #5046

This PR targets the `mqtt-topic-schema-storge` branch that is delivered by #5053 

## Description

Adds the ability to view and edit topic metadata in the UI.

<img width="948" alt="image" src="https://github.com/user-attachments/assets/78d492a2-be44-4c1a-a930-ba80a7c696b9" />


I expect some updates around tests to follow today.