### PR TITLE
Add "Finish Setup" button for Remote Instances

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -329,7 +329,7 @@ import DeviceAssignedToLink from '../pages/application/components/cells/DeviceAs
 import DeviceLink from '../pages/application/components/cells/DeviceLink.vue'
 import Snapshot from '../pages/application/components/cells/Snapshot.vue'
 
-import DeviceLastSeenBadge from '../pages/device/components/DeviceLastSeenBadge.vue'
+import DeviceLastSeenCell from '../pages/device/components/DeviceLastSeenCell.vue'
 import SnapshotAssignDialog from '../pages/instance/VersionHistory/Snapshots/dialogs/SnapshotAssignDialog.vue'
 import InstanceStatusBadge from '../pages/instance/components/InstanceStatusBadge.vue'
 import DeviceAssignApplicationDialog from '../pages/team/Devices/dialogs/DeviceAssignApplicationDialog.vue'
@@ -411,7 +411,7 @@ export default {
             const columns = [
                 { label: 'Remote Instance', key: 'name', sortable: !this.moreThanOnePage, component: { is: markRaw(DeviceLink) } },
                 { label: 'Type', key: 'type', class: ['w-48'], sortable: !this.moreThanOnePage },
-                { label: 'Last Seen', key: 'lastSeenAt', class: ['w-32'], sortable: !this.moreThanOnePage, component: { is: markRaw(DeviceLastSeenBadge) } },
+                { label: 'Last Seen', key: 'lastSeenAt', class: ['w-48'], sortable: !this.moreThanOnePage, component: { is: markRaw(DeviceLastSeenCell) } },
                 { label: 'Last Known Status', class: ['w-32'], component: { is: markRaw(InstanceStatusBadge) } }
             ]
 

--- a/frontend/src/components/FinishSetup.vue
+++ b/frontend/src/components/FinishSetup.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-button kind="secondary" @click="finishSetup">
+    <ff-button kind="secondary" data-action="finish-setup" @click="finishSetup">
         <template #icon-left><ExclamationIcon class="ff-icon" /></template>
         Finish Setup
     </ff-button>

--- a/frontend/src/components/FinishSetup.vue
+++ b/frontend/src/components/FinishSetup.vue
@@ -1,0 +1,32 @@
+<template>
+    <ff-button kind="secondary" @click="finishSetup">
+        <template #icon-left><ExclamationIcon class="ff-icon" /></template>
+        Finish Setup
+    </ff-button>
+    <DeviceCredentialsDialog ref="deviceCredentialsDialog" />
+</template>
+
+<script>
+import { ExclamationIcon } from '@heroicons/vue/outline'
+
+import DeviceActions from '../mixins/DeviceActions.js'
+import DeviceCredentialsDialog from '../pages/team/Devices/dialogs/DeviceCredentialsDialog.vue'
+
+export default {
+    name: 'FinishSetupButton',
+    components: { ExclamationIcon, DeviceCredentialsDialog },
+    mixins: [DeviceActions],
+    props: {
+        device: {
+            type: Object,
+            required: true
+        }
+    },
+    methods: {
+        finishSetup () {
+            const device = this.device
+            this.deviceAction('updateCredentials', device.id, device)
+        }
+    }
+}
+</script>

--- a/frontend/src/mixins/DeviceActions.js
+++ b/frontend/src/mixins/DeviceActions.js
@@ -40,14 +40,16 @@ export default {
     },
     emits: ['delete-device'],
     methods: {
-        deviceAction (action, deviceId) {
-            let device
-            if (this.devices instanceof Map) {
-                // working with DevicesBrowser component
-                device = this.devices.get(deviceId)
-            } else {
-                // working with compact application views
-                device = this.devices.find(e => e.id === deviceId)
+        deviceAction (action, deviceId, d) {
+            let device = d
+            if (!device) {
+                if (!device && this.devices instanceof Map) {
+                    // working with DevicesBrowser component
+                    device = this.devices.get(deviceId)
+                } else {
+                    // working with compact application views
+                    device = this.devices.find(e => e.id === deviceId)
+                }
             }
             if (action === 'edit') {
                 this.showEditDeviceDialog(device)

--- a/frontend/src/pages/device/components/DeviceLastSeenCell.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenCell.vue
@@ -4,7 +4,6 @@
             <template #icon-left><ExclamationIcon class="ff-icon" /></template>
             Finish Setup
         </ff-button>
-        <DeviceCredentialsDialog ref="deviceCredentialsDialog" />
     </template>
     <DeviceLastSeenBadge v-else :lastSeenAt="lastSeenAt" :lastSeenSince="lastSeenSince" />
 </template>
@@ -22,6 +21,7 @@ export default {
         DeviceLastSeenBadge
     },
     mixins: [deviceActionsMixin],
+    inheritAttrs: false,
     props: {
         id: {
             type: String,

--- a/frontend/src/pages/device/components/DeviceLastSeenCell.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenCell.vue
@@ -1,0 +1,60 @@
+<template>
+    <template v-if="neverConnected">
+        <ff-button kind="secondary" @click="finishSetup">
+            <template #icon-left><ExclamationIcon class="ff-icon" /></template>
+            Finish Setup
+        </ff-button>
+        <DeviceCredentialsDialog ref="deviceCredentialsDialog" />
+    </template>
+    <DeviceLastSeenBadge v-else :lastSeenAt="lastSeenAt" :lastSeenSince="lastSeenSince" />
+</template>
+
+<script>
+import { ExclamationIcon } from '@heroicons/vue/outline'
+
+import deviceActionsMixin from '../../../mixins/DeviceActions.js'
+
+import DeviceLastSeenBadge from './DeviceLastSeenBadge.vue'
+
+export default {
+    components: {
+        ExclamationIcon,
+        DeviceLastSeenBadge
+    },
+    mixins: [deviceActionsMixin],
+    props: {
+        id: {
+            type: String,
+            required: true
+        },
+        lastSeenAt: {
+            type: String,
+            default: null
+        },
+        lastSeenSince: {
+            type: String,
+            default: null
+        },
+        lastSeenMs: {
+            type: Number,
+            default: null
+        }
+    },
+    computed: {
+        neverConnected () {
+            return !this.lastSeenAt && !this.lastSeenSince
+        }
+    },
+    methods: {
+        finishSetup () {
+            // ideally, we'd show the credentials dialog here, but we don't have access to this.devices
+            // so for now, let's just redirect to the device page and we'll fix this better later
+            this.$router.push({
+                name: 'Device',
+                params: { id: this.id }
+            })
+            // eventually we can do deviceAction('updateCredentials', id, devices)
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -44,10 +44,7 @@
                                 <ExternalLinkIcon />
                             </span>
                         </button>
-                        <ff-button v-if="neverConnected" kind="secondary" @click="deviceAction('updateCredentials', device.id, device)">
-                            <template #icon-left><ExclamationIcon class="ff-icon" /></template>
-                            Finish Setup
-                        </ff-button>
+                        <FinishSetupButton v-if="neverConnected" :device="device" />
                         <DropdownMenu v-if="hasPermission('device:change-status') && actionsDropdownOptions.length" data-el="device-actions-dropdown" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
                     </div>
                 </template>
@@ -108,19 +105,19 @@
             data-el="assignment-dialog-application"
             @assign-device="assignDeviceToApplication"
         />
-        <DeviceCredentialsDialog ref="deviceCredentialsDialog" />
     </main>
 </template>
 
 <script>
 
-import { ExclamationIcon, ExternalLinkIcon } from '@heroicons/vue/outline'
+import { ExternalLinkIcon } from '@heroicons/vue/outline'
 import { TerminalIcon } from '@heroicons/vue/solid'
 import semver from 'semver'
 import { mapState } from 'vuex'
 
 import deviceApi from '../../api/devices.js'
 import DropdownMenu from '../../components/DropdownMenu.vue'
+import FinishSetupButton from '../../components/FinishSetup.vue'
 import SectionNavigationHeader from '../../components/SectionNavigationHeader.vue'
 import StatusBadge from '../../components/StatusBadge.vue'
 import SubscriptionExpiredBanner from '../../components/banners/SubscriptionExpired.vue'
@@ -136,8 +133,6 @@ import { createPollTimer } from '../../utils/timers.js'
 
 import DeviceAssignApplicationDialog from '../team/Devices/dialogs/DeviceAssignApplicationDialog.vue'
 import DeviceAssignInstanceDialog from '../team/Devices/dialogs/DeviceAssignInstanceDialog.vue'
-
-import DeviceCredentialsDialog from '../team/Devices/dialogs/DeviceCredentialsDialog.vue'
 
 import AssignDeviceDialog from './components/AssignDeviceDialog.vue'
 
@@ -161,7 +156,7 @@ const deviceTransitionStates = [
 export default {
     name: 'DevicePage',
     components: {
-        ExclamationIcon,
+        FinishSetupButton,
         ExternalLinkIcon,
         DeveloperModeToggle,
         DeviceModeBadge,
@@ -173,8 +168,7 @@ export default {
         TeamTrialBanner,
         AssignDeviceDialog,
         DeviceAssignApplicationDialog,
-        DeviceAssignInstanceDialog,
-        DeviceCredentialsDialog
+        DeviceAssignInstanceDialog
     },
     mixins: [permissionsMixin, deviceActionsMixin],
     data: function () {

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -30,20 +30,22 @@
                         <span class="italic">No Application or Instance Assigned</span> - <a class="ff-link" data-action="assign-device" @click="openAssignmentDialog">Assign</a>
                     </div>
                 </template>
-                <template v-if="isDevModeAvailable" #tools>
+                <template #tools>
                     <!--
                         div style 34px is a workaround to prevent the Device Editor button growing taller than adjacent
                         button (size difference is caused by odd padding in the toggle button, which though not visible
                         is still there and affects the button height in this div group)
                     -->
                     <div class="space-x-2 flex align-center" style="height: 34px;">
-                        <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" :disabled="disableModeToggle" :disabledReason="disableModeToggleReason" @mode-change="setDeviceMode" />
-                        <button v-if="!isVisitingAdmin" v-ff-tooltip:left="!editorAvailable ? 'You can edit flows directly when Developer Mode is enabled, and your Edge Instance is connected.' : 'Open Edge Instance Editor'" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">
-                            Open Editor
-                            <span class="ff-btn--icon ff-btn--icon-right">
-                                <ExternalLinkIcon />
-                            </span>
-                        </button>
+                        <template v-if="isDevModeAvailable">
+                            <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" :disabled="disableModeToggle" :disabledReason="disableModeToggleReason" @mode-change="setDeviceMode" />
+                            <button v-if="!isVisitingAdmin" v-ff-tooltip:left="!editorAvailable ? 'You can edit flows directly when Developer Mode is enabled, and your Edge Instance is connected.' : 'Open Edge Instance Editor'" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">
+                                Open Editor
+                                <span class="ff-btn--icon ff-btn--icon-right">
+                                    <ExternalLinkIcon />
+                                </span>
+                            </button>
+                        </template>
                         <FinishSetupButton v-if="neverConnected" :device="device" />
                         <DropdownMenu v-if="hasPermission('device:change-status') && actionsDropdownOptions.length" data-el="device-actions-dropdown" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
                     </div>

--- a/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
@@ -18,7 +18,8 @@
             </div>
         </div>
         <div class="actions">
-            <ff-kebab-menu>
+            <FinishSetupButton v-if="neverConnected" :device="device" />
+            <ff-kebab-menu v-else>
                 <ff-list-item
                     label="Edit Details"
                     @click.stop="$emit('device-action',{action: 'edit', id: device.id})"
@@ -46,6 +47,7 @@
 </template>
 
 <script>
+import FinishSetupButton from '../../../../../components/FinishSetup.vue'
 import StatusBadge from '../../../../../components/StatusBadge.vue'
 import AuditMixin from '../../../../../mixins/Audit.js'
 import deviceActionsMixin from '../../../../../mixins/DeviceActions.js'
@@ -58,7 +60,8 @@ export default {
     components: {
         StatusBadge,
         FfKebabMenu,
-        DaysSince
+        DaysSince,
+        FinishSetupButton
     },
     mixins: [AuditMixin, permissionsMixin, deviceActionsMixin],
     props: {
@@ -71,7 +74,17 @@ export default {
             type: Object
         }
     },
-    emits: ['device-action']
+    emits: ['device-action'],
+    computed: {
+        neverConnected () {
+            return !this.device.lastSeenAt
+        }
+    },
+    methods: {
+        finishSetup () {
+            this.deviceAction('updateCredentials')
+        }
+    }
 }
 </script>
 

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -168,8 +168,8 @@ brokerPassword: ${this.device.credentials.broker.password}
     setup () {
         return {
             show (device) {
-                this.$refs.dialog.show()
                 this.device = device
+                this.$refs.dialog.show()
             }
         }
     }

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog ref="dialog" header="Device Agent Configuration" data-el="team-device-config-dialog">
+    <ff-dialog ref="dialog" :header="`Device Agent Configuration - ${device?.name}`" data-el="team-device-config-dialog">
         <template #default>
             <form class="text-gray-800">
                 <template v-if="!hasCredentials">

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
                 "copy-webpack-plugin": "^12.0.2",
                 "cross-env": "^7.0.3",
                 "css-loader": "^7.1.2",
-                "cypress": "^13.2.0",
+                "cypress": "^13.17.0",
                 "cypress-mailpit": "^0.0.4",
                 "dotenv-webpack": "^8.0.1",
                 "eslint": "^8.48.0",
@@ -9892,9 +9892,9 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/cypress": {
-            "version": "13.16.1",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.16.1.tgz",
-            "integrity": "sha512-17FtCaz0cx7ssWYKXzGB0Vub8xHwpVPr+iPt2fHhLMDhVAPVrplD+rTQsZUsfb19LVBn5iwkEUFjQ1yVVJXsLA==",
+            "version": "13.17.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
+            "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -30954,9 +30954,9 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "cypress": {
-            "version": "13.16.1",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.16.1.tgz",
-            "integrity": "sha512-17FtCaz0cx7ssWYKXzGB0Vub8xHwpVPr+iPt2fHhLMDhVAPVrplD+rTQsZUsfb19LVBn5iwkEUFjQ1yVVJXsLA==",
+            "version": "13.17.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
+            "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
             "dev": true,
             "requires": {
                 "@cypress/request": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "copy-webpack-plugin": "^12.0.2",
         "cross-env": "^7.0.3",
         "css-loader": "^7.1.2",
-        "cypress": "^13.2.0",
+        "cypress": "^13.17.0",
         "cypress-mailpit": "^0.0.4",
         "dotenv-webpack": "^8.0.1",
         "eslint": "^8.48.0",

--- a/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/team/overview.spec.js
@@ -48,6 +48,7 @@ describe('FlowForge - Team Overview (Home) - With License', () => {
                         const deviceOne = res.body.applications[0].devices.find((device) => device.id === deviceOneId)
 
                         deviceOne.status = 'running'
+                        deviceOne.lastSeenAt = new Date()
                         deviceOne.editor = {
                             url: 'http://editor.example.com',
                             enabled: true,
@@ -126,7 +127,7 @@ describe('FlowForge - Team Overview (Home) - With License', () => {
 
                         cy.contains('Last seen: never')
 
-                        cy.get('[data-el="kebab-menu"]').should('exist')
+                        cy.get('[data-action="finish-setup"]').should('exist')
                     })
                 })
             })

--- a/test/e2e/frontend/cypress/tests/applications/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/overview.spec.js
@@ -1273,8 +1273,8 @@ describe('FlowForge - Applications', () => {
                     {
                         id: '1',
                         name: 'a device',
-                        lastSeenAt: null,
-                        lastSeenMs: null,
+                        lastSeenAt: new Date(),
+                        lastSeenMs: (new Date()).getTime(),
                         status: 'offline',
                         mode: 'autonomous',
                         isDeploying: false
@@ -1335,6 +1335,64 @@ describe('FlowForge - Applications', () => {
                     // cancel the dialog
                     cy.get(`[data-el="${item.dialogDataEl}"] ${item.dialogCancelButtonSelector || '[data-action="dialog-cancel"]'}`).click()
                 })
+            })
+
+            it('"Finish Setup" button is shown for devices that have never connected', () => {
+                const devices = [
+                    {
+                        id: '1',
+                        name: 'never seen device',
+                        lastSeenAt: null,
+                        lastSeenMs: null,
+                        status: 'offline',
+                        mode: 'autonomous',
+                        isDeploying: false
+                    }
+                ]
+                cy.intercept('get', '/api/*/applications/*/devices*', {
+                    meta: {},
+                    count: devices.length,
+                    devices
+                }).as('getDevices')
+
+                cy.intercept(
+                    'GET',
+                    '/api/*/teams/*/applications*',
+                    {
+                        count: 1,
+                        applications: [
+                            {
+                                id: 'some-id',
+                                name: 'My App',
+                                description: 'My app description',
+                                instancesSummary: {
+                                    count: 0,
+                                    instances: []
+                                },
+                                devicesSummary: {
+                                    count: 5,
+                                    devices
+                                }
+                            }
+                        ]
+                    }
+                ).as('getApplications')
+                cy.intercept(
+                    'GET',
+                    '/api/*/teams/*/applications/status*',
+                    {
+                        count: 1,
+                        applications: [{ id: 'some-id', instances: [], devices: [] }]
+                    }
+                ).as('getAppStatuses')
+
+                cy.visit('/')
+
+                cy.wait('@getApplications')
+                cy.wait('@getAppStatuses')
+                cy.wait('@getDevices')
+
+                cy.get('[data-el="device-tile"]').first().get('[data-action="finish-setup"]').should('exist')
             })
         })
     })

--- a/test/e2e/frontend/cypress/tests/devices/finish-setup.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/finish-setup.spec.js
@@ -1,0 +1,20 @@
+describe('FlowForge - Devices', () => {
+    beforeEach(() => {
+        cy.login('bob', 'bbPassword')
+        cy.visit('/team/bteam/devices')
+    })
+
+    it('should provide a CTA to "Finish Setup" if the device has never been connected', () => {
+        cy.contains('span', 'application-device-a').click()
+        // check finish setup button exists
+        cy.get('[data-action="finish-setup"]').should('exist')
+    })
+
+    it('should show the "Regenerate Credentials" dialog when the "Finish Setup" CTA is clicked', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-el="team-device-config-dialog"]').should('not.be.visible')
+        // check finish setup button exists
+        cy.get('[data-action="finish-setup"]').click()
+        cy.get('[data-el="team-device-config-dialog"]').should('be.visible')
+    })
+})


### PR DESCRIPTION
## Description

- Adds a "Finish Setup" button to the Device page, and into the device browser table to encourage users to fully connect their device.
- https://github.com/FlowFuse/flowfuse/issues/5104 showed users dismissing the credentials dialog, which is then incredibly difficult to rediscover, causing friction and confusion when onboarding.
- Changes the display logic for `#actions` on the Device page as was hiding "Actions" and "Finish Setup" if developer mode wasn't available as a feature, which doesn't make sense.

Please note that the Device browser version of this is less than ideal. Our data architecture is very messy, and there is no such `this.devices` in the context of the device action, as well not havign access to the full `device` object within a given cell, because the data table breaks it up into individual properties. So, for now, it just routes to the `Device` page, whereby you can then call the regen credentials action.

### Todo

- E2E Tests

## Related Issue(s)

Closes #5104 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

