### PR TITLE
Add deviceLastSeen and remote broker counts to telemetry

### DIFF
--- a/forge/housekeeper/tasks/telemetryMetrics/004-platform.js
+++ b/forge/housekeeper/tasks/telemetryMetrics/004-platform.js
@@ -1,11 +1,15 @@
+const { Op } = require('sequelize')
+
 module.exports = async (app) => {
     let sharedLibraryEntries = 0
     let blueprintCount = 0
     let teamBrokerClients = 0
+    let remoteBrokers = 0
     if (app.license.active()) {
         blueprintCount = await app.db.models.FlowTemplate?.count()
         sharedLibraryEntries = await app.db.models.StorageSharedLibrary?.count()
         teamBrokerClients = await app.db.models.TeamBrokerClient?.count()
+        remoteBrokers = await app.db.models.BrokerCredentials?.count()
     }
     const licenseType = () => {
         if (app.license.active()) {
@@ -21,12 +25,18 @@ module.exports = async (app) => {
     const projectStates = {}
     projectStateCounts.forEach(state => { projectStates[state.state] = state.count })
 
+    const now = Date.now()
+    const devicesByLastSeenNever = await app.db.models.Device.count({ where: { lastSeenAt: null } })
+    const devicesByLastSeenDay = await app.db.models.Device.count({ where: { lastSeenAt: { [Op.gte]: new Date(now - 1000 * 60 * 60 * 24) } } })
+
     return {
         'platform.counts.users': await app.db.models.User.count(),
         'platform.counts.teams': await app.db.models.Team.count(),
         'platform.counts.projects': await app.db.models.Project.count(),
         'platform.counts.projectsByState.suspended': projectStates.suspended || 0,
         'platform.counts.devices': await app.db.models.Device.count(),
+        'platform.counts.devicesByLastSeen.never': devicesByLastSeenNever,
+        'platform.counts.devicesByLastSeen.day': devicesByLastSeenDay,
         'platform.counts.projectSnapshots': await app.db.models.ProjectSnapshot.count(),
         'platform.counts.projectTemplates': await app.db.models.ProjectStack.count(),
         'platform.counts.projectStacks': await app.db.models.ProjectTemplate.count(),
@@ -34,7 +44,7 @@ module.exports = async (app) => {
         'platform.counts.blueprints': blueprintCount,
         'platform.counts.sharedLibraryEntries': sharedLibraryEntries,
         'platform.counts.teamBrokerClients': teamBrokerClients,
-
+        'platform.counts.remoteBrokers': remoteBrokers,
         'platform.config.driver': app.config.driver.type,
         'platform.config.broker.enabled': !!app.config.broker,
         'platform.config.fileStore.enabled': !!app.config.fileStore,


### PR DESCRIPTION
Closes #5183 

Adds the following fields to the telemetry pings packet:

 - `platform.counts.devicesByLastSeen.never`
 - `platform.counts.devicesByLastSeen.day`
 - `platform.counts.remoteBrokers`

Keeping in draft until https://github.com/FlowFuse/usage-ping-collector/pull/30 is merged *and* deployed.