### PR TITLE
Add topic suggestions

### DIFF
--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
@@ -2,15 +2,19 @@
     <main-title title="Payload Schema" class="mt-1" />
 
     <div class="ff-topic-inspecting">
-        <section>
+        <section class="schema-wrapper">
             <sub-title title="Schema" :icon="CodeBracketSquareIcon" />
-            <topic-schema :schema="segment.inferredSchema" />
+            <topic-schema :schema="schema" />
         </section>
 
-        <section>
+        <section v-if="!hasDefinedSchema && isInferredTypePrimitive" class="suggestions-wrapper">
             <sub-title title="Suggestions" :icon="LightBulbIcon" />
             <topic-suggestions>
-                <topic-suggestion format=".json" description="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Deserunt dolores harum modi repudiandae saepe! Adipisci consectetur cum dicta dolorum ducimus id libero nam nemo nisi nobis non omnis quibusdam, suscipit!" />
+                <topic-suggestion
+                    :format="inferredType"
+                    @suggestion-accepted="$emit('suggestion-accepted')"
+                    @suggestion-rejected="$emit('suggestion-rejected')"
+                />
             </topic-suggestions>
         </section>
     </div>
@@ -41,8 +45,23 @@ export default {
             type: Object
         }
     },
+    emits: ['suggestion-accepted', 'suggestion-rejected'],
     setup () {
         return { CodeBracketSquareIcon, LightBulbIcon }
+    },
+    computed: {
+        hasDefinedSchema () {
+            return Object.prototype.hasOwnProperty.call(this.segment.metadata, 'schema')
+        },
+        schema () {
+            return this.segment.metadata.schema ?? null
+        },
+        inferredType () {
+            return this.segment.inferredSchema.type ?? null
+        },
+        isInferredTypePrimitive () {
+            return ['number', 'string', 'boolean'].includes(this.inferredType)
+        }
     }
 }
 </script>

--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
@@ -3,7 +3,13 @@
 
     <div class="ff-topic-inspecting">
         <section class="schema-wrapper">
-            <sub-title title="Schema" :icon="CodeBracketSquareIcon" />
+            <sub-title title="Schema" :icon="CodeBracketSquareIcon">
+                <template v-if="canClearSuggestion" #actions>
+                    <span v-ff-tooltip:left="'Clear accepted suggestion'">
+                        <XCircleIcon class="ff-icon-sm cursor-pointer text-red-500" @click="$emit('clear-suggestion')" />
+                    </span>
+                </template>
+            </sub-title>
             <topic-schema :schema="schema" />
         </section>
 
@@ -21,7 +27,7 @@
 </template>
 
 <script>
-import { LightBulbIcon } from '@heroicons/vue/outline'
+import { LightBulbIcon, XCircleIcon } from '@heroicons/vue/outline'
 
 import CodeBracketSquareIcon from '../../../../../components/icons/CodeBracketSquare.js'
 import MainTitle from '../components/MainTitle.vue'
@@ -37,7 +43,8 @@ export default {
         MainTitle,
         TopicSchema,
         TopicSuggestions,
-        TopicSuggestion
+        TopicSuggestion,
+        XCircleIcon
     },
     props: {
         segment: {
@@ -45,7 +52,7 @@ export default {
             type: Object
         }
     },
-    emits: ['suggestion-accepted', 'suggestion-rejected'],
+    emits: ['suggestion-accepted', 'suggestion-rejected', 'clear-suggestion'],
     setup () {
         return { CodeBracketSquareIcon, LightBulbIcon }
     },
@@ -61,6 +68,9 @@ export default {
         },
         isInferredTypePrimitive () {
             return ['number', 'string', 'boolean'].includes(this.inferredType)
+        },
+        canClearSuggestion () {
+            return this.hasDefinedSchema || this.segment.metadata.schema === null
         }
     }
 }

--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
@@ -2,12 +2,27 @@
     <main-title title="Payload Schema" class="mt-1" />
 
     <div class="ff-topic-inspecting">
-        <sub-title title="Schema" :icon="CodeBracketSquareIcon" />
-        <topic-schema :schema="segment.inferredSchema" />
+        <section>
+            <sub-title title="Schema" :icon="CodeBracketSquareIcon" />
+            <topic-schema :schema="segment.inferredSchema" />
+        </section>
+
+        <section>
+            <sub-title title="Suggestions" :icon="LightBulbIcon" />
+            <div class="p-4 border border-gray-200 bg-gray-50 rounded-md">
+                <ul>
+                    <li class="p-4 border border-gray-200 bg-white rounded-md">
+                        el 1
+                    </li>
+                </ul>
+            </div>
+        </section>
     </div>
 </template>
 
 <script>
