### PR TITLE
Restore "Set Target Snapshot" option when creating Snapshot

### DIFF
--- a/frontend/src/pages/device/VersionHistory/Snapshots/index.vue
+++ b/frontend/src/pages/device/VersionHistory/Snapshots/index.vue
@@ -82,7 +82,7 @@
                         </ff-button>
                         <ff-button
                             kind="primary"
-                            :disabled="!developerMode || busy || !features.deviceEditor || device.ownerType !== 'application'"
+                            :disabled="!canCreateSnapshot"
                             data-action="create-snapshot"
                             @click="$emit('show-create-snapshot-dialog')"
                         >
@@ -165,6 +165,12 @@ export default {
     },
     computed: {
         ...mapState('account', ['teamMembership', 'features']),
+        canCreateSnapshot () {
+            if (!this.developerMode || this.busy) {
+                return false
+            }
+            return this.isOwnedByAnInstance || this.isOwnedByAnApplication
+        },
         columns () {
             const cols = [
                 {
@@ -223,6 +229,9 @@ export default {
         },
         isOwnedByAnInstance () {
             return this.device?.ownerType === 'instance'
+        },
+        isOwnedByAnApplication () {
+            return this.device?.ownerType === 'application'
         },
         isUnassigned () {
             return this.device?.ownerType === ''

--- a/frontend/src/pages/device/VersionHistory/index.vue
+++ b/frontend/src/pages/device/VersionHistory/index.vue
@@ -150,7 +150,7 @@ export default {
             if (!this.developerMode || this.busy) {
                 return false
             }
-            return this.isOwnedByAnInstance || this.isOwnedByAnApplication
+            return this.isOwnedByAnApplication
         }
     },
     methods: {

--- a/frontend/src/pages/device/dialogs/SnapshotCreateDialog.vue
+++ b/frontend/src/pages/device/dialogs/SnapshotCreateDialog.vue
@@ -9,7 +9,7 @@
                         <textarea v-model="input.description" rows="8" class="ff-input ff-text-input" style="height: auto" />
                     </template>
                 </FormRow>
-                <FormRow v-if="showSetAsTarget" v-model="input.setAsTarget" type="checkbox" data-form="snapshot-name">
+                <FormRow v-if="showSetAsTarget" v-model="input.setAsTarget" type="checkbox" data-form="set-as-target">
                     <span v-ff-tooltip:right="setAsTargetToolTip" class="">
                         Set as Target <QuestionMarkCircleIcon class="ff-icon" style="margin: 0px 0px 0px 4px; height: 18px;" />
                     </span>

--- a/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
@@ -16,7 +16,7 @@ describe('FlowForge - Devices - With Billing', () => {
         cy.visit('/team/bteam/devices')
     })
 
-    it('provides an option to enable "Developer Mode" when deviceEditor feature is enabled', () => {
+    it('provides an option to enable "Developer Mode" when deviceEditor feature is enabled and device is owned by an Application', () => {
         cy.contains('span', 'application-device-a').click()
         cy.get('[data-el="device-devmode-toggle"]').should('exist')
     })
@@ -50,6 +50,32 @@ describe('FlowForge - Devices - With Billing', () => {
         cy.get('[data-el="device-devmode-toggle"]').click()
         cy.get('[data-el=platform-dialog] > .ff-dialog-box [data-action="dialog-confirm"]').click() // click confirm
         cy.url().should('not.include', '/developer-mode')
+    })
+
+    it('has the option to "Create Snapshot" if owned by an Application', () => {
+        /// Assigned to nothing
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-el="device-devmode-toggle"]').click() // enable
+        cy.get('[data-nav="version-history"]').click() // switch to Version History
+
+        cy.get('[data-action="create-snapshot"]').should('not.be.disabled')
+        // get first of these buttons
+        cy.get('[data-action="create-snapshot"]').first().click()
+        cy.get('[data-form="set-as-target"]').should('exist')
+
+        // close the dialog
+        cy.get('[data-el="dialog-create-device-snapshot"] [data-action="dialog-cancel"]').click() // click cancel
+
+        cy.get('[data-el="device-devmode-toggle"]').click() // rest to dev mode off
+        cy.get('[data-el=platform-dialog] > .ff-dialog-box [data-action="dialog-confirm"]').click() // click confirm
+    })
+
+    it('does not have the option to "Create Snapshot" if owned by an Hosted Instance', () => {
+        /// Assigned to nothing
+        cy.contains('span', 'assigned-device-a').click()
+        cy.get('[data-nav="version-history"]').click() // switch to Version History
+
+        cy.get('[data-action="create-snapshot"]').should('be.disabled')
     })
 
     it('has the create snapshot disabled if the snapshot is not assigned to an application or instance', () => {


### PR DESCRIPTION
## Description

- Ensures we have the "Set Target Snapshot" option available form the Version History view for Remote Instances in Dev Mode
- Adds E2E coverage to ensure no regression

## Related Issue(s)

Fix #5272 