### PR TITLE
Add status pill to 3rd party broker and start/stop

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -426,6 +426,8 @@ module.exports = {
     // 3rd party broker
     startBrokerAgent: async (broker) => {},
     stopBrokerAgent: async (broker) => {},
-    getBrokerAgentState: async (broker) => {},
+    getBrokerAgentState: async (broker) => {
+        return {connected: true, error: ''}
+    },
     sendBrokerAgentCommand: async (broker, command) => {}
 }

--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -427,7 +427,7 @@ module.exports = {
     startBrokerAgent: async (broker) => {},
     stopBrokerAgent: async (broker) => {},
     getBrokerAgentState: async (broker) => {
-        return {connected: true, error: ''}
+        return { connected: true, error: '' }
     },
     sendBrokerAgentCommand: async (broker, command) => {}
 }

--- a/forge/ee/lib/teamBroker/index.js
+++ b/forge/ee/lib/teamBroker/index.js
@@ -4,6 +4,12 @@ module.exports.init = function (app) {
         app.config.features.register('teamBroker', true, true)
     }
 
+    if (app.config.driver.type === 'localfs' || 
+        app.config.driver.type === 'kubernetes' ||
+        app.config.driver.type === 'stub') {
+        app.config.features.register('3rdPartyBroker', true, true)
+    }
+
     /*
      * need to add functions here to boot clients when team
      * or when client creds removed

--- a/forge/ee/lib/teamBroker/index.js
+++ b/forge/ee/lib/teamBroker/index.js
@@ -4,10 +4,10 @@ module.exports.init = function (app) {
         app.config.features.register('teamBroker', true, true)
     }
 
-    if (app.config.driver.type === 'localfs' || 
+    if (app.config.driver.type === 'localfs' ||
         app.config.driver.type === 'kubernetes' ||
         app.config.driver.type === 'stub') {
-        app.config.features.register('3rdPartyBroker', true, true)
+        app.config.features.register('externalBroker', true, true)
     }
 
     /*

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -368,6 +368,38 @@ module.exports = async function (app) {
     })
 
     /**
+     * Start collection from a Broker
+     */
+        app.post('/:brokerId/start', {
+            preHandler: app.needsPermission('broker:credentials:edit'),
+            schema: { }
+        }, async (request, reply) => {
+            let brokerId = request.params.brokerId
+            if (brokerId === 'team-broker') {
+                reply.status(403).send({})
+            } else {
+                await app.containers.sendBrokerAgentCommand(request.broker,'start')
+                reply.status(200).send({})
+            }
+        })
+    
+        /**
+         * Stop collection from a Broker
+         */
+        app.post('/:brokerId/stop', {
+            preHandler: app.needsPermission('broker:credentials:edit'),
+            schema: { }
+        }, async (request, reply) => {
+            let brokerId = request.params.brokerId
+            if (brokerId === 'team-broker') {
+                reply.status(403).send({})
+            } else {
+                await app.containers.sendBrokerAgentCommand(request.broker,'stop')
+                reply.status(200).send({})
+            }
+        })
+
+    /**
      * Get used Topics from a MQTT Broker
      * @name /api/v1/teams/:teamId/broker/:brokerId/topics
      * @static

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -370,34 +370,32 @@ module.exports = async function (app) {
     /**
      * Start collection from a Broker
      */
