### PR TITLE
Fix the env var table for admin view & update the admin views to use ff-page

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -91,6 +91,13 @@ module.exports = async function (app) {
             }
         }
 
+        project.template.settings.env = project.template.settings.env.map(env => {
+            if (env.hidden) {
+                env.value = ''
+            }
+            return env
+        })
+
         reply.send({ ...project, ...projectState })
     })
 

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -91,12 +91,14 @@ module.exports = async function (app) {
             }
         }
 
-        project.template.settings.env = project.template.settings.env.map(env => {
-            if (env.hidden) {
-                env.value = ''
-            }
-            return env
-        })
+        if (project.template?.settings?.env) {
+            project.template.settings.env = project.template.settings.env.map(env => {
+                if (env.hidden) {
+                    env.value = ''
+                }
+                return env
+            })
+        }
 
         reply.send({ ...project, ...projectState })
     })

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -71,12 +71,14 @@ module.exports = async function (app) {
 
         if (template) {
             const result = app.db.views.ProjectTemplate.template(template)
-            result.settings.env = result.settings.env.map(env => {
-                if (env.hidden) {
-                    env.value = ''
-                }
-                return env
-            })
+            if (result.settings?.env) {
+                result.settings.env = result.settings.env.map(env => {
+                    if (env.hidden) {
+                        env.value = ''
+                    }
+                    return env
+                })
+            }
             reply.send(result)
         } else {
             reply.code(404).send({ code: 'not_found', error: 'Not Found' })

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -68,8 +68,16 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const template = await app.db.models.ProjectTemplate.byId(request.params.templateId)
+
         if (template) {
-            reply.send(app.db.views.ProjectTemplate.template(template))
+            const result = app.db.views.ProjectTemplate.template(template)
+            result.settings.env = result.settings.env.map(env => {
+                if (env.hidden) {
+                    env.value = ''
+                }
+                return env
+            })
+            reply.send(result)
         } else {
             reply.code(404).send({ code: 'not_found', error: 'Not Found' })
         }
@@ -223,6 +231,16 @@ module.exports = async function (app) {
                 }
             }
         }
+        templateSettings.env = templateSettings.env.map((env, key) => {
+            if (env.hidden === true && env.value === '') {
+                // we need to re-map the hidden value so it won't get overwritten
+                const existingVar = template.settings.env.find(currentEnv => currentEnv.name === env.name)
+                if (existingVar) {
+                    env.value = existingVar.value
+                }
+            }
+            return env
+        })
         template.settings = templateSettings
         template.policy = request.body.policy
         await template.save()

--- a/frontend/src/pages/admin/AuditLog.vue
+++ b/frontend/src/pages/admin/AuditLog.vue
@@ -1,9 +1,14 @@
 <template>
-    <AuditLogBrowser ref="AuditLog" :users="users" :logEntries="logEntries" logType="platform" @load-entries="loadEntries">
-        <template #title>
-            <SectionTopMenu hero="Platform Audit Log" info="Recorded events that have taken place at the Platform level." />
+    <ff-page>
+        <template #header>
+            <ff-page-header title="Platform Audit Log">
+                <template #context>
+                    Recorded events that have taken place at the Platform level.
+                </template>
+            </ff-page-header>
         </template>
-    </AuditLogBrowser>
+        <AuditLogBrowser ref="AuditLog" :users="users" :logEntries="logEntries" logType="platform" @load-entries="loadEntries" />
+    </ff-page>
 </template>
 
 <script>
@@ -11,13 +16,11 @@ import { mapState } from 'vuex'
 
 import AdminAPI from '../../api/admin.js'
 import UsersAPI from '../../api/users.js'
