### PR TITLE
Ensure free tour shows when new Free Tier members sign up

### DIFF
--- a/frontend/src/pages/team/Applications/index.vue
+++ b/frontend/src/pages/team/Applications/index.vue
@@ -226,6 +226,7 @@ export default {
         team: 'fetchData',
         tours: {
             handler (tours) {
+                // handles the user manually re-requesting the tour
                 if (tours.welcome) {
                     this.dispatchTour()
                 }
@@ -244,6 +245,11 @@ export default {
                 // allow the Alerts service to have subscription by wrapping in nextTick
                 Alerts.emit('Thanks for signing up to FlowFuse!', 'confirmation')
             })
+        }
+
+        if (this.tours.welcome) {
+            // given we've loaded resources, check for tour status
+            this.dispatchTour()
         }
 
         this.setSearchQuery()


### PR DESCRIPTION
## Description

In https://github.com/FlowFuse/flowfuse/pull/5140/files the logic on when to show the tour was moved into a `watch`, which fires on first load, but before the `fetchData`, wherein we retrieve the list of Applications (used in the tour itself).

So, the logic in `dispatchTour`, which checked for an existence of an Application, failed, and therefore wasn't showing the tour. This means all new Free Tier users onboarding for the past 2 weeks have seen no product tour.

### Related Issues

Closes #5213 