### PR TITLE
Ensure community catalog is set for devices without inherited settings

### DIFF
--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -277,6 +277,7 @@ module.exports = async function (app) {
                     .push(`${app.config.base_url}/api/v1/teams/${team}/npm/catalogue?device=${request.device.hashid}`)
             } else {
                 response.palette.catalogues = [
+                    'https://catalogue.nodered.org/catalogue.json',
                     `${app.config.base_url}/api/v1/teams/${team}/npm/catalogue?device=${request.device.hashid}`
                 ]
             }


### PR DESCRIPTION
## Description
If a device does not have any inherited settings (ie, never had an instance snapshot deployed to it), its settings will be blank. We need to ensure the community catalogue is set alongside the team catalog.