### PR TITLE
Enable resource breach alerts by default in templates and instances

### DIFF
--- a/forge/db/migrations/20250327-01-EE-update-projecttemplates-settings-email-alerts.js
+++ b/forge/db/migrations/20250327-01-EE-update-projecttemplates-settings-email-alerts.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-unused-vars */
+
+/*
+ * Update the JSON string in `ProjectTemplates`.`settings` so that emailAlerts.resource.cpu and emailAlerts.resource.memory are set to true
+ */
+const { DataTypes, QueryInterface } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        // The `type` option is explicitly set to `context.sequelize.QueryTypes.SELECT` to ensure that the query is executed as a SELECT statement.
+        // This ensures the results are always returned as an array of objects.
+        const results = await context.sequelize.query('SELECT "id", "settings", "policy" FROM "ProjectTemplates" WHERE "settings" IS NOT NULL', { type: context.sequelize.QueryTypes.SELECT })
+        for (const result of results) {
+            if (result.settings) {
+                try {
+                    const settings = JSON.parse(result.settings)
+                    const policy = JSON.parse(result.policy || '{}')
+                    settings.emailAlerts = settings.emailAlerts || {}
+                    settings.emailAlerts.resource = settings.emailAlerts.resource || {}
+                    const cpuBefore = settings.emailAlerts.resource.cpu
+                    const memoryBefore = settings.emailAlerts.resource.memory
+                    // if the policy has been set to false by the platform admin, don't modify its setting
+                    if (policy?.emailAlerts?.resource?.cpu !== false) {
+                        settings.emailAlerts.resource.cpu = true
+                    }
+                    if (policy?.emailAlerts?.resource?.memory !== false) {
+                        settings.emailAlerts.resource.memory = true
+                    }
+                    if (cpuBefore === settings.emailAlerts.resource.cpu && memoryBefore === settings.emailAlerts.resource.memory) {
+                        continue
+                    }
+                    const q = `UPDATE "ProjectTemplates" SET "settings" = ? WHERE "id" = ${result.id}`
+                    const replacements = [JSON.stringify(settings)]
+                    await context.sequelize.query(q, { replacements })
+                } catch (error) {
+                    continue
+                }
+            }
+        }
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -219,10 +219,10 @@ module.exports = {
                 await M.Notification.destroy({
                     where: {
                         type: {
-                            [Op.in]: ['instance-crashed', 'instance-safe-mode']
+                            [Op.in]: ['instance-crashed', 'instance-safe-mode', 'instance-resource-cpu', 'instance-resource-memory']
                         },
                         reference: {
-                            [Op.in]: [`instance-crashed:${project.id}`, `instance-safe-mode:${project.id}`]
+                            [Op.in]: [`instance-crashed:${project.id}`, `instance-safe-mode:${project.id}`, `instance-resource-cpu:${project.id}`, `instance-resource-memory:${project.id}`]
                         }
                     }
                 })

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -110,7 +110,21 @@ module.exports = function (app) {
             const settingsCustomHostnameRow = proj.ProjectSettings?.find(row => row.key === KEY_CUSTOM_HOSTNAME)
             result.customHostname = settingsCustomHostnameRow?.value || undefined
         }
-
+        if (app.config.features.enabled('emailAlerts')) {
+            // Default email alert settings
+            if (typeof result.settings.emailAlerts !== 'object') {
+                result.settings.emailAlerts = {}
+            }
+            if (typeof result.settings.emailAlerts.resource !== 'object') {
+                result.settings.emailAlerts.resource = {}
+            }
+            if (typeof result.settings.emailAlerts.resource.cpu !== 'boolean') {
+                result.settings.emailAlerts.resource.cpu = true
+            }
+            if (typeof result.settings.emailAlerts.resource.memory !== 'boolean') {
+                result.settings.emailAlerts.resource.memory = true
+            }
+        }
         if (proj.Application) {
             result.application = app.db.views.Application.applicationSummary(proj.Application)
         }

--- a/forge/ee/lib/alerts/index.js
+++ b/forge/ee/lib/alerts/index.js
@@ -37,9 +37,9 @@ module.exports = {
                         template = templateName.join('-')
                     } else if (emailAlerts?.safe && event === 'safe-mode') {
                         template = 'SafeMode'
-                    } else if (emailAlerts?.resource?.cpu && event === 'resource.cpu') {
+                    } else if ((emailAlerts?.resource?.cpu ?? true) && event === 'resource.cpu') {
                         template = 'InstanceResourceCPUExceeded'
-                    } else if (emailAlerts?.resource?.memory && event === 'resource.memory') {
+                    } else if ((emailAlerts?.resource?.memory ?? true) && event === 'resource.memory') {
                         template = 'InstanceResourceMemoryExceeded'
                     }
                     if (!template || !teamType.getFeatureProperty('emailAlerts', false)) {

--- a/forge/lib/templates.js
+++ b/forge/lib/templates.js
@@ -60,8 +60,8 @@ module.exports = {
         httpNodeAuth_pass: '',
         emailAlerts_crash: false,
         emailAlerts_safe: false,
-        emailAlerts_resource_cpu: false,
-        emailAlerts_resource_memory: false,
+        emailAlerts_resource_cpu: true,
+        emailAlerts_resource_memory: true,
         emailAlerts_recipients: 'owners',
         debugMaxLength: 1000,
         apiMaxLength: '5mb'


### PR DESCRIPTION
closes #5267 
## Description

- Migration to set all templates email alerts for resources (cpu + memory) where the value is not currently set and the policy is NOT explicitly `false` (i.e. already set by a user)
- Assumes a missing value AND email alerts feature enabled as enabled. If user sets explicitly sets these alerts, they will use the set value
- Defaults the values to true for the UI to represent the default state  

## Related Issue(s)

owner: #5267
parent: #5264

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [x] Includes a DB migration? -> add the `area:migration` label

