### PR TITLE
Hide the blueprint step when no blueprints are available

### DIFF
--- a/frontend/src/components/multi-step-forms/instance/MultiStepInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepInstanceForm.vue
@@ -82,6 +82,9 @@ export default {
                 }
             ]
         },
+        hasNoBlueprints () {
+            return this.blueprints.length === 0
+        },
         shouldDisableNextStep () {
             let flag = false
             Object.keys(this.form).forEach(key => {


### PR DESCRIPTION


## Description

Add missing hasNoBlueprints computed prop to properly hide the blueprints step on the MultiStepInstanceForm

## Related Issue(s)

introduced by https://github.com/FlowFuse/flowfuse/pull/5364

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

