### PR TITLE
Show empty state message for unassigned devices

### DIFF
--- a/frontend/src/pages/device/VersionHistory/Snapshots/index.vue
+++ b/frontend/src/pages/device/VersionHistory/Snapshots/index.vue
@@ -1,6 +1,6 @@
 <template>
     <div id="device-snapshots">
-        <div v-if="isOwnedByAnInstance" class="space-y-6">
+        <div v-if="isOwnedByAnInstance || isUnassigned" class="space-y-6">
             <EmptyState :feature-unavailable="!features.deviceEditor">
                 <template #img>
                     <img src="../../../../images/empty-states/instance-snapshots.png">
@@ -223,6 +223,9 @@ export default {
         },
         isOwnedByAnInstance () {
             return this.device?.ownerType === 'instance'
+        },
+        isUnassigned () {
+            return this.device?.ownerType === ''
         }
     },
     watch: {
@@ -245,7 +248,7 @@ export default {
             return snapshot.device?.id === this.device.id
         },
         fetchData: async function () {
-            if (!this.features.deviceEditor) {
+            if (!this.features.deviceEditor || this.isOwnedByAnInstance || this.isUnassigned) {
                 return
             }
             if (this.device.id && this.device.application) {

--- a/frontend/src/pages/device/VersionHistory/index.vue
+++ b/frontend/src/pages/device/VersionHistory/index.vue
@@ -32,7 +32,7 @@
                     v-if="hasPermission('snapshot:import')"
                     kind="secondary"
                     data-action="import-snapshot"
-                    :disabled="busy || isOwnedByAnInstance"
+                    :disabled="busy || isOwnedByAnInstance || isUnassigned"
                     @click="showImportSnapshotDialog"
                 >
                     <template #icon-left><UploadIcon /></template>Upload Snapshot
@@ -138,6 +138,9 @@ export default {
         },
         isOwnedByAnInstance () {
             return this.device?.ownerType === 'instance'
+        },
+        isUnassigned () {
+            return this.device?.ownerType === ''
         }
     },
     methods: {

--- a/test/e2e/frontend/cypress/tests/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/snapshots.spec.js
@@ -19,9 +19,15 @@ describe('FlowForge - Devices', () => {
 
     it('exposes a "Snapshots" tab if not assigned to anything & informs users this is a Enterprise Feature', () => {
         cy.contains('span', 'team2-unassigned-device').click()
+
         cy.get('[data-nav="version-history"]').should('exist')
         cy.get('[data-nav="version-history"]').click()
+
+        cy.get('[data-el="empty-state"]').should('exist')
+        cy.get('[data-el="empty-state"]').contains('Snapshots are available when a Remote Instance is assigned to an Application')
+
         cy.get('[data-el="page-banner-feature-unavailable"]').should('exist')
+        cy.get('[data-el="page-banner-feature-unavailable"]').contains('This is a FlowFuse Enterprise feature. Please upgrade your instance of FlowFuse in order to use it.')
     })
 
     it('exposes the "Version History" tab if assigned to an Instance but the Snapshots tab has an empty state message', () => {


### PR DESCRIPTION
## Description

This scenario was missed when I added the empty state message for instance assigned devices

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5111

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

