### PR TITLE
Persist opened topic state

### DIFF
--- a/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSegment.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSegment.vue
@@ -43,6 +43,7 @@
 <script>
 import { ArchiveIcon } from '@heroicons/vue/outline'
 import { ChevronRightIcon } from '@heroicons/vue/solid'
+import { ref } from 'vue'
 
 import TextCopier from '../../../../../components/TextCopier.vue'
 export default {
@@ -77,10 +78,10 @@ export default {
         }
     },
     emits: ['segment-selected', 'segment-state-changed'],
-    data () {
-        return {
-            isSegmentOpen: false
-        }
+    setup (props) {
+        const isSegmentOpen = ref(props.segment.open)
+
+        return { isSegmentOpen }
     },
     computed: {
         childrenCount () {
@@ -120,9 +121,6 @@ export default {
             },
             immediate: false
         }
-    },
-    mounted () {
-        this.isSegmentOpen = this.segment.open
     },
     methods: {
         rowClick (segment) {

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -122,14 +122,13 @@ export default {
         return {
             loading: false,
             topics: {},
-            inspecting: null,
-            expandedTopics: new Set()
+            inspecting: null
         }
     },
     computed: {
         ...mapState('account', ['team']),
         ...mapGetters('account', ['featuresCheck']),
-        ...mapGetters('product', ['hasFfUnsClients', 'hasBrokers']),
+        ...mapGetters('product', ['hasFfUnsClients', 'hasBrokers', 'brokerExpandedTopics']),
         hierarchy: {
             get () {
                 const hierarchy = {}
@@ -156,7 +155,7 @@ export default {
                             originalMetadata: JSON.stringify(topicLookup[rootName]?.metadata || {}),
                             inferredSchema: topicLookup[rootName]?.inferredSchema || { type: 'unknown' },
                             isRoot: true,
-                            open: this.expandedTopics.has(rootName),
+                            open: this.checkIfTopicOpen(rootName),
                             childrenCount: 0,
                             children: {}
                         }
@@ -177,7 +176,7 @@ export default {
                                 metadata: topicLookup[topic]?.metadata || {},
                                 originalMetadata: JSON.stringify(topicLookup[topic]?.metadata || {}),
                                 inferredSchema: topicLookup[topic]?.inferredSchema || { type: 'unknown' },
-                                open: this.expandedTopics.has(topic),
+                                open: this.checkIfTopicOpen(topic),
                                 childrenCount: 0,
                                 children: {}
                             }
@@ -206,11 +205,7 @@ export default {
             set (segment) {
                 const keys = segment.topic.split('/')
                 let current = this.hierarchy
-                if (segment.state) {
-                    this.expandedTopics.add(segment.topic)
-                } else {
-                    this.expandedTopics.delete(segment.topic)
-                }
+                this.$store.dispatch('product/handleBrokerTopicState', { topic: segment.topic, brokerId: this.brokerId })
 
                 for (let i = 0; i < keys.length; i++) {
                     const key = keys[i]
@@ -247,8 +242,14 @@ export default {
         hasUnsavedChanges () {
             return this.inspecting && JSON.stringify(this.inspecting.metadata) !== this.inspecting.originalMetadata
         },
+        brokerId () {
+            return this.$route.params.brokerId
+        },
         isTeamBroker () {
-            return this.$route.params.brokerId === 'team-broker'
+            return this.brokerId === 'team-broker'
+        },
+        expandedTopics () {
+            return this.brokerExpandedTopics(this.brokerId)
         }
     },
     watch: {
@@ -306,6 +307,9 @@ export default {
         },
         async refreshHierarchy () {
             this.getTopics()
+        },
+        checkIfTopicOpen (topic) {
+            return this.expandedTopics.has(topic)
         }
     }
 }


### PR DESCRIPTION
## Description

Persists open topic state in the vuex store for every team/broker

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5093

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

