### PR TITLE
Fix Sentry Bug - MQTT client may be null

### DIFF
--- a/frontend/src/pages/device/components/DeviceLog.vue
+++ b/frontend/src/pages/device/components/DeviceLog.vue
@@ -126,7 +126,7 @@ export default {
             })
         },
         disconnectMQTT: async function () {
-            if (this.client.connected) {
+            if (this.client?.connected) {
                 this.client.end()
             }
             this.client = null


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Sentry error about client being null when testing for connection.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://sentry.io/organizations/flowfuse/alerts/rules/flowfuse-frontend/14699916/details/

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

