### PR TITLE
Styling: Make it clearer that Pipeline header is interactive

### DIFF
--- a/frontend/src/pages/team/Pipelines/components/TeamPipeline.vue
+++ b/frontend/src/pages/team/Pipelines/components/TeamPipeline.vue
@@ -57,7 +57,7 @@ export default {
     overflow: hidden;
 
     & > .ff-pipeline-header {
-        background: $ff-grey-100;
+        background: $ff-white;
         padding: 15px;
         border-bottom: 1px solid $ff-grey-300;
         transition: ease-in-out .3s;


### PR DESCRIPTION
## Description

Minor CSS change to make the header of the Pipelines in the `/pipelines` view whit instead of grey, to make it more obvious it's an interactive element (grey suggests inactive)

### Before

<img width="1728" alt="Screenshot 2025-03-04 at 09 54 29" src="https://github.com/user-attachments/assets/c692f80c-f8d4-414e-98fc-994694c875bb" />

### After

<img width="1728" alt="Screenshot 2025-03-04 at 09 52 48" src="https://github.com/user-attachments/assets/10e613b5-9c44-4d11-86a1-ae956ebb188a" />
