### PR TITLE
Add option to reload topic hierarchy and remember state

### DIFF
--- a/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSegment.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSegment.vue
@@ -114,7 +114,8 @@ export default {
             handler () {
                 this.$emit('segment-state-changed', {
                     state: this.isSegmentOpen,
-                    path: this.segment.path
+                    path: this.segment.path,
+                    topic: this.segment.topic
                 })
             },
             immediate: false


### PR DESCRIPTION
Closes #5086 

## Description

Adds a button to refresh the topic hierarchy view - whilst remembering the current expanded state of the hierarchy.

There are still cases where the expanded state is forgotten:
 - a reload of the page
 - switching between brokers (which triggers a page reload afaict)

Fixing that will require storing the cache of expanded topics in local storage. Decided that was above and beyond what was needed today.