### PR TITLE
Add guard against loading git tokens if feature unavailable

### DIFF
--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -634,13 +634,15 @@ export default {
         if (!this.allowInstanceSelection) {
             this.input.stageType = StageType.DEVICEGROUP
         }
-        const tokens = await teamApi.getGitTokens(this.team.id)
-        this.gitTokens = tokens.tokens.map((token) => {
-            return {
-                label: token.name,
-                value: token.id
-            }
-        })
+        if (this.gitReposEnabled) {
+            const tokens = await teamApi.getGitTokens(this.team.id)
+            this.gitTokens = tokens.tokens.map((token) => {
+                return {
+                    label: token.name,
+                    value: token.id
+                }
+            })
+        }
     },
     methods: {
         async submit () {


### PR DESCRIPTION
## Description

Accessing the pipeline stage edit form without the git integration feature enabled triggers a warning message as the page is trying to load gitTokens in the background.

This PR adds a guard to prevent that.