-import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import AuditLogBrowser from '../../components/audit-log/AuditLogBrowser.vue'
 
 export default {
     name: 'PlatformAuditLog',
     components: {
-        SectionTopMenu,
         AuditLogBrowser
     },
     data () {

--- a/frontend/src/pages/admin/FlowBlueprints/index.vue
+++ b/frontend/src/pages/admin/FlowBlueprints/index.vue
@@ -1,29 +1,31 @@
 <template>
-    <div class="space-y-6">
-        <SectionTopMenu hero="Flow Blueprints">
-            <template #tools>
-                <div class="tools">
-                    <ff-button data-action="export-flow-blueprints" @click="exportFlowBlueprints">
-                        <template #icon-right>
-                            <DownloadIcon class="ff-icon" />
-                        </template>
-                        Export
-                    </ff-button>
-                    <ff-button data-action="import-flow-blueprints" @click="showImportFlowBlueprintsDialog()">
-                        <template #icon-right>
-                            <UploadIcon class="ff-icon" />
-                        </template>
-                        Import
-                    </ff-button>
-                    <ff-button data-action="create-flow-blueprint" @click="showBlueprintForm()">
-                        <template #icon-right>
-                            <PlusSmIcon class="ff-icon" />
-                        </template>
-                        Create Flow Blueprint
-                    </ff-button>
-                </div>
-            </template>
-        </SectionTopMenu>
+    <ff-page>
+        <template #header>
+            <ff-page-header title="Flow Blueprints">
+                <template #tools>
+                    <div class="tools">
+                        <ff-button data-action="export-flow-blueprints" @click="exportFlowBlueprints">
+                            <template #icon-right>
+                                <DownloadIcon class="ff-icon" />
+                            </template>
+                            Export
+                        </ff-button>
+                        <ff-button data-action="import-flow-blueprints" @click="showImportFlowBlueprintsDialog()">
+                            <template #icon-right>
+                                <UploadIcon class="ff-icon" />
+                            </template>
+                            Import
+                        </ff-button>
+                        <ff-button data-action="create-flow-blueprint" @click="showBlueprintForm()">
+                            <template #icon-right>
+                                <PlusSmIcon class="ff-icon" />
+                            </template>
+                            Create Flow Blueprint
+                        </ff-button>
+                    </div>
+                </template>
+            </ff-page-header>
+        </template>
         <div data-el="blueprints" class="flex flex-wrap gap-4 md:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 max-w-screen-xl">
             <BlueprintTile
                 v-for="(flowBlueprint, index) in activeFlowBlueprints"
@@ -36,17 +38,19 @@
         <div v-if="nextCursor">
             <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
         </div>
-        <SectionTopMenu hero="Inactive Blueprints" />
-        <ff-data-table :columns="columns" :rows="inactiveFlowBlueprints" data-el="inactive-flow-blueprints">
-            <template #context-menu="{row}">
-                <ff-list-item label="Edit Flow Blueprint" @click="showBlueprintForm(row)" />
-                <ff-list-item label="Delete Flow Blueprint" kind="danger" @click="showDeleteBlueprint(row)" />
-            </template>
-        </ff-data-table>
-        <div v-if="nextCursor">
-            <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
+        <div class="mt-6">
+            <SectionTopMenu hero="Inactive Blueprints" />
+            <ff-data-table :columns="columns" :rows="inactiveFlowBlueprints" data-el="inactive-flow-blueprints">
+                <template #context-menu="{row}">
+                    <ff-list-item label="Edit Flow Blueprint" @click="showBlueprintForm(row)" />
+                    <ff-list-item label="Delete Flow Blueprint" kind="danger" @click="showDeleteBlueprint(row)" />
+                </template>
+            </ff-data-table>
+            <div v-if="nextCursor">
+                <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
+            </div>
         </div>
-    </div>
+    </ff-page>
     <FlowBlueprintFormDialog
         ref="adminFlowBlueprintDialog"
         data-el="create-blueprint-dialog"

--- a/frontend/src/pages/admin/InstanceTypes/index.vue
+++ b/frontend/src/pages/admin/InstanceTypes/index.vue
@@ -1,46 +1,49 @@
 <template>
-    <!-- set mb-14 (~56px) on the form to permit access to kebab actions where hubspot chat covers it -->
-    <div class="space-y-6 mb-14">
-        <SectionTopMenu hero="Instance Types">
-            <template #tools>
-                <ff-button data-action="create-type" @click="showCreateInstanceTypeDialog">
-                    <template #icon-right>
-                        <PlusSmIcon />
-                    </template>
-                    Create instance type
-                </ff-button>
-            </template>
-        </SectionTopMenu>
-        <ff-tile-selection data-el="active-types">
-            <ff-tile-selection-option
-                v-for="(instanceType, index) in activeInstanceTypes" :key="index" value=""
-                :editable="true" :price="instanceType.properties?.billingDescription?.split('/')[0]"
-                :price-interval="instanceType.properties?.billingDescription?.split('/')[1]"
-                :label="instanceType.name"
-                :description="instanceType.description" :meta="[{key: 'ID', value: instanceType.id}, {key: 'Instance Count', value: instanceType.instanceCount}, {key: 'Stack Count', value: instanceType.stackCount}]"
-                @edit="showEditInstanceTypeDialog(instanceType)"
-            />
-        </ff-tile-selection>
-        <div v-if="nextCursor">
-            <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
+    <ff-page>
+        <template #header>
+            <ff-page-header title="Instance Types">
+                <template #tools>
+                    <ff-button data-action="create-type" @click="showCreateInstanceTypeDialog">
+                        <template #icon-right>
+                            <PlusSmIcon />
+                        </template>
+                        Create instance type
+                    </ff-button>
+                </template>
+            </ff-page-header>
+        </template>
+        <div class="space-y-6 mb-14">
+            <ff-tile-selection data-el="active-types">
+                <ff-tile-selection-option
+                    v-for="(instanceType, index) in activeInstanceTypes" :key="index" value=""
+                    :editable="true" :price="instanceType.properties?.billingDescription?.split('/')[0]"
+                    :price-interval="instanceType.properties?.billingDescription?.split('/')[1]"
+                    :label="instanceType.name"
+                    :description="instanceType.description" :meta="[{key: 'ID', value: instanceType.id}, {key: 'Instance Count', value: instanceType.instanceCount}, {key: 'Stack Count', value: instanceType.stackCount}]"
+                    @edit="showEditInstanceTypeDialog(instanceType)"
+                />
+            </ff-tile-selection>
+            <div v-if="nextCursor">
+                <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
+            </div>
+            <SectionTopMenu hero="Inactive Types" />
+            <ff-data-table :columns="columns" :rows="inactiveInstanceTypes" data-el="inactive-types">
+                <template #context-menu="{row}">
+                    <ff-list-item label="Edit Instance Type" @click="instanceTypeAction('edit', row.id)" />
+                    <ff-list-item label="Delete Instance Type" kind="danger" @click="instanceTypeAction('delete', row.id)" />
+                </template>
+            </ff-data-table>
+            <div v-if="nextCursor">
+                <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
+            </div>
         </div>
-        <SectionTopMenu hero="Inactive Types" />
-        <ff-data-table :columns="columns" :rows="inactiveInstanceTypes" data-el="inactive-types">
-            <template #context-menu="{row}">
-                <ff-list-item label="Edit Instance Type" @click="instanceTypeAction('edit', row.id)" />
-                <ff-list-item label="Delete Instance Type" kind="danger" @click="instanceTypeAction('delete', row.id)" />
-            </template>
-        </ff-data-table>
-        <div v-if="nextCursor">
-            <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
-        </div>
-    </div>
-    <InstanceTypeEditDialog
-        ref="adminInstanceTypeEditDialog"
-        @instance-type-created="instanceTypeCreated"
-        @instance-type-updated="instanceTypeUpdated"
-        @show-delete-dialog="showConfirmInstanceTypeDeleteDialog"
-    />
+        <InstanceTypeEditDialog
+            ref="adminInstanceTypeEditDialog"
+            @instance-type-created="instanceTypeCreated"
+            @instance-type-updated="instanceTypeUpdated"
+            @show-delete-dialog="showConfirmInstanceTypeDeleteDialog"
+        />
+    </ff-page>
 </template>
 
 <script>

--- a/frontend/src/pages/admin/NotificationsHub.vue
+++ b/frontend/src/pages/admin/NotificationsHub.vue
@@ -1,84 +1,82 @@
 <template>
-    <div class="clear-page-gutters">
-        <div class="ff-instance-header">
+    <ff-page>
+        <template #header>
             <ff-page-header title="Notifications Hub" />
-        </div>
-        <div class="px-3 py-3 md:px-6 md:py-6">
-            <form class="flex flex-col gap-5" data-el="notification-form" @submit.prevent>
-                <section class="flex gap-10">
-                    <section>
-                        <FormRow v-model="form.title" type="input" placeholder="Title" class="mb-5" data-el="notification-title">
-                            Announcement Title
-                            <template #description>Enter a concise title for your announcement.</template>
-                        </FormRow>
-                        <FormRow v-model="form.message" class="mb-5" data-el="notification-message">
-                            Announcement Text
-                            <template #description>Provide the details of your announcement.</template>
-                            <template #input><textarea v-model="form.message" class="w-full max-h-80 min-h-40" rows="4" /></template>
-                        </FormRow>
-                        <FormRow v-model="form.url" type="input" :placeholder="urlPlaceholder" class="mb-5" data-el="notification-external-url">
-                            URL Link
-                            <template #description>Provide an url where users will be redirected when they click on the notification.</template>
-                        </FormRow>
-                    </section>
-                    <section>
-                        <FormHeading>Audience</FormHeading>
-                        <div class="ff-description mb-2 space-y-1">Select the audience of your announcement.</div>
-                        <FormHeading class="mt-4">User Roles:</FormHeading>
+        </template>
+        <form class="flex flex-col gap-5" data-el="notification-form" @submit.prevent>
+            <section class="flex gap-10">
+                <section>
+                    <FormRow v-model="form.title" type="input" placeholder="Title" class="mb-5" data-el="notification-title">
+                        Announcement Title
+                        <template #description>Enter a concise title for your announcement.</template>
+                    </FormRow>
+                    <FormRow v-model="form.message" class="mb-5" data-el="notification-message">
+                        Announcement Text
+                        <template #description>Provide the details of your announcement.</template>
+                        <template #input><textarea v-model="form.message" class="w-full max-h-80 min-h-40" rows="4" /></template>
+                    </FormRow>
+                    <FormRow v-model="form.url" type="input" :placeholder="urlPlaceholder" class="mb-5" data-el="notification-external-url">
+                        URL Link
+                        <template #description>Provide an url where users will be redirected when they click on the notification.</template>
+                    </FormRow>
+                </section>
+                <section>
+                    <FormHeading>Audience</FormHeading>
+                    <div class="ff-description mb-2 space-y-1">Select the audience of your announcement.</div>
+                    <FormHeading class="mt-4">User Roles:</FormHeading>
+                    <div class="grid gap-1 grid-cols-2 items-middle">
+                        <label
+                            v-for="(role, $key) in roleIds"
+                            :key="$key"
+                            class="ff-checkbox text-sm"
+                            :data-el="`audience-role-${role}`"
+                            @keydown.space.prevent="toggleRole(role)"
+                        >
+                            <span ref="input" class="checkbox" :checked="form.roles.includes(role)" tabindex="0" @keydown.space.prevent />
+                            <input v-model="form.roles" type="checkbox" :value="role" @keydown.space.prevent>
+                            {{ role }}
+                        </label>
+                    </div>
+                    <FormHeading class="mt-4">Team Types:</FormHeading>
+                    <div class="grid gap-1 grid-cols-2 items-middle">
+                        <label
+                            v-for="teamType in teamTypes"
+                            :key="teamType.id"
+                            class="ff-checkbox text-sm"
+                            :class="!teamType.active ? ['inactive-team'] : []"
+                            :data-el="`audience-teamType-${teamType.id}`"
+                            @keydown.space.prevent="toggleTeamType(teamType.id)"
+                        >
+                            <span ref="input" class="checkbox" :checked="form.teamTypes.includes(teamType.id)" tabindex="0" @keydown.space.prevent />
+                            <input v-model="form.teamTypes" type="checkbox" :value="teamType.id" @keydown.space.prevent>
+                            {{ teamType.name }}
+                        </label>
+                    </div>
+                    <template v-if="features.billing">
+                        <FormHeading class="mt-4">Billing State:</FormHeading>
                         <div class="grid gap-1 grid-cols-2 items-middle">
                             <label
-                                v-for="(role, $key) in roleIds"
+                                v-for="(billingState, $key) in billingStates"
                                 :key="$key"
                                 class="ff-checkbox text-sm"
-                                :data-el="`audience-role-${role}`"
-                                @keydown.space.prevent="toggleRole(role)"
+                                :data-el="`audience-billing-${billingState}`"
+                                @keydown.space.prevent="toggleBillingState(billingState)"
                             >
-                                <span ref="input" class="checkbox" :checked="form.roles.includes(role)" tabindex="0" @keydown.space.prevent />
-                                <input v-model="form.roles" type="checkbox" :value="role" @keydown.space.prevent>
-                                {{ role }}
+                                <span ref="input" class="checkbox" :checked="form.billing.includes(billingState)" tabindex="0" @keydown.space.prevent />
+                                <input v-model="form.billing" type="checkbox" :value="billingState" @keydown.space.prevent>
+                                {{ billingState }}
                             </label>
                         </div>
-                        <FormHeading class="mt-4">Team Types:</FormHeading>
-                        <div class="grid gap-1 grid-cols-2 items-middle">
-                            <label
-                                v-for="teamType in teamTypes"
-                                :key="teamType.id"
-                                class="ff-checkbox text-sm"
-                                :class="!teamType.active ? ['inactive-team'] : []"
-                                :data-el="`audience-teamType-${teamType.id}`"
-                                @keydown.space.prevent="toggleTeamType(teamType.id)"
-                            >
-                                <span ref="input" class="checkbox" :checked="form.teamTypes.includes(teamType.id)" tabindex="0" @keydown.space.prevent />
-                                <input v-model="form.teamTypes" type="checkbox" :value="teamType.id" @keydown.space.prevent>
-                                {{ teamType.name }}
-                            </label>
-                        </div>
-                        <template v-if="features.billing">
-                            <FormHeading class="mt-4">Billing State:</FormHeading>
-                            <div class="grid gap-1 grid-cols-2 items-middle">
-                                <label
-                                    v-for="(billingState, $key) in billingStates"
-                                    :key="$key"
-                                    class="ff-checkbox text-sm"
-                                    :data-el="`audience-billing-${billingState}`"
-                                    @keydown.space.prevent="toggleBillingState(billingState)"
-                                >
-                                    <span ref="input" class="checkbox" :checked="form.billing.includes(billingState)" tabindex="0" @keydown.space.prevent />
-                                    <input v-model="form.billing" type="checkbox" :value="billingState" @keydown.space.prevent>
-                                    {{ billingState }}
-                                </label>
-                            </div>
-                        </template>
-                    </section>
+                    </template>
                 </section>
-                <section class="actions">
-                    <ff-button :disabled="!canSubmit" data-action="submit" @click.stop.prevent="submitForm">
-                        Send Announcement
-                    </ff-button>
-                </section>
-            </form>
-        </div>
-    </div>
+            </section>
+            <section class="actions">
+                <ff-button :disabled="!canSubmit" data-action="submit" @click.stop.prevent="submitForm">
+                    Send Announcement
+                </ff-button>
+            </section>
+        </form>
+    </ff-page>
 </template>
 
 <script>

--- a/frontend/src/pages/admin/NotificationsHub.vue
+++ b/frontend/src/pages/admin/NotificationsHub.vue
@@ -240,7 +240,4 @@ export default {
 .inactive-team {
     color: $ff-grey-400;
 }
-.clear-page-gutters {
-    margin: -1.75rem
-}
 </style>

--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -1,112 +1,114 @@
 <template>
-    <SectionTopMenu hero="Admin Settings" />
-    <div class="ff-instance-info space-y-4">
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-gray-700">
-            <div class="border rounded px-4 py-2 text-center">
-                <router-link to="/admin/users/general">
-                    <div class="text-xl">{{ stats.userCount }}</div>
-                    <div>Users</div>
-                </router-link>
-                <div class="w-full grid grid-cols-2 pt-1 mt-2 border-t">
-                    <div>{{ stats.adminCount }} {{ $filters.pluralize(stats.adminCount,'admin') }}</div>
-                    <div><router-link to="/admin/users/invitations">{{ stats.inviteCount }} {{ $filters.pluralize(stats.inviteCount,'invite') }}</router-link></div>
+    <ff-page>
+        <template #header>
+            <ff-page-header title="Admin Settings" />
+        </template>
+        <div class="ff-instance-info space-y-4">
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-gray-700">
+                <div class="border rounded px-4 py-2 text-center">
+                    <router-link to="/admin/users/general">
+                        <div class="text-xl">{{ stats.userCount }}</div>
+                        <div>Users</div>
+                    </router-link>
+                    <div class="w-full grid grid-cols-2 pt-1 mt-2 border-t">
+                        <div>{{ stats.adminCount }} {{ $filters.pluralize(stats.adminCount,'admin') }}</div>
+                        <div><router-link to="/admin/users/invitations">{{ stats.inviteCount }} {{ $filters.pluralize(stats.inviteCount,'invite') }}</router-link></div>
+                    </div>
                 </div>
-            </div>
-            <div class="border rounded p-4 text-center">
-                <router-link to="/admin/teams">
-                    <div class="text-xl">{{ stats.teamCount }}</div>
-                    <div>{{ $filters.pluralize(stats.teamCount,'Team') }}</div>
-                </router-link>
-            </div>
-            <div class="border rounded p-4 text-center">
-                <div class="text-xl">{{ stats.instanceCount }}</div>
-                <div>{{ $filters.pluralize(stats.instanceCount,'Instance') }}</div>
-                <div v-if="stats.instancesByState && Object.keys(stats.instancesByState).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
-                    <div v-for="(count, state) in stats.instancesByState" :key="state">
-                        {{ count }} {{ state }}
+                <div class="border rounded p-4 text-center">
+                    <router-link to="/admin/teams">
+                        <div class="text-xl">{{ stats.teamCount }}</div>
+                        <div>{{ $filters.pluralize(stats.teamCount,'Team') }}</div>
+                    </router-link>
+                </div>
+                <div class="border rounded p-4 text-center">
+                    <div class="text-xl">{{ stats.instanceCount }}</div>
+                    <div>{{ $filters.pluralize(stats.instanceCount,'Instance') }}</div>
+                    <div v-if="stats.instancesByState && Object.keys(stats.instancesByState).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
+                        <div v-for="(count, state) in stats.instancesByState" :key="state">
+                            {{ count }} {{ state }}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="border rounded p-4 text-center">
+                    <div class="text-xl">{{ stats.deviceCount }}</div>
+                    <div>{{ $filters.pluralize(stats.deviceCount,'Device') }}</div>
+                    <div v-if="stats.devicesByLastSeen && Object.keys(stats.devicesByLastSeen).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
+                        <div> {{ stats.devicesByLastSeen.day || 0 }} connected</div>
                     </div>
                 </div>
             </div>
-
-            <div class="border rounded p-4 text-center">
-                <div class="text-xl">{{ stats.deviceCount }}</div>
-                <div>{{ $filters.pluralize(stats.deviceCount,'Device') }}</div>
-                <div v-if="stats.devicesByLastSeen && Object.keys(stats.devicesByLastSeen).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
-                    <div> {{ stats.devicesByLastSeen.day || 0 }} connected</div>
-                </div>
-            </div>
-        </div>
-        <div>
-            <FormHeading>License</FormHeading>
-            <table class="w-full">
-                <tr>
-                    <td class="w-40">Type</td>
-                    <td>
-                        <span v-if="!license">FlowFuse Community Edition</span>
-                        <span v-else-if="!license.dev">FlowFuse Enterprise Edition</span>
-                        <span v-else class="font-bold">FlowFuse Development Only</span>
-                    </td>
-                </tr>
-                <template v-if="license">
-                    <tr><td class="w-40 font-medium">Organisation</td><td>{{ license.organisation }}</td></tr>
-                    <tr><td class="w-40 font-medium">Tier</td><td>{{ license.tier }}</td></tr>
-                    <tr><td>{{ expired ? 'Expired' : 'Expires' }}</td><td>{{ license.expires }}<br><span class="text-xs">{{ license.expiresAt }}</span></td></tr>
-                </template>
-                <tr>
-                    <td class="w-40">Users</td>
-                    <td>{{ stats.userCount }} / {{ stats.maxUsers }}</td>
-                </tr>
-                <tr>
-                    <td class="w-40">Teams</td>
-                    <td>{{ stats.teamCount }} / {{ stats.maxTeams }}</td>
-                </tr>
-                <template v-if="stats.maxDevices">
+            <div>
+                <FormHeading>License</FormHeading>
+                <table class="w-full">
                     <tr>
-                        <td class="w-40">Instances</td>
-                        <td>{{ stats.instanceCount }} / {{ stats.maxInstances }}</td>
-                    </tr>
-                    <tr>
-                        <td class="w-40">Devices</td>
+                        <td class="w-40">Type</td>
                         <td>
-                            <div>{{ stats.deviceCount }} / {{ stats.maxDevices }}</div>
+                            <span v-if="!license">FlowFuse Community Edition</span>
+                            <span v-else-if="!license.dev">FlowFuse Enterprise Edition</span>
+                            <span v-else class="font-bold">FlowFuse Development Only</span>
                         </td>
                     </tr>
-                </template>
-                <template v-else>
+                    <template v-if="license">
+                        <tr><td class="w-40 font-medium">Organisation</td><td>{{ license.organisation }}</td></tr>
+                        <tr><td class="w-40 font-medium">Tier</td><td>{{ license.tier }}</td></tr>
+                        <tr><td>{{ expired ? 'Expired' : 'Expires' }}</td><td>{{ license.expires }}<br><span class="text-xs">{{ license.expiresAt }}</span></td></tr>
+                    </template>
                     <tr>
-                        <td class="w-40">Instances + Devices</td>
-                        <td>{{ stats.instanceCount + stats.deviceCount }} / {{ stats.maxInstances }}</td>
+                        <td class="w-40">Users</td>
+                        <td>{{ stats.userCount }} / {{ stats.maxUsers }}</td>
                     </tr>
-                </template>
-                <template v-if="stats.maxMqttClients">
                     <tr>
-                        <td class="w-40">Team MQTT Clients</td>
-                        <td>{{ stats.mqttClientCount }} / {{ stats.maxMqttClients }}</td>
+                        <td class="w-40">Teams</td>
+                        <td>{{ stats.teamCount }} / {{ stats.maxTeams }}</td>
                     </tr>
-                </template>
-            </table>
+                    <template v-if="stats.maxDevices">
+                        <tr>
+                            <td class="w-40">Instances</td>
+                            <td>{{ stats.instanceCount }} / {{ stats.maxInstances }}</td>
+                        </tr>
+                        <tr>
+                            <td class="w-40">Devices</td>
+                            <td>
+                                <div>{{ stats.deviceCount }} / {{ stats.maxDevices }}</div>
+                            </td>
+                        </tr>
+                    </template>
+                    <template v-else>
+                        <tr>
+                            <td class="w-40">Instances + Devices</td>
+                            <td>{{ stats.instanceCount + stats.deviceCount }} / {{ stats.maxInstances }}</td>
+                        </tr>
+                    </template>
+                    <template v-if="stats.maxMqttClients">
+                        <tr>
+                            <td class="w-40">Team MQTT Clients</td>
+                            <td>{{ stats.mqttClientCount }} / {{ stats.maxMqttClients }}</td>
+                        </tr>
+                    </template>
+                </table>
+            </div>
+            <div>
+                <FormHeading>Version</FormHeading>
+                <table class="w-full">
+                    <tr><td class="w-40">Forge Application</td><td>{{ settings['version:forge'] }}</td></tr>
+                    <tr><td>NodeJS</td><td>{{ settings['version:node'] }}</td></tr>
+                </table>
+            </div>
         </div>
-        <div>
-            <FormHeading>Version</FormHeading>
-            <table class="w-full">
-                <tr><td class="w-40">Forge Application</td><td>{{ settings['version:forge'] }}</td></tr>
-                <tr><td>NodeJS</td><td>{{ settings['version:node'] }}</td></tr>
-            </table>
-        </div>
-    </div>
+    </ff-page>
 </template>
 
 <script>
 import adminApi from '../../api/admin.js'
 import Settings from '../../api/settings.js'
 import FormHeading from '../../components/FormHeading.vue'
-import SectionTopMenu from '../../components/SectionTopMenu.vue'
 
 export default {
     name: 'AdminSettingsGeneral',
     components: {
-        FormHeading,
-        SectionTopMenu
+        FormHeading
     },
     data: function () {
         return {

--- a/frontend/src/pages/admin/Settings/index.vue
+++ b/frontend/src/pages/admin/Settings/index.vue
@@ -1,14 +1,12 @@
 <template>
-    <div class="clear-page-gutters">
-        <div class="ff-instance-header">
+    <ff-page>
+        <template #header>
             <ff-page-header title="Settings" :tabs="sideNavigation" />
+        </template>
+        <div class="flex-grow">
+            <router-view />
         </div>
-        <div class="px-3 py-3 md:px-6 md:py-6">
-            <div class="flex-grow">
-                <router-view />
-            </div>
-        </div>
-    </div>
+    </ff-page>
 </template>
 
 <script>

--- a/frontend/src/pages/admin/Settings/index.vue
+++ b/frontend/src/pages/admin/Settings/index.vue
@@ -29,7 +29,4 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.clear-page-gutters {
-    margin: -1.75rem
-}
 </style>

--- a/frontend/src/pages/admin/Stacks/index.vue
+++ b/frontend/src/pages/admin/Stacks/index.vue
@@ -1,55 +1,60 @@
 <template>
-    <div class="space-y-6">
-        <FormHeading>Active Stacks</FormHeading>
-        <ff-loading v-if="loadingActive" message="Loading Stacks..." />
-        <ff-data-table
-            v-if="!loadingActive"
-            data-el="active-stacks"
-            :columns="activeColumns"
-            :rows="activeStacks"
-            :show-search="true"
-            search-placeholder="Search by Stack Name..."
-            no-data-message="No Active Stacks Found"
-        >
-            <template #actions>
-                <ff-button @click="showCreateStackDialog">
-                    <template #icon-right>
-                        <PlusSmIcon />
-                    </template>
-                    Create stack
-                </ff-button>
-            </template>
-            <template #context-menu="{row}">
-                <ff-list-item label="Create New Version" @click="stackAction('createNewVersion', row.id)" />
-                <ff-list-item label="Edit Properties" @click="stackAction('editProperties', row.id)" />
-                <ff-list-item label="Delete Stack" kind="danger" @click="stackAction('delete', row.id)" />
-            </template>
-        </ff-data-table>
-        <div v-if="nextActiveCursor">
-            <a v-if="!loadingActive" class="forge-button-inline" data-action="load-more-active" @click.stop="loadActiveItems">Load more...</a>
+    <ff-page>
+        <template #header>
+            <ff-page-header title="Stacks" />
+        </template>
+        <div class="space-y-6">
+            <FormHeading>Active Stacks</FormHeading>
+            <ff-loading v-if="loadingActive" message="Loading Stacks..." />
+            <ff-data-table
+                v-if="!loadingActive"
+                data-el="active-stacks"
+                :columns="activeColumns"
+                :rows="activeStacks"
+                :show-search="true"
+                search-placeholder="Search by Stack Name..."
+                no-data-message="No Active Stacks Found"
+            >
+                <template #actions>
+                    <ff-button @click="showCreateStackDialog">
+                        <template #icon-right>
+                            <PlusSmIcon />
+                        </template>
+                        Create stack
+                    </ff-button>
+                </template>
+                <template #context-menu="{row}">
+                    <ff-list-item label="Create New Version" @click="stackAction('createNewVersion', row.id)" />
+                    <ff-list-item label="Edit Properties" @click="stackAction('editProperties', row.id)" />
+                    <ff-list-item label="Delete Stack" kind="danger" @click="stackAction('delete', row.id)" />
+                </template>
+            </ff-data-table>
+            <div v-if="nextActiveCursor">
+                <a v-if="!loadingActive" class="forge-button-inline" data-action="load-more-active" @click.stop="loadActiveItems">Load more...</a>
+            </div>
+            <FormHeading>Inactive Stacks</FormHeading>
+            <ff-loading v-if="loadingInactive" message="Loading Stacks..." />
+            <ff-data-table
+                v-if="!loadingInactive"
+                data-el="inactive-stacks"
+                :columns="inactiveColumns"
+                :rows="inactiveStacks"
+                :show-search="true"
+                search-placeholder="Search by Stack Name..."
+                no-data-message="No Inactive Stacks Found"
+            >
+                <template #context-menu="{row}">
+                    <ff-list-item label="Create New Version" @click="stackAction('createNewVersion', row.id)" />
+                    <ff-list-item label="Edit Properties" @click="stackAction('editProperties', row.id)" />
+                    <ff-list-item label="Delete Stack" kind="danger" @click="stackAction('delete', row.id)" />
+                </template>
+            </ff-data-table>
+            <div v-if="nextInactiveCursor">
+                <a v-if="!loadingInactive" class="forge-button-inline" data-action="load-more-inactive" @click.stop="loadInactiveItems">Load more...</a>
+            </div>
         </div>
-        <FormHeading>Inactive Stacks</FormHeading>
-        <ff-loading v-if="loadingInactive" message="Loading Stacks..." />
-        <ff-data-table
-            v-if="!loadingInactive"
-            data-el="inactive-stacks"
-            :columns="inactiveColumns"
-            :rows="inactiveStacks"
-            :show-search="true"
-            search-placeholder="Search by Stack Name..."
-            no-data-message="No Inactive Stacks Found"
-        >
-            <template #context-menu="{row}">
-                <ff-list-item label="Create New Version" @click="stackAction('createNewVersion', row.id)" />
-                <ff-list-item label="Edit Properties" @click="stackAction('editProperties', row.id)" />
-                <ff-list-item label="Delete Stack" kind="danger" @click="stackAction('delete', row.id)" />
-            </template>
-        </ff-data-table>
-        <div v-if="nextInactiveCursor">
-            <a v-if="!loadingInactive" class="forge-button-inline" data-action="load-more-inactive" @click.stop="loadInactiveItems">Load more...</a>
-        </div>
-    </div>
-    <AdminStackEditDialog ref="adminStackEditDialog" @stack-created="stackCreated" @stack-updated="stackUpdated" />
+        <AdminStackEditDialog ref="adminStackEditDialog" @stack-created="stackCreated" @stack-updated="stackUpdated" />
+    </ff-page>
 </template>
 
 <script>

--- a/frontend/src/pages/admin/TeamTypes/index.vue
+++ b/frontend/src/pages/admin/TeamTypes/index.vue
@@ -1,49 +1,52 @@
 <template>
-    <!-- set mb-14 (~56px) on the form to permit access to kebab actions where hubspot chat covers it -->
-    <div class="space-y-6 mb-14">
-        <SectionTopMenu hero="Team Types">
-            <template #tools>
-                <ff-button data-action="create-type" @click="showEditTeamTypeDialog()">
-                    <template #icon-right>
-                        <PlusSmIcon />
-                    </template>
-                    Create team type
-                </ff-button>
-            </template>
-        </SectionTopMenu>
-        <ff-tile-selection data-el="active-types">
-            <ff-tile-selection-option
-                v-for="(teamType, index) in activeTeamTypes"
-                :key="index"
-                value=""
-                :price="teamType.properties?.billingDescription?.split('/')[0] || ''"
-                :price-interval="teamType.properties?.billingDescription?.split('/')[1] || ''"
-                :label="teamType.name" :description="teamType.description"
-                :meta="[{key: 'ID', value: teamType.id}, {key: 'Team Count', value: teamType.teamCount}]"
-                :editable="true"
-                @edit="showEditTeamTypeDialog(teamType)"
-            />
-        </ff-tile-selection>
-        <div v-if="nextCursor">
-            <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
+    <ff-page>
+        <template #header>
+            <ff-page-header title="Team Types">
+                <template #tools>
+                    <ff-button data-action="create-type" @click="showEditTeamTypeDialog()">
+                        <template #icon-right>
+                            <PlusSmIcon />
+                        </template>
+                        Create team type
+                    </ff-button>
+                </template>
+            </ff-page-header>
+        </template>
+        <div class="space-y-6 mb-14">
+            <ff-tile-selection data-el="active-types">
+                <ff-tile-selection-option
+                    v-for="(teamType, index) in activeTeamTypes"
+                    :key="index"
+                    value=""
+                    :price="teamType.properties?.billingDescription?.split('/')[0] || ''"
+                    :price-interval="teamType.properties?.billingDescription?.split('/')[1] || ''"
+                    :label="teamType.name" :description="teamType.description"
+                    :meta="[{key: 'ID', value: teamType.id}, {key: 'Team Count', value: teamType.teamCount}]"
+                    :editable="true"
+                    @edit="showEditTeamTypeDialog(teamType)"
+                />
+            </ff-tile-selection>
+            <div v-if="nextCursor">
+                <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
+            </div>
+            <SectionTopMenu hero="Inactive Types" />
+            <ff-data-table :columns="columns" :rows="inactiveTeamTypes" data-el="inactive-types">
+                <template #context-menu="{row}">
+                    <ff-list-item label="Edit Team Type" @click="teamTypeAction('edit', row.id)" />
+                    <ff-list-item label="Delete Team Type" kind="danger" @click="teamTypeAction('delete', row.id)" />
+                </template>
+            </ff-data-table>
+            <div v-if="nextCursor">
+                <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
+            </div>
         </div>
-        <SectionTopMenu hero="Inactive Types" />
-        <ff-data-table :columns="columns" :rows="inactiveTeamTypes" data-el="inactive-types">
-            <template #context-menu="{row}">
-                <ff-list-item label="Edit Team Type" @click="teamTypeAction('edit', row.id)" />
-                <ff-list-item label="Delete Team Type" kind="danger" @click="teamTypeAction('delete', row.id)" />
-            </template>
-        </ff-data-table>
-        <div v-if="nextCursor">
-            <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
-        </div>
-    </div>
-    <TeamTypeEditDialog
-        ref="adminTeamTypeEditDialog"
-        @team-type-created="teamTypeCreated"
-        @team-type-updated="teamTypeUpdated"
-        @show-delete-dialog="showConfirmTeamTypeDeleteDialog"
-    />
+        <TeamTypeEditDialog
+            ref="adminTeamTypeEditDialog"
+            @team-type-created="teamTypeCreated"
+            @team-type-updated="teamTypeUpdated"
+            @show-delete-dialog="showConfirmTeamTypeDeleteDialog"
+        />
+    </ff-page>
 </template>
 
 <script>

--- a/frontend/src/pages/admin/Teams.vue
+++ b/frontend/src/pages/admin/Teams.vue
@@ -1,59 +1,63 @@
 <template>
-    <div class="ff-admin-audit">
-        <div>
-            <SectionTopMenu hero="Teams" />
-            <ff-data-table
-                v-model:search="teamSearch"
-                :columns="columns"
-                :rows="teams"
-                :rows-selectable="true"
-                :show-search="true"
-                search-placeholder="Search Teams..."
-                :search-fields="['name', 'id']"
-                :show-load-more="!!nextCursor"
-                :loading="loading"
-                loading-message="Loading Teams"
-                no-data-message="No Teams Found"
-                data-el="teams-table"
-                @row-selected="viewTeam"
-                @load-more="loadItems"
-            />
-        </div>
-        <div>
-            <SectionTopMenu hero="Filters" />
-            <FormHeading class="mt-4">Sort:</FormHeading>
-            <div data-el="sort-options">
-                <ff-dropdown v-model="filters.sortBy" class="w-full">
-                    <ff-dropdown-option
-                        v-for="sortOpt in sortOptions" :key="sortOpt.id"
-                        :label="`${sortOpt.label}`" :value="sortOpt.id"
-                    />
-                </ff-dropdown>
+    <ff-page>
+        <template #header>
+            <ff-page-header title="Teams" />
+        </template>
+        <div class="ff-admin-audit">
+            <div>
+                <ff-data-table
+                    v-model:search="teamSearch"
+                    :columns="columns"
+                    :rows="teams"
+                    :rows-selectable="true"
+                    :show-search="true"
+                    search-placeholder="Search Teams..."
+                    :search-fields="['name', 'id']"
+                    :show-load-more="!!nextCursor"
+                    :loading="loading"
+                    loading-message="Loading Teams"
+                    no-data-message="No Teams Found"
+                    data-el="teams-table"
+                    @row-selected="viewTeam"
+                    @load-more="loadItems"
+                />
             </div>
-            <FormHeading class="mt-4">Team Type:</FormHeading>
-            <div data-el="filter-team-types" class="pl-2 space-y-2">
-                <FormRow
-                    v-for="teamType in teamTypes"
-                    :key="teamType.id"
-                    v-model="filters.teamType[teamType.id]"
-                    type="checkbox"
-                >
-                    {{ teamType.name }}
-                </FormRow>
-            </div>
-
-            <template v-if="features.billing">
-                <FormHeading class="mt-4">Billing State:</FormHeading>
-                <div data-el="filter-team-types" class="pl-2 space-y-2">
-                    <FormRow v-model="filters.suspended" type="checkbox">Suspended</FormRow>
-                    <FormRow v-model="filters.billing.active" :disabled="filters.suspended" type="checkbox">Active</FormRow>
-                    <FormRow v-model="filters.billing.trial" :disabled="filters.suspended" type="checkbox">Trial</FormRow>
-                    <FormRow v-model="filters.billing.canceled" :disabled="filters.suspended" type="checkbox">Canceled</FormRow>
-                    <FormRow v-model="filters.billing.unmanaged" :disabled="filters.suspended" type="checkbox">Unmanaged</FormRow>
+            <div>
+                <SectionTopMenu hero="Filters" />
+                <FormHeading class="mt-4">Sort:</FormHeading>
+                <div data-el="sort-options">
+                    <ff-dropdown v-model="filters.sortBy" class="w-full">
+                        <ff-dropdown-option
+                            v-for="sortOpt in sortOptions" :key="sortOpt.id"
+                            :label="`${sortOpt.label}`" :value="sortOpt.id"
+                        />
+                    </ff-dropdown>
                 </div>
-            </template>
+                <FormHeading class="mt-4">Team Type:</FormHeading>
+                <div data-el="filter-team-types" class="pl-2 space-y-2">
+                    <FormRow
+                        v-for="teamType in teamTypes"
+                        :key="teamType.id"
+                        v-model="filters.teamType[teamType.id]"
+                        type="checkbox"
+                    >
+                        {{ teamType.name }}
+                    </FormRow>
+                </div>
+
+                <template v-if="features.billing">
+                    <FormHeading class="mt-4">Billing State:</FormHeading>
+                    <div data-el="filter-team-types" class="pl-2 space-y-2">
+                        <FormRow v-model="filters.suspended" type="checkbox">Suspended</FormRow>
+                        <FormRow v-model="filters.billing.active" :disabled="filters.suspended" type="checkbox">Active</FormRow>
+                        <FormRow v-model="filters.billing.trial" :disabled="filters.suspended" type="checkbox">Trial</FormRow>
+                        <FormRow v-model="filters.billing.canceled" :disabled="filters.suspended" type="checkbox">Canceled</FormRow>
+                        <FormRow v-model="filters.billing.unmanaged" :disabled="filters.suspended" type="checkbox">Unmanaged</FormRow>
+                    </div>
+                </template>
+            </div>
         </div>
-    </div>
+    </ff-page>
 </template>
 
 <script>

--- a/frontend/src/pages/admin/Template/components/LockSetting.vue
+++ b/frontend/src/pages/admin/Template/components/LockSetting.vue
@@ -6,7 +6,6 @@
         <FormRow
             v-else-if="editTemplate"
             v-model="localValue"
-            class="w-24"
             type="select"
             wrapper-class="flex gap-15"
             append-class="ml-2"

--- a/frontend/src/pages/admin/Template/components/LockSetting.vue
+++ b/frontend/src/pages/admin/Template/components/LockSetting.vue
@@ -6,6 +6,7 @@
         <FormRow
             v-else-if="editTemplate"
             v-model="localValue"
+            class="w-auto"
             type="select"
             wrapper-class="flex gap-15"
             append-class="ml-2"

--- a/frontend/src/pages/admin/Template/index.vue
+++ b/frontend/src/pages/admin/Template/index.vue
@@ -1,36 +1,34 @@
 <template>
-    <div class="flex flex-col sm:flex-row mb-8 max-w-4xl">
-        <div class="flex-grow">
-            <div class="text-gray-800 text-xl">
-                <router-link class="ff-link font-bold" :to="{path: '/admin/templates'}">Templates</router-link>
-                <!-- <nav-item :icon="icons.breadcrumbSeparator" label="sss"></nav-item> -->
-                <ChevronRightIcon class="ff-icon" />
-                <span v-if="!isNew">{{ template.name }}</span>
-                <span v-if="isNew">Create a new template</span>
+    <ff-page>
+        <template #header>
+            <ff-page-header :title="isNew ? 'Create a new template' : template.name" :tabs="sideNavigation">
+                <template #breadcrumbs>
+                    <ff-nav-breadcrumb :to="{path: '/admin/templates'}">Templates</ff-nav-breadcrumb>
+                </template>
+                <template #tools>
+                    <div class="text-right space-x-4 flex h-8">
+                        <template v-if="!isNew">
+                            <ff-button v-if="unsavedChanges" kind="secondary" class="ml-4" data-el="discard-changes" @click="cancelEdit">Discard changes</ff-button>
+                            <ff-button class="ml-4" :disabled="hasErrors || !unsavedChanges" @click="showSaveTemplateDialog">Save changes</ff-button>
+                        </template>
+                        <template v-else-if="isNew">
+                            <ff-button :to="{ name: 'admin-templates' }" kind="secondary">Cancel</ff-button>
+                            <ff-button :disabled="hasErrors || !createValid" class="ml-4" @click="createTemplate">Create template</ff-button>
+                        </template>
+                    </div>
+                </template>
+            </ff-page-header>
+        </template>
+        <div class="flex flex-col sm:flex-row">
+            <SectionSideMenu :options="sideNavigation" />
+            <div class="flex-grow">
+                <router-view v-model="editable" :editTemplate="true" />
             </div>
         </div>
-        <div class="text-right space-x-4 flex h-8">
-            <template v-if="!isNew">
-                <ff-button v-if="unsavedChanges" kind="secondary" class="ml-4" data-el="discard-changes" @click="cancelEdit">Discard changes</ff-button>
-                <ff-button class="ml-4" :disabled="hasErrors || !unsavedChanges" @click="showSaveTemplateDialog">Save changes</ff-button>
-            </template>
-            <template v-else-if="isNew">
-                <ff-button :to="{ name: 'admin-templates' }" kind="secondary">Cancel</ff-button>
-                <ff-button :disabled="hasErrors || !createValid" class="ml-4" @click="createTemplate">Create template</ff-button>
-            </template>
-        </div>
-    </div>
-    <div class="flex flex-col sm:flex-row">
-        <SectionSideMenu :options="sideNavigation" />
-        <div class="flex-grow">
-            <router-view v-model="editable" :editTemplate="true" />
-        </div>
-    </div>
+    </ff-page>
 </template>
 
 <script>
-import { ChevronRightIcon } from '@heroicons/vue/solid'
-
 import { mapState } from 'vuex'
 
 import templateApi from '../../../api/templates.js'
@@ -50,8 +48,7 @@ import {
 export default {
     name: 'AdminTemplate',
     components: {
-        SectionSideMenu,
-        ChevronRightIcon
+        SectionSideMenu
     },
     data () {
         return {
@@ -83,10 +80,7 @@ export default {
             unsavedChanges: false,
             modulesChanged: false,
             needsRestart: false,
-            hasErrors: false,
-            icons: {
-                breadcrumbSeparator: ChevronRightIcon
-            }
+            hasErrors: false
         }
     },
     computed: {

--- a/frontend/src/pages/admin/Template/index.vue
+++ b/frontend/src/pages/admin/Template/index.vue
@@ -1,7 +1,7 @@
 <template>
     <ff-page>
         <template #header>
-            <ff-page-header :title="isNew ? 'Create a new template' : template.name" :tabs="sideNavigation">
+            <ff-page-header :title="isNew ? 'Create a new template' : template.name">
                 <template #breadcrumbs>
                     <ff-nav-breadcrumb :to="{path: '/admin/templates'}">Templates</ff-nav-breadcrumb>
                 </template>
@@ -22,7 +22,7 @@
         <div class="flex flex-col sm:flex-row">
             <SectionSideMenu :options="sideNavigation" />
             <div class="flex-grow">
-                <router-view v-model="editable" :editTemplate="true" />
+                <router-view v-model="editable" :originalEnvVars="original.settings.env ?? []" :editTemplate="true" />
             </div>
         </div>
     </ff-page>
@@ -169,6 +169,8 @@ export default {
                                     envChanged = true
                                 } else if (original.policy !== field.policy) {
                                     envChanged = true
+                                } else if (original.hidden !== field.hidden) {
+                                    envChanged = true
                                 }
                             } else {
                                 envChanged = true
@@ -295,7 +297,8 @@ export default {
                     template.settings.env.push({
                         name: envField.name.trim(),
                         value: envField.value,
-                        policy: envField.policy
+                        policy: envField.policy,
+                        hidden: envField.hidden
                     })
                 }
             })

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -59,7 +59,7 @@
                                 class="font-mono"
                                 :containerClass="'w-full' + (!readOnly && (editTemplate || item.policy === undefined)) ? ' env-cell-uneditable':''"
                                 :inputClass="item.deprecated ? 'w-full text-yellow-700 italic' : 'w-full'"
-                                :error="errors[item.index].error"
+                                :error="errors[item.index] ? errors[item.index].error : null"
                                 :disabled="isDisabledName(item)"
                                 value-empty-text=""
                                 data-el="var-name"
@@ -223,7 +223,7 @@ export default {
         },
         filteredRows: function () {
             if (this.search === '') {
-                return this.editable.settings.env.filter(row => !row.deprecated)
+                return this.editable?.settings?.env?.filter(row => !row.deprecated)
             }
             const search = this.search.toLowerCase()
             return this.editable.settings.env.filter(row => {

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -66,7 +66,7 @@
                                 :type="(!readOnly && (editTemplate || item.policy === undefined)) ? 'text' : 'uneditable'"
                             />
                         </td>
-                        <td class="ff-data-table--cell !p-1 border w-3/5 align-top max-w-xl" :class="{'align-middle':item.encrypted}">
+                        <td class="ff-data-table--cell !p-1 border w-3/5 max-w-xl" :class="{'align-middle':item.encrypted, 'align-top': !item.hidden}">
                             <div v-if="!item.encrypted" class="w-full">
                                 <template v-if="(!readOnly && (editTemplate || item.policy === undefined || item.policy))">
                                     <textarea
@@ -77,7 +77,9 @@
                                     />
                                 </template>
                                 <template v-else>
+                                    <span v-if="item.hidden" class="italic text-gray-300">Value hidden</span>
                                     <FormRow
+                                        v-else
                                         v-model="item.value"
                                         class="font-mono"
                                         containerClass="w-full env-cell-uneditable"

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -321,14 +321,12 @@ export default {
                 hidden: false,
                 policy: this.editTemplate ? false : undefined
             }
-            console.log('field', field)
             this.envVarLookup[field.name] = this.editable.settings.env.length
             this.editable.settings.env.push(field)
             // focus the new row?
             if (focusNewRow) {
                 this.$nextTick(() => {
                     const row = this.$el.querySelector('tr:last-child input')
-                    console.log('row', row)
                     if (row) {
                         row.focus()
                         // select the text in the input

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -63,13 +63,12 @@
                                 :disabled="isDisabledName(item)"
                                 value-empty-text=""
                                 data-el="var-name"
-                                :type="(!readOnly && (editTemplate || item.policy === undefined))?'text':'uneditable'"
+                                :type="(!readOnly && (editTemplate || item.policy === undefined)) ? 'text' : 'uneditable'"
                             />
                         </td>
                         <td class="ff-data-table--cell !p-1 border w-3/5 align-top max-w-xl" :class="{'align-middle':item.encrypted}">
                             <div v-if="!item.encrypted" class="w-full">
                                 <template v-if="(!readOnly && (editTemplate || item.policy === undefined || item.policy))">
-                                    <!-- editable -->
                                     <textarea
                                         v-model="item.value"
                                         :placeholder="item.hidden ? 'Value hidden' : ''"
@@ -202,12 +201,13 @@ export default {
         },
         originalEnvVars: {
             type: Array,
-            required: true
+            default: () => []
         }
     },
     emits: ['update:modelValue', 'validated'],
     data () {
         return {
+            ogEnvVars: [],
             addedCount: 0,
             input: {},
             envVarLookup: {},
@@ -249,6 +249,12 @@ export default {
     mounted () {
         this.updateLookup()
         this.validate()
+        // save the original env vars
+        if (!this.originalEnvVars || this.originalEnvVars.length === 0) {
+            this.ogEnvVars = this.editable.settings.env
+        } else {
+            this.ogEnvVars = this.originalEnvVars
+        }
     },
     methods: {
         openInfoDialog () {
@@ -315,12 +321,14 @@ export default {
                 hidden: false,
                 policy: this.editTemplate ? false : undefined
             }
+            console.log('field', field)
             this.envVarLookup[field.name] = this.editable.settings.env.length
             this.editable.settings.env.push(field)
             // focus the new row?
             if (focusNewRow) {
                 this.$nextTick(() => {
                     const row = this.$el.querySelector('tr:last-child input')
+                    console.log('row', row)
                     if (row) {
                         row.focus()
                         // select the text in the input

--- a/frontend/src/pages/admin/Templates/index.vue
+++ b/frontend/src/pages/admin/Templates/index.vue
@@ -1,16 +1,21 @@
 <template>
-    <!-- set mb-14 (~56px) on the form to permit access to kebab actions where hubspot chat covers it -->
-    <div class="space-y-6 mb-14">
-        <SectionTopMenu hero="Templates">
-            <template #tools>
-                <ff-button :to="{ name: 'admin-templates-template', params: { id: 'create' } }">
-                    <template #icon-right>
-                        <PlusSmIcon />
-                    </template>
-                    Create template
-                </ff-button>
-            </template>
-        </SectionTopMenu>
+    <ff-page>
+        <template #header>
+            <ff-page-header title="Templates">
+                <template #tools>
+                    <ff-button :to="{ name: 'admin-templates-template', params: { id: 'create' } }">
+                        <template #icon-right>
+                            <PlusSmIcon />
+                        </template>
+                        Create template
+                    </ff-button>
+                </template>
+            </ff-page-header>
+        </template>
+        <!-- set mb-14 (~56px) on the form to permit access to kebab actions where hubspot chat covers it -->
+        <div v-if="loading" class="space-y-6 mb-14">
+            <ff-loading message="Loading Templates..." />
+        </div>
         <ff-loading v-if="loading" message="Loading Templates..." />
         <ff-data-table
             v-if="!loading"
@@ -31,7 +36,7 @@
         <div v-if="nextCursor">
             <a v-if="!loading" class="forge-button-inline" @click.stop="loadItems">Load more...</a>
         </div>
-    </div>
+    </ff-page>
 </template>
 
 <script>
@@ -42,15 +47,12 @@ import { mapState } from 'vuex'
 
 import templatesApi from '../../../api/templates.js'
 
-import SectionTopMenu from '../../../components/SectionTopMenu.vue'
-
 import UserCell from '../../../components/tables/cells/UserCell.vue'
 import Dialog from '../../../services/dialog.js'
 
 export default {
     name: 'AdminTemplates',
     components: {
-        SectionTopMenu,
         PlusSmIcon
     },
     data () {

--- a/frontend/src/pages/admin/Templates/index.vue
+++ b/frontend/src/pages/admin/Templates/index.vue
@@ -3,7 +3,7 @@
         <template #header>
             <ff-page-header title="Templates">
                 <template #tools>
-                    <ff-button :to="{ name: 'admin-templates-template', params: { id: 'create' } }">
+                    <ff-button :to="{ name: 'admin-templates-template', params: { id: 'create' } }" size="small">
                         <template #icon-right>
                             <PlusSmIcon />
                         </template>
@@ -12,8 +12,7 @@
                 </template>
             </ff-page-header>
         </template>
-        <!-- set mb-14 (~56px) on the form to permit access to kebab actions where hubspot chat covers it -->
-        <div v-if="loading" class="space-y-6 mb-14">
+        <div v-if="loading" class="space-y-6">
             <ff-loading message="Loading Templates..." />
         </div>
         <ff-loading v-if="loading" message="Loading Templates..." />

--- a/frontend/src/pages/admin/Users/General.vue
+++ b/frontend/src/pages/admin/Users/General.vue
@@ -1,6 +1,5 @@
 <template>
-    <!-- set mb-14 (~56px) on the form to permit access to kebab actions where hubspot chat covers it -->
-    <div class="space-y-6 mb-14">
+    <div class="space-y-6">
         <ff-data-table
             v-model:search="userSearch"
             :columns="columns"

--- a/frontend/src/pages/admin/Users/UserDetails.vue
+++ b/frontend/src/pages/admin/Users/UserDetails.vue
@@ -1,60 +1,66 @@
 <template>
-    <div class="flex flex-col sm:flex-row mb-8">
-        <div class="flex-grow">
-            <div class="text-gray-800 text-xl">
-                <router-link class="ff-link font-bold" :to="{name: 'admin-users'}">Users</router-link>
-                <!-- <nav-item :icon="icons.breadcrumbSeparator" label="sss"></nav-item> -->
-                <ChevronRightIcon class="ff-icon" />
-                <span>{{ user.username }}</span>
-            </div>
-        </div>
-        <div>
-            <ff-button data-action="editUser" @click="showEditUserDialog()">Edit</ff-button>
-        </div>
-    </div>
-    <div>
-        <div class="flex items-center mb-4">
-            <div class="mr-3"><img :src="user.avatar" class="h-14 v-14 rounded-md"></div>
-            <div class="flex flex-col">
-                <div class="text-xl font-bold">{{ user.name }}</div>
-                <div class="text-l text-gray-400">{{ user.username }}</div>
-            </div>
-            <div class="ml-3 space-x-1">
-                <span v-if="user.admin" class="forge-badge forge-status-running">admin</span>
-                <span v-if="user.suspended" class="forge-badge forge-status-error">suspended</span>
-            </div>
-        </div>
-        <div class="mb-4">
-            <table class="table-fixed w-full mb-2">
-                <tr class="border-b">
-                    <td class="w-1/4 font-medium py-2">Email</td>
-                    <td class="flex">
-                        {{ user.email }}
-                        <div class="ml-3 space-x-1">
-                            <span v-if="user.sso_enabled" class="forge-badge forge-status-safe">sso-enabled</span>
-                            <span v-else-if="user.email_verified" class="forge-badge forge-status-running">verified</span>
-                            <span v-else class="forge-badge forge-status-error">unverified</span>
+    <ff-page>
+        <template #header>
+            <ff-page-header>
+                <template #breadcrumbs>
+                    <div class="flex-grow">
+                        <div class="text-gray-800 text-xl">
+                            <router-link class="ff-link font-bold" :to="{name: 'admin-users'}">Users</router-link>
+                            <!-- <nav-item :icon="icons.breadcrumbSeparator" label="sss"></nav-item> -->
+                            <ChevronRightIcon class="ff-icon" />
+                            <span>{{ user.username }}</span>
                         </div>
-                    </td>
-                </tr>
-                <tr class="border-b">
-                    <td class="w-1/4 font-medium py-2">Registered At</td>
-                    <td class="py-1">{{ user.createdAt }}</td>
-                </tr>
-            </table>
+                    </div>
+                </template>
+                <template #tools>
+                    <ff-button data-action="editUser" @click="showEditUserDialog()">Edit</ff-button>
+                </template>
+            </ff-page-header>
+        </template>
+        <div>
+            <div class="flex items-center mb-4">
+                <div class="mr-3"><img :src="user.avatar" class="h-14 v-14 rounded-md"></div>
+                <div class="flex flex-col">
+                    <div class="text-xl font-bold">{{ user.name }}</div>
+                    <div class="text-l text-gray-400">{{ user.username }}</div>
+                </div>
+                <div class="ml-3 space-x-1">
+                    <span v-if="user.admin" class="forge-badge forge-status-running">admin</span>
+                    <span v-if="user.suspended" class="forge-badge forge-status-error">suspended</span>
+                </div>
+            </div>
+            <div class="mb-4">
+                <table class="table-fixed w-full mb-2">
+                    <tr class="border-b">
+                        <td class="w-1/4 font-medium py-2">Email</td>
+                        <td class="flex">
+                            {{ user.email }}
+                            <div class="ml-3 space-x-1">
+                                <span v-if="user.sso_enabled" class="forge-badge forge-status-safe">sso-enabled</span>
+                                <span v-else-if="user.email_verified" class="forge-badge forge-status-running">verified</span>
+                                <span v-else class="forge-badge forge-status-error">unverified</span>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr class="border-b">
+                        <td class="w-1/4 font-medium py-2">Registered At</td>
+                        <td class="py-1">{{ user.createdAt }}</td>
+                    </tr>
+                </table>
+            </div>
+            <FormHeading>Teams</FormHeading>
+            <ff-data-table
+                :columns="columns"
+                :rows="teams"
+                :rows-selectable="true"
+                :loading="loadingTeams"
+                loading-message="Loading Teams"
+                no-data-message="No Teams Found"
+                data-el="teams-table"
+            />
         </div>
-        <FormHeading>Teams</FormHeading>
-        <ff-data-table
-            :columns="columns"
-            :rows="teams"
-            :rows-selectable="true"
-            :loading="loadingTeams"
-            loading-message="Loading Teams"
-            no-data-message="No Teams Found"
-            data-el="teams-table"
-        />
-    </div>
-    <AdminUserEditDialog ref="adminUserEditDialog" @user-updated="userUpdated" @user-deleted="userDeleted" />
+        <AdminUserEditDialog ref="adminUserEditDialog" @user-updated="userUpdated" @user-deleted="userDeleted" />
+    </ff-page>
 </template>
 
 <script>

--- a/frontend/src/pages/admin/Users/createUser.vue
+++ b/frontend/src/pages/admin/Users/createUser.vue
@@ -1,8 +1,20 @@
 <template>
-    <main>
-        <div class="max-w-2xl m-auto">
+    <ff-page>
+        <template #header>
+            <ff-page-header>
+                <template #breadcrumbs>
+                    <div class="flex-grow">
+                        <div class="text-gray-800 text-xl">
+                            <router-link class="ff-link font-bold" :to="{name: 'admin-users'}">Users</router-link>
+                            <ChevronRightIcon class="ff-icon" />
+                            <span>Create</span>
+                        </div>
+                    </div>
+                </template>
+            </ff-page-header>
+        </template>
+        <div class="max-w-2xl">
             <form class="space-y-6">
-                <FormHeading>Create a new user</FormHeading>
                 <FormRow v-model="input.username" :error="errors.username">Username</FormRow>
                 <FormRow v-model="input.name" :placeholder="input.username" :error="errors.name">Full Name</FormRow>
                 <FormRow v-model="input.email" :error="errors.email">Email</FormRow>
@@ -20,11 +32,11 @@
                 </ff-button>
             </form>
         </div>
-    </main>
+    </ff-page>
 </template>
 
 <script>
-import { ChevronLeftIcon } from '@heroicons/vue/solid'
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/solid'
 import { mapState } from 'vuex'
 
 import usersApi from '../../../api/users.js'
@@ -36,6 +48,7 @@ let zxcvbn
 export default {
     name: 'AdminCreateUser',
     components: {
+        ChevronRightIcon,
         FormRow,
         FormHeading
     },

--- a/frontend/src/pages/admin/Users/index.vue
+++ b/frontend/src/pages/admin/Users/index.vue
@@ -1,14 +1,10 @@
 <template>
-    <div class="clear-page-gutters">
-        <div class="ff-instance-header">
+    <ff-page>
+        <template #header>
             <ff-page-header title="Users" :tabs="sideNavigation" />
-        </div>
-        <div class="px-3 py-3 md:px-6 md:py-6">
-            <div class="flex-grow">
-                <router-view />
-            </div>
-        </div>
-    </div>
+        </template>
+        <router-view />
+    </ff-page>
 </template>
 
 <script>

--- a/frontend/src/pages/admin/Users/index.vue
+++ b/frontend/src/pages/admin/Users/index.vue
@@ -25,7 +25,4 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.clear-page-gutters {
-    margin: -1.75rem
-}
 </style>

--- a/frontend/src/pages/admin/index.vue
+++ b/frontend/src/pages/admin/index.vue
@@ -1,9 +1,5 @@
 <template>
-    <ff-page>
-        <div class="">
-            <router-view />
-        </div>
-    </ff-page>
+    <router-view />
 </template>
 
 <script>

--- a/frontend/src/pages/admin/routes.js
+++ b/frontend/src/pages/admin/routes.js
@@ -106,14 +106,7 @@ export default [
                         path: 'create',
                         component: AdminCreateUser,
                         meta: {
-                            title: 'Admin - Create User',
-                            menu: {
-                                type: 'back',
-                                backTo: {
-                                    label: 'Back to Users',
-                                    to: { name: 'admin-users-general' }
-                                }
-                            }
+                            title: 'Admin - Create User'
                         }
                     },
                     {

--- a/frontend/src/pages/admin/routes.js
+++ b/frontend/src/pages/admin/routes.js
@@ -121,14 +121,7 @@ export default [
                         path: ':id',
                         component: AdminUserDetails,
                         meta: {
-                            title: 'Admin - User',
-                            menu: {
-                                type: 'back',
-                                backTo: {
-                                    label: 'Back to Users',
-                                    to: { name: 'admin-users-general' }
-                                }
-                            }
+                            title: 'Admin - User'
                         }
                     }
                 ]

--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -10,43 +10,41 @@
             <SubscriptionExpiredBanner :team="team" />
             <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
         </Teleport>
-        <div class="ff-instance-header">
-            <ff-page-header :title="deviceGroup?.name" :tabs="navigation">
-                <template #breadcrumbs>
-                    <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'Applications', params: {team_slug: team.slug}}">
-                        Applications
-                    </ff-nav-breadcrumb>
-                    <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'Application', params: {team_slug: team.slug, id: application.id}}">
-                        {{ application.name }}
-                    </ff-nav-breadcrumb>
-                    <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'ApplicationDeviceGroups', params: {id: application?.id}}">
-                        Device Groups
-                    </ff-nav-breadcrumb>
-                </template>
-                <template #tools>
-                    <div class="ff-target-snapshot-info">
-                        <p class="ff-title">Target Snapshot: </p>
-                        <div class="flex gap-2 pr-2" data-el="device-group-target-snapshot">
-                            <span class="flex items-center space-x-2 pt-1 text-gray-500 italic">
-                                <ExclamationIcon v-if="!targetSnapshot" class="text-yellow-600 w-4" />
-                                <CheckCircleIcon v-else class="text-green-700 w-4" />
-                            </span>
-                            <div class="flex flex-col">
-                                <span v-if="targetSnapshot" data-el="snapshot-name">{{ targetSnapshot.name }}</span>
-                                <span v-else data-el="snapshot-name">No Target Snapshot Set</span>
-                                <span v-if="targetSnapshot" class="text-xs text-gray-500" data-el="snapshot-id">{{ targetSnapshot.id }}</span>
-                            </div>
+        <ff-page-header :title="deviceGroup?.name" :tabs="navigation">
+            <template #breadcrumbs>
+                <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'Applications', params: {team_slug: team.slug}}">
+                    Applications
+                </ff-nav-breadcrumb>
+                <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'Application', params: {team_slug: team.slug, id: application.id}}">
+                    {{ application.name }}
+                </ff-nav-breadcrumb>
+                <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'ApplicationDeviceGroups', params: {id: application?.id}}">
+                    Device Groups
+                </ff-nav-breadcrumb>
+            </template>
+            <template #tools>
+                <div class="ff-target-snapshot-info">
+                    <p class="ff-title">Target Snapshot: </p>
+                    <div class="flex gap-2 pr-2" data-el="device-group-target-snapshot">
+                        <span class="flex items-center space-x-2 pt-1 text-gray-500 italic">
+                            <ExclamationIcon v-if="!targetSnapshot" class="text-yellow-600 w-4" />
+                            <CheckCircleIcon v-else class="text-green-700 w-4" />
+                        </span>
+                        <div class="flex flex-col">
+                            <span v-if="targetSnapshot" data-el="snapshot-name">{{ targetSnapshot.name }}</span>
+                            <span v-else data-el="snapshot-name">No Target Snapshot Set</span>
+                            <span v-if="targetSnapshot" class="text-xs text-gray-500" data-el="snapshot-id">{{ targetSnapshot.id }}</span>
                         </div>
                     </div>
-                </template>
-                <template #context>
-                    <div>
-                        Application:
-                        <router-link :to="{name: 'Application', params: {id: application?.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ application?.name }}</router-link>
-                    </div>
-                </template>
-            </ff-page-header>
-        </div>
+                </div>
+            </template>
+            <template #context>
+                <div>
+                    Application:
+                    <router-link :to="{name: 'Application', params: {id: application?.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ application?.name }}</router-link>
+                </div>
+            </template>
+        </ff-page-header>
         <div class="px-3 py-3 md:px-6 md:py-6">
             <router-view
                 :application="application"

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -7,13 +7,11 @@
     <main v-else class="ff-with-status-header">
         <ConfirmApplicationDeleteDialog ref="confirmApplicationDeleteDialog" @confirm="deleteApplication" />
         <ConfirmInstanceDeleteDialog ref="confirmInstanceDeleteDialog" @confirm="onInstanceDeleted" />
-        <div class="ff-instance-header">
-            <ff-page-header :title="application.name" :tabs="navigation">
-                <template #breadcrumbs>
-                    <ff-nav-breadcrumb v-if="team" :to="{name: 'Applications', params: {team_slug: team.slug}}">Applications</ff-nav-breadcrumb>
-                </template>
-            </ff-page-header>
-        </div>
+        <ff-page-header :title="application.name" :tabs="navigation">
+            <template #breadcrumbs>
+                <ff-nav-breadcrumb v-if="team" :to="{name: 'Applications', params: {team_slug: team.slug}}">Applications</ff-nav-breadcrumb>
+            </template>
+        </ff-page-header>
         <div class="px-3 py-3 md:px-6 md:py-6">
             <router-view
                 :application="application"

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -4,54 +4,52 @@
             <SubscriptionExpiredBanner :team="team" />
             <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
         </Teleport>
-        <div class="ff-instance-header">
-            <SectionNavigationHeader :tabs="navigation">
-                <template #breadcrumbs>
-                    <ff-nav-breadcrumb :to="{name: 'TeamDevices', params: {team_slug: team.slug}}">Remote Instances</ff-nav-breadcrumb>
-                    <ff-nav-breadcrumb>{{ device.name }}</ff-nav-breadcrumb>
-                </template>
-                <template #status>
-                    <div class="flex flex-wrap gap-2">
-                        <DeviceLastSeenBadge :last-seen-at="device.lastSeenAt" :last-seen-ms="device.lastSeenMs" :last-seen-since="device.lastSeenSince" />
-                        <StatusBadge :status="device.status" :instanceId="device.id" instanceType="device" />
-                        <DeviceModeBadge v-if="isDevModeAvailable " :mode="device.mode" />
-                    </div>
-                </template>
-                <template #context>
-                    <div v-if="device?.ownerType === 'application' && device.application" data-el="device-assigned-application">
-                        Application:
-                        <ff-team-link :to="{name: 'Application', params: {id: device.application?.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ device.application?.name }}</ff-team-link>
-                    </div>
-                    <div v-else-if="device?.ownerType === 'instance' && device.instance" data-el="device-assigned-instance">
-                        Instance:
-                        <ff-team-link :to="{name: 'Instance', params: {id: device.instance.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ device.instance.name }}</ff-team-link>
-                    </div>
-                    <div v-else data-el="device-assigned-none">
-                        <span class="italic">No Application or Instance Assigned</span> - <a class="ff-link" data-action="assign-device" @click="openAssignmentDialog">Assign</a>
-                    </div>
-                </template>
-                <template #tools>
-                    <!--
-                        div style 34px is a workaround to prevent the Device Editor button growing taller than adjacent
-                        button (size difference is caused by odd padding in the toggle button, which though not visible
-                        is still there and affects the button height in this div group)
-                    -->
-                    <div class="space-x-2 flex align-center" style="height: 34px;">
-                        <template v-if="isDevModeAvailable">
-                            <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" :disabled="disableModeToggle" :disabledReason="disableModeToggleReason" @mode-change="setDeviceMode" />
-                            <button v-if="!isVisitingAdmin" v-ff-tooltip:left="!editorAvailable ? 'You can edit flows directly when Developer Mode is enabled, and your Edge Instance is connected.' : 'Open Edge Instance Editor'" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">
-                                Open Editor
-                                <span class="ff-btn--icon ff-btn--icon-right">
-                                    <ExternalLinkIcon />
-                                </span>
-                            </button>
-                        </template>
-                        <FinishSetupButton v-if="neverConnected" :device="device" />
-                        <DropdownMenu v-if="hasPermission('device:change-status') && actionsDropdownOptions.length" data-el="device-actions-dropdown" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
-                    </div>
-                </template>
-            </SectionNavigationHeader>
-        </div>
+        <SectionNavigationHeader :tabs="navigation">
+            <template #breadcrumbs>
+                <ff-nav-breadcrumb :to="{name: 'TeamDevices', params: {team_slug: team.slug}}">Remote Instances</ff-nav-breadcrumb>
+                <ff-nav-breadcrumb>{{ device.name }}</ff-nav-breadcrumb>
+            </template>
+            <template #status>
+                <div class="flex flex-wrap gap-2">
+                    <DeviceLastSeenBadge :last-seen-at="device.lastSeenAt" :last-seen-ms="device.lastSeenMs" :last-seen-since="device.lastSeenSince" />
+                    <StatusBadge :status="device.status" :instanceId="device.id" instanceType="device" />
+                    <DeviceModeBadge v-if="isDevModeAvailable " :mode="device.mode" />
+                </div>
+            </template>
+            <template #context>
+                <div v-if="device?.ownerType === 'application' && device.application" data-el="device-assigned-application">
+                    Application:
+                    <ff-team-link :to="{name: 'Application', params: {id: device.application?.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ device.application?.name }}</ff-team-link>
+                </div>
+                <div v-else-if="device?.ownerType === 'instance' && device.instance" data-el="device-assigned-instance">
+                    Instance:
+                    <ff-team-link :to="{name: 'Instance', params: {id: device.instance.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ device.instance.name }}</ff-team-link>
+                </div>
+                <div v-else data-el="device-assigned-none">
+                    <span class="italic">No Application or Instance Assigned</span> - <a class="ff-link" data-action="assign-device" @click="openAssignmentDialog">Assign</a>
+                </div>
+            </template>
+            <template #tools>
+                <!--
+                    div style 34px is a workaround to prevent the Device Editor button growing taller than adjacent
+                    button (size difference is caused by odd padding in the toggle button, which though not visible
+                    is still there and affects the button height in this div group)
+                -->
+                <div class="space-x-2 flex align-center" style="height: 34px;">
+                    <template v-if="isDevModeAvailable">
+                        <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" :disabled="disableModeToggle" :disabledReason="disableModeToggleReason" @mode-change="setDeviceMode" />
+                        <button v-if="!isVisitingAdmin" v-ff-tooltip:left="!editorAvailable ? 'You can edit flows directly when Developer Mode is enabled, and your Edge Instance is connected.' : 'Open Edge Instance Editor'" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">
+                            Open Editor
+                            <span class="ff-btn--icon ff-btn--icon-right">
+                                <ExternalLinkIcon />
+                            </span>
+                        </button>
+                    </template>
+                    <FinishSetupButton v-if="neverConnected" :device="device" />
+                    <DropdownMenu v-if="hasPermission('device:change-status') && actionsDropdownOptions.length" data-el="device-actions-dropdown" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
+                </div>
+            </template>
+        </SectionNavigationHeader>
         <div class="mt-4 sm:mt-8">
             <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
                 <div class="ff-banner" data-el="banner-device-as-admin">You are viewing this device as an Administrator</div>

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/suggestions/TopicSuggestion.vue
@@ -37,6 +37,7 @@ import Dialog from '../../../../../../services/dialog.js'
 
 import ObjectProperties from '../schema/ObjectProperties.vue'
 
+// eslint-disable-next-line vue/one-component-per-file
 export default {
     name: 'TopicSuggestion',
     components: {

--- a/frontend/src/ui-components/components/form/ListBox.vue
+++ b/frontend/src/ui-components/components/form/ListBox.vue
@@ -66,7 +66,7 @@ export default {
         modelValue: {
             required: false,
             default: null,
-            type: [Number, Object, String, null]
+            type: [Boolean, Number, Object, String, null]
         },
         options: {
             required: false,


### PR DESCRIPTION
## Description

- Modifies the env var table to create a local copy of the "original" env vars if one isn't passed to it.
- Whilst fixing that, realised the at this was a lot more difficult because none for the admin pages had been updated to use `ff-page`, so dove into updating them all whilst there. Removes the need for a lot of custom CSS, overrides, etc, and ensures consistent layouts across the platform
    - Includes removing deprecated `ff-instance-header` and `clear-page-gutters` CSS classes too

## Related Issue(s)

Closes #5398 