### PR TITLE
Add 3rd Party broker endpoint

### DIFF
--- a/forge/db/views/BrokerCredentials.js
+++ b/forge/db/views/BrokerCredentials.js
@@ -1,6 +1,6 @@
 module.exports = function (app) {
     app.addSchema({
-        $id: '3rdPartyBroker',
+        $id: 'MQTTBroker',
         type: 'object',
         properties: {
             id: { type: 'string' },

--- a/forge/db/views/BrokerCredentials.js
+++ b/forge/db/views/BrokerCredentials.js
@@ -1,31 +1,41 @@
-module.exports = {
-    credentials: function (app, credentials) {
-        const filtered = []
-        credentials.forEach(c => {
-            filtered.push(this.clean(app, c))
-        })
-        return filtered
-    },
-    clean: function (app, cred) {
-        const result = cred.toJSON()
-        const cleaned = {
-            id: result.hashid,
-            name: result.name,
-            host: result.host,
-            port: result.port,
-            protocol: result.protocol,
-            ssl: result.ssl,
-            verifySSL: result.verifySSL,
-            clientId: result.clientId
+module.exports = function (app) {
+    app.addSchema({
+        $id: '3rdPartyBroker',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            host: { type: 'string' },
+            port: { type: 'number' },
+            protocol: { type: 'string' },
+            ssl: { type: 'boolean' },
+            verifySSL: { type: 'boolean' },
+            clientId: { type: 'string' }
+        },
+        additionalProperties: true
+    })
+    return {
+        clean: function (cred) {
+            const result = cred.toJSON()
+            const cleaned = {
+                id: result.hashid,
+                name: result.name,
+                host: result.host,
+                port: result.port,
+                protocol: result.protocol,
+                ssl: result.ssl,
+                verifySSL: result.verifySSL,
+                clientId: result.clientId
+            }
+            return cleaned
+        },
+        cleanList: function (list) {
+            const filtered = []
+            list.brokers.forEach(u => {
+                filtered.push(this.clean(u))
+            })
+            list.brokers = filtered
+            return list
         }
-        return cleaned
-    },
-    cleanList: function (app, list) {
-        const filtered = []
-        list.brokers.forEach(u => {
-            filtered.push(this.clean(app, u))
-        })
-        list.brokers = filtered
-        return list
     }
 }

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -107,20 +107,7 @@ module.exports = async function (app) {
                 }
             },
             body: {
-                type: 'object',
-                properties: {
-                    name: { type: 'string' },
-                    host: { type: 'string' },
-                    port: { type: 'number' },
-                    protocol: { type: 'string' },
-                    protocolVersion: { type: 'number' },
-                    ssl: { type: 'boolean' },
-                    verifySSL: { type: 'boolean' },
-                    clientId: { type: 'string' },
-                    credentials: {
-                        type: 'object'
-                    }
-                }
+                $ref: '3rdPartyBroker'
             },
             response: {
                 201: {

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -69,7 +69,7 @@ module.exports = async function (app) {
                         brokers: {
                             type: 'array',
                             items: {
-                                $ref: '3rdPartyBroker'
+                                $ref: 'MQTTBroker'
                             }
                         }
                     },
@@ -107,11 +107,11 @@ module.exports = async function (app) {
                 }
             },
             body: {
-                $ref: '3rdPartyBroker'
+                $ref: 'MQTTBroker'
             },
             response: {
                 201: {
-                    $ref: '3rdPartyBroker'
+                    $ref: 'MQTTBroker'
                 },
                 '4xx': {
                     $ref: 'APIError'
@@ -182,7 +182,7 @@ module.exports = async function (app) {
             },
             response: {
                 200: {
-                    $ref: '3rdPartyBroker'
+                    $ref: 'MQTTBroker'
                 },
                 '4xx': {
                     $ref: 'APIError'
@@ -250,7 +250,7 @@ module.exports = async function (app) {
             },
             response: {
                 200: {
-                    $ref: '3rdPartyBroker'
+                    $ref: 'MQTTBroker'
                 },
                 '4xx': {
                     $ref: 'APIError'
@@ -294,7 +294,7 @@ module.exports = async function (app) {
             },
             response: {
                 200: {
-                    $ref: '3rdPartyBroker'
+                    $ref: 'MQTTBroker'
                 },
                 '4xx': {
                     $ref: 'APIError'
@@ -312,7 +312,7 @@ module.exports = async function (app) {
                 clean.state = state
                 reply.send(clean)
             } catch (err) {
-                reply.status(500).send({ error: 'unknown_erorr', message: err.toString() })
+                reply.status(500).send({ error: 'unknown_error', message: err.toString() })
             }
         } else {
             reply.status(40).send({ error: 'not_supported', message: 'not supported' })
@@ -362,7 +362,7 @@ module.exports = async function (app) {
                 await request.broker.destroy()
                 reply.send({})
             } catch (err) {
-                reply.status(500).send({ error: 'unknown_erorr', message: err.toString() })
+                reply.status(500).send({ error: 'unknown_error', message: err.toString() })
             }
         } else {
             reply.status(404).send({ error: 'not_found', message: 'not found' })

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -315,7 +315,7 @@ module.exports = async function (app) {
                 reply.status(500).send({ error: 'unknown_erorr', message: err.toString() })
             }
         } else {
-            reply.status(40).send({error: 'not_supported', message: 'not supported'})
+            reply.status(40).send({ error: 'not_supported', message: 'not supported' })
         }
     })
 
@@ -365,7 +365,7 @@ module.exports = async function (app) {
                 reply.status(500).send({ error: 'unknown_erorr', message: err.toString() })
             }
         } else {
-            reply.status(404).send({error: 'not_found', message: 'not found'})
+            reply.status(404).send({ error: 'not_found', message: 'not found' })
         }
     })
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
- GET /api/v1/teams/:teamId/brokers/:brokerId

returns a broker object (with no credentials) and a extra `status` field that shows if the client is connected to the broker

This is to be used to add a status pill to 3rd party brokers

Also fix the schema for the broker apis and fixes the db.views.BrokerCredentials functons

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

