### PR TITLE
Fix un-scrollable notifications drawer

### DIFF
--- a/frontend/src/stylesheets/components/notifications.scss
+++ b/frontend/src/stylesheets/components/notifications.scss
@@ -97,6 +97,7 @@ $ff-notifications-drawer-side-padding: 6px;
     flex: 1;
     width: 100%;
     background-color: $ff-grey-100;
+    overflow: auto;
     $read: $ff-grey-400;
     $info: blue;
     $warning: $ff-yellow-600;


### PR DESCRIPTION
## Description

adds a missing overflow property on the notifications drawer to enable scroll.

Easiest way to get a bunch of notifications in the drawer is to display the read ones.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5186

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

