### PR TITLE
Fix event capture for removing team member

### DIFF
--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -268,7 +268,7 @@ const changeTeamMemberRole = (teamId, userId, role) => {
 
 const removeTeamMember = (teamId, userId) => {
     return client.delete(`/api/v1/teams/${teamId}/members/${userId}`).then(() => {
-        product.capture('$ff-team-created', {
+        product.capture('$ff-team-member-removed', {
             'member-removed': userId,
             'removed-at': (new Date()).toISOString()
         }, {


### PR DESCRIPTION
## Description

Noticed then when reviewing some "team created" data with Greg, we are, for some unknown reason, logging `team-capture` when a member is removed from a team. This fixes that.