### PR TITLE
Add a devices/:deviceId/history API endpoint

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -251,7 +251,6 @@ curl -ks -w "\n" -XPOST \
                         "customHostnames":true,
                         "staticAssets":true,
                         "projectHistory":true,
-                        "deviceHistory":true,
                         "teamBroker":true
                     },
                     "instances": {
@@ -297,7 +296,6 @@ curl -ks -w "\n" -XPOST \
                         "staticAssets":true,
                         "bom":true,
                         "projectHistory":true,
-                        "deviceHistory":true,
                         "teamBroker":true
                     },
                     "instances": {

--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -251,6 +251,7 @@ curl -ks -w "\n" -XPOST \
                         "customHostnames":true,
                         "staticAssets":true,
                         "projectHistory":true,
+                        "deviceHistory":true,
                         "teamBroker":true
                     },
                     "instances": {
@@ -296,6 +297,7 @@ curl -ks -w "\n" -XPOST \
                         "staticAssets":true,
                         "bom":true,
                         "projectHistory":true,
+                        "deviceHistory":true,
                         "teamBroker":true
                     },
                     "instances": {
@@ -393,7 +395,7 @@ kubectl run flowfuse-setup-4 \
   --image bitnami/postgresql:14.10.0-debian-11-r3 \
   -- psql -h flowfuse-pr-$PR_NUMBER-postgresql -U forge -d flowforge -c \
   "INSERT INTO public.\"TeamMembers\" (\"role\",\"UserId\",\"TeamId\")\
-    VALUES 
+    VALUES
       (30, 2, 1),
       (30, 2, 2),
       (30, 2, 3),

--- a/forge/db/models/AuditLog.js
+++ b/forge/db/models/AuditLog.js
@@ -153,7 +153,7 @@ module.exports = {
                     }
 
                     const where = {
-                        entityId,
+                        entityId: '' + entityId,
                         entityType,
                         event: {
                             [Op.in]: events

--- a/forge/db/models/AuditLog.js
+++ b/forge/db/models/AuditLog.js
@@ -95,7 +95,7 @@ module.exports = {
                         log: rows
                     }
                 },
-                forProjectHistory: async (projectId, pagination = {}) => {
+                forTimelineHistory: async (entityId, entityType, pagination = {}) => {
                     // Premise:
                     //  we want to generate a timeline of events for a project, including snapshots
                     //  so that user can see "things that changed" the project and any immediate snapshots.
@@ -107,21 +107,56 @@ module.exports = {
                     //    Additionally, flag snapshot existence in the info object as { snapshotExists: true/false }
                     //    (The info object is a permitted field in the audit log entry body (schema))
                     // * Return the log entries as { meta: Object, count: Number, timeline: Array<Object> }
-
+                    let events = []
                     const limit = parseInt(pagination.limit) || 100
+
+                    if (entityType === 'project') {
+                        events = [
+                            'project.created',
+                            'project.deleted',
+                            'flows.set', // flows deployed by user
+                            'project.settings.updated',
+                            'project.snapshot.created', // snapshot created manually or automatically
+                            'project.snapshot.rolled-back', // snapshot rolled back by user
+                            'project.snapshot.imported' // result of a pipeline deployment
+                        ]
+                    } else if (entityType === 'device') {
+                        events = [
+                            'flows.set',
+                            'device.restarted',
+                            'device.settings.updated'
+                            // 'device.assigned',
+                            // 'device.credential.generated',
+                            // 'device.developer-mode.disabled',
+                            // 'device.developer-mode.enabled',
+                            // 'device.remote-access.disabled',
+                            // 'device.remote-access.enabled',
+                            // 'team.device.assigned',
+                            // 'team.device.bulk-deleted',
+                            // 'team.device.created',
+                            // 'team.device.credentials-generated',
+                            // 'team.device.deleted',
+                            // 'team.device.developer-mode.disabled',
+                            // 'team.device.developer-mode.enabled',
+                            // 'team.device.provisioning.created',
+                            // 'team.device.remote-access.disabled',
+                            // 'team.device.remote-access.enabled',
+                            // 'team.device.unassigned',
+                            // 'team.device.updated',
+                            // 'application.device.assigned',
+                            // 'application.device.snapshot.created',
+                            // 'application.device.unassigned',
+                            // 'application.deviceGroup.created',
+                            // 'application.deviceGroup.deleted',
+                            // 'application.deviceGroup.members.changed'
+                        ]
+                    }
+
                     const where = {
-                        entityId: projectId,
-                        entityType: 'project',
+                        entityId,
+                        entityType,
                         event: {
-                            [Op.in]: [
-                                'project.created',
-                                'project.deleted',
-                                'flows.set', // flows deployed by user
-                                'project.settings.updated',
-                                'project.snapshot.created', // snapshot created manually or automatically
-                                'project.snapshot.rolled-back', // snapshot rolled back by user
-                                'project.snapshot.imported' // result of a pipeline deployment
-                            ]
+                            [Op.in]: events
                         }
                     }
                     const result = {

--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -20,6 +20,8 @@ module.exports = fp(async function (app, opts) {
         app.config.features.register('deviceGroups', true, true)
         // Set the Project History timeline Feature Flag
         app.config.features.register('projectHistory', true, true)
+        // Set the Device History timeline Feature Flag
+        app.config.features.register('deviceHistory', true, true)
         // Set the Bill of Materials Feature Flag
         app.config.features.register('bom', true, true)
     }

--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -20,8 +20,6 @@ module.exports = fp(async function (app, opts) {
         app.config.features.register('deviceGroups', true, true)
         // Set the Project History timeline Feature Flag
         app.config.features.register('projectHistory', true, true)
-        // Set the Device History timeline Feature Flag
-        app.config.features.register('deviceHistory', true, true)
         // Set the Bill of Materials Feature Flag
         app.config.features.register('bom', true, true)
     }

--- a/forge/ee/routes/deviceHistory/index.js
+++ b/forge/ee/routes/deviceHistory/index.js
@@ -1,13 +1,14 @@
-const projectShared = require('../../../routes/api/shared/project.js')
+const deviceShared = require('../../../routes/api/shared/device.js')
 
 module.exports = async function (app) {
-    app.addHook('preHandler', projectShared.defaultPreHandler.bind(null, app))
+    app.addHook('preHandler', deviceShared.defaultPreHandler.bind(null, app))
     app.addHook('preHandler', async (request, reply) => {
-        const team = await app.db.models.Team.byId(request.project.TeamId)
+        const id = request.device?.Team?.id
+        const team = await app.db.models.Team.byId(id)
         if (team) {
             request.team = team
             // Check this feature is enabled for this team type.
-            if (team.TeamType.getFeatureProperty('projectHistory', true)) {
+            if (team.TeamType.getFeatureProperty('deviceHistory', true)) {
                 return
             }
         }
@@ -24,13 +25,13 @@ module.exports = async function (app) {
     app.get('/', {
         preHandler: app.needsPermission('project:history'),
         schema: {
-            summary: 'Get instance history',
+            summary: 'Get Device history',
             hide: true, // mark as explicitly hidden (internal for now)
-            tags: [/* 'Instances' */], // no tag hides route from swagger (internal for now)
+            tags: [/* 'Devices' */], // no tag hides route from swagger (internal for now)
             params: {
                 type: 'object',
                 properties: {
-                    instanceId: { type: 'string' }
+                    deviceId: { type: 'string' }
                 }
             },
             query: {
@@ -56,8 +57,8 @@ module.exports = async function (app) {
     }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const logEntries = await app.db.models.AuditLog.forTimelineHistory(
-            request.project.id,
-            'project',
+            request.device.id,
+            'device',
             paginationOptions
         )
         const timelineView = app.db.views.AuditLog.timelineList(logEntries?.timeline || [])

--- a/forge/ee/routes/deviceHistory/index.js
+++ b/forge/ee/routes/deviceHistory/index.js
@@ -8,7 +8,7 @@ module.exports = async function (app) {
         if (team) {
             request.team = team
             // Check this feature is enabled for this team type.
-            if (team.TeamType.getFeatureProperty('deviceHistory', true)) {
+            if (team.TeamType.getFeatureProperty('projectHistory', true)) {
                 return
             }
         }
@@ -23,7 +23,7 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.devices
      */
     app.get('/', {
-        preHandler: app.needsPermission('device:history'),
+        preHandler: app.needsPermission('project:history'),
         schema: {
             summary: 'Get Device history',
             hide: true, // mark as explicitly hidden (internal for now)

--- a/forge/ee/routes/deviceHistory/index.js
+++ b/forge/ee/routes/deviceHistory/index.js
@@ -15,15 +15,15 @@ module.exports = async function (app) {
         reply.code(404).send({ code: 'not_found', error: 'Not Found' })
     })
     /**
-     * Get project history
-     *  - returns a timeline of changes to the project
+     * Get device history
+     *  - returns a timeline of changes to the device
      *  - ?cursor= can be used to set the 'most recent log entry' to query from
      *  - ?limit= can be used to modify how many entries to return
-     * @name /api/v1/projects/:id/history
-     * @memberof forge.routes.api.project
+     * @name /api/v1/devices/:id/history
+     * @memberof forge.routes.api.devices
      */
     app.get('/', {
-        preHandler: app.needsPermission('project:history'),
+        preHandler: app.needsPermission('device:history'),
         schema: {
             summary: 'Get Device history',
             hide: true, // mark as explicitly hidden (internal for now)

--- a/forge/ee/routes/index.js
+++ b/forge/ee/routes/index.js
@@ -28,6 +28,7 @@ module.exports = async function (app) {
         await app.register(require('./customHostnames'), { prefix: '/api/v1/projects/:projectId/customHostname', logLevel: app.config.logging.http })
         await app.register(require('./staticAssets'), { prefix: '/api/v1/projects/:projectId/files', logLevel: app.config.logging.http })
         await app.register(require('./projectHistory'), { prefix: '/api/v1/projects/:instanceId/history', logLevel: app.config.logging.http })
+        await app.register(require('./deviceHistory'), { prefix: '/api/v1/devices/:deviceId/history', logLevel: app.config.logging.http })
         await app.register(require('./teamBroker'), { prefix: '/api/v1/teams/:teamId/broker', logLevel: app.config.logging.http })
 
         // Important: keep SSO last to avoid its error handling polluting other routes.

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -128,9 +128,6 @@ const Permissions = {
     // Projects
     'project:history': { description: 'View Hosted Instances project history', role: Roles.Member },
 
-    // Devices
-    'device:history': { description: 'View Remote Instances history', role: Roles.Member },
-
     // Application
     'application:bom': { description: 'Get the Application Bill of Materials', role: Roles.Owner },
 

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -126,7 +126,10 @@ const Permissions = {
      */
 
     // Projects
-    'project:history': { description: 'View project history', role: Roles.Member },
+    'project:history': { description: 'View Hosted Instances project history', role: Roles.Member },
+
+    // Devices
+    'device:history': { description: 'View Remote Instances history', role: Roles.Member },
 
     // Application
     'application:bom': { description: 'Get the Application Bill of Materials', role: Roles.Owner },

--- a/forge/routes/api/shared/device.js
+++ b/forge/routes/api/shared/device.js
@@ -1,0 +1,31 @@
+module.exports = {
+    defaultPreHandler: async (app, request, reply) => {
+        if (request.params.deviceId !== undefined) {
+            if (request.params.deviceId) {
+                try {
+                    // StorageFlow needed for last updates time (live status)
+                    request.device = await app.db.models.Device.byId(request.params.deviceId, { includeStorageFlows: true })
+                    if (!request.device) {
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                        return
+                    }
+                    if (request.session.User) {
+                        request.teamMembership = await request.session.User.getTeamMembership(request.device.Team.id)
+                        if (!request.teamMembership && !request.session.User.admin) {
+                            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                            return // eslint-disable-line no-useless-return
+                        }
+                    } else if (request.session.ownerId !== request.params.deviceId) {
+                        // AccesToken being used - but not owned by this project
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                        return // eslint-disable-line no-useless-return
+                    }
+                } catch (err) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                }
+            } else {
+                reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+            }
+        }
+    }
+}

--- a/test/unit/forge/ee/routes/deviceHistory/deviceHistory_spec.js
+++ b/test/unit/forge/ee/routes/deviceHistory/deviceHistory_spec.js
@@ -43,7 +43,7 @@ describe('Devices API (EE)', function () {
         async function enableTeamTypeFeatureFlag (enabled) {
             const defaultTeamType = await app.db.models.TeamType.findOne({ where: { name: 'starter' } })
             const defaultTeamTypeProperties = defaultTeamType.properties
-            defaultTeamTypeProperties.features.deviceHistory = enabled
+            defaultTeamTypeProperties.features.projectHistory = enabled
             defaultTeamType.properties = defaultTeamTypeProperties
             await defaultTeamType.save()
         }

--- a/test/unit/forge/ee/routes/deviceHistory/deviceHistory_spec.js
+++ b/test/unit/forge/ee/routes/deviceHistory/deviceHistory_spec.js
@@ -1,0 +1,296 @@
+const sleep = require('util').promisify(setTimeout)
+
+// eslint-disable-next-line no-unused-vars
+const should = require('should')
+
+const sinon = require('sinon')
+
+const TestModelFactory = require('../../../../../lib/TestModelFactory.js')
+const setup = require('../../setup')
+
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe('Devices API (EE)', function () {
+    describe('History timeline', function () {
+        const TestObjects = {
+            /** admin */ alice: null,
+            /** owner */ bob: null,
+            /** member */ chris: null,
+            /** viewer */ dave: null,
+            /** non member */ elvis: null,
+            device: null,
+            deviceTwo: null,
+            team: null,
+            application: null,
+            stack: null,
+            template: null,
+            projectType: null,
+            tokens: {
+                alice: null,
+                bob: null,
+                chris: null,
+                dave: null,
+                elvis: null
+            },
+            /** @type {TestModelFactory} */
+            factory: null
+        }
+
+        let app
+        const sandbox = sinon.createSandbox()
+
+        async function enableTeamTypeFeatureFlag (enabled) {
+            const defaultTeamType = await app.db.models.TeamType.findOne({ where: { name: 'starter' } })
+            const defaultTeamTypeProperties = defaultTeamType.properties
+            defaultTeamTypeProperties.features.deviceHistory = enabled
+            defaultTeamType.properties = defaultTeamTypeProperties
+            await defaultTeamType.save()
+        }
+
+        async function login (username, password) {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/account/login',
+                payload: { username, password, remember: false }
+            })
+            response.cookies.should.have.length(1)
+            response.cookies[0].should.have.property('name', 'sid')
+            TestObjects.tokens[username] = response.cookies[0].value
+        }
+
+        before(async function () {
+            app = await setup()
+            sandbox.stub(app.log, 'info')
+            sandbox.stub(app.log, 'warn')
+            sandbox.stub(app.log, 'error')
+
+            const factory = new TestModelFactory(app)
+
+            TestObjects.factory = factory
+
+            TestObjects.device = await TestObjects.factory.createDevice(
+                { name: 'device-one' },
+                app.team,
+                null,
+                app.application
+            )
+
+            TestObjects.deviceTwo = await TestObjects.factory.createDevice(
+                { name: 'device-two' },
+                app.team,
+                null,
+                app.application
+            )
+
+            TestObjects.team = app.team
+            TestObjects.application = app.application
+            TestObjects.stack = app.stack
+            TestObjects.template = app.template
+            TestObjects.projectType = app.projectType
+
+            TestObjects.alice = await app.db.models.User.byUsername('alice')
+            TestObjects.bob = await TestObjects.factory.createUser({ admin: false, username: 'bob', name: 'Bob Solo', email: 'bob@example.com', password: 'bbPassword' })
+            TestObjects.chris = await TestObjects.factory.createUser({ admin: false, username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
+            TestObjects.dave = await TestObjects.factory.createUser({ admin: false, username: 'dave', name: 'Dave Vader', email: 'dave@example.com', email_verified: true, password: 'ddPassword' })
+
+            await TestObjects.team.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+            await TestObjects.team.addUser(TestObjects.chris, { through: { role: Roles.Member } })
+            await TestObjects.team.addUser(TestObjects.dave, { through: { role: Roles.Viewer } })
+
+            TestObjects.elvis = await TestObjects.factory.createUser({ admin: false, username: 'elvis', name: 'Elvis Dooku', email: 'elvis@example.com', email_verified: true, password: 'eePassword' })
+            const team2 = await TestObjects.factory.createTeam({ name: 'PTeam' })
+            await team2.addUser(TestObjects.elvis, { through: { role: Roles.Member } })
+
+            await login('alice', 'aaPassword')
+            await login('bob', 'bbPassword')
+            await login('chris', 'ccPassword')
+            await login('dave', 'ddPassword')
+            await login('elvis', 'eePassword')
+        })
+
+        beforeEach(async function () {
+            await enableTeamTypeFeatureFlag(true)
+        })
+
+        after(async function () {
+            await app.close()
+            sandbox.restore()
+        })
+
+        it('Owner should get a timeline of changes to the project', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/devices/${TestObjects.device.hashid}/history`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(200)
+            const body = response.json()
+            body.should.have.property('meta')
+            body.should.have.property('count')
+            body.should.have.property('timeline')
+        })
+        it('Member should get a timeline of changes to the project', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/devices/${TestObjects.device.hashid}/history`,
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            response.statusCode.should.equal(200)
+            const body = response.json()
+            body.should.have.property('meta')
+            body.should.have.property('count')
+            body.should.have.property('timeline')
+        })
+        it('Viewer should not be able to access project history (403)', async function () {
+        // 403: Forbidden - The user does not have permission to access the resource
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/devices/${TestObjects.device.hashid}/history`,
+                cookies: { sid: TestObjects.tokens.dave }
+            })
+            response.statusCode.should.equal(403)
+        })
+        it('Non member should not be able to access project history (404)', async function () {
+        // 404: Not Found - The requested resource could not be found
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/devices/${TestObjects.device.hashid}/history`,
+                cookies: { sid: TestObjects.tokens.elvis }
+            })
+            response.statusCode.should.equal(404)
+        })
+        it('Anonymous should not be able to access project history (401)', async function () {
+        // 401: Unauthorized - The user is not authenticated
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/devices/${TestObjects.device.hashid}/history`
+            })
+            response.statusCode.should.equal(401)
+        })
+        it('Should return 404 when the teamtype feature flag is disabled', async function () {
+            await enableTeamTypeFeatureFlag(false)
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/devices/${TestObjects.device.hashid}/history`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(404)
+        })
+
+        describe('Timeline Data', function () {
+            async function simulateModifyFlows (device, user) {
+                // since we don't have running instances to post flows, we just simulate the event
+                await app.db.controllers.AuditLog.deviceLog(device.id, user.id, 'flows.set', { type: 'flows' })
+            }
+
+            async function simulateRestart (device, user) {
+                // since we don't have running instances to post flows, we just simulate the event
+                await app.db.controllers.AuditLog.deviceLog(device.id, user.id, 'device.restarted', { device })
+            }
+
+            async function modifySettings (device, newSettings, user) {
+                app.auditLog.Device.device.settings.updated(user.id, null, device, newSettings)
+                // await app.inject({
+                //     method: 'PUT',
+                //     url: `/api/v1/devices/${device.id}`,
+                //     payload: { settings: newSettings },
+                //     cookies: { sid: TestObjects.tokens.bob }
+                // })
+            }
+            before(async function () {
+                // clear all snapshots & audit logs
+                await app.db.models.ProjectSnapshot.destroy({ where: {} })
+                await app.db.models.AuditLog.destroy({ where: {} })
+
+                // Simulate below events by pushing entries to the audit log and generating snapshots
+                // 1. Modify flows
+                // 2. Modify settings
+                // 3. Restart
+
+                // NOTE: The tests rely on specific ordering of events, so every event has a different
+                // timestamp, we add a small delay between each event.
+                // IRL, these events would be triggered by user actions and any 2 events occurring
+                // at the same ms would be highly unlikely and ultimately, of little consequence.
+                await simulateModifyFlows(TestObjects.device, TestObjects.bob)
+                await sleep(10)
+                await modifySettings(TestObjects.device, { header: { title: 'changed' } }, TestObjects.bob)
+                await sleep(10)
+                await simulateRestart(TestObjects.device, TestObjects.tokens.bob)
+            })
+
+            it('Should return a timeline of changes to the project', async function () {
+                const response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/devices/${TestObjects.device.hashid}/history`,
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(200)
+
+                const body = response.json()
+                body.should.have.property('meta')
+                body.should.have.property('count')
+                body.should.have.property('timeline').and.be.an.Array()
+                body.timeline.should.have.length(3)
+
+                // check a selection of entries
+                const entry1 = body.timeline[0]
+                entry1.should.have.property('createdAt')
+                entry1.should.have.property('user').and.be.an.Object()
+                entry1.user.should.have.property('id').and.be.a.String()
+                entry1.should.have.property('event', 'device.restarted')
+                entry1.should.have.property('data').and.be.an.Object()
+
+                const entry2 = body.timeline[1]
+                entry2.should.have.property('createdAt')
+                entry2.should.have.property('user').and.be.an.Object()
+                entry2.user.should.have.property('id').and.be.a.String()
+                entry2.should.have.property('event', 'device.settings.updated')
+                entry2.should.have.property('data').and.be.an.Object()
+
+                const entry3 = body.timeline[2]
+                entry3.should.have.property('createdAt')
+                entry3.should.have.property('user').and.be.an.Object()
+                entry3.user.should.have.property('id').and.be.a.String()
+                entry3.should.have.property('event', 'flows.set') // pipeline deployment
+                entry3.should.have.property('data').and.be.an.Object()
+            })
+
+            describe('Pagination', function () {
+                it('Should limit response', async function () {
+                    const response = await app.inject({
+                        method: 'GET',
+                        url: `/api/v1/devices/${TestObjects.device.hashid}/history?limit=2`,
+                        cookies: { sid: TestObjects.tokens.bob }
+                    })
+                    response.statusCode.should.equal(200)
+                    const body = response.json()
+                    body.should.have.property('count', 2)
+                })
+
+                it('Should use cursor', async function () {
+                    const response = await app.inject({
+                        method: 'GET',
+                        url: `/api/v1/devices/${TestObjects.device.hashid}/history?limit=1`,
+                        cookies: { sid: TestObjects.tokens.bob }
+                    })
+                    response.statusCode.should.equal(200)
+                    const body1 = response.json()
+                    body1.meta.should.have.property('next_cursor')
+
+                    const response2 = await app.inject({
+                        method: 'GET',
+                        url: `/api/v1/devices/${TestObjects.device.hashid}/history?cursor=${body1.meta.next_cursor}&limit=2`,
+                        cookies: { sid: TestObjects.tokens.bob }
+                    })
+                    response2.statusCode.should.equal(200)
+                    const body2 = response2.json()
+
+                    body2.meta.should.have.property('next_cursor')
+                    body2.meta.next_cursor.should.not.equal(body1.meta.next_cursor)
+                })
+            })
+        })
+    })
+})


### PR DESCRIPTION
## Description

Add a `devices/:deviceId/history` API endpoint and alter the existing project history auditLog model to query devices as well

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/4873

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

