### PR TITLE
Improve the labelling of a Pipeline for improved navigation

### DIFF
--- a/frontend/src/pages/team/Pipelines/components/TeamPipeline.vue
+++ b/frontend/src/pages/team/Pipelines/components/TeamPipeline.vue
@@ -4,16 +4,12 @@
             :to="{name: 'ApplicationPipelines', params: {id: pipeline.application.id}}"
             class="ff-pipeline-header flex gap-5 self-end items-center truncate"
         >
-            <span class="name">
-                {{ pipeline.name }}
-            </span>
-            <router-link
-                :to="{name: 'Application', params: {id: pipeline.application.id}}"
-                class="ff-pipeline-application-name truncate"
-                @click.stop
-            >
-                {{ pipeline.application.name }}
-            </router-link>
+            <div class="flex flex-col gap-0.5">
+                <span class="name">
+                    {{ pipeline.name }}
+                </span>
+                <span class="text-xs text-gray-500">{{ pipeline.application.name }}</span>
+            </div>
             <span class="to">
                 <ChevronRightIcon class="ff-icon " />
             </span>


### PR DESCRIPTION
## Description

- Removes the nested link to the "Application" to keep just the whole header a navigation item to the Pipelines view.
- Restyle the Application's name in the header to be nested under the Pipeline name, as it made it difficult to process the Pipeline name vs. the Application name

### Before

<img width="1728" alt="Screenshot 2025-03-04 at 10 04 15" src="https://github.com/user-attachments/assets/c3aee145-1974-4a9b-b8a5-1a87658df0b0" />

### After

<img width="1728" alt="Screenshot 2025-03-04 at 10 01 07" src="https://github.com/user-attachments/assets/453c4dc2-0b2f-45b5-8cf6-2f6a0edb5a76" />

## Related Issue(s)

Closes #5088