### PR TITLE
Add option to disable manual billing

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -585,6 +585,23 @@ module.exports.init = async function (app) {
                 await app.db.controllers.Subscription.createUnmanagedSubscription(team)
             }
         },
+        /**
+         * If in unmanaged mode, this will update the subscription to be 'canceled'
+         * but leave all instances running.
+         *
+         * The team will need to create a new stripe subscription before they
+         * can continue accessing the team.
+         *
+         * @param {*} team
+         */
+        disableManualBilling: async (team) => {
+            app.log.info(`Disabling manual billing for team ${team.hashid}`)
+            const subscription = await team.getSubscription()
+            if (subscription && subscription.status === app.db.models.Subscription.STATUS.UNMANAGED) {
+                subscription.status = app.db.models.Subscription.STATUS.CANCELED
+                await subscription.save()
+            }
+        },
         updateTrialSettings: async (team, settings) => {
             // Team must already be in trial mode without a Stripe subscription
             const subscription = await team.getSubscription()

--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -446,6 +446,33 @@ module.exports = async function (app) {
     })
 
     /**
+     * Disables manual billing for a team
+     * Admin only
+     * @name /ee/billing/teams/:team/manual
+     * @static
+     * @memberof forge.ee.billing
+     */
+    app.delete('/teams/:teamId/manual', {
+        preHandler: app.needsPermission('team:billing:manual')
+    }, async (request, response) => {
+        const team = request.team
+        try {
+            await app.billing.disableManualBilling(team)
+            response.code(200).send({})
+        } catch (err) {
+            // Standard errors
+            let responseMessage
+            if (err.errors) {
+                responseMessage = err.errors.map(err => err.message).join(',')
+            } else {
+                responseMessage = err.toString()
+            }
+            // Catch all
+            response.code(500).type('application/json').send({ code: err.code || 'unexpected_error', error: responseMessage })
+        }
+    })
+
+    /**
      * Update team trial settings
      * Admin only
      * @name /ee/billing/teams/:team/trial

--- a/frontend/src/api/billing.js
+++ b/frontend/src/api/billing.js
@@ -30,7 +30,11 @@ const setupManualBilling = async (teamId, teamTypeId) => {
         return res.data
     })
 }
-
+const disableManualBilling = async (teamId, teamTypeId) => {
+    return client.delete('/ee/billing/teams/' + teamId + '/manual').then(res => {
+        return res.data
+    })
+}
 const setTrialExpiry = async (teamId, trialEndsAt) => {
     return client.post('/ee/billing/teams/' + teamId + '/trial', {
         trialEndsAt
@@ -82,6 +86,7 @@ export default {
     getSubscriptionInfo,
     createSubscription,
     setupManualBilling,
+    disableManualBilling,
     setTrialExpiry,
     sendTeamTypeContact
 }

--- a/frontend/src/pages/team/Brokers/Settings/index.vue
+++ b/frontend/src/pages/team/Brokers/Settings/index.vue
@@ -30,7 +30,7 @@ export default {
             return Dialog.showAsync({
                 header: `Delete ${this.activeBroker.name}`,
                 kind: 'danger',
-                text: `Are you sure you want delete your ${this.activeBroker.name} broker configuration?`,
+                text: `Are you sure you want to delete your ${this.activeBroker.name} broker configuration?`,
                 confirmLabel: 'Yes, delete'
             })
                 .then(answer => {


### PR DESCRIPTION
Closes #5123 

## Description

This adds a button and api for an admin to disable manual billing mode on a team.

Once disabled, the team has no subscription so has to checkout via stripe again to continue using their team.