### PR TITLE
Add a starting state for the MQTT-Schema-Agent status

### DIFF
--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -337,6 +337,8 @@ export default {
                 .then(response => {
                     if (response?.state?.connected) {
                         this.brokerState = 'connected'
+                    } else if (response?.state?.error === 'error_getting_status') {
+                        this.brokerState = 'starting'
                     } else {
                         this.brokerState = 'error'
                     }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

On K8s the agent can take a few moments to start (pulling container). This adds a state of starting so as not to show polling errors.

depends on 
- https://github.com/FlowFuse/driver-localfs/pull/166
- https://github.com/FlowFuse/driver-k8s/pull/201

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

