### PR TITLE
Prompt users with "Restart now" dialog when making settings changes

### DIFF
--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -22,7 +22,7 @@
 
             <interview-popup v-if="interview?.enabled" :flag="interview.flag" :payload="interview.payload" />
 
-            <ff-dialog ref="dialog" data-el="platform-dialog" :header="dialog.header" :kind="dialog.kind" :disable-primary="dialog.disablePrimary" :confirm-label="dialog.confirmLabel" :canBeCanceled="dialog.canBeCanceled" @cancel="clearDialog(true)" @confirm="dialog.onConfirm">
+            <ff-dialog ref="dialog" data-el="platform-dialog" :header="dialog.header" :kind="dialog.kind" :disable-primary="dialog.disablePrimary" :confirm-label="dialog.confirmLabel" :cancel-label="dialog.cancelLabel" :canBeCanceled="dialog.canBeCanceled" @cancel="clearDialog(true)" @confirm="dialog.onConfirm">
                 <template v-if="dialog.textLines">
                     <div class="space-y-2">
                         <p v-for="(text, $index) in dialog.textLines" :key="$index">{{ text }}</p>

--- a/frontend/src/mixins/Dialog.js
+++ b/frontend/src/mixins/Dialog.js
@@ -48,6 +48,7 @@ export default {
                 this.dialog.html = msg.html
                 this.dialog.is = markRaw(msg.is)
                 this.dialog.confirmLabel = msg.confirmLabel
+                this.dialog.cancelLabel = msg.cancelLabel
                 this.dialog.kind = msg.kind
                 this.dialog.disablePrimary = msg.disablePrimary
                 if (Object.prototype.hasOwnProperty.call(msg, 'canBeCanceled')) {

--- a/frontend/src/pages/instance/Settings/Alerts.vue
+++ b/frontend/src/pages/instance/Settings/Alerts.vue
@@ -153,15 +153,18 @@ export default {
             })
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            Dialog.show({
-                header: 'Restart Required',
-                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
-                confirmLabel: 'Restart Now',
-                cancelLabel: 'Restart Later'
-            }, () => {
-                // restart the instance
-                this.$emit('restart-instance')
-            })
+            // is instance running
+            if (this.project.meta.state === 'running') {
+                Dialog.show({
+                    header: 'Restart Required',
+                    html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                    confirmLabel: 'Restart Now',
+                    cancelLabel: 'Restart Later'
+                }, () => {
+                    // restart the instance
+                    this.$emit('restart-instance')
+                })
+            }
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Alerts.vue
+++ b/frontend/src/pages/instance/Settings/Alerts.vue
@@ -10,7 +10,7 @@ import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
-import alerts from '../../../services/alerts.js'
+import Dialog from '../../../services/dialog.js'
 import TemplateSettingsAlert from '../../admin/Template/sections/Alerts.vue'
 import {
     getObjectValue,
@@ -34,7 +34,7 @@ export default {
             required: true
         }
     },
-    emits: ['instance-updated', 'save-button-state'],
+    emits: ['instance-updated', 'save-button-state', 'restart-instance'],
     data () {
         return {
             unsavedChanges: false,
@@ -153,7 +153,15 @@ export default {
             })
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            alerts.emit('Instance successfully updated.', 'confirmation')
+            Dialog.show({
+                header: 'Restart Required',
+                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                confirmLabel: 'Restart Now',
+                cancelLabel: 'Restart Later'
+            }, () => {
+                // restart the instance
+                this.$emit('restart-instance')
+            })
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Editor.vue
+++ b/frontend/src/pages/instance/Settings/Editor.vue
@@ -146,15 +146,18 @@ export default {
             })
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            Dialog.show({
-                header: 'Restart Required',
-                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
-                confirmLabel: 'Restart Now',
-                cancelLabel: 'Restart Later'
-            }, () => {
-                // restart the instance
-                this.$emit('restart-instance')
-            })
+            // is instance running
+            if (this.project.meta.state === 'running') {
+                Dialog.show({
+                    header: 'Restart Required',
+                    html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                    confirmLabel: 'Restart Now',
+                    cancelLabel: 'Restart Later'
+                }, () => {
+                    // restart the instance
+                    this.$emit('restart-instance')
+                })
+            }
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Editor.vue
+++ b/frontend/src/pages/instance/Settings/Editor.vue
@@ -11,7 +11,7 @@ import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
-import alerts from '../../../services/alerts.js'
+import Dialog from '../../../services/dialog.js'
 import TemplateSettingsEditor from '../../admin/Template/sections/Editor.vue'
 import {
     getObjectValue,
@@ -36,7 +36,7 @@ export default {
             required: true
         }
     },
-    emits: ['instance-updated', 'save-button-state'],
+    emits: ['instance-updated', 'save-button-state', 'restart-instance'],
     data () {
         return {
             unsavedChanges: false,
@@ -146,7 +146,15 @@ export default {
             })
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
+            Dialog.show({
+                header: 'Restart Required',
+                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                confirmLabel: 'Restart Now',
+                cancelLabel: 'Restart Later'
+            }, () => {
+                // restart the instance
+                this.$emit('restart-instance')
+            })
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -192,15 +192,18 @@ export default {
                     setTimeout(() => this.$emit('instance-updated'), 1000)
                 })
                 .then(() => {
-                    Dialog.show({
-                        header: 'Restart Required',
-                        html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
-                        confirmLabel: 'Restart Now',
-                        cancelLabel: 'Restart Later'
-                    }, () => {
-                        // restart the instance
-                        this.$emit('restart-instance')
-                    })
+                    // is instance running
+                    if (this.project.meta.state === 'running') {
+                        Dialog.show({
+                            header: 'Restart Required',
+                            html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                            confirmLabel: 'Restart Now',
+                            cancelLabel: 'Restart Later'
+                        }, () => {
+                            // restart the instance
+                            this.$emit('restart-instance')
+                        })
+                    }
                 })
                 .catch(e => e)
         },

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -15,8 +15,7 @@ import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
-import alerts from '../../../services/alerts.js'
-import dialog from '../../../services/dialog.js'
+import Dialog from '../../../services/dialog.js'
 import TemplateSettingsEnvironment from '../../admin/Template/sections/Environment.vue'
 import {
     prepareTemplateForEdit
@@ -36,7 +35,7 @@ export default {
                 text: 'You have unsaved changes. Are you sure you want to leave?',
                 confirmLabel: 'Yes, lose changes'
             }
-            const answer = await dialog.showAsync(dialogOpts)
+            const answer = await Dialog.showAsync(dialogOpts)
             if (answer === 'confirm') {
                 next()
             } else {
@@ -53,7 +52,7 @@ export default {
             required: true
         }
     },
-    emits: ['instance-updated', 'save-button-state'],
+    emits: ['instance-updated', 'save-button-state', 'restart-instance'],
     data () {
         return {
             unsavedChanges: false,
@@ -192,7 +191,17 @@ export default {
                     // wait before we reload the instance so we don't get a blip by returning the old values
                     setTimeout(() => this.$emit('instance-updated'), 1000)
                 })
-                .then(() => alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000))
+                .then(() => {
+                    Dialog.show({
+                        header: 'Restart Required',
+                        html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                        confirmLabel: 'Restart Now',
+                        cancelLabel: 'Restart Later'
+                    }, () => {
+                        // restart the instance
+                        this.$emit('restart-instance')
+                    })
+                })
                 .catch(e => e)
         },
         onFormValidated (hasErrors) {

--- a/frontend/src/pages/instance/Settings/LauncherSettings.vue
+++ b/frontend/src/pages/instance/Settings/LauncherSettings.vue
@@ -158,15 +158,18 @@ export default {
             }
             await InstanceApi.updateInstance(this.project.id, { launcherSettings })
             this.$emit('instance-updated')
-            Dialog.show({
-                header: 'Restart Required',
-                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
-                confirmLabel: 'Restart Now',
-                cancelLabel: 'Restart Later'
-            }, () => {
-                // restart the instance
-                this.$emit('restart-instance')
-            })
+            // is instance running
+            if (this.project.meta.state === 'running') {
+                Dialog.show({
+                    header: 'Restart Required',
+                    html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                    confirmLabel: 'Restart Now',
+                    cancelLabel: 'Restart Later'
+                }, () => {
+                    // restart the instance
+                    this.$emit('restart-instance')
+                })
+            }
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/LauncherSettings.vue
+++ b/frontend/src/pages/instance/Settings/LauncherSettings.vue
@@ -34,7 +34,8 @@ import InstanceApi from '../../../api/instances.js'
 import FormHeading from '../../../components/FormHeading.vue'
 import FormRow from '../../../components/FormRow.vue'
 import permissionsMixin from '../../../mixins/Permissions.js'
-import alerts from '../../../services/alerts.js'
+import Alerts from '../../../services/alerts.js'
+import Dialog from '../../../services/dialog.js'
 
 export default {
     name: 'LauncherSettings',
@@ -50,7 +51,7 @@ export default {
             required: true
         }
     },
-    emits: ['instance-updated', 'save-button-state'],
+    emits: ['instance-updated', 'save-button-state', 'restart-instance'],
     data () {
         return {
             mounted: false,
@@ -152,12 +153,20 @@ export default {
                 }
             }
             if (!this.validateFormInputs()) {
-                alerts.emit('Please correct the errors before saving.', 'error')
+                Alerts.emit('Please correct the errors before saving.', 'error')
                 return
             }
             await InstanceApi.updateInstance(this.project.id, { launcherSettings })
             this.$emit('instance-updated')
-            alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
+            Dialog.show({
+                header: 'Restart Required',
+                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                confirmLabel: 'Restart Now',
+                cancelLabel: 'Restart Later'
+            }, () => {
+                // restart the instance
+                this.$emit('restart-instance')
+            })
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Palette.vue
+++ b/frontend/src/pages/instance/Settings/Palette.vue
@@ -190,15 +190,18 @@ export default {
             })
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            Dialog.show({
-                header: 'Restart Required',
-                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
-                confirmLabel: 'Restart Now',
-                cancelLabel: 'Restart Later'
-            }, () => {
-                // restart the instance
-                this.$emit('restart-instance')
-            })
+            // is instance running
+            if (this.project.meta.state === 'running') {
+                Dialog.show({
+                    header: 'Restart Required',
+                    html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                    confirmLabel: 'Restart Now',
+                    cancelLabel: 'Restart Later'
+                }, () => {
+                    // restart the instance
+                    this.$emit('restart-instance')
+                })
+            }
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Palette.vue
+++ b/frontend/src/pages/instance/Settings/Palette.vue
@@ -15,7 +15,7 @@ import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
-import alerts from '../../../services/alerts.js'
+import Dialog from '../../../services/dialog.js'
 import TemplateSectionCatalogue from '../../admin/Template/sections/Catalogues.vue'
 import TemplateSectionNPM from '../../admin/Template/sections/NPMRegistry.vue'
 import TemplateSettingsPalette from '../../admin/Template/sections/Palette.vue'
@@ -45,7 +45,7 @@ export default {
             required: true
         }
     },
