### PR TITLE
Force license Tier to be lowercase

### DIFF
--- a/forge/licensing/index.js
+++ b/forge/licensing/index.js
@@ -70,7 +70,7 @@ module.exports = fp(async function (app, opts) {
                 if (Object.hasOwn(activeLicense, key)) {
                     if (key === 'tier') {
                         return activeLicense[key]?.toLowerCase()
-                    } 
+                    }
                     return activeLicense[key]
                 }
                 return undefined

--- a/forge/licensing/index.js
+++ b/forge/licensing/index.js
@@ -68,6 +68,9 @@ module.exports = fp(async function (app, opts) {
             }
             if (activeLicense) {
                 if (Object.hasOwn(activeLicense, key)) {
+                    if (key === 'tier') {
+                        return activeLicense[key]?.toLowerCase()
+                    } 
                     return activeLicense[key]
                 }
                 return undefined


### PR DESCRIPTION
fixes #5133

## Description

<!-- Describe your changes in detail -->
Forces license api to return lower case version of tier when queried.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#5133

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

