### PR TITLE
Ensure schema buttons are always shown

### DIFF
--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="unified-namespace-hierarchy">
         <main-title title="Topic Hierarchy">
-            <template v-if="selectedSegment" #actions>
+            <template #actions>
                 <ff-button v-if="shouldDisplayRefreshButton" kind="secondary" @click="$emit('refresh-hierarchy')">
                     <template #icon><RefreshIcon /></template>
                 </ff-button>


### PR DESCRIPTION
Part of #5211 

Ensures the schema buttons are always shown - you shouldn't need to select a topic segment to get it to appear.