### PR TITLE
Reset store state on logout

### DIFF
--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -69,7 +69,6 @@ const state = initialState
 
 // getters
 const getters = {
-    ...commonMutations,
     settings (state) {
         return state.settings
     },
@@ -231,6 +230,7 @@ const getters = {
     }
 }
 
+// mutations
 const mutations = {
     ...commonMutations,
     setSettings (state, settings) {
@@ -304,7 +304,7 @@ const mutations = {
 
 // actions
 const actions = {
-    ...commonActions(initialState, meta, 'account'),
+    ...commonActions(initialState, meta),
     async checkState ({ commit, dispatch }, redirectUrlAfterLogin) {
         try {
             const settings = await settingsApi.getSettings()

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -53,8 +53,13 @@ const meta = {
             storage: 'localStorage'
             // clearOnLogout: true (cleared by default)
         },
+        settings: {
+            storage: 'localStorage',
+            clearOnLogout: false
+        },
         features: {
-            storage: 'localStorage'
+            storage: 'localStorage',
+            clearOnLogout: false
         },
         teamMembership: {
             storage: 'sessionStorage'

--- a/frontend/src/store/common/actions.js
+++ b/frontend/src/store/common/actions.js
@@ -1,0 +1,17 @@
+export default (initialState, meta) => ({
+    $resetState ({ commit }) {
+        initialState = initialState()
+
+        if (meta.persistence) {
+            // remove any initial state keys from the initial state that should be ignored while clearing state
+            Object.entries(meta.persistence)
+                .forEach(([key, value]) => {
+                    if (value.clearOnLogout === false) {
+                        delete initialState[key]
+                    }
+                })
+        }
+
+        commit('$resetState', initialState)
+    }
+})

--- a/frontend/src/store/common/mutations.js
+++ b/frontend/src/store/common/mutations.js
@@ -1,0 +1,10 @@
+export default {
+    $resetState (state, initialState) {
+        // resetting current state with given state (by this stage, the given initial state should be pruned to only
+        // override required keys)
+        Object.keys(initialState)
+            .forEach(key => {
+                state[key] = initialState[key]
+            })
+    }
+}

--- a/frontend/src/store/product.js
+++ b/frontend/src/store/product.js
@@ -1,7 +1,10 @@
 import brokerApi from '../api/broker.js'
 
+import commonActions from './common/actions.js'
+import commonMutations from './common/mutations.js'
+
 // initial state
-const state = () => ({
+const initialState = () => ({
     flags: null,
     interview: null,
     UNS: {
@@ -12,6 +15,17 @@ const state = () => ({
         expandedTopics: {}
     }
 })
+
+const meta = {
+    persistence: {
+        brokers: {
+            storage: 'localStorage'
+            // clearOnLogout: true (cleared by default)
+        }
+    }
+}
+
+const state = initialState
 
 // getters
 const getters = {
@@ -33,7 +47,9 @@ const getters = {
     }
 }
 
+// mutations
 const mutations = {
+    ...commonMutations,
     setFlags (state, flags) {
         state.flags = flags
     },
@@ -103,16 +119,12 @@ const mutations = {
         }
 
         state.brokers.expandedTopics[team.slug][brokerId][topic] = ''
-    },
-    clearBrokers (state) {
-        state.brokers = {
-            expandedTopics: {}
-        }
     }
 }
 
 // actions
 const actions = {
+    ...commonActions(initialState, meta, 'product'),
     async checkFlags (state) {
         try {
             window.posthog?.onFeatureFlags((flags, values) => {
@@ -206,11 +218,5 @@ export default {
     getters,
     actions,
     mutations,
-    meta: {
-        persistence: {
-            brokers: {
-                storage: 'localStorage'
-            }
-        }
-    }
+    meta
 }

--- a/frontend/src/store/product.js
+++ b/frontend/src/store/product.js
@@ -124,7 +124,7 @@ const mutations = {
 
 // actions
 const actions = {
-    ...commonActions(initialState, meta, 'product'),
+    ...commonActions(initialState, meta),
     async checkFlags (state) {
         try {
             window.posthog?.onFeatureFlags((flags, values) => {

--- a/frontend/src/store/ux.js
+++ b/frontend/src/store/ux.js
@@ -482,7 +482,7 @@ const mutations = {
 }
 
 const actions = {
-    ...commonActions(initialState, meta, 'ux'),
+    ...commonActions(initialState, meta),
     openRightDrawer ({ commit }, { component }) {
         commit('openRightDrawer', { component })
     },

--- a/frontend/src/store/ux.js
+++ b/frontend/src/store/ux.js
@@ -11,7 +11,10 @@ import ProjectsIcon from '../components/icons/Projects.js'
 import usePermissions from '../composables/Permissions.js'
 import { Roles } from '../utils/roles.js'
 
-const state = () => ({
+import commonActions from './common/actions.js'
+import commonMutations from './common/mutations.js'
+
+const initialState = () => ({
     leftDrawer: {
         state: false,
         component: null
@@ -35,6 +38,23 @@ const state = () => ({
     },
     isNewlyCreatedUser: false
 })
+
+const meta = {
+    persistence: {
+        tours: {
+            storage: 'localStorage'
+            // clearOnLogout: true (cleared by default)
+        },
+        isNewlyCreatedUser: {
+            storage: 'localStorage'
+        },
+        userActions: {
+            storage: 'localStorage'
+        }
+    }
+}
+
+const state = initialState
 
 const getters = {
     hiddenLeftDrawer: (state, getters) => {
@@ -417,6 +437,7 @@ const getters = {
 }
 
 const mutations = {
+    ...commonMutations,
     openRightDrawer (state, { component }) {
         state.rightDrawer.state = true
         state.rightDrawer.component = component
@@ -461,6 +482,7 @@ const mutations = {
 }
 
 const actions = {
+    ...commonActions(initialState, meta, 'ux'),
     openRightDrawer ({ commit }, { component }) {
         commit('openRightDrawer', { component })
     },
@@ -512,17 +534,5 @@ export default {
     getters,
     mutations,
     actions,
-    meta: {
-        persistence: {
-            tours: {
-                storage: 'localStorage'
-            },
-            isNewlyCreatedUser: {
-                storage: 'localStorage'
-            },
-            userActions: {
-                storage: 'localStorage'
-            }
-        }
-    }
+    meta
 }


### PR DESCRIPTION
## Description

adds a global way of resetting store state on user logou

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5115

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