-    emits: ['instance-updated', 'save-button-state'],
+    emits: ['instance-updated', 'save-button-state', 'restart-instance'],
     data () {
         return {
             // unsavedChanges: false,
@@ -190,7 +190,15 @@ export default {
             })
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            alerts.emit('Instance successfully updated.', 'confirmation')
+            Dialog.show({
+                header: 'Restart Required',
+                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                confirmLabel: 'Restart Now',
+                cancelLabel: 'Restart Later'
+            }, () => {
+                // restart the instance
+                this.$emit('restart-instance')
+            })
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -49,7 +49,7 @@ import InstanceApi from '../../../api/instances.js'
 import FormHeading from '../../../components/FormHeading.vue'
 import featuresMixin from '../../../mixins/Features.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
-import alerts from '../../../services/alerts.js'
+import Dialog from '../../../services/dialog.js'
 import TokenCreated from '../../account/Security/dialogs/TokenCreated.vue'
 import ExpiryCell from '../../account/components/ExpiryCell.vue'
 import TemplateSettingsSecurity from '../../admin/Template/sections/Security.vue'
@@ -82,7 +82,7 @@ export default {
             required: true
         }
     },
-    emits: ['instance-updated', 'save-button-state'],
+    emits: ['instance-updated', 'save-button-state', 'restart-instance'],
     data () {
         return {
             unsavedChanges: false,
@@ -227,7 +227,15 @@ export default {
             }
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            alerts.emit('Instance settings successfully updated. Restart the instance to apply the changes.', 'confirmation', 6000)
+            Dialog.show({
+                header: 'Restart Required',
+                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                confirmLabel: 'Restart Now',
+                cancelLabel: 'Restart Later'
+            }, () => {
+                // restart the instance
+                this.$emit('restart-instance')
+            })
         },
         async getTokens () {
             const response = await InstanceApi.getHTTPTokens(this.project.id)

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -227,15 +227,18 @@ export default {
             }
             await InstanceApi.updateInstance(this.project.id, { settings })
             this.$emit('instance-updated')
-            Dialog.show({
-                header: 'Restart Required',
-                html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
-                confirmLabel: 'Restart Now',
-                cancelLabel: 'Restart Later'
-            }, () => {
+            // is instance running
+            if (this.project.meta.state === 'running') {
+                Dialog.show({
+                    header: 'Restart Required',
+                    html: '<p>Instance settings have been successfully updated, but the Instance must be restarted for these settings to take effect.</p><p>Would you like to restart the Instance now?</p>',
+                    confirmLabel: 'Restart Now',
+                    cancelLabel: 'Restart Later'
+                }, () => {
                 // restart the instance
-                this.$emit('restart-instance')
-            })
+                    this.$emit('restart-instance')
+                })
+            }
         },
         async getTokens () {
             const response = await InstanceApi.getHTTPTokens(this.project.id)

--- a/frontend/src/pages/instance/Settings/index.vue
+++ b/frontend/src/pages/instance/Settings/index.vue
@@ -25,6 +25,7 @@
                     :project="instance"
                     :instance="instance"
                     @instance-updated="$emit('instance-updated')"
+                    @restart-instance="restartInstance"
                     @instance-confirm-suspend="$emit('instance-confirm-suspend')"
                     @instance-confirm-delete="$emit('instance-confirm-delete')"
                     @save-button-state="onSaveButtonStateChange"
@@ -39,6 +40,7 @@ import { mapState } from 'vuex'
 
 import SectionSideMenu from '../../../components/SectionSideMenu.vue'
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
+import instanceActionsMixin from '../../../mixins/InstanceActions.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
 
 export default {
@@ -47,7 +49,7 @@ export default {
         SectionTopMenu,
         SectionSideMenu
     },
-    mixins: [permissionsMixin],
+    mixins: [permissionsMixin, instanceActionsMixin],
     inheritAttrs: false,
     props: {
         instance: {
@@ -122,6 +124,9 @@ export default {
             ) {
                 this.$refs.settingsPage.saveSettings()
             }
+        },
+        restartInstance () {
+            this.instanceRestart(this.instance) // from the InstanceActions mixin
         }
     }
 }

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -87,6 +87,7 @@ import ConfirmInstanceDeleteDialog from './Settings/dialogs/ConfirmInstanceDelet
 import DashboardLink from './components/DashboardLink.vue'
 import InstanceEditorLink from './components/EditorLink.vue'
 import InstanceStatusBadge from './components/InstanceStatusBadge.vue'
+
 export default {
     name: 'InstancePage',
     components: {

--- a/frontend/src/services/dialog.js
+++ b/frontend/src/services/dialog.js
@@ -8,6 +8,7 @@ const subscriptions = []
  * @param {string} text The dialog text - can include newlines (\n) and they will be formatted properly
  * @param {string} html The dialog html (instead of text - use with caution to avoid XSS)
  * @param {string} confirmLabel The dialog confirm button label
+ * @param {string} cancelLabel The dialog cancel button label
  */
 
 export default {

--- a/frontend/src/ui-components/components/DialogBox.vue
+++ b/frontend/src/ui-components/components/DialogBox.vue
@@ -10,7 +10,7 @@
             </div>
             <div class="ff-dialog-actions">
                 <slot name="actions">
-                    <ff-button v-if="canBeCanceled" kind="secondary" data-action="dialog-cancel" @click="cancel()">Cancel</ff-button>
+                    <ff-button v-if="canBeCanceled" kind="secondary" data-action="dialog-cancel" @click="cancel()">{{ cancelLabel }}</ff-button>
                     <ff-button :kind="kind" data-action="dialog-confirm" :disabled="disablePrimary" @click="confirm()">{{ confirmLabel }}</ff-button>
                 </slot>
             </div>
@@ -33,6 +33,10 @@ export default {
         confirmLabel: {
             type: String,
             default: 'Confirm'
+        },
+        cancelLabel: {
+            type: String,
+            default: 'Cancel'
         },
         disablePrimary: {
             type: Boolean,

--- a/test/e2e/frontend/cypress/tests/instances/settings/environment.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances/settings/environment.spec.js
@@ -12,6 +12,13 @@ describe('FlowForge - Instance - Settings Environment', () => {
             .then((response) => {
                 instanceId = response.body.projects[1].id
                 cy.visit(`/instance/${instanceId}/settings/environment`)
+                cy.intercept('GET', `/api/v1/projects/${instanceId}`, async (req) => {
+                    req.continue((res) => {
+                        // intercept the request to get the instance status and force "running"
+                        res.body.meta.state = 'running'
+                    })
+                }).as('getInstance')
+                cy.wait('@getInstance')
             })
     })
 

--- a/test/e2e/frontend/cypress/tests/instances/settings/environment.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances/settings/environment.spec.js
@@ -62,6 +62,10 @@ describe('FlowForge - Instance - Settings Environment', () => {
         cy.get('[data-el="save-settings-button"]').click()
         cy.wait('@updateSettings')
 
+        cy.get('[data-el="platform-dialog"]').should('be.visible')
+        cy.get('[data-el="platform-dialog"]').contains('Restart Required')
+        cy.get('[data-el="platform-dialog"] [data-action="dialog-cancel"]').click()
+
         cy.get('[data-el="save-settings-button"]').should('be.disabled')
 
         // check that the hidden var name and visibility can't be changed
@@ -81,6 +85,10 @@ describe('FlowForge - Instance - Settings Environment', () => {
         cy.get('[data-el="save-settings-button"]').click()
         cy.wait('@updateSettings')
 
+        cy.get('[data-el="platform-dialog"]').should('be.visible')
+        cy.get('[data-el="platform-dialog"]').contains('Restart Required')
+        cy.get('[data-el="platform-dialog"] [data-action="dialog-cancel"]').click()
+
         cy.get('[data-el="env-vars-table"] [data-row="row-new_var"]').within(() => {
             cy.get('[data-el="var-name"] input').should('be.disabled')
             cy.get('[data-el="var-value"]').should('be.empty')
@@ -95,6 +103,10 @@ describe('FlowForge - Instance - Settings Environment', () => {
 
         cy.get('[data-el="save-settings-button"]').click()
         cy.wait('@updateSettings')
+
+        cy.get('[data-el="platform-dialog"]').should('be.visible')
+        cy.get('[data-el="platform-dialog"]').contains('Restart Required')
+        cy.get('[data-el="platform-dialog"] [data-action="dialog-cancel"]').click()
 
         cy.get('[data-el="save-settings-button"]').should('be.disabled')
     })

--- a/test/e2e/frontend/cypress/tests/instances/settings/launcher.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances/settings/launcher.spec.js
@@ -78,6 +78,10 @@ describe('FlowFuse - Instance - Settings - Launcher', () => {
         cy.get('[data-el="save-settings-button"]').click()
         cy.wait('@updateInstance')
 
+        cy.get('[data-el="platform-dialog"]').should('be.visible')
+        cy.get('[data-el="platform-dialog"]').contains('Restart Required')
+        cy.get('[data-el="platform-dialog"] [data-action="dialog-cancel"]').click()
+
         // refresh page
         navigateToInstanceSettings('BTeam', 'instance-2-1')
         cy.get('[data-el="section-side-menu"] li').contains('Launcher').click()


### PR DESCRIPTION
## Description

- Uses the `Dialog` service, instead of alerts to prompt a user to restart their Instance, when making changes to the Instance settings.
- Need to add/update E2E coverage

## Related Issue(s)

Closes #5282 