### PR TITLE
Allow a dev-mode device at Stage 0 to be triggered

### DIFF
--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="stage" class="ff-pipeline-stage" data-el="ff-pipeline-stage" :class="{'ff-pipeline-stage--error': inDeveloperMode}">
+    <div v-if="stage" class="ff-pipeline-stage" data-el="ff-pipeline-stage" :class="{'ff-pipeline-stage--error': inDeveloperMode && stageIndex > 0}">
         <div class="ff-pipeline-stage-banner">
             <div class="ff-pipeline-stage-banner-name">
                 <label>{{ stage.name }}</label>
@@ -33,7 +33,7 @@
                     v-if="stage.stageType !== StageType.DEVICEGROUP"
                     v-ff-tooltip:right="'Run Pipeline Stage'"
                     data-action="stage-run"
-                    :class="{'ff-disabled': !playEnabled || !pipeline?.id || deploying || inDeveloperMode}"
+                    :class="{'ff-disabled': !playEnabled || !pipeline?.id || deploying }"
                     @click="runStage"
                 >
                     <PlayIcon
@@ -213,6 +213,9 @@ export default {
     },
     emits: ['stage-deleted', 'stage-deploy-starting', 'stage-deploy-started', 'stage-deploy-failed'],
     computed: {
+        stageIndex () {
+            return this.pipeline.stages.indexOf(this.stage)
+        },
         deploying () {
             return this.stage.isDeploying
         },
@@ -258,9 +261,9 @@ export default {
                 }
             }
 
-            if (this.pipeline.stages.length > 0 && this.pipeline.stages.indexOf(this.stage) > 0) {
+            if (this.pipeline.stages.length > 0 && this.stageIndex > 0) {
                 route.query = {
-                    sourceStage: this.pipeline.stages[this.pipeline.stages.indexOf(this.stage)].id
+                    sourceStage: this.pipeline.stages[this.stageIndex].id
                 }
             }
 


### PR DESCRIPTION
Closes https://github.com/FlowFuse/flowfuse/issues/5079

## Description

This updates the UI constraints applied around Pipelines to allow a Device in Dev Mode to be a valid first stage in a pipeline.

This simplifies the workflow for using pipelines with Dev Mode devices; you don't have to take the device out of dev mode in order to move its snapshot to other devices.

This is a simple iteration that allows for the existing Deploy Actions to be chosen. There is scope to add a 'Create Snapshot' action - but that would only work if the device was in dev mode. Given the complications that introduces, in the spirit of fast iteration, I'm going with the existing available actions.

The workflow is then:

1. Put device in dev mode, work on flows
2. When ready to deploy via pipeline, create a snapshot (or rely on the auto-snapshot from your last deploy)
3. Ensure the pipeline stage is configured to 'use latest snapshot' - *not* 'use active snapshot'.

This last point is one small potential gotcha. Whilst the device is in dev mode, the 'active' snapshot is whatever snapshot was deployed to the device *before* it was put into dev mode. The 'latest' snapshot is the most recently created one.

In terms of UX changes, for a Stage0 device in dev mode, I've removed the red warning banner, but left the warning text in place.

<img width="758" alt="image" src="https://github.com/user-attachments/assets/fe78b05b-c701-4480-a203-f4859ffb14a9" />

