### PR TITLE
Fix npmrc settings merge

### DIFF
--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -262,7 +262,8 @@ module.exports = async function (app) {
                 response.palette = {}
             }
             if (response.palette.npmrc) {
-                settings.palette.npmrc = `${settings.settings.palette.npmrc}\n` +
+                settings.palette = settings.palette || {}
+                settings.palette.npmrc = `${settings.palette.npmrc || ''}\n` +
                     `@flowfuse-${team}:registry=${app.config.npmRegistry.url}\n` +
                     `//${npmRegURL.host}:_auth="${token}"\n`
             } else {


### PR DESCRIPTION
We are seeing some devices fail to pickup their settings from the platform due to an error: `Cannot read properties of undefined (reading 'palette')`

This fixes that.