### PR TITLE
Add API to get teams npm packages

### DIFF
--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -22,6 +22,8 @@ module.exports = fp(async function (app, opts) {
         app.config.features.register('projectHistory', true, true)
         // Set the Bill of Materials Feature Flag
         app.config.features.register('bom', true, true)
+        // Set npm Feature Flag
+        app.config.features.register('npm', true, true)
     }
 
     // Set the Team Library Feature Flag

--- a/forge/ee/routes/catalogues/index.js
+++ b/forge/ee/routes/catalogues/index.js
@@ -1,12 +1,14 @@
 const axios = require('axios')
 
 module.exports = async function (app) {
-
     /**
-     * 
+     * Get Teams npm packages
+     * @name /api/v1/teams/:teamId/npm/packages
+     * @static
+     * @memberof forge.routes.api.team.npm
      */
     app.get('/npm/packages', {
-        preHandler: app.needsPermission('team:packages:read') 
+        preHandler: app.needsPermission('team:packages:read')
     }, async (request, reply) => {
         try {
             const packageList = await axios.get(`${app.config.npmRegistry?.url}/-/all`, {
@@ -20,7 +22,7 @@ module.exports = async function (app) {
 
             const packages = {}
             for (const package in packageList.data) {
-                if (package == '_updated') {
+                if (package === '_updated') {
                     continue
                 }
                 if (package.startsWith(`@${request.teamId}/`)) {
@@ -34,6 +36,12 @@ module.exports = async function (app) {
         }
     })
 
+    /**
+     * Get Team catlogue
+     * @name /api/v1/teams/:teamId/catalogue
+     * @static
+     * @memberof forge.routes.api.team.npm
+     */
     app.get('/catalogue', {
         config: {
             allowAnonymous: true

--- a/forge/ee/routes/catalogues/index.js
+++ b/forge/ee/routes/catalogues/index.js
@@ -1,6 +1,39 @@
 const axios = require('axios')
 
 module.exports = async function (app) {
+
+    /**
+     * 
+     */
+    app.get('/npm/packages', {
+        preHandler: app.needsPermission('team:packages:read') 
+    }, async (request, reply) => {
+        try {
+            const packageList = await axios.get(`${app.config.npmRegistry?.url}/-/all`, {
+                // If we can swap this for a teams creds or token then the
+                // filtering will all be done in the npm repo
+                auth: {
+                    username: app.config.npmRegistry.admin.username,
+                    password: app.config.npmRegistry.admin.password
+                }
+            })
+
+            const packages = {}
+            for (const package in packageList.data) {
+                if (package == '_updated') {
+                    continue
+                }
+                if (package.startsWith(`@${request.teamId}/`)) {
+                    packages[package] = packageList.data[package]
+                }
+            }
+
+            reply.send(packages)
+        } catch (err) {
+            reply.status(500).send({ error: 'unkown_error', message: err.toString() })
+        }
+    })
+
     app.get('/catalogue', {
         config: {
             allowAnonymous: true
@@ -11,6 +44,8 @@ module.exports = async function (app) {
 
             try {
                 const packageList = await axios.get(`${app.config.npmRegistry?.url}/-/all`, {
+                    // If we can swap this for a teams creds or token then the
+                    // filtering will all be done in the npm repo
                     auth: {
                         username: app.config.npmRegistry.admin.username,
                         password: app.config.npmRegistry.admin.password

--- a/forge/ee/routes/catalogues/index.js
+++ b/forge/ee/routes/catalogues/index.js
@@ -65,7 +65,7 @@ module.exports = async function (app) {
                     if (package === '_updated') {
                         continue
                     }
-                    if (package.startsWith(`@${request.teamId}/`)) {
+                    if (package.startsWith(`@${request.params.teamId}/`)) {
                         modules.push({
                             id: package,
                             description: packageList.data[package].description,

--- a/forge/ee/routes/catalogues/index.js
+++ b/forge/ee/routes/catalogues/index.js
@@ -38,11 +38,11 @@ module.exports = async function (app) {
 
     /**
      * Get Team catlogue
-     * @name /api/v1/teams/:teamId/catalogue
+     * @name /api/v1/teams/:teamId/npm/catalogue
      * @static
      * @memberof forge.routes.api.team.npm
      */
-    app.get('/catalogue', {
+    app.get('/npm/catalogue', {
         config: {
             allowAnonymous: true
         }

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -195,7 +195,11 @@ const Permissions = {
     'broker:credentials:list': { description: 'List 3rd Party Broker credentials', role: Roles.Owner },
     'broker:credentials:create': { description: 'Create new Broker credentials', role: Roles.Owner },
     'broker:credentials:edit': { description: 'Edit Broker Credentials', role: Roles.Owner },
-    'broker:credentials:delete': { description: 'Delete Broker Credentials', role: Roles.Owner }
+    'broker:credentials:delete': { description: 'Delete Broker Credentials', role: Roles.Owner },
+
+    // Team Packages
+    'team:packages:read': { description: 'List Teams Private Packages', role: Roles.Member },
+    'team:packages:manage': { description: 'Manage Teams Private Packages', role: Roles.Owner }
 }
 
 module.exports = {

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -117,8 +117,9 @@
                     <FormRow v-model="input.properties.features.bom" type="checkbox">Bill of Materials / Dependencies</FormRow>
                     <FormRow v-model="input.properties.features.teamBroker" type="checkbox">Team Broker</FormRow>
                     <FormRow v-model="input.properties.features.projectHistory" type="checkbox">Version History Timeline</FormRow>
+                    <FormRow v-model="input.properties.features.npm" type="checkbox">NPM Packages</FormRow>
                     <!-- to make the grid work nicely, only needed if there is an odd number of checkbox features above-->
-                    <!--                    <span />-->
+                    <span />
                     <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
                     <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow>
                 </div>
@@ -234,6 +235,9 @@ export default {
                     }
                     if (this.input.properties.features.projectHistory === undefined) {
                         this.input.properties.features.projectHistory = false
+                    }
+                    if (this.input.properties.features.npm === undefined) {
+                        this.input.properties.features.npm = false
                     }
                 } else {
                     this.editDisabled = false

--- a/test/unit/forge/ee/routes/catalogue/index_spec.js
+++ b/test/unit/forge/ee/routes/catalogue/index_spec.js
@@ -1,7 +1,10 @@
 const should = require('should') // eslint-disable-line
 const setup = require('../../setup')
 
-describe('Team Catalogue', function () {
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe.only('Team Catalogue', function () {
     let app
     const TestObjects = { tokens: {} }
     let httpServer
@@ -11,7 +14,7 @@ describe('Team Catalogue', function () {
             license,
             npmRegistry: {
                 enabled: true,
-                url: 'http://localhost:4873',
+                url: 'http://localhost:9752',
                 admin: {
                     username: 'admin',
                     password: 'secret'
@@ -64,10 +67,13 @@ describe('Team Catalogue', function () {
                 res.end(JSON.stringify(retVal))
             }
         })
-        httpserver.listen(9752)
+        httpServer.listen(9752, ()=> {
+            console.log('listening on 9752')
+        })
     })
 
     after(async function () {
+        httpServer.close()
         await app.close()
     })
 
@@ -82,6 +88,14 @@ describe('Team Catalogue', function () {
         TestObjects.tokens[username] = response.cookies[0].value
     }
     it('Get Team Catalogue', async function () {
-
+        const response = await app.inject({
+            method: 'GET',
+            url: `/api/v1/teams/${app.team.hashid}/npm/catalogue?teamId=${app.team.hashid}`,
+        })
+        response.statusCode.should.equal(200)
+        const result = response.json()
+        result.should.have.property('name', `FlowFuse Team ${app.team.name} catalogue`)
+        result.should.have.property('modules')
+        result.modules[0].should.have.property('id', `@${app.team.hashid}/one`)
     })
 })

--- a/test/unit/forge/ee/routes/catalogue/index_spec.js
+++ b/test/unit/forge/ee/routes/catalogue/index_spec.js
@@ -1,0 +1,87 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../../setup')
+
+describe('Team Catalogue', function () {
+    let app
+    const TestObjects = { tokens: {} }
+    let httpServer
+    before(async function () {
+        const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZkNDFmNmRjLTBmM2QtNGFmNy1hNzk0LWIyNWFhNGJmYTliZCIsInZlciI6IjIwMjQtMDMtMDQiLCJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGdXNlIERldmVsb3BtZW50IiwibmJmIjoxNzMwNjc4NDAwLCJleHAiOjIwNzc3NDcyMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxMCwidGVhbXMiOjEwLCJpbnN0YW5jZXMiOjEwLCJtcXR0Q2xpZW50cyI6NiwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTczMDcyMTEyNH0.02KMRf5kogkpH3HXHVSGprUm0QQFLn21-3QIORhxFgRE9N5DIE8YnTH_f8W_21T6TlYbDUmf4PtWyj120HTM2w'
+        app = await setup({
+            license,
+            npmRegistry: {
+                enabled: true,
+                url: 'http://localhost:4873',
+                admin: {
+                    username: 'admin',
+                    password: 'secret'
+                }
+            }
+        })
+
+        await login('alice', 'aaPassword')
+
+        const userBob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+        app.userBob = userBob
+        await app.team.addUser(userBob, { through: { role: Roles.Owner } })
+        // Run all the tests with bob - non-admin Team Owner
+        await login('bob', 'bbPassword')
+
+        httpServer = require('http').createServer((req, res) => {
+            if (/^\/-\/all/.test(req.url)) {
+                res.writeHead(200, { 'Content-Type': 'application/json' })
+                const retVal = {
+                    '_updated': 99999
+                }
+                retVal[`@${app.team.hashid}/one`] =  {
+                    name: `@${app.team.hashid}/one`,
+                    'dist-tags': {
+                        'latest': '1.0.0'
+                    },
+                    'time': {
+                        'modified': '2025-02-18T10:13:18.950Z'
+                    },
+                    'license': 'Apache-2.0',
+                    'versions': {
+                        '1.0.0': 'latest'
+                    }
+                  
+                }
+                retVal[`@${app.team.hashid}/two`] =  {
+                    name: `@${app.team.hashid}/two`,
+                    'dist-tags': {
+                        'latest': '1.0.0'
+                    },
+                    'time': {
+                        'modified': '2025-02-18T10:13:18.950Z'
+                    },
+                    'license': 'Apache-2.0',
+                    'versions': {
+                        '1.0.0': 'latest'
+                    }
+                  
+                }
+                res.end(JSON.stringify(retVal))
+            }
+        })
+        httpserver.listen(9752)
+    })
+
+    after(async function () {
+        await app.close()
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+    it('Get Team Catalogue', async function () {
+
+    })
+})

--- a/test/unit/forge/ee/routes/catalogue/index_spec.js
+++ b/test/unit/forge/ee/routes/catalogue/index_spec.js
@@ -4,7 +4,7 @@ const setup = require('../../setup')
 const FF_UTIL = require('flowforge-test-utils')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
 
-describe.only('Team Catalogue', function () {
+describe('Team Catalogue', function () {
     let app
     const TestObjects = { tokens: {} }
     let httpServer
@@ -34,42 +34,38 @@ describe.only('Team Catalogue', function () {
             if (/^\/-\/all/.test(req.url)) {
                 res.writeHead(200, { 'Content-Type': 'application/json' })
                 const retVal = {
-                    '_updated': 99999
+                    _updated: 99999
                 }
-                retVal[`@${app.team.hashid}/one`] =  {
+                retVal[`@${app.team.hashid}/one`] = {
                     name: `@${app.team.hashid}/one`,
                     'dist-tags': {
-                        'latest': '1.0.0'
+                        latest: '1.0.0'
                     },
-                    'time': {
-                        'modified': '2025-02-18T10:13:18.950Z'
+                    time: {
+                        modified: '2025-02-18T10:13:18.950Z'
                     },
-                    'license': 'Apache-2.0',
-                    'versions': {
+                    license: 'Apache-2.0',
+                    versions: {
                         '1.0.0': 'latest'
                     }
-                  
                 }
-                retVal[`@${app.team.hashid}/two`] =  {
+                retVal[`@${app.team.hashid}/two`] = {
                     name: `@${app.team.hashid}/two`,
                     'dist-tags': {
-                        'latest': '1.0.0'
+                        latest: '1.0.0'
                     },
-                    'time': {
-                        'modified': '2025-02-18T10:13:18.950Z'
+                    time: {
+                        modified: '2025-02-18T10:13:18.950Z'
                     },
-                    'license': 'Apache-2.0',
-                    'versions': {
+                    license: 'Apache-2.0',
+                    versions: {
                         '1.0.0': 'latest'
                     }
-                  
                 }
                 res.end(JSON.stringify(retVal))
             }
         })
-        httpServer.listen(9752, ()=> {
-            console.log('listening on 9752')
-        })
+        httpServer.listen(9752)
     })
 
     after(async function () {
@@ -90,7 +86,7 @@ describe.only('Team Catalogue', function () {
     it('Get Team Catalogue', async function () {
         const response = await app.inject({
             method: 'GET',
-            url: `/api/v1/teams/${app.team.hashid}/npm/catalogue?teamId=${app.team.hashid}`,
+            url: `/api/v1/teams/${app.team.hashid}/npm/catalogue?teamId=${app.team.hashid}`
         })
         response.statusCode.should.equal(200)
         const result = response.json()

--- a/test/unit/forge/ee/routes/catalogue/index_spec.js
+++ b/test/unit/forge/ee/routes/catalogue/index_spec.js
@@ -5,131 +5,201 @@ const FF_UTIL = require('flowforge-test-utils')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
 
 describe('Team Catalogue', function () {
-    let app
-    const TestObjects = { tokens: {} }
-    let httpServer
-    before(async function () {
-        const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZkNDFmNmRjLTBmM2QtNGFmNy1hNzk0LWIyNWFhNGJmYTliZCIsInZlciI6IjIwMjQtMDMtMDQiLCJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGdXNlIERldmVsb3BtZW50IiwibmJmIjoxNzMwNjc4NDAwLCJleHAiOjIwNzc3NDcyMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxMCwidGVhbXMiOjEwLCJpbnN0YW5jZXMiOjEwLCJtcXR0Q2xpZW50cyI6NiwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTczMDcyMTEyNH0.02KMRf5kogkpH3HXHVSGprUm0QQFLn21-3QIORhxFgRE9N5DIE8YnTH_f8W_21T6TlYbDUmf4PtWyj120HTM2w'
-        app = await setup({
-            license,
-            npmRegistry: {
-                enabled: true,
-                url: 'http://localhost:9752',
-                admin: {
-                    username: 'admin',
-                    password: 'secret'
+    describe('Enabled', function () {
+        let app
+        const TestObjects = { tokens: {} }
+        let httpServer
+        before(async function () {
+            const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZkNDFmNmRjLTBmM2QtNGFmNy1hNzk0LWIyNWFhNGJmYTliZCIsInZlciI6IjIwMjQtMDMtMDQiLCJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGdXNlIERldmVsb3BtZW50IiwibmJmIjoxNzMwNjc4NDAwLCJleHAiOjIwNzc3NDcyMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxMCwidGVhbXMiOjEwLCJpbnN0YW5jZXMiOjEwLCJtcXR0Q2xpZW50cyI6NiwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTczMDcyMTEyNH0.02KMRf5kogkpH3HXHVSGprUm0QQFLn21-3QIORhxFgRE9N5DIE8YnTH_f8W_21T6TlYbDUmf4PtWyj120HTM2w'
+            app = await setup({
+                license,
+                npmRegistry: {
+                    enabled: true,
+                    url: 'http://localhost:9752',
+                    admin: {
+                        username: 'admin',
+                        password: 'secret'
+                    }
+                }
+            })
+
+            await login('alice', 'aaPassword')
+
+            const userBob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+            app.userBob = userBob
+            await app.team.addUser(userBob, { through: { role: Roles.Owner } })
+            // Run all the tests with bob - non-admin Team Owner
+            await login('bob', 'bbPassword')
+
+            const userChris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
+            await app.team.addUser(userChris, { through: { role: Roles.Member } })
+            await login('chris', 'ccPassword')
+
+            const defaultTeamType = await app.db.models.TeamType.findOne({ where: { id: 1 } })
+            const defaultTeamTypeProperties = defaultTeamType.properties
+
+            if (defaultTeamTypeProperties.features) {
+                defaultTeamTypeProperties.features.npm = true
+            } else {
+                defaultTeamTypeProperties.features = {
+                    npm: true
                 }
             }
+
+            app.defaultTeamType.properties = defaultTeamTypeProperties
+            await app.defaultTeamType.save()
+
+            httpServer = require('http').createServer((req, res) => {
+                if (/^\/-\/all/.test(req.url)) {
+                    res.writeHead(200, { 'Content-Type': 'application/json' })
+                    const retVal = {
+                        _updated: 99999
+                    }
+                    retVal[`@${app.team.hashid}/one`] = {
+                        name: `@${app.team.hashid}/one`,
+                        'dist-tags': {
+                            latest: '1.0.0'
+                        },
+                        time: {
+                            modified: '2025-02-18T10:13:18.950Z'
+                        },
+                        license: 'Apache-2.0',
+                        versions: {
+                            '1.0.0': 'latest'
+                        }
+                    }
+                    retVal[`@${app.team.hashid}/two`] = {
+                        name: `@${app.team.hashid}/two`,
+                        'dist-tags': {
+                            latest: '1.0.0'
+                        },
+                        time: {
+                            modified: '2025-02-18T10:13:18.950Z'
+                        },
+                        license: 'Apache-2.0',
+                        versions: {
+                            '1.0.0': 'latest'
+                        }
+                    }
+                    retVal['@foo/two'] = {
+                        name: '@foo/two',
+                        'dist-tags': {
+                            latest: '1.0.0'
+                        },
+                        time: {
+                            modified: '2025-02-18T10:13:18.950Z'
+                        },
+                        license: 'Apache-2.0',
+                        versions: {
+                            '1.0.0': 'latest'
+                        }
+                    }
+                    res.end(JSON.stringify(retVal))
+                }
+            })
+            httpServer.listen(9752)
         })
 
-        await login('alice', 'aaPassword')
+        after(async function () {
+            httpServer.close()
+            await app.close()
+        })
 
-        const userBob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
-        app.userBob = userBob
-        await app.team.addUser(userBob, { through: { role: Roles.Owner } })
-        // Run all the tests with bob - non-admin Team Owner
-        await login('bob', 'bbPassword')
-
-        const userChris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
-        await app.team.addUser(userChris, { through: { role: Roles.Member } })
-        await login('chris', 'ccPassword')
-
-        httpServer = require('http').createServer((req, res) => {
-            if (/^\/-\/all/.test(req.url)) {
-                res.writeHead(200, { 'Content-Type': 'application/json' })
-                const retVal = {
-                    _updated: 99999
-                }
-                retVal[`@${app.team.hashid}/one`] = {
-                    name: `@${app.team.hashid}/one`,
-                    'dist-tags': {
-                        latest: '1.0.0'
-                    },
-                    time: {
-                        modified: '2025-02-18T10:13:18.950Z'
-                    },
-                    license: 'Apache-2.0',
-                    versions: {
-                        '1.0.0': 'latest'
+        async function login (username, password) {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/account/login',
+                payload: { username, password, remember: false }
+            })
+            response.cookies.should.have.length(1)
+            response.cookies[0].should.have.property('name', 'sid')
+            TestObjects.tokens[username] = response.cookies[0].value
+        }
+        it('Get Team Catalogue', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${app.team.hashid}/npm/catalogue?teamId=${app.team.hashid}`
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('name', `FlowFuse Team ${app.team.name} catalogue`)
+            result.should.have.property('modules')
+            result.modules.should.have.a.lengthOf(2)
+            result.modules[0].should.have.property('id', `@${app.team.hashid}/one`)
+        })
+        it('Get Team Packages by Owner', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${app.team.hashid}/npm/packages`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property(`@${app.team.hashid}/one`)
+            result[`@${app.team.hashid}/one`].should.have.property('name', `@${app.team.hashid}/one`)
+            result[`@${app.team.hashid}/one`].should.have.property('license', 'Apache-2.0')
+        })
+        it('Get Team Packages by Member', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${app.team.hashid}/npm/packages`,
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            response.statusCode.should.equal(200)
+        })
+    })
+    describe('Not Enabled for Team', function () {
+        let app
+        const TestObjects = { tokens: {} }
+        before(async function () {
+            const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZkNDFmNmRjLTBmM2QtNGFmNy1hNzk0LWIyNWFhNGJmYTliZCIsInZlciI6IjIwMjQtMDMtMDQiLCJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGdXNlIERldmVsb3BtZW50IiwibmJmIjoxNzMwNjc4NDAwLCJleHAiOjIwNzc3NDcyMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxMCwidGVhbXMiOjEwLCJpbnN0YW5jZXMiOjEwLCJtcXR0Q2xpZW50cyI6NiwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTczMDcyMTEyNH0.02KMRf5kogkpH3HXHVSGprUm0QQFLn21-3QIORhxFgRE9N5DIE8YnTH_f8W_21T6TlYbDUmf4PtWyj120HTM2w'
+            app = await setup({
+                license,
+                npmRegistry: {
+                    enabled: true,
+                    url: 'http://localhost:9752',
+                    admin: {
+                        username: 'admin',
+                        password: 'secret'
                     }
                 }
-                retVal[`@${app.team.hashid}/two`] = {
-                    name: `@${app.team.hashid}/two`,
-                    'dist-tags': {
-                        latest: '1.0.0'
-                    },
-                    time: {
-                        modified: '2025-02-18T10:13:18.950Z'
-                    },
-                    license: 'Apache-2.0',
-                    versions: {
-                        '1.0.0': 'latest'
-                    }
-                }
-                retVal[`@foo/two`] = {
-                    name: `@foo/two`,
-                    'dist-tags': {
-                        latest: '1.0.0'
-                    },
-                    time: {
-                        modified: '2025-02-18T10:13:18.950Z'
-                    },
-                    license: 'Apache-2.0',
-                    versions: {
-                        '1.0.0': 'latest'
-                    }
-                }
-                res.end(JSON.stringify(retVal))
-            }
-        })
-        httpServer.listen(9752)
-    })
+            })
+            await login('alice', 'aaPassword')
 
-    after(async function () {
-        httpServer.close()
-        await app.close()
-    })
+            const userBob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+            app.userBob = userBob
+            await app.team.addUser(userBob, { through: { role: Roles.Owner } })
+            // Run all the tests with bob - non-admin Team Owner
+            await login('bob', 'bbPassword')
+        })
+        after(async function () {
+            await app.close()
+        })
+        async function login (username, password) {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/account/login',
+                payload: { username, password, remember: false }
+            })
+            response.cookies.should.have.length(1)
+            response.cookies[0].should.have.property('name', 'sid')
+            TestObjects.tokens[username] = response.cookies[0].value
+        }
 
-    async function login (username, password) {
-        const response = await app.inject({
-            method: 'POST',
-            url: '/account/login',
-            payload: { username, password, remember: false }
+        it('Get Team Catalogue', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${app.team.hashid}/npm/catalogue?teamId=${app.team.hashid}`
+            })
+            response.statusCode.should.equal(404)
         })
-        response.cookies.should.have.length(1)
-        response.cookies[0].should.have.property('name', 'sid')
-        TestObjects.tokens[username] = response.cookies[0].value
-    }
-    it('Get Team Catalogue', async function () {
-        const response = await app.inject({
-            method: 'GET',
-            url: `/api/v1/teams/${app.team.hashid}/npm/catalogue?teamId=${app.team.hashid}`
+        it('Get Team Packages by Owner', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${app.team.hashid}/npm/packages`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(404)
         })
-        response.statusCode.should.equal(200)
-        const result = response.json()
-        result.should.have.property('name', `FlowFuse Team ${app.team.name} catalogue`)
-        result.should.have.property('modules')
-        result.modules.should.have.a.lengthOf(2)
-        result.modules[0].should.have.property('id', `@${app.team.hashid}/one`)
-    })
-    it('Get Team Packages by Owner', async function () {
-        const response = await app.inject({
-            method: 'GET',
-            url: `/api/v1/teams/${app.team.hashid}/npm/packages`,
-            cookies: { sid: TestObjects.tokens.bob }
-        })
-        response.statusCode.should.equal(200)
-        const result = response.json()
-        result.should.have.property(`@${app.team.hashid}/one`)
-        result[`@${app.team.hashid}/one`].should.have.property('name', `@${app.team.hashid}/one`)
-        result[`@${app.team.hashid}/one`].should.have.property('license', 'Apache-2.0')
-    })
-    it('Get Team Packages by Member', async function () {
-        const response = await app.inject({
-            method: 'GET',
-            url: `/api/v1/teams/${app.team.hashid}/npm/packages`,
-            cookies: { sid: TestObjects.tokens.chris }
-        })
-        response.statusCode.should.equal(200)
     })
 })


### PR DESCRIPTION
part of #5190

## Description

<!-- Describe your changes in detail -->
Adds endpoint for querying a teams npm packages

- GET `/api/v1/teams/:teamId/npm/packages`

returns
```
{
  "@teamId/packageOne": {
    "name": "@teamId/packageOne",
    "dist-tags": {
      "latest": "1.0.0"
    },
    "maintainers": [],
    "author": "",
    "readmeFilename": "",
    "time": {
      "modified": "2025-02-17T17:47:49.589Z"
    },
    "license": "Apache-2.0",
    "versions": {
      "1.0.0": "latest"
    }
  }
  "@teamId/packageTwo": {
    "name": "@teamId/packageTwo",
    "dist-tags": {
      "latest": "1.0.0"
    },
    "maintainers": [],
    "author": "",
    "readmeFilename": "",
    "time": {
      "modified": "2025-02-17T17:47:49.589Z"
    },
    "license": "Apache-2.0",
    "versions": {
      "1.0.0": "latest"
    }
  }
}
```

(This is a filtered version of the standard output for a npm registry)

Builds on #5173 but as that is feature flagged both can be merged as soon as review happy

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#5190 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

