### PR TITLE
Add a new start tour button in the main dropdown menu that restarts the product tour

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -75,7 +75,7 @@
     </div>
 </template>
 <script>
-import { AcademicCapIcon, AdjustmentsIcon, CogIcon, LogoutIcon, MenuIcon, PlusIcon, QuestionMarkCircleIcon, UserAddIcon, XIcon } from '@heroicons/vue/solid'
+import { AcademicCapIcon, AdjustmentsIcon, CogIcon, CursorClickIcon, LogoutIcon, MenuIcon, PlusIcon, QuestionMarkCircleIcon, UserAddIcon, XIcon } from '@heroicons/vue/solid'
 import { ref } from 'vue'
 import { mapActions, mapGetters, mapState } from 'vuex'
 
@@ -108,17 +108,17 @@ export default {
                     icon: CogIcon,
                     tag: 'user-settings',
                     onclick: this.$router.push,
-                    onclickparams: { name: 'User Settings' }
+                    onclickparams: { name: 'User Settings' },
+                    hidden: false
                 },
-                this.user.admin
-                    ? {
-                        label: 'Admin Settings',
-                        icon: AdjustmentsIcon,
-                        tag: 'admin-settings',
-                        onclick: this.$router.push,
-                        onclickparams: { name: 'Admin Settings' }
-                    }
-                    : undefined,
+                {
+                    label: 'Admin Settings',
+                    icon: AdjustmentsIcon,
+                    tag: 'admin-settings',
+                    onclick: this.$router.push,
+                    onclickparams: { name: 'Admin Settings' },
+                    hidden: !this.user.admin
+                },
                 {
                     label: 'Documentation',
                     icon: QuestionMarkCircleIcon,
@@ -126,21 +126,25 @@ export default {
                     onclick: (route) => window.open(route.url, '_blank'),
                     onclickparams: { url: 'https://flowfuse.com/docs/' }
                 },
-                this.isTrialAccount || !this.featuresCheck?.isHostedInstancesEnabledForTeam
-                    ? {
-                        label: 'Getting Started',
-                        icon: AcademicCapIcon,
-                        tag: 'getting-started',
-                        onclick: this.openEducationModal
-                    }
-                    : undefined,
+                {
+                    label: 'Getting Started',
+                    icon: AcademicCapIcon,
+                    tag: 'getting-started',
+                    onclick: this.openEducationModal
+                },
+                {
+                    label: 'Welcome Tour',
+                    icon: CursorClickIcon,
+                    tag: 'welcome-tour',
+                    onclick: this.startWelcomeTour
+                },
                 {
                     label: 'Sign Out',
                     icon: LogoutIcon,
                     tag: 'sign-out',
                     onclick: this.signOut
                 }
-            ].filter(option => option !== undefined)
+            ].filter(option => !option.hidden)
         },
         showInviteButton () {
             return this.team && this.hasPermission('team:user:invite') && this.$route.name !== 'team-members-members'
@@ -181,6 +185,18 @@ export default {
         openEducationModal () {
             this.activateTour('education')
             product.capture('clicked-open-education-modal')
+        },
+        startWelcomeTour () {
+            return this.$store.dispatch('ux/resetTours')
+                // it's unfortunate that we can't redirect premium users straight to the application device page, but we
+                // don't have available applications at this moment in time so they'll get redirected twice
+                .then(() => this.$router.push({ name: 'Applications' }))
+                .then(() => {
+                    // breathing room for the page, instances and devices to load for the tour to work properly
+                    setTimeout(() => {
+                        this.$store.dispatch('ux/activateTour', 'welcome')
+                    }, 1000)
+                })
         }
     }
 }

