### PR TITLE
BUG: display the refresh button for the team-broker

### DIFF
--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -4,7 +4,7 @@
             <div class="title mb-5 flex gap-3 items-center">
                 <img src="../../../../images/icons/tree-view.svg" alt="tree-icon" class="ff-icon-sm">
                 <h3 class="my-2 flex-grow" data-el="subtitle">Topic Hierarchy</h3>
-                <ff-button v-if="brokerState === 'connected'" kind="secondary" @click="refreshHierarchy()">
+                <ff-button v-if="shouldDisplayRefreshButton" kind="secondary" @click="refreshHierarchy()">
                     <template #icon><RefreshIcon /></template>
                 </ff-button>
                 <ff-button v-if="shouldDisplaySchemaButton" :to="{ name: 'team-broker-docs', params: { brokerId: $route.params.brokerId } }">
@@ -97,7 +97,6 @@
 </template>
 
 <script>
-
 import { RefreshIcon } from '@heroicons/vue/solid'
 import { mapGetters, mapState } from 'vuex'
 
@@ -251,6 +250,9 @@ export default {
         },
         expandedTopics () {
             return this.brokerExpandedTopics(this.brokerId)
+        },
+        shouldDisplayRefreshButton () {
+            return this.isTeamBroker || this.brokerState === 'connected'
         }
     },
     watch: {


### PR DESCRIPTION
## Description

Fixes the refresh topic button not being displayed for the team broker.

## Related Issue(s)

did not create one

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

