### PR TITLE
Extend invitation expiration date when resending it

### DIFF
--- a/forge/db/models/Invitation.js
+++ b/forge/db/models/Invitation.js
@@ -135,6 +135,12 @@ module.exports = {
                             { model: M.User, as: 'invitee' }
                         ]
                     })
+                },
+                extendExpirationDate: async (id) => {
+                    return this.update(
+                        { expiresAt: Date.now() + DEFAULT_INVITATION_EXPIRY },
+                        { where: { id } }
+                    )
                 }
             }
         }

--- a/forge/db/views/Invitation.js
+++ b/forge/db/views/Invitation.js
@@ -33,31 +33,34 @@ module.exports = function (app) {
         }
     })
 
+    function invitation (t) {
+        const d = t.get({ plain: true })
+        const result = {
+            id: d.hashid,
+            role: d.role,
+            createdAt: d.createdAt,
+            expiresAt: d.expiresAt,
+            sentAt: d.sentAt,
+            team: app.db.views.Team.teamSummary(t.team),
+            invitor: app.db.views.User.userSummary(d.invitor)
+        }
+        if (d.external) {
+            result.invitee = {
+                external: true,
+                email: d.email
+            }
+        } else {
+            result.invitee = app.db.views.User.userSummary(d.invitee)
+        }
+        return result
+    }
+
     function invitationList (invitations) {
-        return invitations.map((t) => {
-            const d = t.get({ plain: true })
-            const result = {
-                id: d.hashid,
-                role: d.role,
-                createdAt: d.createdAt,
-                expiresAt: d.expiresAt,
-                sentAt: d.sentAt,
-                team: app.db.views.Team.teamSummary(t.team),
-                invitor: app.db.views.User.userSummary(d.invitor)
-            }
-            if (d.external) {
-                result.invitee = {
-                    external: true,
-                    email: d.email
-                }
-            } else {
-                result.invitee = app.db.views.User.userSummary(d.invitee)
-            }
-            return result
-        })
+        return invitations.map((t) => invitation(t))
     }
 
     return {
+        invitation,
         invitationList
     }
 }

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -218,13 +218,21 @@ const removeTeamInvitation = (teamId, inviteId) => {
     })
 }
 const resendTeamInvitation = (teamId, inviteId) => {
-    return client.post(`/api/v1/teams/${teamId}/invitations/${inviteId}`).then(() => {
-        product.capture('$ff-invite-resent', {
-            'invite-id': inviteId
-        }, {
-            team: teamId
+    return client.post(`/api/v1/teams/${teamId}/invitations/${inviteId}`)
+        .then((response) => response.data)
+        .then((invitation) => {
+            product.capture('$ff-invite-resent', {
+                'invite-id': inviteId
+            }, {
+                team: teamId
+            })
+
+            invitation.roleName = RoleNames[invitation.role || Roles.Member]
+            invitation.createdSince = daysSince(invitation.createdAt)
+            invitation.expires = elapsedTime(invitation.expiresAt, Date.now())
+
+            return invitation
         })
-    })
 }
 
 const create = async (options) => {

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -98,12 +98,17 @@ export default {
                 html: `Do you want to resend the invitation to <i>${invite.invitee.email || invite.invitee.name}</i> ?`,
                 confirmLabel: 'Resend'
             }, async () => {
-                try {
-                    await teamApi.resendTeamInvitation(invite.team.id, invite.id)
-                        .then(() => Alerts.emit('The invitation email was sent successfully', 'confirmation'))
-                } catch (err) {
-                    Alerts.emit('Failed to resend invitation: ' + err.toString(), 'warning', 7500)
-                }
+                teamApi.resendTeamInvitation(invite.team.id, invite.id)
+                    .then((res) => {
+                        const idx = this.invitations.findIndex(inv => inv.id === res.id)
+
+                        if (idx !== -1) {
+                            this.invitations[idx] = res
+                        }
+
+                        Alerts.emit('The invitation email was sent successfully', 'confirmation')
+                    })
+                    .catch((err) => Alerts.emit('Failed to resend invitation: ' + err.toString(), 'warning', 7500))
             })
         },
         async fetchData () {

--- a/test/unit/forge/routes/api/teamInvitations_spec.js
+++ b/test/unit/forge/routes/api/teamInvitations_spec.js
@@ -451,7 +451,7 @@ describe('Team Invitations API', function () {
             result.should.have.property('team')
             result.should.have.property('invitor')
             result.should.have.property('invitee')
-            // app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
+            app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
         })
         it('Returns a 404 when an invitation is not found', async () => {
             app.config.email.transport.getMessageQueue().should.have.lengthOf(0)

--- a/test/unit/forge/routes/api/teamInvitations_spec.js
+++ b/test/unit/forge/routes/api/teamInvitations_spec.js
@@ -427,7 +427,7 @@ describe('Team Invitations API', function () {
         })
         it('Queues an email when a valid invitation id is provided', async () => {
             const invitation = await app.db.controllers.Invitation.createInvitations(
-                TestObjects.tokens.bob,
+                TestObjects.bob,
                 TestObjects.BTeam,
                 [
                     TestObjects.chris.email
@@ -443,8 +443,15 @@ describe('Team Invitations API', function () {
                 cookies: { sid: TestObjects.tokens.bob }
             })
             const result = response.json()
-            result.should.have.property('status', 'okay')
-            app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
+            result.should.have.property('id')
+            result.should.have.property('role')
+            result.should.have.property('createdAt')
+            result.should.have.property('expiresAt')
+            result.should.have.property('sentAt')
+            result.should.have.property('team')
+            result.should.have.property('invitor')
+            result.should.have.property('invitee')
+            // app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
         })
         it('Returns a 404 when an invitation is not found', async () => {
             app.config.email.transport.getMessageQueue().should.have.lengthOf(0)


### PR DESCRIPTION
## Description

follow up for https://github.com/FlowFuse/flowfuse/issues/5150. It extends the invitation expiration date when re-sending them

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5150

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

