### PR TITLE
Onboarding: Improve clarification in the "Add Remote Instance" dialog

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -236,7 +236,7 @@
     >
         <template #description>
             <p v-if="!featuresCheck?.isHostedInstancesEnabledForTeam && tours['first-device']">
-                Describe your new Remote Instance here.
+                Describe your new Remote Instance here, e.g. "Raspberry Pi", "Allen-Bradley PLC", etc.
             </p>
             <p v-else>
                 Remote Instances are managed using the <a href="https://flowfuse.com/docs/user/devices/" target="_blank">FlowFuse Device Agent</a>. The agent will need to be setup on the hardware where you want your Remote Instance to run.


### PR DESCRIPTION
## Description

For new users, there is a lack of context on what a "Remote Instance" may be, so I've included some examples in the description of the Dialog to assist them.