--- a/frontend/src/store/ux.js
+++ b/frontend/src/store/ux.js
@@ -25,7 +25,7 @@ const state = () => ({
         education: false,
         'first-device': false
     },
-    completeTours: [],
+    completeTours: {},
     mainNav: {
         context: 'team',
         backToButton: null
@@ -451,7 +451,14 @@ const mutations = {
     },
     deactivateTour (state, tour) {
         state.tours[tour] = false
-        state.completeTours.push(tour)
+        state.completeTours[tour] = true
+    },
+    resetTours (state) {
+        Object.keys(state.tours)
+            .forEach(key => {
+                state.tours[key] = false
+            })
+        state.completeTours = {}
     },
     setUserAction (state, { action, payload }) {
         if (Object.prototype.hasOwnProperty.call(state.userActions, action)) {
@@ -493,6 +500,9 @@ const actions = {
     },
     deactivateTour ({ commit, state }, tour) {
         commit('deactivateTour', tour)
+    },
+    resetTours ({ commit }) {
+        commit('resetTours')
     },
     validateUserAction ({ commit }, action) {
         commit('setUserAction', { action, payload: true })

--- a/frontend/src/tours/tour-welcome.json
+++ b/frontend/src/tours/tour-welcome.json
@@ -17,8 +17,8 @@
         "on": "bottom"
     }
 }, {
-    "title": "Concept: Edge Devices",
-    "text": "<p><b>Edge Devices</b> are Node-RED instances that are managed and deployed <i>remotely</i>.</p><p>Whether hardware in factories or a Raspberry Pi on your desk, FlowFuse helps you manage hundreds of remote deployments.</p>",
+    "title": "Concept: Remote Instances",
+    "text": "<p><b>Remote Instances</b> are Node-RED instances that are managed and deployed <i>remotely</i>.</p><p>Whether hardware in factories or a Raspberry Pi on your desk, FlowFuse helps you manage hundreds of remote deployments.</p>",
     "attachTo": {
         "element": "section[data-el=\"application-devices-none\"], section[data-el=\"application-devices\"]",
         "on": "bottom"
@@ -46,7 +46,7 @@
     }
 }, {
     "title": "Concept: Device Groups",
-    "text": "<p><b>Device Groups</b> are collections of <b>Edge Devices</b> that can be used in <b>Pipelines</b> in order to deploy the same Node-RED flows out to multiple pieces of hardware in one-click.</p>",
+    "text": "<p><b>Device Groups</b> are collections of <b>Remote Instances</b> that can be used in <b>Pipelines</b> in order to deploy the same Node-RED flows out to multiple pieces of hardware in one-click.</p>",
     "attachTo": {
         "element": "a[data-nav=\"application-device-groups\"] ",
         "on": "left"

--- a/frontend/src/tours/tour-welcome.json
+++ b/frontend/src/tours/tour-welcome.json
@@ -13,14 +13,14 @@
     "title": "Concept: Hosted Instances",
     "text": "<p><b>Hosted Instances</b> refer to instances of Node-RED running at the <i>same</i> host as FlowFuse.</p>",
     "attachTo": {
-        "element": "div[data-el=\"application-instance-item\"]",
+        "element": "[data-el=\"application-instance-item\"]",
         "on": "bottom"
     }
 }, {
     "title": "Concept: Edge Devices",
     "text": "<p><b>Edge Devices</b> are Node-RED instances that are managed and deployed <i>remotely</i>.</p><p>Whether hardware in factories or a Raspberry Pi on your desk, FlowFuse helps you manage hundreds of remote deployments.</p>",
     "attachTo": {
-        "element": "section[data-el=\"application-devices-none\"]",
+        "element": "section[data-el=\"application-devices-none\"], section[data-el=\"application-devices\"]",
         "on": "bottom"
     }
 }, {


### PR DESCRIPTION
## Description

Adds a new 'Welcome tour' button in the main dropdown menu that re-starts the product tour. The product tour it starts is dependent based on the current team context and it's type
I also made the getting started menu entry available all the time because the tours also reference it and it would not make sense to have it visible to specific situations as we did until now.
Slightly altered the welcome tour to highlight appropriate sections even if devices or instances were present at the moment of starting the tour.


## Related Issue(s)

closes https://github.com/FlowFuse/customer/issues/301

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

