### PR TITLE
Add `npm` to the restricted project name list

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -34,7 +34,8 @@ const BANNED_NAME_LIST = [
     'mqtt',
     'broker',
     'egress',
-    'npm'
+    'npm',
+    'registry'
 ]
 
 /** @type {FFModel} */

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -33,7 +33,8 @@ const BANNED_NAME_LIST = [
     'billing',
     'mqtt',
     'broker',
-    'egress'
+    'egress',
+    'npm'
 ]
 
 /** @type {FFModel} */


### PR DESCRIPTION
part of https://github.com/FlowFuse/flowfuse/issues/5165

## Description

<!-- Describe your changes in detail -->
This is to prevent projects named `npm`

to allow for the registry to be hosted on that name

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#5165


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

