### PR TITLE
Add resource capacity breach 75% notifications

### DIFF
--- a/forge/ee/lib/alerts/index.js
+++ b/forge/ee/lib/alerts/index.js
@@ -37,6 +37,10 @@ module.exports = {
                         template = templateName.join('-')
                     } else if (emailAlerts?.safe && event === 'safe-mode') {
                         template = 'SafeMode'
+                    } else if (emailAlerts?.resource?.cpu && event === 'resource.cpu') {
+                        template = 'InstanceResourceCPUExceeded'
+                    } else if (emailAlerts?.resource?.memory && event === 'resource.memory') {
+                        template = 'InstanceResourceMemoryExceeded'
                     }
                     if (!template || !teamType.getFeatureProperty('emailAlerts', false)) {
                         return

--- a/forge/lib/templates.js
+++ b/forge/lib/templates.js
@@ -25,6 +25,8 @@ module.exports = {
         'httpNodeAuth_pass',
         'emailAlerts_crash',
         'emailAlerts_safe',
+        'emailAlerts_resource_cpu',
+        'emailAlerts_resource_memory',
         'emailAlerts_recipients',
         'debugMaxLength',
         'apiMaxLength'
@@ -58,6 +60,8 @@ module.exports = {
         httpNodeAuth_pass: '',
         emailAlerts_crash: false,
         emailAlerts_safe: false,
+        emailAlerts_resource_cpu: false,
+        emailAlerts_resource_memory: false,
         emailAlerts_recipients: 'owners',
         debugMaxLength: 1000,
         apiMaxLength: '5mb'
@@ -88,6 +92,8 @@ module.exports = {
         httpNodeAuth_pass: true,
         emailAlerts_crash: true,
         emailAlerts_safe: true,
+        emailAlerts_resource_cpu: true,
+        emailAlerts_resource_memory: true,
         emailAlerts_recipients: true,
         debugMaxLength: true,
         apiMaxLength: true

--- a/forge/postoffice/templates/InstanceResourceCPUExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceCPUExceeded.js
@@ -1,0 +1,86 @@
+module.exports = {
+    subject: 'FlowFuse Instance CPU exceeded 75%',
+    text:
+`Hello
+
+Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" is using more than 75% of its CPU.
+
+This can occur for a number of reasons including:
+- incorrect instance size for your workload
+- an issue in your flows or functions causing high CPU usage
+- an issue in a third-party library or node
+
+Possible solutions:
+- try selecting a larger instance type
+- try disabling some nodes to see if the problem settles down after a restart
+- check your flows for loops or functions that are causing high CPU usage
+- check the issue tracker of your contrib nodes
+- check the instance logs for clues and errors
+
+{{#if log.text}}
+------------------------------------------------------
+Logs:
+
+{{#log.text}}
+Timestamp: {{{timestamp}}}
+Severity: {{{level}}}
+Message: {{{message}}}
+
+{{/log.text}}
+
+Note: Timestamps in this log are in UTC (Coordinated Universal Time).
+------------------------------------------------------
+{{/if}}
+
+You can access the instance and its logs here:
+
+{{{ url }}}
+
+`,
+    html:
+`<p>Hello</p>
+<p>Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" is using more than 75% of its CPU.</p>
+
+<p>
+This can occur for a number of reasons including:
+<ul>
+<li>incorrect instance size for your workload/li>
+<li>an issue in your flows or functions holding that are causing high CPU usage/li>
+<li>an issue in a third-party library or node/li>
+</ul>
+
+Possible solutions:
+<ul>
+<li>try selecting a larger instance type</li>
+<li>try disabling some nodes to see if the problem settles down after a restart</li>
+<li>check your flows for loops or functions that are causing high CPU usage</li>
+<li>check the issue tracker of your contrib nodes</li>
+<li>check the instance logs for clues and errors</li>
+</p>
+
+
+{{#if log.html}}
+<p>
+Logs:
+<table style="width: 100%; font-size: small; font-family: monospace; white-space: pre;">
+    <tr>
+        <th style="text-align: left; min-width: 135px;">Timestamp</th>
+        <th style="text-align: left; white-space: nowrap;">Severity</th>
+        <th style="text-align: left;">Message</th>
+    </tr>
+    {{#log.html}}
+    <tr>
+        <td style="vertical-align: text-top;">{{{timestamp}}}</td>
+        <td style="vertical-align: text-top;">{{{level}}}</td>
+        <td>{{{message}}}</td>
+    </tr>
+    {{/log.html}}
+</table>
+<i>Note: Timestamps in this log are in UTC (Coordinated Universal Time).</i>
+</p>
+{{/if}}
+
+<p>You can access the instance and its logs here</p>
+<a href="{{{ url }}}">Instance Logs</a>
+`
+}

--- a/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
@@ -1,0 +1,86 @@
+module.exports = {
+    subject: 'FlowFuse Instance Memory usage exceeded 75%',
+    text:
+`Hello
+
+Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" is using more than 75% of its available memory.
+
+This can occur for a number of reasons including:
+- incorrect instance size for your workload
+- an issue in your flows or functions holding onto memory
+- an issue in a third-party library or node
+
+Possible solutions:
+- try selecting a larger instance type
+- try disabling some nodes to see if the problem settles down after a restart
+- when polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion
+- check your flows for large data structures being held in memory, particularly in context
+- check the issue tracker of your contrib nodes
+
+{{#if log.text}}
+------------------------------------------------------
+Logs:
+
+{{#log.text}}
+Timestamp: {{{timestamp}}}
+Severity: {{{level}}}
+Message: {{{message}}}
+
+{{/log.text}}
+
+Note: Timestamps in this log are in UTC (Coordinated Universal Time).
+------------------------------------------------------
+{{/if}}
+
+You can access the instance and its logs here:
+
+{{{ url }}}
+
+`,
+    html:
+`<p>Hello</p>
+<p>Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" is using more than 75% of its available memory.</p>
+
+<p>
+This can occur for a number of reasons including:
+<ul>
+<li>incorrect instance size for your workload/li>
+<li>an issue in your flows holding onto memory/li>
+<li>an issue in a third-party library or node/li>
+</ul>
+
+Possible solutions:
+<ul>
+<li>try selecting a larger instance type</li>
+<li>try disabling some nodes to see if the problem settles down after a restart</li>
+<li>when polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion</li>
+<li>check your flows for large data structures being held in memory, particularly in context</li>
+<li>check the issue tracker of your contrib nodes</li>
+</p>
+
+
+{{#if log.html}}
+<p>
+Logs:
+<table style="width: 100%; font-size: small; font-family: monospace; white-space: pre;">
+    <tr>
+        <th style="text-align: left; min-width: 135px;">Timestamp</th>
+        <th style="text-align: left; white-space: nowrap;">Severity</th>
+        <th style="text-align: left;">Message</th>
+    </tr>
+    {{#log.html}}
+    <tr>
+        <td style="vertical-align: text-top;">{{{timestamp}}}</td>
+        <td style="vertical-align: text-top;">{{{level}}}</td>
+        <td>{{{message}}}</td>
+    </tr>
+    {{/log.html}}
+</table>
+<i>Note: Timestamps in this log are in UTC (Coordinated Universal Time).</i>
+</p>
+{{/if}}
+
+<p>You can access the instance and its logs here</p>
+<a href="{{{ url }}}">Instance Logs</a>
+`
+}

--- a/frontend/src/components/notifications/Generic.vue
+++ b/frontend/src/components/notifications/Generic.vue
@@ -54,6 +54,16 @@ export default {
                     icon: 'device',
                     title: 'Node-RED Device Safe Mode',
                     message: '"<i>{{device.name}}</i>" is running in safe mode'
+                },
+                'instance-resource-cpu': {
+                    icon: 'instance',
+                    title: 'Node-RED Instance CPU Usage',
+                    message: 'CPU usage of "<i>{{instance.name}}</i>" has spent more than 5 minutes at more than 75% of CPU limit. This instance may benefit from being upgraded to a larger Instance type'
+                },
+                'instance-resource-memory': {
+                    icon: 'instance',
+                    title: 'Node-RED Instance Memory Usage',
+                    message: 'Memory usage of "<i>{{instance.name}}</i>" has spent more than 5 minutes at more than 75% of memory limit. This instance may benefit from being upgraded to a larger Instance type'
                 }
             }
         }

--- a/frontend/src/pages/admin/Template/sections/Alerts.vue
+++ b/frontend/src/pages/admin/Template/sections/Alerts.vue
@@ -23,6 +23,24 @@
             </div>
             <LockSetting v-model="editable.policy.emailAlerts_safe" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.emailAlerts_safe" />
         </div>
+        <div class="flex flex-col, sm:flex-row sm:ml-4">
+            <div class="space-y-4 w-full max-w-md sm:mr-8">
+                <FormRow v-model="editable.settings.emailAlerts_resource_cpu" type="checkbox" :disabled="!editTemplate && !editable.policy.emailAlerts_resource_cpu">
+                    Node-RED CPU usage has exceeded 75% for 5 minutes
+                    <template #append><ChangeIndicator :value="editable.changed.settings.emailAlerts_resource_cpu" /></template>
+                </FormRow>
+            </div>
+            <LockSetting v-model="editable.policy.emailAlerts_resource_cpu" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.emailAlerts_resource_cpu" />
+        </div>
+        <div class="flex flex-col, sm:flex-row sm:ml-4">
+            <div class="space-y-4 w-full max-w-md sm:mr-8">
+                <FormRow v-model="editable.settings.emailAlerts_resource_memory" type="checkbox" :disabled="!editTemplate && !editable.policy.emailAlerts_resource_memory">
+                    Node-RED memory usage has exceeded 75% for 5 minutes
+                    <template #append><ChangeIndicator :value="editable.changed.settings.emailAlerts_resource_memory" /></template>
+                </FormRow>
+            </div>
+            <LockSetting v-model="editable.policy.emailAlerts_resource_memory" class="flex justify-end flex-col" :editTemplate="editTemplate" :changed="editable.changed.policy.emailAlerts_resource_memory" />
+        </div>
         <FormHeading>Who to notify</FormHeading>
         <div class="flex flex-col sm:flex-row sm:ml-4">
             <div class="space-y-4 w-full max-w-md sm:mr-8">

--- a/test/unit/forge/ee/lib/alerts/alerts_spec.js
+++ b/test/unit/forge/ee/lib/alerts/alerts_spec.js
@@ -191,6 +191,46 @@ describe('Instance Alerts emails', function () {
             app.postoffice.send.calledOnce.should.be.true()
             app.postoffice.send.firstCall.args[1].should.equal('Crashed-uncaught-exception')
         })
+        it('Resource warning, instance-resource-cpu, via api', async function () {
+            sinon.spy(app.postoffice, 'send')
+            const response = await app.inject({
+                method: 'POST',
+                url: `/logging/${app.TestObjects.instance.id}/audit`,
+                payload: {
+                    event: 'resource.cpu'
+                },
+                headers: {
+                    authorization: `Bearer ${app.TestObjects.tokens.instance}`
+                }
+            })
+            response.statusCode.should.equal(200)
+            inbox.messages.should.have.length(1)
+            inbox.messages[0].html.should.match(/Your FlowFuse Instance .* in Team .* is using more than 75% of its CPU/)
+            inbox.messages[0].text.should.match(/Your FlowFuse Instance .* in Team .* is using more than 75% of its CPU/)
+            // ensure correct template was used
+            app.postoffice.send.calledOnce.should.be.true()
+            app.postoffice.send.firstCall.args[1].should.equal('InstanceResourceCPUExceeded')
+        })
+        it('Resource warning, instance-resource-memory, via api', async function () {
+            sinon.spy(app.postoffice, 'send')
+            const response = await app.inject({
+                method: 'POST',
+                url: `/logging/${app.TestObjects.instance.id}/audit`,
+                payload: {
+                    event: 'resource.memory'
+                },
+                headers: {
+                    authorization: `Bearer ${app.TestObjects.tokens.instance}`
+                }
+            })
+            response.statusCode.should.equal(200)
+            inbox.messages.should.have.length(1)
+            inbox.messages[0].html.should.match(/Your FlowFuse Instance .* in Team .* is using more than 75% of its available memory/)
+            inbox.messages[0].text.should.match(/Your FlowFuse Instance .* in Team .* is using more than 75% of its available memory/)
+            // ensure correct template was used
+            app.postoffice.send.calledOnce.should.be.true()
+            app.postoffice.send.firstCall.args[1].should.equal('InstanceResourceMemoryExceeded')
+        })
         it('Owner notified of safe-mode', async function () {
             await app.auditLog.alerts.generate(app.TestObjects.instance.id, 'safe-mode')
             inbox.messages.should.have.length(1)

--- a/test/unit/forge/ee/lib/alerts/setup.js
+++ b/test/unit/forge/ee/lib/alerts/setup.js
@@ -47,6 +47,10 @@ module.exports = async function (config = {
             emailAlerts: {
                 crash: true,
                 safe: true,
+                resource: {
+                    cpu: true,
+                    memory: true
+                },
                 recipients: 'owners'
             }
         },


### PR DESCRIPTION
closes #5266

## Description

* Adds email templates for CPU/memory breaches
  ![image](https://github.com/user-attachments/assets/595f7853-b972-4a5f-9a7c-f8d3ff0729a4)
  ![image](https://github.com/user-attachments/assets/4e46f876-9f29-4c7d-ac12-5481801c5a6b)

* Adds notifications for CPU/memory breaches
  ![image](https://github.com/user-attachments/assets/3a729fc2-f9e9-4c2a-a6de-84a5c7d6dd75)

* Adds enable/disable settings for CPU/memory breaches
  ![image](https://github.com/user-attachments/assets/a01077eb-2371-4efe-86e9-dba9b39d2d00)



### Adds Unit tests: 
```
▼ Instance Alerts emails
  ▼ Alerts
    ✔ Resource warning, instance-resource-cpu, via api
    ✔ Resource warning, instance-resource-memory, via api
```


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

