### PR TITLE
Block the 3rd party broker access to test.mosquitto.org

### DIFF
--- a/frontend/src/pages/team/Brokers/components/BrokerForm.vue
+++ b/frontend/src/pages/team/Brokers/components/BrokerForm.vue
@@ -220,14 +220,23 @@ export default {
             if (this.form.host.length === 0) {
                 return false
             }
+            if (this.form.host === 'test.mosquitto.org') {
+                return false
+            }
 
             return true
         },
         formErrors () {
-            return {
-                name: this.form.name.length ? '' : 'Name is mandatory',
-                host: this.form.host.length ? '' : 'Host is mandatory'
+            const errors = {
+                name: this.form.name.length ? '' : 'Name is mandatory'
             }
+
+            if (this.form.host.length === 0) {
+                errors.host = 'Host is mandatory'
+            } else if (this.form.host === 'test.mosquitto.org') {
+                errors.host = 'test.mosquitto.org is not allowed'
+            }
+            return errors
         }
     },
     watch: {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Prevent subscribing to `#` on `test.mosquitto.org` as not to load the 166000 topics

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