-        app.post('/:brokerId/start', {
-            preHandler: app.needsPermission('broker:credentials:edit'),
-            schema: { }
-        }, async (request, reply) => {
-            let brokerId = request.params.brokerId
-            if (brokerId === 'team-broker') {
-                reply.status(403).send({})
-            } else {
-                await app.containers.sendBrokerAgentCommand(request.broker,'start')
-                reply.status(200).send({})
-            }
-        })
-    
-        /**
-         * Stop collection from a Broker
-         */
-        app.post('/:brokerId/stop', {
-            preHandler: app.needsPermission('broker:credentials:edit'),
-            schema: { }
-        }, async (request, reply) => {
-            let brokerId = request.params.brokerId
-            if (brokerId === 'team-broker') {
-                reply.status(403).send({})
-            } else {
-                await app.containers.sendBrokerAgentCommand(request.broker,'stop')
-                reply.status(200).send({})
-            }
-        })
+    app.post('/:brokerId/start', {
+        preHandler: app.needsPermission('broker:credentials:edit'),
+        schema: { }
+    }, async (request, reply) => {
+        if (request.params.brokerId === 'team-broker') {
+            reply.status(403).send({})
+        } else {
+            await app.containers.sendBrokerAgentCommand(request.broker, 'start')
+            reply.status(200).send({})
+        }
+    })
+
+    /**
+     * Stop collection from a Broker
+     */
+    app.post('/:brokerId/stop', {
+        preHandler: app.needsPermission('broker:credentials:edit'),
+        schema: { }
+    }, async (request, reply) => {
+        if (request.params.brokerId === 'team-broker') {
+            reply.status(403).send({})
+        } else {
+            await app.containers.sendBrokerAgentCommand(request.broker, 'stop')
+            reply.status(200).send({})
+        }
+    })
 
     /**
      * Get used Topics from a MQTT Broker

--- a/frontend/src/api/broker.js
+++ b/frontend/src/api/broker.js
@@ -40,7 +40,6 @@ const getBrokers = (teamId) => {
 }
 
 const getBrokerStatus = (teamId, brokerId) => {
-    console.log('getBrokerStatus')
     return client.get(`/api/v1/teams/${teamId}/brokers/${brokerId}`)
         .then(res => res.data)
 }

--- a/frontend/src/api/broker.js
+++ b/frontend/src/api/broker.js
@@ -39,6 +39,12 @@ const getBrokers = (teamId) => {
         .then(res => res.data)
 }
 
+const getBrokerStatus = (teamId, brokerId) => {
+    console.log('getBrokerStatus')
+    return client.get(`/api/v1/teams/${teamId}/brokers/${brokerId}`)
+        .then(res => res.data)
+}
+
 const createBroker = (teamId, payload) => {
     return client.post(`/api/v1/teams/${teamId}/brokers`, payload)
         .then(res => res.data)
@@ -68,6 +74,16 @@ const updateBrokerTopic = (teamId, brokerId, topicId, payload) => {
         .then(res => res.data)
 }
 
+const startBroker = (teamId, brokerId) => {
+    return client.post(`/api/v1/teams/${teamId}/brokers/${brokerId}/start`)
+        .then(res => res.data)
+}
+
+const stopBroker = (teamId, brokerId) => {
+    return client.post(`/api/v1/teams/${teamId}/brokers/${brokerId}/stop`)
+        .then(res => res.data)
+}
+
 export default {
     getClients,
     getClient,
@@ -80,5 +96,8 @@ export default {
     deleteBroker,
     getBrokerTopics,
     addBrokerTopic,
-    updateBrokerTopic
+    updateBrokerTopic,
+    getBrokerStatus,
+    startBroker,
+    stopBroker
 }

--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -8,7 +8,7 @@
     >
         <ExclamationCircleIcon v-if="status === 'error' || status === 'crashed'" class="w-4 h-4" />
         <ExclamationIcon v-if="status === 'suspended' || status === 'stopped' || status === 'warning'" class="w-4 h-4" />
-        <PlayIcon v-if="status === 'running'" class="w-4 h-4" />
+        <PlayIcon v-if="['running', 'connected'].includes(status)" class="w-4 h-4" />
         <InformationCircleIcon v-if="status === 'info'" class="w-4 h-4" />
         <CheckCircleIcon v-if="status === 'success'" class="w-4 h-4" />
         <StopIcon v-if="status === 'stopping' || status === 'suspending'" class="w-4 h-4" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -182,6 +182,7 @@
         @apply text-yellow-900;
     }
     .forge-status-success,
+    .forge-status-connected,
     .forge-status-running {
         @apply bg-green-200;
         @apply border-green-400;

--- a/frontend/src/pages/team/Brokers/components/BrokerStatusBadge.vue
+++ b/frontend/src/pages/team/Brokers/components/BrokerStatusBadge.vue
@@ -1,0 +1,36 @@
+<template>
+    <StatusBadge
+        :status="status"
+        :text="text"
+        :pendingChange="optimisticStateChange || pendingStateChange"
+    />
+</template>
+
+<script>
+import StatusBadge from '../../../../components/StatusBadge.vue'
+
+export default {
+    name: 'BrokerStatusBadge',
+    components: {
+        StatusBadge
+    },
+    props: {
+        status: {
+            type: String,
+            default: null
+        },
+        pendingStateChange: {
+            type: Boolean,
+            default: false
+        },
+        optimisticStateChange: {
+            type: Boolean,
+            default: false
+        },
+        text: {
+            type: [Number, String],
+            default: null
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -100,7 +100,8 @@ export default {
     data () {
         return {
             loading: true,
-            brokerState: 'running'
+            brokerState: 'running',
+            stateInterval: null
         }
     },
     computed: {
@@ -261,6 +262,19 @@ export default {
                 this.loading = false
             })
             .catch(e => e)
+        this.stateInterval = setInterval(async () => {
+            if (this.activeBrokerId !== 'team-broker') {
+                const state = await brokerAPI.getBrokerStatus(this.team.id, this.activeBrokerId)
+                if (state.state.connected) {
+                    this.brokerState = 'running'
+                } else {
+                    this.brokerState = 'error'
+                }
+            }
+        },5000)
+    },
+    unmounted () {
+        clearInterval(this.stateInterval)
     },
     methods: {
         ...mapActions('product', ['fetchUnsClients']),

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -271,7 +271,7 @@ export default {
                     this.brokerState = 'error'
                 }
             }
-        },5000)
+        }, 5000)
     },
     unmounted () {
         clearInterval(this.stateInterval)

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -6,6 +6,10 @@
                     {{ pageTitle.context }}
                 </template>
 
+                <template #status v-if="broker.id !== 'team-broker'">
+                    <BrokerStatusBadge :status="brokerState" />
+                </template>
+
                 <template #pictogram>
                     <img alt="info" src="../../../images/pictograms/mqtt_broker_red.png">
                 </template>
@@ -73,10 +77,13 @@ import FfLoading from '../../../components/Loading.vue'
 import usePermissions from '../../../composables/Permissions.js'
 import FfButton from '../../../ui-components/components/Button.vue'
 import { Roles } from '../../../utils/roles.js'
+import BrokerStatusBadge from './components/BrokerStatusBadge.vue'
+
+import brokerAPI from '../../../api/broker.js'
 
 export default {
     name: 'TeamBrokers',
-    components: { FfLoading, EmptyState, FfButton },
+    components: { BrokerStatusBadge, FfLoading, EmptyState, FfButton },
     beforeRouteLeave (to, from, next) {
         if (to.params?.team_slug !== from.params?.team_slug) {
             this.clearUns()
@@ -91,7 +98,8 @@ export default {
     },
     data () {
         return {
-            loading: true
+            loading: true,
+            brokerState: 'running'
         }
     },
     computed: {
@@ -125,6 +133,16 @@ export default {
                         })
                 default:
                     return this.$router.push({ name: 'team-brokers-hierarchy', params: { brokerId } })
+                        .then(() => {
+                                brokerAPI.getBrokerStatus(this.team.id,this.activeBrokerId).then(brokerState => {
+                                if (brokerState.state.connected) {
+                                    this.brokerState = 'running'
+                                } else {
+                                    this.brokerState = 'error'
+                                }
+                                }).catch(e => {
+                                })
+                        })
                         .finally(() => {
                             this.loading = false
                         })

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -7,7 +7,7 @@
                 </template>
 
                 <template #status>
-                    <BrokerStatusBadge v-if="broker?.id !== 'team-broker'" :status="brokerState" />
+                    <BrokerStatusBadge v-if="broker?.id !== 'team-broker'" :status="brokerState" :pendingStateChange="!brokerState" />
                 </template>
 
                 <template #pictogram>
@@ -100,7 +100,7 @@ export default {
     data () {
         return {
             loading: true,
-            brokerState: 'updating',
+            brokerState: '',
             brokerStatusPollingInterval: null
         }
     },

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -333,7 +333,7 @@ export default {
             return brokerAPI.getBrokerStatus(this.team.id, this.activeBrokerId)
                 .then(response => {
                     if (response?.state?.connected) {
-                        this.brokerState = 'running'
+                        this.brokerState = 'connected'
                     } else {
                         this.brokerState = 'error'
                     }

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -6,7 +6,7 @@
                     {{ pageTitle.context }}
                 </template>
 
-                <template #status v-if="broker.id !== 'team-broker'">
+                <template v-if="broker.id !== 'team-broker'" #status>
                     <BrokerStatusBadge :status="brokerState" />
                 </template>
 
@@ -71,15 +71,16 @@
 
 import { mapActions, mapGetters, mapState } from 'vuex'
 
+import brokerAPI from '../../../api/broker.js'
+
 import EmptyState from '../../../components/EmptyState.vue'
 import FfLoading from '../../../components/Loading.vue'
 
 import usePermissions from '../../../composables/Permissions.js'
 import FfButton from '../../../ui-components/components/Button.vue'
 import { Roles } from '../../../utils/roles.js'
-import BrokerStatusBadge from './components/BrokerStatusBadge.vue'
 
-import brokerAPI from '../../../api/broker.js'
+import BrokerStatusBadge from './components/BrokerStatusBadge.vue'
 
 export default {
     name: 'TeamBrokers',
@@ -134,14 +135,16 @@ export default {
                 default:
                     return this.$router.push({ name: 'team-brokers-hierarchy', params: { brokerId } })
                         .then(() => {
-                                brokerAPI.getBrokerStatus(this.team.id,this.activeBrokerId).then(brokerState => {
-                                if (brokerState.state.connected) {
-                                    this.brokerState = 'running'
-                                } else {
-                                    this.brokerState = 'error'
-                                }
-                                }).catch(e => {
-                                })
+                            return brokerAPI.getBrokerStatus(this.team.id, this.activeBrokerId)
+                        })
+                        .then(brokerState => {
+                            if (brokerState.state.connected) {
+                                this.brokerState = 'running'
+                            } else {
+                                this.brokerState = 'error'
+                            }
+                        })
+                        .catch(e => {
                         })
                         .finally(() => {
                             this.loading = false

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -344,6 +344,7 @@ export default {
                 })
         },
         clearBrokerStatusPollingInterval () {
+            this.brokerState = ''
             if (this.brokerStatusPollingInterval) {
                 clearInterval(this.brokerStatusPollingInterval)
             }

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -253,9 +253,6 @@ export default {
                             this.brokerState = 'error'
                             console.error(e)
                         })
-                        .finally(() => {
-                            this.loading = false
-                        })
                 }
             },
             immediate: true
@@ -335,7 +332,7 @@ export default {
         getBrokerState () {
             return brokerAPI.getBrokerStatus(this.team.id, this.activeBrokerId)
                 .then(response => {
-                    if (response.state.connected) {
+                    if (response?.state?.connected) {
                         this.brokerState = 'running'
                     } else {
                         this.brokerState = 'error'


### PR DESCRIPTION
part of #5084
## Description

<!-- Describe your changes in detail -->
Adds
- endpoint to start/stop on topic colletion in agent
- add frontend api to query status and start/stop topic collection
- adds status pill vue object
- queries status of broker on broker id change

Needs to poll status, not just on id change

Also needs to show error message on settings tab if problem

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

