### PR TITLE
Changed Bill Of Materials instance link to instance palette settings.

### DIFF
--- a/frontend/src/components/bill-of-materials/InstancesItem.vue
+++ b/frontend/src/components/bill-of-materials/InstancesItem.vue
@@ -9,7 +9,7 @@
             </h6>
             <h6 v-else>
                 <IconNodeRedSolid class="ff-icon text-red-700" />
-                <router-link :to="{name: 'instance-overview', params: {id: instance.id}}" class="ff-link truncate">
+                <router-link :to="{name: 'instance-settings-palette', params: {id: instance.id}}" class="ff-link truncate">
                     {{ instance.name }}
                 </router-link>
             </h6>


### PR DESCRIPTION
## Description

Changed the instance link at Bill Of Materials page to go directory to the palette settings tab, most likely you want to go to that page when clicking there.

## Related Issue(s)

When I want to update the dependencies I always needs to go the the palette settings tab. The fastest way to go there is from the Bill Of Materials page.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

