### PR TITLE
Add detected schema info to topic hierarchy

### DIFF
--- a/frontend/src/pages/team/Brokers/ChooseBroker.vue
+++ b/frontend/src/pages/team/Brokers/ChooseBroker.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="create-broker py-20 flex flex-col gap-9" data-el="choose-broker">
         <section class="flex gap-6 justify-center relative z-10 flex-wrap">
-            <h2>Chose which Broker you'd like to get setup with:</h2>
+            <h2>Choose which Broker you'd like to get setup with:</h2>
         </section>
 
         <section class="flex gap-6 justify-center relative z-10 flex-wrap">
@@ -77,7 +77,7 @@ export default {
                 {
                     title: 'Bring your Own Broker',
                     content: [
-                        'Requires a third-party broker to be setup'
+                        'Connect and monitor your own MQTT Broker'
                     ],
                     contentType: 'dash',
                     to: { name: 'team-brokers-new' },

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSchema.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSchema.vue
@@ -1,0 +1,82 @@
+<template>
+    <div class="topic-schema">
+        <div v-if="schemaType === 'string'">
+            <b>Type</b>: String
+        </div>
+        <div v-else-if="schemaType === 'number'">
+            <b>Type</b>: Number
+        </div>
+        <div v-else-if="schemaType === 'boolean'">
+            <b>Type</b>: JSON Boolean
+        </div>
+        <div v-else-if="schemaType === 'object'">
+            <div class="mb-2"><b>Type</b>: JSON Object</div>
+            <div class="font-mono">
+                <div>{</div>
+                <div v-for="(property, name) in schema.properties" :key="name" class="ml-4">{{ name }} ({{ property.type }})</div>
+                <div>}</div>
+            </div>
+        </div>
+        <div v-else-if="schemaType === 'array'">
+            <div class="mb-2"><b>Type</b>: JSON Array</div>
+            <div class="font-mono">
+                <div>[</div>
+                <div class="ml-4">...</div>
+                <div v-if="schema.items?.type" class="ml-4">({{ schema.items.type }})</div>
+                <div v-else class="ml-4">(unknown)</div>
+                <div class="ml-4">...</div>
+                <div>]</div>
+            </div>
+        </div>
+        <div v-else-if="schemaType === 'bin'">
+            <b>Type</b>: Binary Data
+        </div>
+        <div v-else class="topic-schema-unknown">
+            We haven't been able to determine the payload format
+        </div>
+    </div>
+</template>
+
+<script>
+
+export default {
+    name: 'TopicSchema',
+    components: { },
+    props: {
+        schema: {
+            required: true,
+            type: Object
+        }
+    },
+    emits: [],
+    data () {
+        return {
+        }
+    },
+    computed: {
+        schemaType: function () {
+            return this.schema?.type
+        }
+    },
+    methods: {
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.topic-schema {
+    background-color: $ff-indigo-50;
+    color: $ff-indigo-600;
+    border-radius: 6px;
+    border: 1px solid $ff-indigo-100;
+    padding: 10px 6px;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+}
+
+.topic-schema-unknown {
+    color: $ff-grey-500;
+    text-align: center;
+    font-style: italic;
+}
+</style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -123,13 +123,7 @@ export default {
             loading: false,
             topics: {},
             inspecting: null,
-            expandedTopics: new Set([
-                'AcmeFactory',
-                'AcmeFactory/Southampton',
-                'AcmeFactory/Southampton/Widget',
-                'AcmeFactory/Southampton/Widget/Assembly1',
-                'AcmeFactory/Southampton/Widget/Assembly1/Injection',
-                'AcmeFactory/Southampton/Widget/Assembly1/Injection/config'])
+            expandedTopics: new Set()
         }
     },
     computed: {

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -15,10 +15,13 @@
                 </template>
 
                 <template #helptext>
-                    <p>The <b>Broker</b> feature provides a centralized framework for managing and visualizing your entire data ecosystem, consolidating MQTT broker instances and topic structures within a single interface.</p>
-                    <p>Within the Broker, <b>Client</b> page allows you to manage the clients that have access to the Broker, with customizable Access Control List (ACL) rules for secure and controlled data flow.</p>
+                    <p>The <b>Broker</b> feature provides a way to framework for managing and visualizing your entire data ecosystem, consolidating MQTT broker instances and topic structures within a single interface.</p>
+                    <template v-if="isTeamBroker">
+                        <p>The FlowFuse Team Broker is an MQTT broker ready to start using within your team.</p>
+                        <p>The <b>Client</b> page allows you to manage the clients that have access to the Broker, with customizable Access Control List (ACL) rules for secure and controlled data flow.</p>
+                    </template>
                     <p>The topic <b>Hierarchy</b> offers a clear, organized visualization of the topics being used within your broker.</p>
-                    <p>Together, these components deliver an integrated approach to managing client connections, security settings, and message flow, supporting efficient and secure data communication across your system.</p>
+                    <p>These components deliver an integrated approach to managing client connections, security settings, and message flow, supporting efficient and secure data communication across your system.</p>
                     <p>Documentation <a href="https://flowfuse.com/docs/user/teambroker" target="_blank">here</a></p>
                 </template>
 

--- a/test/e2e/frontend/cypress/tests-ee/brokers/brokers.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/brokers/brokers.spec.js
@@ -69,7 +69,7 @@ describe('FlowFuse - Brokers', () => {
         cy.get('[data-el="add-new-broker"]').should('not.exist')
         cy.get('[data-el="brokers-list"]').should('not.exist')
 
-        cy.contains('Chose which Broker you\'d like to get setup with:')
+        cy.contains('Choose which Broker you\'d like to get setup with:')
 
         cy.get('[data-el="medium-tile"]').should('have.length', 2)
         cy.get('[data-el="medium-tile"][data-value="FlowFuse Broker"]').should('exist')


### PR DESCRIPTION
## Description

Adds schema info, if available, to the topic inspector.

Also updates the info dialog to reflect difference between team- and external- brokers.

For ease of review, here are how different detected payloads appear. Note - these only shows for external brokers as we don't have payload inspection for the Team Broker yet.

 - Unknown format:

<img width="573" alt="image" src="https://github.com/user-attachments/assets/c9bc2bcc-9578-436a-8ce6-0b0ef35b6e7a" />

<img width="376" alt="image" src="https://github.com/user-attachments/assets/23e09d6a-b6f5-47f2-83c2-8e3d9f0a90f0" />

<img width="232" alt="image" src="https://github.com/user-attachments/assets/1ce9f80a-353f-49fd-ad3f-cd337c92b7e8" />

<img width="160" alt="image" src="https://github.com/user-attachments/assets/3ec00115-d14e-4c10-ad0f-4f9caf98d19b" />


<img width="207" alt="image" src="https://github.com/user-attachments/assets/1963094f-4600-404e-92f0-1e0ab50d9965" />

<img width="196" alt="image" src="https://github.com/user-attachments/assets/bd31be90-0a99-4dc3-9a49-2cae3b3964ab" />

<img width="205" alt="image" src="https://github.com/user-attachments/assets/99cdc818-0f59-458c-b095-43e325612905" />


