### PR TITLE
Show Node-RED version for Devices and Snapshots

### DIFF
--- a/forge/db/models/ProjectSnapshot.js
+++ b/forge/db/models/ProjectSnapshot.js
@@ -155,7 +155,7 @@ module.exports = {
                         where,
                         order: [['id', 'DESC']],
                         limit,
-                        attributes: ['hashid', 'id', 'name', 'description', 'createdAt', 'updatedAt', 'ProjectId', 'DeviceId', 'ownerType'],
+                        attributes: ['hashid', 'id', 'name', 'description', 'createdAt', 'updatedAt', 'ProjectId', 'DeviceId', 'ownerType', 'settings'],
                         include: [{
                             model: M.User,
                             attributes: ['hashid', 'id', 'username', 'avatar']

--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -31,7 +31,8 @@ module.exports = function (app) {
             deviceGroup: {
                 nullable: true,
                 allOf: [{ $ref: 'DeviceGroupSummary' }]
-            }
+            },
+            nrVersion: { type: 'string' }
         }
     })
 

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -104,6 +104,10 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const result = app.db.views.Device.device(request.device)
+        const nrVersion = await request.device.getSetting('editor')
+        if (nrVersion) {
+            result.nrVersion = nrVersion.nodeRedVersion
+        }
         // ingress-nginx will set a cookie on /api/v1/devices - which will cannot allow to override
         // that of the device-specific cookie. So clear it out.
         if (request.cookies.FFSESSION) {

--- a/frontend/src/components/dialogs/AssetDetailDialog.vue
+++ b/frontend/src/components/dialogs/AssetDetailDialog.vue
@@ -6,6 +6,7 @@
             </div>
         </template>
         <template #actions>
+            Node-RED {{ nrVersion }}
             <div class="flex justify-end">
                 <ff-button data-action="dialog-confirm" @click="confirm()">Close</ff-button>
             </div>
@@ -44,6 +45,18 @@ export default {
     computed: {
         flow () {
             return this.payload?.flows?.flows || []
+        },
+        nrVersion () {
+            try {
+                const mods = this.payload?.settings?.modules
+                if (mods) {
+                    return mods['node-red'] || 'ben'
+                } else {
+                    return ''
+                }
+            } catch (e) {
+                console.log(e)
+            }
         },
         header () {
             return this.payload?.name || this.title || 'Flow'

--- a/frontend/src/components/dialogs/AssetDetailDialog.vue
+++ b/frontend/src/components/dialogs/AssetDetailDialog.vue
@@ -52,7 +52,7 @@ export default {
         nrVersion () {
             const mods = this.payload?.settings?.modules
             if (mods) {
-                return mods['node-red'] || 'ben'
+                return mods['node-red'] || 'unknown'
             }
             return ''
         },

--- a/frontend/src/components/dialogs/AssetDetailDialog.vue
+++ b/frontend/src/components/dialogs/AssetDetailDialog.vue
@@ -47,16 +47,11 @@ export default {
             return this.payload?.flows?.flows || []
         },
         nrVersion () {
-            try {
-                const mods = this.payload?.settings?.modules
-                if (mods) {
-                    return mods['node-red'] || 'ben'
-                } else {
-                    return ''
-                }
-            } catch (e) {
-                console.log(e)
+            const mods = this.payload?.settings?.modules
+            if (mods) {
+                return mods['node-red'] || 'ben'
             }
+            return ''
         },
         header () {
             return this.payload?.name || this.title || 'Flow'

--- a/frontend/src/components/dialogs/AssetDetailDialog.vue
+++ b/frontend/src/components/dialogs/AssetDetailDialog.vue
@@ -52,7 +52,7 @@ export default {
         nrVersion () {
             const mods = this.payload?.settings?.modules
             if (mods) {
-                return mods['node-red'] || 'unknown'
+                return mods['node-red'] || 'Unavailable'
             }
             return ''
         },

--- a/frontend/src/components/dialogs/AssetDetailDialog.vue
+++ b/frontend/src/components/dialogs/AssetDetailDialog.vue
@@ -1,12 +1,15 @@
 <template>
-    <ff-dialog ref="dialog" :header="header" confirm-label="Close" :closeOnConfirm="true" data-el="flow-view-dialog" boxClass="!min-w-[80%] !min-h-[80%] !w-[80%] !h-[80%]" contentClass="overflow-hidden flex-grow" @confirm="confirm()">
+    <ff-dialog
+        ref="dialog" :header="header" :sub-header="`Node-RED Version: ${nrVersion}`" confirm-label="Close" :closeOnConfirm="true"
+        data-el="flow-view-dialog" boxClass="!min-w-[80%] !min-h-[80%] !w-[80%] !h-[80%]"
+        contentClass="overflow-hidden flex-grow" @confirm="confirm()"
+    >
         <template #default>
             <div ref="viewer" data-el="ff-flow-previewer" class="ff-flow-viewer" @click.stop.prevent>
                 Loading...
             </div>
         </template>
         <template #actions>
-            Node-RED {{ nrVersion }}
             <div class="flex justify-end">
                 <ff-button data-action="dialog-confirm" @click="confirm()">Close</ff-button>
             </div>

--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -23,6 +23,14 @@
                         />
                     </template>
                 </InfoCardRow>
+                <InfoCardRow property="Node-RED Version:">
+                    <template #value>
+                        <StatusBadge
+                            :status="nrVersionWarning ? 'error' : 'success'"
+                            :text="device.nrVersion || 'unknown'" v-ff-tooltip="agentVersionWarning"
+                        />
+                    </template>
+                </InfoCardRow>
             </template>
         </InfoCard>
         <InfoCard header="Deployment:">
@@ -154,6 +162,11 @@ export default {
                 return 'Devices assigned to an application must be version 1.15 or greater in order to receive snapshots and updates'
             }
             return ''
+        },
+        nrVersionWarning: function () {
+            if (!this.device?.nrVersion) {
+                return 'Devices must have connected and initialized to report Node-RED version'
+            }
         }
     },
     mounted () {

--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -167,6 +167,7 @@ export default {
             if (!this.device?.nrVersion) {
                 return 'Devices must have connected and initialized to report Node-RED version'
             }
+            return ''
         }
     },
     mounted () {

--- a/frontend/src/pages/device/VersionHistory/Snapshots/index.vue
+++ b/frontend/src/pages/device/VersionHistory/Snapshots/index.vue
@@ -240,6 +240,11 @@ export default {
                     }
                 },
                 {
+                    label: 'Node-RED version',
+                    class: ['w-56'],
+                    key: 'modules.node-red'
+                },
+                {
                     label: 'Created By',
                     class: ['w-48 hidden md:table-cell'],
                     component: {

--- a/frontend/src/ui-components/components/DialogBox.vue
+++ b/frontend/src/ui-components/components/DialogBox.vue
@@ -1,7 +1,10 @@
 <template>
     <div ref="container" class="ff-dialog-container" :class="'ff-dialog-container--' + (open ? 'open' : 'closed')">
         <div class="ff-dialog-box" :class="boxClass">
-            <div class="ff-dialog-header" data-sentry-unmask>{{ header }}</div>
+            <div class="ff-dialog-header" data-sentry-unmask>
+                {{ header }}
+                <span v-if="subHeader" class="ff-dialog-subheader">{{ subHeader }}</span>
+            </div>
             <div ref="content" class="ff-dialog-content" :class="contentClass">
                 <slot></slot>
             </div>
@@ -22,6 +25,10 @@ export default {
         header: {
             type: String,
             default: 'Dialog Box'
+        },
+        subHeader: {
+            type: String,
+            default: ''
         },
         confirmLabel: {
             type: String,

--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -27,6 +27,7 @@
 
 .ff-icon-lg {
   width: 24px;
+  width: 24px;
   height: 24px;
   display: inline-block;
 }
@@ -879,6 +880,13 @@ li.ff-list-item {
       padding: 0 $ff-unit-lg;
       color: $ff-white;
       font-weight: 600;
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    &-subheader {
+      opacity: 0.65;
+      display: block;
     }
     &-content {
       padding: $ff-funit-lg;


### PR DESCRIPTION
closes #5246 
## Description

<!-- Describe your changes in detail -->
Adds NR version to Snapshot view and Device Overview

![Screenshot from 2025-03-20 10-47-21](https://github.com/user-attachments/assets/e30f85c8-ceb3-401a-8a77-e419cffbaddb)

![Screenshot from 2025-03-20 11-00-14](https://github.com/user-attachments/assets/47b34057-3432-4aeb-8147-daf80e39bc98)
The location of the Node-RED version needs work here, but I just proved it could be done...


![image](https://github.com/user-attachments/assets/86a2bcd9-396d-4fb9-8130-2a2d48430edd)


## Related Issue(s)
#5246

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

