### PR TITLE
Update schema generate for 3rd party brokers

### DIFF
--- a/forge/db/models/MQTTTopicSchema.js
+++ b/forge/db/models/MQTTTopicSchema.js
@@ -10,7 +10,20 @@ module.exports = {
     name: 'MQTTTopicSchema',
     schema: {
         topic: { type: DataTypes.STRING, allowNull: false },
-        metadata: { type: DataTypes.TEXT, allowNull: true },
+        metadata: {
+            type: DataTypes.TEXT,
+            allowNull: true,
+            get () {
+                const rawValue = this.getDataValue('metadata')
+                if (rawValue === undefined || rawValue === null) {
+                    return rawValue
+                }
+                return JSON.parse(rawValue)
+            },
+            set (value) {
+                this.setDataValue('metadata', JSON.stringify(value))
+            }
+        },
         inferredSchema: { type: DataTypes.TEXT, allowNull: true }
     },
     indexes: [

--- a/forge/db/views/MQTTTopicSchema.js
+++ b/forge/db/views/MQTTTopicSchema.js
@@ -4,7 +4,7 @@ module.exports = {
         const cleaned = {
             id: result.hashid,
             topic: result.topic,
-            metadata: result.metadata ? JSON.parse(result.metadata) : { },
+            metadata: result.metadata || { },
             inferredSchema: result.inferredSchema ? JSON.parse(result.inferredSchema) : undefined
         }
         return cleaned

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -1,6 +1,4 @@
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifySession)
-
     app.addHook('preHandler', async (request, reply) => {
         if (request.params.teamId !== undefined || request.params.teamSlug !== undefined) {
             // let teamId = request.params.teamId
@@ -465,7 +463,7 @@ module.exports = async function (app) {
                     topicObj.inferredSchema = JSON.stringify(topicInfo.type)
                 }
                 if (Object.hasOwn(topicInfo, 'metadata')) {
-                    topicObj.metadata = JSON.stringify(topicInfo.metadata)
+                    topicObj.metadata = topicInfo.metadata
                 }
                 try {
                     await app.db.models.MQTTTopicSchema.upsert(topicObj, {
@@ -524,7 +522,8 @@ module.exports = async function (app) {
         const topic = await app.db.models.MQTTTopicSchema.get(request.params.teamId, brokerId, request.params.topicId)
         if (topic) {
             if (request.body.metadata) {
-                topic.metadata = JSON.stringify(request.body.metadata)
+                topic.metadata = request.body.metadata
+                console.log('updating to metadata', request.body.metadata)
                 await topic.save()
             }
             reply.status(201).send(app.db.views.MQTTTopicSchema.clean(topic))

--- a/forge/ee/routes/teamBroker/index.js
+++ b/forge/ee/routes/teamBroker/index.js
@@ -1,8 +1,6 @@
 const schemaApi = require('./schema')
 
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifySession)
-
     app.addHook('preHandler', async (request, reply) => {
         if (request.params.teamId !== undefined || request.params.teamSlug !== undefined) {
             // let teamId = request.params.teamId

--- a/forge/ee/routes/teamBroker/schema.js
+++ b/forge/ee/routes/teamBroker/schema.js
@@ -1,9 +1,50 @@
 const YAML = require('yaml')
 module.exports = async function (app) {
-    app.get('/team-broker/schema.yml', async (request, reply) => {
-        const topics = await app.db.models.MQTTTopicSchema.getTeamBroker(request.team.hashid)
-        const list = topics.topics.map(t => t.topic)
-        list.sort()
+    app.addHook('preHandler', async (request, reply) => {
+        if (request.params.teamId !== undefined || request.params.teamSlug !== undefined) {
+            // let teamId = request.params.teamId
+            if (request.params.teamSlug) {
+                // If :teamSlug is provided, need to lookup the team to get
+                // its id for subsequent checks
+                request.team = await app.db.models.Team.bySlug(request.params.teamSlug)
+                if (!request.team) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                    return
+                }
+                // teamId = request.team.hashid
+            }
+
+            if (!request.team) {
+                // For a :teamId route, we can now lookup the full team object
+                request.team = await app.db.models.Team.byId(request.params.teamId)
+                if (!request.team) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                    return
+                }
+
+                const teamType = await request.team.getTeamType()
+                if (!teamType.getFeatureProperty('teamBroker', false)) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                    return // eslint-disable-line no-useless-return
+                }
+            }
+
+            if (request.params.brokerId && request.params.brokerId !== 'team-broker') {
+                request.broker = await app.db.models.BrokerCredentials.byId(request.params.brokerId)
+                if (!request.broker) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                    return // eslint-disable-line no-useless-return
+                }
+            }
+        }
+        if (!request.teamMembership && request.session.User) {
+            request.teamMembership = await request.session.User.getTeamMembership(request.team.id)
+        }
+    })
+
+    app.get('/:brokerId/schema.yml', {
+        preHandler: app.needsPermission('broker:topics:list')
+    }, async (request, reply) => {
         const schema = {
             asyncapi: '3.0.0',
             info: {
@@ -12,33 +53,63 @@ module.exports = async function (app) {
                 description: 'An auto-generated schema of the topics being used on the team broker'
             }
         }
-        // Add the team-broker details
 
-        // Figure out the hostname for the team broker
-        let teamBrokerHost = app.config.broker?.teamBroker?.host
-        if (!teamBrokerHost) {
-            // No explict value set, default to broker.${domain}
-            if (app.config.domain) {
-                teamBrokerHost = `broker.${app.config.domain}`
+        let topics
+        const isTeamBroker = request.params.brokerId === 'team-broker'
+        if (isTeamBroker) {
+            schema.info.title = `${request.team.name} Team Broker`
+            schema.info.description = 'An auto-generated schema of the topics being used on the team broker'
+            topics = await app.db.models.MQTTTopicSchema.getTeamBroker(request.team.hashid)
+            // Figure out the hostname for the team broker
+            let teamBrokerHost = app.config.broker?.teamBroker?.host
+            if (!teamBrokerHost) {
+                // No explict value set, default to broker.${domain}
+                if (app.config.domain) {
+                    teamBrokerHost = `broker.${app.config.domain}`
+                }
             }
-        }
-        if (teamBrokerHost) {
+            if (teamBrokerHost) {
+                schema.servers = {
+                    'team-broker': {
+                        host: teamBrokerHost,
+                        protocol: 'mqtt',
+                        security: [{
+                            type: 'userPassword'
+                        }]
+                    }
+                }
+            }
+        } else {
+            schema.info.title = `${request.broker.name}`
+            schema.info.description = `An auto-generated schema of the topics being used on the '${request.broker.name}' broker`
+            topics = await app.db.models.MQTTTopicSchema.byBroker(request.broker.id)
+
             schema.servers = {
-                'team-broker': {
-                    host: teamBrokerHost,
-                    protocol: 'mqtt',
-                    security: [{
+                [request.broker.name]: {
+                    host: request.broker.host + ':' + request.broker.port,
+                    protocol: 'mqtt'
+                }
+            }
+            if (request.broker.credentials) {
+                const creds = JSON.parse(request.broker.credentials)
+                if (creds.username && creds.password) {
+                    schema.servers[request.broker.name].security = [{
                         type: 'userPassword'
                     }]
                 }
             }
         }
 
-        if (list.length > 0) {
+        const topicList = topics.topics
+        topicList.sort((A, B) => A.topic.localeCompare(B.topic))
+        if (topicList.length > 0) {
             schema.channels = {}
-            list.forEach(topic => {
-                schema.channels[topic] = {
-                    address: topic
+            topicList.forEach(topicObj => {
+                schema.channels[topicObj.topic] = {
+                    address: topicObj.topic
+                }
+                if (topicObj.metadata?.description) {
+                    schema.channels[topicObj.topic].description = topicObj.metadata?.description
                 }
             })
         }

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -42,7 +42,7 @@
                 </template>
             </div>
         </div>
-        <div class="ff-topic-inspector" style="width: 50%;">
+        <div v-if="!loading && topics.length > 0" class="ff-topic-inspector" style="width: 50%;">
             <div class="title mb-5 flex gap-3 items-center">
                 <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
                 <h3 class="my-2 flex-grow" data-el="subtitle">Topic Inspector</h3>
@@ -206,7 +206,7 @@ export default {
         shouldDisplaySchemaButton () {
             // For now, only show schema on Team Broker. This will need to be extended for 3rd party
             // brokers later
-            return this.featuresCheck.isMqttBrokerFeatureEnabled && this.$route.params.brokerId === 'team-broker'
+            return this.featuresCheck.isMqttBrokerFeatureEnabled
         },
         selectedTopic () {
             if (!this.inspecting) {
@@ -248,7 +248,7 @@ export default {
             this.inspecting = segment
         },
         openSchema () {
-            openInANewTab(`/api/v1/teams/${this.team.id}/broker/team-broker/schema.yml`, '_blank')
+            openInANewTab(`/api/v1/teams/${this.team.id}/broker/${this.$route.params.brokerId}/schema.yml`, '_blank')
         },
         async saveTopicMeta () {
             if (this.inspecting.id) {


### PR DESCRIPTION
Closes #5082

## Description

Adds support for asyncapi schema generation for 3rd party brokers.

 - Updates `metadata` model definition to provide custom get/set functions - consumers don't need to worry about JSON parse/stringify.
 - Removes a duplicate verifySession preHandler on the routes - the parent route already had it registered
 - Adds the schema button for 3rd party brokers
 - Updates the 'empty' view to cover the inspector panel as well