### PR TITLE
Formatted Schema Documentation View

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -82,6 +82,7 @@
                 "vue/max-attributes-per-line": "off",
                 "vue/attribute-hyphenation": "off",
                 "vue/singleline-html-element-content-newline": "off",
+                "vue/component-definition-name-casing": "off",
 
                 // plugin:promise
                 "promise/always-return": "off" // common Vue.js pattern

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,6 +27,11 @@
                     <router-view />
                 </ff-layout-box>
             </template>
+            <template v-else-if="pageLayout === 'docs'">
+                <ff-layout-docs>
+                    <router-view />
+                </ff-layout-docs>
+            </template>
             <template v-else-if="pageLayout === 'plain'">
                 <ff-layout-plain>
                     <router-view />
@@ -64,6 +69,7 @@ import Offline from './components/Offline.vue'
 import LicenseBanner from './components/banners/LicenseBanner.vue'
 import EducationModal from './components/dialogs/EducationModal.vue'
 import FFLayoutBox from './layouts/Box.vue'
+import FFLayoutDocs from './layouts/Docs.vue'
 import FFLayoutPlain from './layouts/Plain.vue'
 import FFLayoutPlatform from './layouts/Platform.vue'
 import Login from './pages/Login.vue'
@@ -84,6 +90,7 @@ export default {
         Offline,
         'ff-layout-platform': FFLayoutPlatform,
         'ff-layout-box': FFLayoutBox,
+        'ff-layout-docs': FFLayoutDocs,
         'ff-layout-plain': FFLayoutPlain
     },
     computed: {
@@ -119,8 +126,7 @@ export default {
         },
         pageLayout () {
             const layout = this.$route.meta?.layout
-
-            return ['platform', 'modal', 'plain'].includes(layout) ? layout : 'platform'
+            return ['platform', 'modal', 'plain', 'docs'].includes(layout) ? layout : 'platform'
         }
     },
     mounted () {

--- a/frontend/src/api/broker.js
+++ b/frontend/src/api/broker.js
@@ -88,6 +88,11 @@ const suspendBroker = (teamId, brokerId) => {
         .then(res => res.data)
 }
 
+const getJsonSchema = (teamId, brokerId) => {
+    return client.get(`/api/v1/teams/${teamId}/broker/${brokerId}/schema`)
+        .then(res => res.data)
+}
+
 export default {
     getClients,
     getClient,
@@ -104,5 +109,6 @@ export default {
     getBrokerStatus,
     startBroker,
     stopBroker,
-    suspendBroker
+    suspendBroker,
+    getJsonSchema
 }

--- a/frontend/src/layouts/Docs.vue
+++ b/frontend/src/layouts/Docs.vue
@@ -1,0 +1,31 @@
+<template>
+    <div class="ff-layout--docs">
+        <div class="ff-layout--docs-contents">
+            <div id="platform-banner" />
+            <slot />
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'ff-layout-docs',
+    data () {
+        return { }
+    }
+}
+</script>
+
+<style lang="scss">
+.ff-layout--docs {
+    background-color: white;
+    &-contents {
+        max-width: 1012px;
+        margin: auto;
+        padding: 16px;
+    }
+    h1 {
+        margin: 16px 0;
+    }
+}
+</style>

--- a/frontend/src/pages/team/Brokers/Docs/components/TopicDocs.vue
+++ b/frontend/src/pages/team/Brokers/Docs/components/TopicDocs.vue
@@ -7,7 +7,9 @@
             </div>
         </div>
         <div class="ff-topic-docs-row-meta">
-            Meta Data
+            <label>Description:</label>
+            <p v-if="topic.description">{{ topic.description }}</p>
+            <p v-else class="ff-empty-state">No description available.</p>
         </div>
     </div>
 </template>
@@ -37,7 +39,6 @@ export default {
 <style lang="scss" scoped>
 .ff-topic-docs {
     border: 1px solid $ff-blue-300;
-    font-weight: bold;
     border-radius: 6px;
     &.open {
         .ff-icon {
@@ -50,7 +51,7 @@ export default {
         }
         .ff-topic-docs-row-meta {
             padding: 12px;
-            height: 100px;
+            max-height: 100px;
         }
     }
 }
@@ -58,6 +59,7 @@ export default {
     transition: 0.15s transform;
 }
 .ff-topic-docs-row-header {
+    font-weight: bold;
     background-color: $ff-blue-50;
     padding: 12px;
     font-weight: bold;
@@ -72,9 +74,20 @@ export default {
 }
 .ff-topic-docs-row-meta {
     padding: 0 12px;
-    height: 0px;
+    max-height: 0px;
     min-height: 0;
     overflow: hidden;
-    transition: 0.3s height, 0.3s padding;
+    transition: 0.3s max-height, 0.3s padding;
+    label {
+        display: block;
+        font-weight: bold;
+        margin-bottom: 3px;
+    }
+    .ff-empty-state {
+        color: $ff-grey-400;
+        background-color: $ff-grey-50;
+        padding: 12px;
+        margin-top: 6px;
+    }
 }
 </style>

--- a/frontend/src/pages/team/Brokers/Docs/components/TopicDocs.vue
+++ b/frontend/src/pages/team/Brokers/Docs/components/TopicDocs.vue
@@ -1,0 +1,80 @@
+<template>
+    <div class="ff-topic-docs" :class="{'open': expanded}">
+        <div class="ff-topic-docs-row-header" @click="expanded = !expanded">
+            <label>{{ topic.address }}</label>
+            <div>
+                <ChevronLeftIcon class="ff-icon" />
+            </div>
+        </div>
+        <div class="ff-topic-docs-row-meta">
+            Meta Data
+        </div>
+    </div>
+</template>
+
+<script>
+import { ChevronLeftIcon } from '@heroicons/vue/outline'
+
+export default {
+    name: 'TopicDocs',
+    components: {
+        ChevronLeftIcon
+    },
+    props: {
+        topic: {
+            type: Object,
+            required: true
+        }
+    },
+    data () {
+        return {
+            expanded: false
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.ff-topic-docs {
+    border: 1px solid $ff-blue-300;
+    font-weight: bold;
+    border-radius: 6px;
+    &.open {
+        .ff-icon {
+            transform: rotate(-90deg);
+        }
+        .ff-topic-docs-row-header {
+            border-bottom-left-radius: 0px;
+            border-bottom-right-radius: 0px;
+            border-bottom: 1px solid $ff-blue-300;
+        }
+        .ff-topic-docs-row-meta {
+            padding: 12px;
+            height: 100px;
+        }
+    }
+}
+.ff-icon {
+    transition: 0.15s transform;
+}
+.ff-topic-docs-row-header {
+    background-color: $ff-blue-50;
+    padding: 12px;
+    font-weight: bold;
+    border-radius: 6px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    &:hover {
+        cursor: pointer;
+        background-color: $ff-blue-100;
+    }
+}
+.ff-topic-docs-row-meta {
+    padding: 0 12px;
+    height: 0px;
+    min-height: 0;
+    overflow: hidden;
+    transition: 0.3s height, 0.3s padding;
+}
+</style>

--- a/frontend/src/pages/team/Brokers/Docs/index.vue
+++ b/frontend/src/pages/team/Brokers/Docs/index.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <router-link class="ff-return-link" :to="{ name: 'team-unified-namespace' }">
+        <router-link class="ff-return-link" :to="{ name: 'team-brokers-hierarchy', params: { brokerId: brokerId } }">
             <ChevronLeftIcon class="ff-icon ff-icon-sm" />
             Return to FlowFuse
         </router-link>

--- a/frontend/src/pages/team/Brokers/Docs/index.vue
+++ b/frontend/src/pages/team/Brokers/Docs/index.vue
@@ -1,0 +1,101 @@
+<template>
+    <div>
+        <router-link class="ff-return-link" :to="{ name: 'team-unified-namespace' }">
+            <ChevronLeftIcon class="ff-icon ff-icon-sm" />
+            Return to FlowFuse
+        </router-link>
+    </div>
+    <div>
+        <h1>
+            {{ schema.info.title }}
+            <ff-button @click="downloadSchema">
+                <template #icon-right><ExternalLinkIcon /></template>
+                View Raw Schema
+            </ff-button>
+        </h1>
+        <p>{{ schema.info.description }}</p>
+    </div>
+    <div class="ff-schema-docs-hierarchy">
+        <ff-topic-docs v-for="(data, topic) in schema.channels" :key="topic" :topic="data" />
+    </div>
+</template>
+
+<script>
+import { ChevronLeftIcon } from '@heroicons/vue/outline'
+import { ExternalLinkIcon } from '@heroicons/vue/solid'
+import { mapState } from 'vuex'
+
+import BrokerAPI from '../../../../api/broker.js'
+import { useNavigationHelper } from '../../../../composables/NavigationHelper.js'
+
+import FFTopicDocs from './components/TopicDocs.vue'
+const { openInANewTab } = useNavigationHelper()
+
+export default {
+    name: 'UNSDocs',
+    components: {
+        'ff-topic-docs': FFTopicDocs,
+        ExternalLinkIcon,
+        ChevronLeftIcon
+    },
+    data () {
+        return {
+            loading: true,
+            error: null,
+            schema: null
+        }
+    },
+    computed: {
+        ...mapState('account', ['team']),
+        brokerId () {
+            return this.$route.params.brokerId
+        }
+    },
+    async mounted () {
+        await this.loadSchema()
+    },
+    methods: {
+        async loadSchema () {
+            this.loading = true
+            return BrokerAPI.getJsonSchema(this.team.id, this.brokerId)
+                .then((response) => {
+                    this.schema = response
+                    this.loading = false
+                }).catch((error) => {
+                    console.error(error)
+                    this.loading = false
+                })
+        },
+        downloadSchema () {
+            openInANewTab(`/api/v1/teams/${this.team.id}/broker/${this.brokerId}/schema.yml`, '_blank')
+        }
+    }
+}
+</script>
+<style lang="scss" scoped>
+.ff-return-link {
+    padding: 9px 12px;
+    border-radius: 6px;
+    border: 1px solid $ff-grey-200;
+    transition: border-color 0.3s;
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    &:hover {
+        border-color: $ff-indigo-500;
+        color: $ff-indigo-500;
+        cursor: pointer;
+    }
+}
+.ff-schema-docs-hierarchy {
+    margin: 24px 0;
+    display: flex;
+    gap: 12px;
+    flex-direction: column;
+}
+h1 {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+</style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -280,7 +280,7 @@ export default {
             this.inspecting = segment
         },
         openSchema () {
-            openInANewTab(`/api/v1/teams/${this.team.id}/broker/${this.$route.params.brokerId}/schema.yml`, '_blank')
+            openInANewTab(`/team/${this.team.slug}/broker/${this.$route.params.brokerId}/docs`)
         },
         async saveTopicMeta () {
             if (this.inspecting.id) {

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -4,12 +4,11 @@
             <div class="title mb-5 flex gap-3 items-center">
                 <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
                 <h3 class="my-2 flex-grow" data-el="subtitle">Topic Hierarchy</h3>
-                <ff-button kind="tertiary" @click="refreshHierarchy()">
+                <ff-button kind="secondary" @click="refreshHierarchy()">
                     <template #icon><RefreshIcon /></template>
                 </ff-button>
 
-                <ff-button v-if="shouldDisplaySchemaButton" @click="openSchema()">
-                    <template #icon-right><ExternalLinkIcon /></template>
+                <ff-button v-if="shouldDisplaySchemaButton" :to="{ name: 'team-broker-docs', params: { brokerId: $route.params.brokerId } }">
                     Open Schema
                 </ff-button>
             </div>
@@ -100,7 +99,7 @@
 
 <script>
 
-import { ExternalLinkIcon, RefreshIcon } from '@heroicons/vue/solid'
+import { RefreshIcon } from '@heroicons/vue/solid'
 import { mapGetters, mapState } from 'vuex'
 
 import brokerApi from '../../../../api/broker.js'
@@ -108,16 +107,13 @@ import EmptyState from '../../../../components/EmptyState.vue'
 
 import FormRow from '../../../../components/FormRow.vue'
 import TextCopier from '../../../../components/TextCopier.vue'
-import { useNavigationHelper } from '../../../../composables/NavigationHelper.js'
 
 import TopicSchema from './components/TopicSchema.vue'
 import TopicSegment from './components/TopicSegment.vue'
 
-const { openInANewTab } = useNavigationHelper()
-
 export default {
     name: 'BrokerHierarchy',
-    components: { TopicSchema, TopicSegment, EmptyState, ExternalLinkIcon, RefreshIcon, FormRow, TextCopier },
+    components: { TopicSchema, TopicSegment, EmptyState, RefreshIcon, FormRow, TextCopier },
     data () {
         return {
             loading: false,
@@ -278,9 +274,6 @@ export default {
         },
         segmentSelected (segment) {
             this.inspecting = segment
-        },
-        openSchema () {
-            openInANewTab(`/team/${this.team.slug}/broker/${this.$route.params.brokerId}/docs`)
         },
         async saveTopicMeta () {
             if (this.inspecting.id) {

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -40,7 +40,8 @@
                             data-el="add-new-broker"
                             @click="$router.push({ name: 'team-brokers-add', params: {brokerId: ''} })"
                         >
-                            Add a new Broker
+                            <template #icon-left><PlusIcon /></template>
+                            Add Broker
                         </ff-button>
                     </section>
                 </template>
@@ -72,6 +73,7 @@
 
 <script>
 
+import { PlusIcon } from '@heroicons/vue/outline'
 import { mapActions, mapGetters, mapState } from 'vuex'
 
 import brokerAPI from '../../../api/broker.js'
@@ -80,14 +82,13 @@ import EmptyState from '../../../components/EmptyState.vue'
 import FfLoading from '../../../components/Loading.vue'
 
 import usePermissions from '../../../composables/Permissions.js'
-import FfButton from '../../../ui-components/components/Button.vue'
 import { Roles } from '../../../utils/roles.js'
 
 import BrokerStatusBadge from './components/BrokerStatusBadge.vue'
 
 export default {
     name: 'TeamBrokers',
-    components: { BrokerStatusBadge, FfLoading, EmptyState, FfButton },
+    components: { BrokerStatusBadge, FfLoading, EmptyState, PlusIcon },
     beforeRouteLeave (to, from, next) {
         if (to.params?.team_slug !== from.params?.team_slug) {
             this.clearUns()

--- a/frontend/src/pages/team/Brokers/routes.js
+++ b/frontend/src/pages/team/Brokers/routes.js
@@ -70,7 +70,7 @@ export default [{
         }
     ]
 }, {
-    name: 'team-namespace-docs',
+    name: 'team-broker-docs',
     path: 'broker/:brokerId/docs',
     component: BrokerDocs,
     meta: {

--- a/frontend/src/pages/team/Brokers/routes.js
+++ b/frontend/src/pages/team/Brokers/routes.js
@@ -1,12 +1,13 @@
 import BrokerChoose from './ChooseBroker.vue'
 import BrokersClients from './Clients/index.vue'
+import BrokerDocs from './Docs/index.vue'
 import FirstClient from './FirstClient.vue'
 import BrokersHierarchy from './Hierarchy/index.vue'
 import BrokerNew from './NewBroker.vue'
 import BrokerSettings from './Settings/index.vue'
 import Brokers from './index.vue'
 
-export default {
+export default [{
     name: 'team-brokers',
     path: 'brokers',
     component: Brokers,
@@ -68,4 +69,12 @@ export default {
             }
         }
     ]
-}
+}, {
+    name: 'team-namespace-docs',
+    path: 'broker/:brokerId/docs',
+    component: BrokerDocs,
+    meta: {
+        title: 'Topic Hierarchy Documentation',
+        layout: 'docs'
+    }
+}]

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -39,7 +39,7 @@ export default [
                     title: 'Team - Overview'
                 },
                 children: [
-                    BrokersRoutes,
+                    ...BrokersRoutes,
                     {
                         path: 'applications',
                         children: [


### PR DESCRIPTION
## Description

- This PR creates a new "Documentation" view for a given MQTT schema
- It lists all published-to topics that are discovered by our MQTT Agent, as well as any user descriptions defined in the "Topic Hierarchy" view.
- I've also cleaned up some of the buttons in the topic hierarchy view as well

<img width="1728" alt="Screenshot 2025-02-12 at 12 42 01" src="https://github.com/user-attachments/assets/21d71067-81de-4b0d-b124-d583c394a807" />

<img width="1728" alt="Screenshot 2025-02-12 at 12 40 37" src="https://github.com/user-attachments/assets/70655aae-f465-4692-8fe8-b3f4513cadf1" />

## Related Issue(s)

Closes #5013 