+import { LightBulbIcon } from '@heroicons/vue/outline'
+
 import CodeBracketSquareIcon from '../../../../../components/icons/CodeBracketSquare.js'
 import MainTitle from '../components/MainTitle.vue'
 import SubTitle from '../components/SubTitle.vue'
@@ -27,13 +42,16 @@ export default {
         }
     },
     setup () {
-        return { CodeBracketSquareIcon }
+        return { CodeBracketSquareIcon, LightBulbIcon }
     }
 }
 </script>
 
 <style scoped lang="scss">
 .ff-topic-inspecting {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
     background: $ff-white;
     padding: 10px;
     border-radius: 6px;

--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
@@ -9,13 +9,9 @@
 
         <section>
             <sub-title title="Suggestions" :icon="LightBulbIcon" />
-            <div class="p-4 border border-gray-200 bg-gray-50 rounded-md">
-                <ul>
-                    <li class="p-4 border border-gray-200 bg-white rounded-md">
-                        el 1
-                    </li>
-                </ul>
-            </div>
+            <topic-suggestions>
+                <topic-suggestion format=".json" description="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Deserunt dolores harum modi repudiandae saepe! Adipisci consectetur cum dicta dolorum ducimus id libero nam nemo nisi nobis non omnis quibusdam, suscipit!" />
+            </topic-suggestions>
         </section>
     </div>
 </template>
@@ -27,13 +23,17 @@ import CodeBracketSquareIcon from '../../../../../components/icons/CodeBracketSq
 import MainTitle from '../components/MainTitle.vue'
 import SubTitle from '../components/SubTitle.vue'
 import TopicSchema from '../components/TopicSchema.vue'
+import TopicSuggestion from '../components/suggestions/TopicSuggestion.vue'
+import TopicSuggestions from '../components/suggestions/TopicSuggestions.vue'
 
 export default {
     name: 'PayloadSchema',
     components: {
         SubTitle,
         MainTitle,
-        TopicSchema
+        TopicSchema,
+        TopicSuggestions,
+        TopicSuggestion
     },
     props: {
         segment: {

--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/index.vue
@@ -14,7 +14,11 @@
         <template v-if="segment">
             <payload-metadata :segment="localSegment" @segment-updated="onSegmentUpdated" />
 
-            <payload-schema :segment="localSegment" />
+            <payload-schema
+                :segment="localSegment"
+                @suggestion-accepted="onSuggestionAccepted"
+                @suggestion-rejected="onSuggestionRejected"
+            />
         </template>
 
         <EmptyState v-else>
@@ -105,6 +109,14 @@ export default {
         },
         onSegmentUpdated (segment) {
             this.localSegment = segment
+        },
+        onSuggestionAccepted () {
+            this.localSegment.metadata.schema = this.localSegment.inferredSchema
+            this.saveTopicMeta()
+        },
+        onSuggestionRejected () {
+            this.localSegment.metadata.schema = null
+            this.saveTopicMeta()
         }
     }
 }

--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/index.vue
@@ -18,6 +18,7 @@
                 :segment="localSegment"
                 @suggestion-accepted="onSuggestionAccepted"
                 @suggestion-rejected="onSuggestionRejected"
+                @clear-suggestion="onSuggestionCleared"
             />
         </template>
 
@@ -116,6 +117,10 @@ export default {
         },
         onSuggestionRejected () {
             this.localSegment.metadata.schema = null
+            this.saveTopicMeta()
+        },
+        onSuggestionCleared () {
+            delete this.localSegment.metadata.schema
             this.saveTopicMeta()
         }
     }

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/SubTitle.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/SubTitle.vue
@@ -1,7 +1,12 @@
 <template>
-    <div class="flex gap-2 items-center mb-2">
-        <component :is="icon" v-if="icon" class="ff-icon-sm" />
-        <span class="text-gray-800 block text-sm font-medium">{{ title }}</span>
+    <div class="flex gap-2 items-center justify-between mb-2">
+        <div class="flex gap-2 items-center ">
+            <component :is="icon" v-if="icon" class="ff-icon-sm" />
+            <span class="text-gray-800 block text-sm font-medium">{{ title }}</span>
+        </div>
+        <div class="actions leading-none">
+            <slot name="actions" />
+        </div>
     </div>
 </template>
 

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSchema.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSchema.vue
@@ -1,39 +1,46 @@
 <template>
     <div class="topic-schema">
-        <div v-if="schemaType === 'string'">
-            <b>Type</b>: String
-        </div>
-        <div v-else-if="schemaType === 'number'">
-            <b>Type</b>: Number
-        </div>
-        <div v-else-if="schemaType === 'boolean'">
-            <b>Type</b>: JSON Boolean
-        </div>
-        <div v-else-if="schemaType === 'object'">
-            <div class="mb-2"><b>Type</b>: JSON Object</div>
-            <div class="font-mono">
-                <div>{</div>
-                <div v-for="(property, name) in schema.properties" :key="name" class="ml-4">{{ name }} ({{ property.type }})</div>
-                <div>}</div>
+        <template v-if="schema === null">
+            <p class="text-center opacity-50">
+                No schema defined
+            </p>
+        </template>
+        <template v-else>
+            <div v-if="schemaType === 'string'">
+                <b>Type</b>: String
             </div>
-        </div>
-        <div v-else-if="schemaType === 'array'">
-            <div class="mb-2"><b>Type</b>: JSON Array</div>
-            <div class="font-mono">
-                <div>[</div>
-                <div class="ml-4">...</div>
-                <div v-if="schema.items?.type" class="ml-4">({{ schema.items.type }})</div>
-                <div v-else class="ml-4">(unknown)</div>
-                <div class="ml-4">...</div>
-                <div>]</div>
+            <div v-else-if="schemaType === 'number'">
+                <b>Type</b>: Number
             </div>
-        </div>
-        <div v-else-if="schemaType === 'bin'">
-            <b>Type</b>: Binary Data
-        </div>
-        <div v-else class="topic-schema-unknown">
-            We haven't been able to determine the payload format
-        </div>
+            <div v-else-if="schemaType === 'boolean'">
+                <b>Type</b>: JSON Boolean
+            </div>
+            <div v-else-if="schemaType === 'object'">
+                <div class="mb-2"><b>Type</b>: JSON Object</div>
+                <div class="font-mono">
+                    <div>{</div>
+                    <div v-for="(property, name) in schema.properties" :key="name" class="ml-4">{{ name }} ({{ property.type }})</div>
+                    <div>}</div>
+                </div>
+            </div>
+            <div v-else-if="schemaType === 'array'">
+                <div class="mb-2"><b>Type</b>: JSON Array</div>
+                <div class="font-mono">
+                    <div>[</div>
+                    <div class="ml-4">...</div>
+                    <div v-if="schema.items?.type" class="ml-4">({{ schema.items.type }})</div>
+                    <div v-else class="ml-4">(unknown)</div>
+                    <div class="ml-4">...</div>
+                    <div>]</div>
+                </div>
+            </div>
+            <div v-else-if="schemaType === 'bin'">
+                <b>Type</b>: Binary Data
+            </div>
+            <div v-else class="topic-schema-unknown">
+                We haven't been able to determine the payload format
+            </div>
+        </template>
     </div>
 </template>
 
@@ -45,7 +52,7 @@ export default {
     props: {
         schema: {
             required: true,
-            type: Object
+            type: [Object, null]
         }
     },
     emits: [],

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
@@ -1,5 +1,5 @@
 <template>
-    <li class="suggestion p-4 border border-gray-200 bg-white rounded-md flex gap-10 items-center">
+    <li class="suggestion p-4 border border-gray-200 bg-white rounded-md flex gap-10 items-center justify-between">
         <div class="content flex flex-col gap-1">
             <div class="title-wrapper">
                 <span class="title">Message Format: </span>

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
@@ -8,7 +8,7 @@
             <div class="description-wrapper">
                 <p v-if="description" class="description opacity-50 text-xs leading-none">{{ description }}</p>
                 <p v-else class="description opacity-50 text-xs leading-none">
-                    FlowFuse has detected that the messages sent to this topic are {{ format.toUpperCase() }}. Would you like to enforce this on your Schema?
+                    FlowFuse has detected that the messages sent to this topic are {{ format.toUpperCase() }}. Would you like to save this to your Schema?
                 </p>
             </div>
         </div>

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
@@ -1,0 +1,70 @@
+<template>
+    <li class="suggestion p-4 border border-gray-200 bg-white rounded-md flex gap-10 items-center">
+        <div class="content flex flex-col gap-1">
+            <div class="title-wrapper">
+                <span class="title">Message Format: </span>
+                <span class="format">{{ format }}</span>
+            </div>
+            <div class="description-wrapper">
+                <p class="description opacity-50 text-xs leading-none">{{ description }}</p>
+            </div>
+        </div>
+        <div class="actions flex gap-3 items-center">
+            <span v-ff-tooltip:left="'Accept'">
+                <CheckCircleIcon class="accept ff-icon-md cursor-pointer color:green" @click="accept" />
+            </span>
+            <span v-ff-tooltip:left="'Reject'">
+                <XCircleIcon class="reject ff-icon-md cursor-pointer color:green" @click="reject" />
+            </span>
+        </div>
+    </li>
+</template>
+
+<script>
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/vue/outline'
+
+export default {
+    name: 'TopicSuggestion',
+    components: {
+        CheckCircleIcon,
+        XCircleIcon
+    },
+    props: {
+        format: {
+            required: true,
+            type: String
+        },
+        description: {
+            required: true,
+            type: String
+        }
+    },
+    methods: {
+        accept () {
+            console.log('accept')
+        },
+        reject () {
+            console.log('reject')
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.suggestion {
+    .content {
+        .format {
+            color: $ff-indigo-500;
+        }
+    }
+
+    .actions {
+        .accept {
+            color: $ff-green-500
+        }
+        .reject {
+            color: $ff-red-500
+        }
+    }
+}
+</style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
@@ -3,10 +3,13 @@
         <div class="content flex flex-col gap-1">
             <div class="title-wrapper">
                 <span class="title">Message Format: </span>
-                <span class="format">{{ format }}</span>
+                <span class="format">{{ capitalize(format) }}</span>
             </div>
             <div class="description-wrapper">
-                <p class="description opacity-50 text-xs leading-none">{{ description }}</p>
+                <p v-if="description" class="description opacity-50 text-xs leading-none">{{ description }}</p>
+                <p v-else class="description opacity-50 text-xs leading-none">
+                    FlowFuse has detected that the messages sent to this topic are {{ format.toUpperCase() }}. Would you like to enforce this on your Schema?
+                </p>
             </div>
         </div>
         <div class="actions flex gap-3 items-center">
@@ -23,6 +26,8 @@
 <script>
 import { CheckCircleIcon, XCircleIcon } from '@heroicons/vue/outline'
 
+import { capitalize } from '../../../../../../composables/String.js'
+
 export default {
     name: 'TopicSuggestion',
     components: {
@@ -35,16 +40,19 @@ export default {
             type: String
         },
         description: {
-            required: true,
-            type: String
+            required: false,
+            type: String,
+            default: null
         }
     },
+    emits: ['suggestion-accepted', 'suggestion-rejected'],
     methods: {
+        capitalize,
         accept () {
-            console.log('accept')
+            this.$emit('suggestion-accepted')
         },
         reject () {
-            console.log('reject')
+            this.$emit('suggestion-rejected')
         }
     }
 }

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestions.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestions.vue
@@ -1,0 +1,18 @@
+<template>
+    <div class="topic-suggestions p-2 border border-gray-200 bg-gray-50 rounded-md">
+        <ul>
+            <slot />
+        </ul>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'TopicSuggestions'
+
+}
+</script>
+
+<style scoped lang="scss">
+.topic-suggestions {}
+</style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestions.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestions.vue
@@ -12,4 +12,3 @@ export default {
 
 }
 </script>
-

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestions.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestions.vue
@@ -13,6 +13,3 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
-.topic-suggestions {}
-</style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestions.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestions.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="topic-suggestions p-2 border border-gray-200 bg-gray-50 rounded-md">
+    <div class="p-2 border border-gray-200 bg-gray-50 rounded-md">
         <ul>
             <slot />
         </ul>

--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -19,6 +19,12 @@
   display: inline-block;
 }
 
+.ff-icon-md {
+  width: 20px;
+  height: 20px;
+  display: inline-block;
+}
+
 .ff-icon-lg {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
based on https://github.com/FlowFuse/flowfuse/pull/5197

## Description

Adds the ability to accept/reject inferred topic suggestions.
Once a suggestion has been accepted/rejected, users have the possibility to clear that suggestion.
Currently only primitive type suggestions are displayed.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5201

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

