### PR TITLE
missing team id when loading blueprints on the multi-step forms

### DIFF
--- a/frontend/src/components/multi-step-forms/instance/MultiStepApplicationsInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepApplicationsInstanceForm.vue
@@ -108,10 +108,17 @@ export default {
             return this.applications.length === 0
         }
     },
-    mounted () {
-        // we need to get blueprints early on when we load the form in order to be able to hide the blueprints step if
-        // there aren't any
-        this.getBlueprints()
+    watch: {
+        team: {
+            immediate: true,
+            handler (team) {
+                // we need to get blueprints early on when we load the form in order to be able to hide the blueprints step if
+                // there aren't any
+                if (team) {
+                    this.getBlueprints()
+                }
+            }
+        }
     },
     methods: {
         updateForm (payload, stepKey) {

--- a/frontend/src/components/multi-step-forms/instance/MultiStepInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepInstanceForm.vue
@@ -92,8 +92,17 @@ export default {
             return flag
         }
     },
-    mounted () {
-        this.getBlueprints()
+    watch: {
+        team: {
+            immediate: true,
+            handler (team) {
+                // we need to get blueprints early on when we load the form in order to be able to hide the blueprints step if
+                // there aren't any
+                if (team) {
+                    this.getBlueprints()
+                }
+            }
+        }
     },
     methods: {
         updateForm (payload) {


### PR DESCRIPTION
## Description

Fixes the blueprint request on the multi-step forms when the team is not yet properly loaded

By moving the getBluepints method in a immediate watcher from the created method, it will force the multi step components to grab blueprints whenever the team changes (or in this case, eventually load), even if the form is mounted before the team is properly loaded.

## Related Issue(s)

caused by https://github.com/FlowFuse/flowfuse/pull/5364

https://flowfuse.sentry.io/issues/6504362686/?environment=production&project=4505958486441984&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=2
https://flowfuse.sentry.io/issues/6504414282/?environment=production&project=4505958486441984&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=4

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

