### PR TITLE
fix(ci): Adjust `detect_changed_files` script to run properly against default branch

### DIFF
--- a/.github/scripts/detect_changed_files.sh
+++ b/.github/scripts/detect_changed_files.sh
@@ -5,7 +5,14 @@ set -e
 # Script to check if files from specific pattern groups have changed in a PR
 # Groups: backend, postgres, ui
 
-changed_files=$(git diff --name-only "origin/$GITHUB_BASE_REF...HEAD")
+if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+  echo "Running on main branch, comparing with previous commit"
+  changed_files=$(git diff --name-only HEAD^ HEAD)
+else
+  echo "Running on non-default branch, comparing with $GITHUB_BASE_REF branch"
+  changed_files=$(git diff --name-only origin/$GITHUB_BASE_REF...HEAD)
+fi
+
 
 if [ -z "$changed_files" ]; then
   echo "No files changed in this PR compared to $GITHUB_BASE_REF branch."


### PR DESCRIPTION
## Description

This pull request adjust `detect_changed_files.sh` script to run propewr `git diff` command when executed against `main` branch.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

