### PR TITLE
Add button to allow start/stop of MQTT agent

### DIFF
--- a/forge/db/views/BrokerCredentials.js
+++ b/forge/db/views/BrokerCredentials.js
@@ -25,7 +25,8 @@ module.exports = function (app) {
                 protocol: result.protocol,
                 ssl: result.ssl,
                 verifySSL: result.verifySSL,
-                clientId: result.clientId
+                clientId: result.clientId,
+                state: result.state
             }
             return cleaned
         },

--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -305,9 +305,9 @@ module.exports = async function (app) {
     }, async (request, reply) => {
         if (request.params.brokerId !== 'team-broker') {
             try {
-                const state = await app.containers.getBrokerAgentState(request.broker)
+                const status = await app.containers.getBrokerAgentState(request.broker)
                 const clean = app.db.views.BrokerCredentials.clean(request.broker)
-                clean.state = state
+                clean.status = status
                 reply.send(clean)
             } catch (err) {
                 reply.status(500).send({ error: 'unknown_error', message: err.toString() })
@@ -377,11 +377,11 @@ module.exports = async function (app) {
         if (request.params.brokerId === 'team-broker') {
             reply.status(403).send({})
         } else {
-            if (request.broker.status === 'running') {
+            if (request.broker.state === 'running') {
                 await app.containers.sendBrokerAgentCommand(request.broker, 'start')
             } else {
                 await app.containers.startBrokerAgent(request.broker)
-                request.broker.status = 'running'
+                request.broker.state = 'running'
                 await request.broker.save()
             }
             reply.status(200).send({})
@@ -414,7 +414,7 @@ module.exports = async function (app) {
             reply.status(403).send({})
         } else {
             await app.containers.stopBrokerAgent(request.broker)
-            request.broker.status = 'suspended'
+            request.broker.state = 'suspended'
             await request.broker.save()
             reply.status(200).send({})
         }

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -4,14 +4,6 @@
             <div class="title mb-5 flex gap-3 items-center">
                 <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
                 <h3 class="my-2 flex-grow" data-el="subtitle">Topic Hierarchy</h3>
-                <ff-button kind="secondary" @click="toggleAgent()">
-                    <template v-if="brokerState === 'connected'">
-                        Stop
-                    </template>
-                    <template v-else>
-                        Start
-                    </template>
-                </ff-button>
                 <ff-button v-if="brokerState === 'connected'" kind="secondary" @click="refreshHierarchy()">
                     <template #icon><RefreshIcon /></template>
                 </ff-button>
@@ -125,7 +117,12 @@ const { openInANewTab } = useNavigationHelper()
 export default {
     name: 'BrokerHierarchy',
     components: { TopicSchema, TopicSegment, EmptyState, ExternalLinkIcon, RefreshIcon, FormRow, TextCopier },
-    inject: ['brokerState'],
+    props: {
+        brokerState: {
+            type: String,
+            required: true
+        }
+    },
     data () {
         return {
             loading: false,
@@ -314,16 +311,6 @@ export default {
         },
         async refreshHierarchy () {
             this.getTopics()
-        },
-        async toggleAgent () {
-            const state = await brokerApi.getBrokerStatus(this.team.id, this.$route.params.brokerId)
-            if (state.state === 'running') {
-                await brokerApi.suspendBroker(this.team.id, this.$route.params.brokerId)
-                this.brokerState = 'suspending'
-            } else {
-                await brokerApi.startBroker(this.team.id, this.$route.params.brokerId)
-                this.brokerState = 'starting'
-            }
         }
     }
 }

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -4,11 +4,19 @@
             <div class="title mb-5 flex gap-3 items-center">
                 <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
                 <h3 class="my-2 flex-grow" data-el="subtitle">Topic Hierarchy</h3>
-                <ff-button kind="secondary" @click="refreshHierarchy()">
+                <ff-button kind="secondary" @click="toggleAgent()">
+                    <template v-if="brokerState === 'connected'">
+                        Stop
+                    </template>
+                    <template v-else>
+                        Start
+                    </template>
+                </ff-button>
+                <ff-button v-if="brokerState === 'connected'" kind="secondary" @click="refreshHierarchy()">
                     <template #icon><RefreshIcon /></template>
                 </ff-button>
-
-                <ff-button v-if="shouldDisplaySchemaButton" :to="{ name: 'team-broker-docs', params: { brokerId: $route.params.brokerId } }">
+                <ff-button v-if="shouldDisplaySchemaButton" @click="openSchema()">
+                    <template #icon-right><ExternalLinkIcon /></template>
                     Open Schema
                 </ff-button>
             </div>
@@ -99,7 +107,7 @@
 
 <script>
 
-import { RefreshIcon } from '@heroicons/vue/solid'
+import { ExternalLinkIcon, RefreshIcon } from '@heroicons/vue/solid'
 import { mapGetters, mapState } from 'vuex'
 
 import brokerApi from '../../../../api/broker.js'
@@ -107,13 +115,17 @@ import EmptyState from '../../../../components/EmptyState.vue'
 
 import FormRow from '../../../../components/FormRow.vue'
 import TextCopier from '../../../../components/TextCopier.vue'
+import { useNavigationHelper } from '../../../../composables/NavigationHelper.js'
 
 import TopicSchema from './components/TopicSchema.vue'
 import TopicSegment from './components/TopicSegment.vue'
 
+const { openInANewTab } = useNavigationHelper()
+
 export default {
     name: 'BrokerHierarchy',
-    components: { TopicSchema, TopicSegment, EmptyState, RefreshIcon, FormRow, TextCopier },
+    components: { TopicSchema, TopicSegment, EmptyState, ExternalLinkIcon, RefreshIcon, FormRow, TextCopier },
+    inject: ['brokerState'],
     data () {
         return {
             loading: false,
@@ -275,6 +287,9 @@ export default {
         segmentSelected (segment) {
             this.inspecting = segment
         },
+        openSchema () {
+            openInANewTab(`/api/v1/teams/${this.team.id}/broker/${this.$route.params.brokerId}/schema.yml`, '_blank')
+        },
         async saveTopicMeta () {
             if (this.inspecting.id) {
                 // This is a preexisting topic in the database
@@ -299,6 +314,16 @@ export default {
         },
         async refreshHierarchy () {
             this.getTopics()
+        },
+        async toggleAgent () {
+            const state = await brokerApi.getBrokerStatus(this.team.id, this.$route.params.brokerId)
+            if (state.state === 'running') {
+                await brokerApi.suspendBroker(this.team.id, this.$route.params.brokerId)
+                this.brokerState = 'suspending'
+            } else {
+                await brokerApi.startBroker(this.team.id, this.$route.params.brokerId)
+                this.brokerState = 'starting'
+            }
         }
     }
 }

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -98,14 +98,13 @@ export default {
     },
     setup () {
         const { hasAMinimumTeamRoleOf } = usePermissions()
-
         return { hasAMinimumTeamRoleOf }
     },
     data () {
         return {
             loading: true,
-            brokerState: '',
-            brokerStatusPollingInterval: null
+            brokerStatusPollingInterval: null,
+            brokerState: ''
         }
     },
     computed: {
@@ -359,7 +358,7 @@ export default {
                 clearInterval(this.brokerStatusPollingInterval)
             }
         }
-    } 
+    }
 }
 </script>
 

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -27,7 +27,7 @@
 
                 <template #tools>
                     <section v-if="!loading && shouldDisplayTools && featuresCheck.isExternalMqttBrokerFeatureEnabled" class="flex gap-3 flex-wrap">
-                        <ff-toggle-switch v-model="active" mode="async" :loading="statePending" @click="toggleAgent" />
+                        <ff-toggle-switch v-if="activeBrokerId !== 'team-broker'" v-model="active" mode="async" :loading="statePending" @click="toggleAgent" />
                         <ff-listbox
                             v-if="brokers.length > 1"
                             v-model="activeBrokerId"

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -349,7 +349,7 @@ export default {
                     if (response?.state === 'running') {
                         if (response?.status?.connected) {
                             this.brokerState = 'connected'
-                        } else if (response?.state?.error === 'error_getting_status') {
+                        } else if (response?.status?.error === 'error_getting_status') {
                             this.brokerState = 'starting'
                         } else {
                             this.brokerState = 'error'

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -336,12 +336,16 @@ export default {
         getBrokerState () {
             return brokerAPI.getBrokerStatus(this.team.id, this.activeBrokerId)
                 .then(response => {
-                    if (response?.state?.connected) {
-                        this.brokerState = 'connected'
-                    } else if (response?.state?.error === 'error_getting_status') {
-                        this.brokerState = 'starting'
+                    if (response?.state === 'running') {
+                        if (response?.status?.connected) {
+                            this.brokerState = 'connected'
+                        } else if (response?.state?.error === 'error_getting_status') {
+                            this.brokerState = 'starting'
+                        } else {
+                            this.brokerState = 'error'
+                        }
                     } else {
-                        this.brokerState = 'error'
+                        this.brokerState = 'suspended'
                     }
                 })
                 .catch(e => {
@@ -355,7 +359,7 @@ export default {
                 clearInterval(this.brokerStatusPollingInterval)
             }
         }
-    }
+    } 
 }
 </script>
 


### PR DESCRIPTION
closes #5084
## Description

Adds a button to the hierarchy page start/stop the MQTT-Schema-Agent

There is also some state/status renaming to make things consistent and meaningful

![image](https://github.com/user-attachments/assets/e81e0f62-b5ce-470c-8650-f9fe6aa43757)

![image](https://github.com/user-attachments/assets/da143aab-9024-4abf-b78d-155b88ea7d46)

![image](https://github.com/user-attachments/assets/f30fdbef-ef8b-4569-bb4d-7f430bb7ff98)

![image](https://github.com/user-attachments/assets/7fff9797-8241-4dc7-8e7f-980f7307aac1)


## Related Issue(s)

<!-- What issue does this PR relate to? -->
#5084

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

