### PR TITLE
Add the ability to pass down vue components to the global dialog modal

### DIFF
--- a/frontend/src/layouts/Plain.vue
+++ b/frontend/src/layouts/Plain.vue
@@ -5,6 +5,7 @@
         </div>
         <ff-dialog ref="dialog" data-el="platform-dialog" :header="dialog.header" :kind="dialog.kind" :disable-primary="dialog.disablePrimary" :confirm-label="dialog.confirmLabel" @cancel="clearDialog(true)" @confirm="dialog.onConfirm">
             <p v-if="dialog.text">{{ dialog.text }}</p>
+            <component :is="dialog.is.component" v-bind="dialog.is.payload" v-else-if="dialog.is" />
             <!-- eslint-disable-next-line vue/no-v-html -->
             <div class="space-y-2" v-html="dialog.html" />
         </ff-dialog>

--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -28,6 +28,8 @@
                         <p v-for="(text, $index) in dialog.textLines" :key="$index">{{ text }}</p>
                     </div>
                 </template>
+                <component :is="dialog.is.component" v-bind="dialog.is.payload" v-else-if="dialog.is" />
+
                 <p v-else-if="dialog.text">{{ dialog.text }}</p>
                 <!-- eslint-disable-next-line vue/no-v-html -->
                 <div v-else class="space-y-2" v-html="dialog.html" />

--- a/frontend/src/mixins/Dialog.js
+++ b/frontend/src/mixins/Dialog.js
@@ -1,3 +1,5 @@
+import { markRaw } from 'vue'
+
 import dialog from '../services/dialog.js'
 
 export default {
@@ -8,6 +10,7 @@ export default {
                 text: null,
                 textLines: null,
                 html: null,
+                is: null,
                 confirmLabel: null,
                 kind: null,
                 canBeCanceled: true,
@@ -26,6 +29,7 @@ export default {
                 text: null,
                 textLines: null,
                 html: null,
+                is: null,
                 confirmLabel: null,
                 kind: null,
                 canBeCanceled: true,
@@ -42,6 +46,7 @@ export default {
                 this.dialog.text = msg.text
                 this.dialog.textLines = msg.text?.split('\n')
                 this.dialog.html = msg.html
+                this.dialog.is = markRaw(msg.is)
                 this.dialog.confirmLabel = msg.confirmLabel
                 this.dialog.kind = msg.kind
                 this.dialog.disablePrimary = msg.disablePrimary


### PR DESCRIPTION
## Description

allows  greater flexibility on global dialogs in order to pass down entire vue components

Example:

- With an existing component
```javascript
<template>
     <button @click="preview">Click Meee</button>
</template>

<script>
import ExampleComponent    from '/path/to/example-component.vue'
import Dialog from '/src/services/dialog.js'

export default {
    name: 'ExampleComponent',
    methods: {
        preview () {
            const suggestion = this.inferredSuggestion
            Dialog.show({
                header: 'Modal Title',
                kind: 'primary',
                is: {
                    component: ExampleComponent,
                    payload: {
                        componentProp1: 'value1',
                        componentProp2: 'value1',
                    }
                },
                confirmLabel: 'OK',
                canBeCanceled: false
            }
        }
    }
}
</script>
```
- With a dynamic component
```vue
<template>
     <button @click="preview">Click Meee</button>
</template>

<script>
import { defineComponent } from 'vue'
import Dialog from '/src/services/dialog.js'

export default {
    name: 'ExampleComponent',
    methods: {
        preview () {
            const suggestion = this.inferredSuggestion
            Dialog.show({
                header: 'Modal Title',
                kind: 'primary',
                is: {
                    component: defineComponent({
                        data () {
                            return {
                                counter: 1
                            }
                        },
                        computed: {
                            remainder () {
                                return this.counter % 5
                            }
                        },
                        methods: {
                            increment () {
                                this.counter++
                            }
                        },
                        template: `Your total count is: ${{counter}} which has a remainder of ${{remainder}} when divided by 5.`
                    })
                },
                confirmLabel: 'OK',
                canBeCanceled: false
            }
        }
    }
}
</script
```

Note:
Dialog.text takes precedence and Dialog.html is rendered under the component

## Related Issue(s)

none

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

