### PR TITLE
Add the external url in the UI

### DIFF
--- a/frontend/src/components/blueprints/BlueprintTile.vue
+++ b/frontend/src/components/blueprints/BlueprintTile.vue
@@ -7,27 +7,38 @@
             <label>{{ blueprint.name }}</label>
             <p>{{ blueprint.description }}</p>
         </div>
-        <div class="ff-blueprint-tile--actions" :class="{'justify-between': showDefault, 'justify-end': !showDefault}">
-            <div v-if="showDefault" v-ff-tooltip:bottom="'Default Blueprint'" class="text-green-600 flex items-center gap-1">
-                <CheckCircleIcon class="ff-icon-lg" />
-                <label class="text-green-800">Default</label>
+        <div class="ff-blueprint-tile--actions justify-between">
+            <div class="left flex gap-2">
+                <ff-button
+                    v-if="displayExternalUrlButton && blueprint.externalUrl"
+                    kind="secondary"
+                    @click.prevent="openInANewTab(blueprint.externalUrl)"
+                >
+                    More Info
+                </ff-button>
+                <div v-if="showDefault" v-ff-tooltip:bottom="'Default Blueprint'" class="text-green-600 flex items-center gap-1">
+                    <CheckCircleIcon class="ff-icon-lg" />
+                    <label class="text-green-800">Default</label>
+                </div>
             </div>
-            <ff-button
-                v-if="displayPreviewButton"
-                data-action="show-blueprint"
-                class="ff-btn--secondary"
-                @click="$refs.flowRendererDialog.show(blueprint)"
-            >
-                <template #icon>
-                    <ProjectIcon />
-                </template>
-            </ff-button>
-            <ff-button v-if="!editable" data-action="select-blueprint" @click="choose(blueprint)">
-                Select
-            </ff-button>
-            <ff-button v-else data-action="edit-blueprint" @click="$emit('selected', blueprint)">
-                Edit
-            </ff-button>
+            <div class="right flex gap-2">
+                <ff-button
+                    v-if="displayPreviewButton"
+                    data-action="show-blueprint"
+                    class="ff-btn--secondary"
+                    @click="$refs.flowRendererDialog.show(blueprint)"
+                >
+                    <template #icon>
+                        <ProjectIcon />
+                    </template>
+                </ff-button>
+                <ff-button v-if="!editable" data-action="select-blueprint" @click="choose(blueprint)">
+                    Select
+                </ff-button>
+                <ff-button v-else data-action="edit-blueprint" @click="$emit('selected', blueprint)">
+                    Edit
+                </ff-button>
+            </div>
         </div>
         <AssetDetailDialog v-if="displayPreviewButton" ref="flowRendererDialog" :title="blueprint.name" />
     </div>
@@ -39,6 +50,7 @@ import { defineAsyncComponent } from 'vue'
 import { mapState } from 'vuex'
 
 import ProjectIcon from '../../components/icons/Projects.js'
+import { useNavigationHelper } from '../../composables/NavigationHelper.js'
 import product from '../../services/product.js'
 import FfDialog from '../../ui-components/components/DialogBox.vue'
 import FormRow from '../FormRow.vue'
@@ -66,12 +78,22 @@ export default {
             type: Boolean,
             default: true
         },
+        displayExternalUrlButton: {
+            type: Boolean,
+            default: false
+        },
         active: {
             type: Boolean,
             default: false
         }
     },
     emits: ['selected'],
+    setup () {
+        const { openInANewTab } = useNavigationHelper()
+        return {
+            openInANewTab
+        }
+    },
     computed: {
         ...mapState('account', ['team']),
         categoryClass () {

--- a/frontend/src/pages/admin/FlowBlueprints/dialogs/FlowBlueprintFormDialog.vue
+++ b/frontend/src/pages/admin/FlowBlueprints/dialogs/FlowBlueprintFormDialog.vue
@@ -68,6 +68,11 @@
                     <template #description>JSON representation of the npm modules required for this template</template>
                     <template #input><textarea v-model="input.modules" class="w-full" rows="4" /></template>
                 </FormRow>
+
+                <FormRow v-model="input.externalUrl" :error="errors.externalUrl" data-form="modules">
+                    External URL
+                    <template #description>External URL</template>
+                </FormRow>
             </form>
         </template>
         <template #actions>
@@ -118,6 +123,7 @@ export default {
                     icon: flowBlueprint?.icon ?? '',
                     order: flowBlueprint?.order ?? '',
                     default: flowBlueprint?.default ?? false,
+                    externalUrl: flowBlueprint?.externalUrl ?? '',
 
                     flows: flowBlueprint?.flows ? JSON.stringify(flowBlueprint.flows) : '',
                     modules: flowBlueprint?.modules ? JSON.stringify(flowBlueprint.modules) : '',
@@ -141,6 +147,7 @@ export default {
                 defaultStack: '',
                 icon: '',
                 default: false,
+                externalUrl: 'false',
                 teamTypeScope: [],
                 order: 0
             },

--- a/frontend/src/pages/instance/Blueprints/BlueprintSelection.vue
+++ b/frontend/src/pages/instance/Blueprints/BlueprintSelection.vue
@@ -13,6 +13,7 @@
                 :key="print.id"
                 :blueprint="print"
                 :display-preview-button="previewTiles"
+                :display-external-url-button="true"
                 :active="activeBlueprint && activeBlueprint.id === print.id"
                 @selected="$emit('selected', print)"
             />

--- a/frontend/src/pages/team/Library/Blueprints.vue
+++ b/frontend/src/pages/team/Library/Blueprints.vue
@@ -9,6 +9,7 @@
                     class="blueprint-tile"
                     :blueprint="blueprint"
                     :data-el="blueprint.id"
+                    :display-external-url-button="true"
                     @selected="onBlueprintSelect"
                 />
             </div>


### PR DESCRIPTION
## Description

allow admin users to set a blueprint's external url from the ui
added a new more info action button to the blueprint tile which is visible to user facing page tiles (instance creation and blueprint library) while hidden on the admin blueprints page
some styling

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5126

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

