### PR TITLE
Support Multiple Device Groups in pipeline - frontend

### DIFF
--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -262,10 +262,14 @@ export default {
             if (!this.formValid) {
                 return
             }
-
-            const sourceSnapshot = this.snapshots.find(
-                (snapshot) => snapshot.id === this.input.selectedSnapshotId
-            )
+            let sourceSnapshot
+            if (this.stage.stageType === StageType.DEVICEGROUP) {
+                sourceSnapshot = this.snapshots[0]
+            } else {
+                sourceSnapshot = this.snapshots.find(
+                    (snapshot) => snapshot.id === this.input.selectedSnapshotId
+                )
+            }
 
             this.$emit('deploy-stage', this.target, sourceSnapshot)
 

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -245,6 +245,13 @@ export default {
                     this.stage.instance.id
                 )
                 this.snapshots = data.snapshots
+            } else if (this.stage.stageType === StageType.DEVICEGROUP) {
+                if (!this.stage.deviceGroup.hasTargetSnapshot) {
+                    this.snapshots = []
+                } else {
+                    const data = await SnapshotsApi.getSummary(this.stage.deviceGroup.targetSnapshotId)
+                    this.snapshots = [data]
+                }
             } else {
                 throw Error(`Unknown stage type ${this.stage.stageType}`)
             }

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -41,7 +41,7 @@
             </p>
 
             <template v-if="(promptForSnapshot || useLatestSnapshot) && loadingSnapshots">
-                <ff-loading message="Loading Stage Snapshots..." />
+                <ff-loading message="Loading..." />
             </template>
             <template v-else-if="promptForSnapshot">
                 <form class="space-y-2" @submit.prevent="confirm">

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -101,37 +101,45 @@
                 </form>
             </template>
             <template v-else-if="useLatestSnapshot">
-                <div v-if="!hasSnapshots" class="error-banner">
-                    No snapshots have been created for this stage's
-                    <template v-if="stage.stageType == StageType.INSTANCE">
-                        instance yet!<br><br>
+                <template v-if="stage.stageType == StageType.DEVICEGROUP">
+                    <div v-if="!hasSnapshots" class="error-banner">
+                        This stage's device group does not have a target snapshot
+                        set yet!
+                    </div>
+                </template>
+                <template v-else>
+                    <div v-if="!hasSnapshots" class="error-banner">
+                        No snapshots have been created for this stage's
+                        <template v-if="stage.stageType == StageType.INSTANCE">
+                            instance yet!<br><br>
 
-                        Snapshots can be managed on the
-                        <router-link
-                            :to="{
-                                name: 'instance-snapshots',
-                                params: { id: stage.instance.id },
-                            }"
-                        >
-                            Instance Snapshots
-                        </router-link>
-                        page.
-                    </template>
-                    <template v-else-if="stage.stageType === StageType.DEVICE">
-                        device yet!<br><br>
+                            Snapshots can be managed on the
+                            <router-link
+                                :to="{
+                                    name: 'instance-snapshots',
+                                    params: { id: stage.instance.id },
+                                }"
+                            >
+                                Instance Snapshots
+                            </router-link>
+                            page.
+                        </template>
+                        <template v-else-if="stage.stageType === StageType.DEVICE">
+                            device yet!<br><br>
 
-                        Device snapshots can be managed on the
-                        <router-link
-                            :to="{
-                                name: 'DeviceSnapshots',
-                                params: { id: stage.device.id },
-                            }"
-                        >
-                            Device Snapshots
-                        </router-link>
-                        page.
-                    </template>
-                </div>
+                            Device snapshots can be managed on the
+                            <router-link
+                                :to="{
+                                    name: 'DeviceSnapshots',
+                                    params: { id: stage.device.id },
+                                }"
+                            >
+                                Device Snapshots
+                            </router-link>
+                            page.
+                        </template>
+                    </div>
+                </template>
             </template>
         </template>
         <template #actions>
@@ -145,6 +153,7 @@
 import DeviceApi from '../../api/devices.js'
 import { StageAction, StageType } from '../../api/pipeline.js'
 import SnapshotApi from '../../api/projectSnapshots.js'
