### PR TITLE
Resend team invitations

### DIFF
--- a/forge/auditLog/team.js
+++ b/forge/auditLog/team.js
@@ -29,6 +29,10 @@ module.exports = {
                     const body = generateBody({ error, user, role })
                     await log('team.user.invited', actionedBy, team?.id, body)
                 },
+                async reInvited (actionedBy, error, team, user, role) {
+                    const body = generateBody({ error, user, role })
+                    await log('team.user.invite-resent', actionedBy, team?.id, body)
+                },
                 async uninvited (actionedBy, error, team, user, role) {
                     const body = generateBody({ error, user, role })
                     await log('team.user.uninvited', actionedBy, team?.id, body)

--- a/forge/routes/api/teamInvitations.js
+++ b/forge/routes/api/teamInvitations.js
@@ -163,37 +163,7 @@ module.exports = async function (app) {
                 try {
                     // controllers.Invitation.createInvitations will have already
                     // rejected external requests if team:user:invite:external set to false
-                    if (invite.external) {
-                        let signupLink = `${app.config.base_url}/account/create?email=${encodeURIComponent(invite.email)}`
-                        if (app.license.active()) {
-                            // Check if this is for an SSO-enabled domain with auto-create turned on
-                            const providerConfig = await app.db.models.SAMLProvider.forEmail(invite.email)
-                            if (providerConfig?.options?.provisionNewUsers) {
-                                signupLink = `${app.config.base_url}`
-                            }
-                        }
-                        await app.postoffice.send(
-                            invite,
-                            'UnknownUserInvitation',
-                            {
-                                invite,
-                                signupLink
-                            }
-                        )
-                        await app.auditLog.Team.team.user.invited(request.session.User, null, request.team, invite, role)
-                    } else {
-                        if (app.postoffice.enabled()) {
-                            await app.postoffice.send(
-                                invite.invitee,
-                                'TeamInvitation',
-                                {
-                                    teamName: invite.team.name,
-                                    signupLink: `${app.config.base_url}/account/teams/invitations`
-                                }
-                            )
-                        }
-                        await app.auditLog.Team.team.user.invited(request.session.User, null, request.team, invite.invitee, role)
-                    }
+                    await app.db.controllers.Invitation.sendNotification(invite, user, request.team, role)
                 } catch (err) {
                     errorCount++
                     result.message[user] = 'Error sending invitation email'
@@ -245,6 +215,44 @@ module.exports = async function (app) {
             }
             await invitation.destroy()
             await app.auditLog.Team.team.user.uninvited(request.session.User, null, request.team, invitedUser, role)
+            reply.send({ status: 'okay' })
+        } else {
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+        }
+    })
+
+    /**
+     * Resend an invitation
+     * POST [/api/v1/teams/:teamId/invitations]/:invitationId
+     */
+    app.post('/:invitationId', {
+        schema: {
+            summary: 'Resend an invitation',
+            tags: ['Team Invitations'],
+            params: {
+                type: 'object',
+                properties: {
+                    teamId: { type: 'string' },
+                    invitationId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        const invitation = await app.db.models.Invitation.byId(request.params.invitationId)
+        if (invitation && invitation.teamId === request.team.id) {
+            const role = invitation.role || Roles.Member
+            const invitedUser = app.auditLog.formatters.userObject(invitation.external ? invitation : invitation.invitee)
+
+            await app.db.controllers.Invitation.sendNotification(invitation, invitedUser, request.team, role, true)
+
             reply.send({ status: 'okay' })
         } else {
             reply.code(404).send({ code: 'not_found', error: 'Not Found' })

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -217,6 +217,15 @@ const removeTeamInvitation = (teamId, inviteId) => {
         })
     })
 }
+const resendTeamInvitation = (teamId, inviteId) => {
+    return client.post(`/api/v1/teams/${teamId}/invitations/${inviteId}`).then(() => {
+        product.capture('$ff-invite-resent', {
+            'invite-id': inviteId
+        }, {
+            team: teamId
+        })
+    })
+}
 
 const create = async (options) => {
     return client.post('/api/v1/teams/', options).then(res => {
@@ -460,6 +469,7 @@ export default {
     getTeamInvitations,
     createTeamInvitation,
     removeTeamInvitation,
+    resendTeamInvitation,
     getTeamAuditLog,
     getTeamUserMembership,
     getTeamDevices,

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -98,7 +98,7 @@ export default {
                 confirmLabel: 'Resend'
             }, async () => {
                 try {
-                    console.log('re-sending')
+                    await teamApi.resendTeamInvitation(invite.team.id, invite.id)
                 } catch (err) {
                     Alerts.emit('Failed to resend invitation: ' + err.toString(), 'warning', 7500)
                 }

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -5,7 +5,13 @@
             <div class="text-right" />
             <ff-data-table data-el="invites-table" :columns="inviteColumns" :rows="invitations">
                 <template #row-actions="{row}">
-                    <ff-button kind="tertiary" class="ff-btn-xs ff-btn--tertiary" data-action="remove-invite" @click="resendInvite(row)">
+                    <ff-button
+                        v-if="!!settings.email"
+                        kind="tertiary"
+                        class="ff-btn-xs ff-btn--tertiary"
+                        data-action="remove-invite"
+                        @click="resendInvite(row)"
+                    >
                         <template #icon>
                             <RefreshIcon />
                         </template>
@@ -26,6 +32,7 @@ import { RefreshIcon, TrashIcon } from '@heroicons/vue/outline'
 import { markRaw } from 'vue'
 
 import { useRoute, useRouter } from 'vue-router'
+import { mapState } from 'vuex'
 
 import teamApi from '../../../api/team.js'
 import InviteUserCell from '../../../components/tables/cells/InviteUserCell.vue'
@@ -55,6 +62,9 @@ export default {
                 { label: 'Expires In', class: ['w-40'], key: 'expires' }
             ]
         }
+    },
+    computed: {
+        ...mapState('account', ['settings'])
     },
     watch: {
         teamMembership: 'fetchData',


### PR DESCRIPTION
## Description

- extracted the email notification part from the team invitation controller and re-used it to resend the invitation email on demand on a new api endpoint
- added a new auditLog event to differentiate between invitation creation and invitation resend events
- replaced the kebab menu on the invitation row in the invitation list with action buttons
- added a new button to resend the invitation email
- added dialog confirmation for both resending and deleting invitation actions
- added product capture events for posthog when re-sending invitations

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5150

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

