### PR TITLE
Allow a trial team to downgrade to freemium

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -531,6 +531,11 @@ module.exports.init = async function (app) {
                     app.log.warn(`Problem updating team ${team.hashid} subscription: ${err.message}`)
                     throw err
                 }
+            } else if (subscription && subscription.isTrial() && targetTeamType.getProperty('billing.disabled', false)) {
+                // This team is a trial team that is changing to a disabled-billing team
+                // The cleanest approach here is to delete the subscription object to get
+                // things into the right state
+                await subscription.destroy()
             } else {
                 const err = new Error('Team subscription not active')
                 err.code = 'billing_required'


### PR DESCRIPTION
## Description

Missed this path in the original work in #5237 ; was not able to downgrade an active Trial team back to Freemium.

This fixes the check that was blocking that path.