+import SnapshotsApi from '../../api/snapshots.js'
 import FormRow from '../FormRow.vue'
 
 export default {

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -12,7 +12,10 @@
             </p>
             <p class="my-4">
                 This will
-                <template v-if="stage.action === StageAction.CREATE_SNAPSHOT">
+                <template v-if="stage.stageType === StageType.DEVICEGROUP">
+                    use the group's target snapshot from "{{ stage.name }}" and
+                </template>
+                <template v-else-if="stage.action === StageAction.CREATE_SNAPSHOT">
                     create a new snapshot in "{{ stage.name }}" and
                 </template>
                 <template v-else-if="stage.action === StageAction.USE_LATEST_SNAPSHOT">

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -182,11 +182,11 @@ export default {
     },
     computed: {
         promptForSnapshot () {
-            return this.stage.action === StageAction.PROMPT
+            return this.stage.stageType !== StageType.DEVICEGROUP && this.stage.action === StageAction.PROMPT
         },
 
         useLatestSnapshot () {
-            return this.stage.action === StageAction.USE_LATEST_SNAPSHOT
+            return this.stage.stageType === StageType.DEVICEGROUP || this.stage.action === StageAction.USE_LATEST_SNAPSHOT
         },
 
         formValid () {

--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -33,7 +33,7 @@
                     @stage-deploy-failed="stageDeployFailed(stage)"
                     @stage-deleted="stageDeleted($index)"
                 />
-                <Transition v-if="stage.stageType !== StageType.DEVICEGROUP" name="fade">
+                <Transition name="fade">
                     <ChevronRightIcon
                         v-if="$index <= pipeline.stages.length - 1"
                         class="ff-icon mt-4 flex-shrink-0"
@@ -44,7 +44,7 @@
                     />
                 </Transition>
             </template>
-            <Transition v-if="!lastStageIsDeviceGroup" name="fade">
+            <Transition name="fade">
                 <PipelineStage @click="addStage" />
             </Transition>
         </div>

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -30,7 +30,6 @@
                     />
                 </span>
                 <span
-                    v-if="stage.stageType !== StageType.DEVICEGROUP"
                     v-ff-tooltip:right="'Run Pipeline Stage'"
                     data-action="stage-run"
                     :class="{'ff-disabled': !playEnabled || !pipeline?.id || deploying }"
@@ -120,7 +119,10 @@
             <div v-if="playEnabled" class="ff-pipeline-stage-row">
                 <label>Deploy Action:</label>
                 <span>
-                    <template v-if="stage.action === StageAction.CREATE_SNAPSHOT">
+                    <template v-if="stage.stageType === StageType.DEVICEGROUP">
+                        Use group snapshot
+                    </template>
+                    <template v-else-if="stage.action === StageAction.CREATE_SNAPSHOT">
                         Create new snapshot
                     </template>
                     <template v-else-if="stage.action === StageAction.USE_ACTIVE_SNAPSHOT">

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -167,7 +167,7 @@
                     <slot name="pictogram"><img src="../../../images/pictograms/snapshot_red.png"></slot>
                     <div v-if="input.stageType === StageType.INSTANCE">
                         <p>
-                            When a instance Pipeline stage type is triggered an Instance Snapshot is deployed to the next stage. You can configure how this stage picks what snapshot to deploy.
+                            When an instance Pipeline stage type is triggered an Instance Snapshot is deployed to the next stage. You can configure how this stage picks what snapshot to deploy.
                         </p>
                         <p>
                             <b>Create New Snapshot:</b> Creates a new snapshot using the current flows and settings.

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -511,6 +511,12 @@ export default {
     created () {
         this.StageType = StageType
     },
+    mounted () {
+        // set the stagetype to device group if the last stage is a device group itself (only permit device groups after a device group)
+        if (!this.allowInstanceSelection) {
+            this.input.stageType = StageType.DEVICEGROUP
+        }
+    },
     methods: {
         async submit () {
             this.loading.creating = !this.isEdit

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -455,9 +455,22 @@ export default {
         deviceGroupsEnabled () {
             return this.features?.deviceGroups && this.team?.type.properties.features?.deviceGroups
         },
+        devicesGroupsNotInUse () {
+            const deviceGroupIdsInUse = this.pipeline.stages.reduce((acc, stage) => {
+                stage.deviceGroups.forEach((deviceGroup) => {
+                    acc.add(deviceGroup.id)
+                })
+
+                return acc
+            }, new Set())
+
+            return this.deviceGroups.filter((deviceGroup) => {
+                return !deviceGroupIdsInUse.has(deviceGroup.id) || deviceGroup.id === this.input.deviceGroupId
+            })
+        },
         deviceGroupOptions () {
             return [
-                ...this.deviceGroups?.map((device) => {
+                ...this.devicesGroupsNotInUse?.map((device) => {
                     return {
                         label: device.name,
                         value: device.id

--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -191,20 +191,22 @@ export default {
             }
         },
         stageDeployFailed (stage, nextStage) {
-            if (this.instanceStatusMap.has(nextStage.instance.id)) {
-                clearInterval(this.polling.instances)
-                this.instanceStatusMap.get(nextStage.instance.id).isDeploying = false
-            }
-
-            if (this.deviceStatusMap.has(nextStage.device.id)) {
-                clearInterval(this.polling.devices)
-                this.deviceStatusMap.get(nextStage.device.id).isDeploying = false
-            }
-
-            const nextStageDeviceGroupMapId = `${nextStage.id}:${nextStage.deviceGroup?.id}`
-            if (this.deviceGroupStatusMap.has(nextStageDeviceGroupMapId)) {
-                clearInterval(this.polling.deviceGroups)
-                this.deviceGroupStatusMap.get(nextStageDeviceGroupMapId).isDeploying = false
+            if (nextStage.instance?.id) {
+                if (this.instanceStatusMap.has(nextStage.instance.id)) {
+                    clearInterval(this.polling.instances)
+                    this.instanceStatusMap.get(nextStage.instance.id).isDeploying = false
+                }
+            } else if (nextStage.device?.id) {
+                if (this.deviceStatusMap.has(nextStage.device.id)) {
+                    clearInterval(this.polling.devices)
+                    this.deviceStatusMap.get(nextStage.device.id).isDeploying = false
+                }
+            } else if (nextStage.deviceGroup?.id) {
+                const nextStageDeviceGroupMapId = `${nextStage.id}:${nextStage.deviceGroup?.id}`
+                if (this.deviceGroupStatusMap.has(nextStageDeviceGroupMapId)) {
+                    clearInterval(this.polling.deviceGroups)
+                    this.deviceGroupStatusMap.get(nextStageDeviceGroupMapId).isDeploying = false
+                }
             }
         },
         startPollingForDeployStatus (stage, nextStage) {

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -600,7 +600,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         cy.get('[data-form="stage-type"]').find('.ff-tile-selection-option[data-form="tile-selection-option-device-group"]').should('have.class', 'disabled')
     })
 
-    it('cannot add any more stages after a device group', () => {
+    it('can only add a device group stage after a device group', () => {
         cy.intercept('GET', '/api/v1/applications/*/pipelines').as('getPipelines')
         cy.intercept('POST', '/api/v1/pipelines').as('createPipeline')
 
@@ -655,9 +655,13 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         cy.get('[data-action="add-stage"]').click()
 
         cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
-            // now there is a device group at the end stage, check to ensure add-stage is not be present
-            cy.get('[data-action="add-stage"]').should('not.exist')
+            // click on add stage and ensure only the device group option is available
+            cy.get('[data-action="add-stage"]').click()
         })
+        // ensure only device group is available
+        cy.get('[data-form="tile-selection-option-device-group"]').should('not.have.class', 'disabled')
+        cy.get('[data-form="tile-selection-option-instance"]').should('have.class', 'disabled')
+        cy.get('[data-form="tile-selection-option-device"]').should('have.class', 'disabled')
     })
 
     it('can create a new device group', () => {

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -1,3 +1,4 @@
+/// <reference types="cypress" />
 describe('FlowForge - Application - DevOps Pipelines', () => {
     let application
     let team


### PR DESCRIPTION
closes #5258 

## Description

* Updates UX for setting device multiple consecutive device groups in a pipeline
* Prevents user setting invalid pipeline 
   * e.g. prevent adding a group to the end of `instance -> group` pipeline
   * e.g. prevent updating a stage that would result in `instance -> group -> device` pipeline

### Point of note
The parent issue tasks stated "Add Action dropdown when Device Group is selected with single 'Use latest snapshot' option"
To simplify matters, this PR instead does not show any option as Device Groups only have one snapshot - the current target sanpshot.

### TODO:
- [x] Fix UI tests broken by expanded capabilities

## Related Issue(s)

Owner: #5258 
Parent: #4539 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

