### PR TITLE
Fix incorrect status code in broker api

### DIFF
--- a/forge/ee/routes/teamBroker/3rdPartyBroker.js
+++ b/forge/ee/routes/teamBroker/3rdPartyBroker.js
@@ -313,7 +313,7 @@ module.exports = async function (app) {
                 reply.status(500).send({ error: 'unknown_error', message: err.toString() })
             }
         } else {
-            reply.status(40).send({ error: 'not_supported', message: 'not supported' })
+            reply.status(400).send({ error: 'not_supported', message: 'not supported' })
         }
     })
 


### PR DESCRIPTION
Reported via Sentry - one of the broker api routes was returning a status code of `40` rather than `400`.