### PR TITLE
Sort instance table by date desc by default

### DIFF
--- a/frontend/src/pages/team/Instances.vue
+++ b/frontend/src/pages/team/Instances.vue
@@ -36,7 +36,7 @@
             <template v-else-if="instancesAvailable">
                 <ff-data-table
                     v-if="instances.length > 0"
-                    data-el="instances-table" :columns="columns" :rows="instances" :show-search="true" search-placeholder="Search Instances..."
+                    data-el="instances-table" :columns="columns" :rows="instances" :show-search="true" search-placeholder="Search Instances..." initialSortKey="flowLastUpdatedAt" initialSortOrder="desc"
                     :rows-selectable="!dashboardRoleOnly"
                     @row-selected="openInstance"
                 >

--- a/frontend/src/ui-components/components/data-table/DataTable.vue
+++ b/frontend/src/ui-components/components/data-table/DataTable.vue
@@ -176,7 +176,7 @@ export default {
         },
         initialSortKey: {
             type: String,
-            default: undefined
+            default: ''
         },
         initialSortOrder: {
             type: String,

--- a/frontend/src/ui-components/components/data-table/DataTable.vue
+++ b/frontend/src/ui-components/components/data-table/DataTable.vue
@@ -174,6 +174,14 @@ export default {
             type: Array,
             default: () => []
         },
+        initialSortKey: {
+            type: String,
+            default: undefined
+        },
+        initialSortOrder: {
+            type: String,
+            default: 'desc'
+        },
         showLoadMore: {
             type: Boolean,
             default: false
@@ -302,6 +310,8 @@ export default {
         if (this.$route?.query?.searchQuery) {
             this.internalSearch = this.$route.query.searchQuery
         }
+        this.sort.key = this.initialSortKey
+        this.sort.order = this.orders.includes(this.initialSortOrder) ? this.initialSortOrder : this.orders[0]
     },
     methods: {
         toggleAllChecks (pointerEvents) {


### PR DESCRIPTION
closes #5232

## Description

* Adds new props `initialSortKey` and `initialSortOrder` to data table
* Sets new props `initialSortKey="flowLastUpdatedAt"` and `initialSortOrder="desc"` on instances table


## Related Issue(s)

#5232

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

