### PR TITLE
Allow request errors to 3rd party urls to percolate up

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -10,29 +10,25 @@ const client = axios.create({
     timeout: 30000
 })
 
-// Authentication
+// Common error handler
 client.interceptors.response.use(function (response) {
     return response
 }, function (error) {
-    if (error.response && error.response.status === 401 && !store.state.account.pending && !store.state.account.loginInflight) {
+    if (/^http/.test(error.config.url)) {
+        // This request is to an external URL. Allow this error to pass back to the caller
+        return Promise.reject(error)
+    }
+
+    // This is an error response from our own API (or failure to reach it)
+    if (error.code === 'ERR_NETWORK') {
+        // Backend failed to respond
+        store.dispatch('account/setOffline', true)
+    } else if (error.response && error.response.status === 401 && !store.state.account.pending && !store.state.account.loginInflight) {
         // 401 when !pending && !loginInflight means the session has expired
         store.dispatch('account/logout')
-        return Promise.reject(error)
-    } else if (error.code === 'ERR_NETWORK') {
-        // network error
-        store.dispatch('account/setOffline', true)
-    }
-    return Promise.reject(error)
-})
-
-// 500 Internal Server Errors
-client.interceptors.response.use(function (response) {
-    return response
-}, function (error) {
-    if (error.response && error.response.status === 500) {
+    } else if (error.response && error.response.status === 500) {
         // show toast notification
         Alerts.emit(error.response.data.error + ': ' + error.response.data.message, 'warning', 7500)
-        return Promise.reject(error)
     }
     return Promise.reject(error)
 })

--- a/frontend/src/components/bill-of-materials/DependencyItem.vue
+++ b/frontend/src/components/bill-of-materials/DependencyItem.vue
@@ -107,7 +107,11 @@ export default {
     methods: {
         pluralize,
         async getExternalDependency () {
-            this.externalDependency = await ExternalClient.getNpmDependency(this.title)
+            try {
+                this.externalDependency = await ExternalClient.getNpmDependency(this.title)
+            } catch (error) {
+                console.error(`Failed to lookup dependency ${this.title} : ${error.message}`)
+            }
         },
         toggleOpenState () {
             this.isOpen = !this.isOpen


### PR DESCRIPTION
Fixes #5329 

 - Consolidates the request error handlers to a single handler.
 - Removes any special handling of errors to 3rd-party urls so that they can be handled by the calling component.
 - Adds cleaner logging if there are request errors around the BOM component