### PR TITLE
Do not reset stage type if it is already valid

### DIFF
--- a/forge/ee/lib/gitops/index.js
+++ b/forge/ee/lib/gitops/index.js
@@ -108,11 +108,11 @@ module.exports.init = async function (app) {
             }
             const result = await app.db.controllers.Snapshot.exportSnapshot(snapshot, exportOptions)
             const snapshotExport = app.db.views.ProjectSnapshot.snapshotExport(result)
-            const snapshotFile = path.join(workingDir, repoOptions.path || 'snapshot.json')
+            const snapshotFile = path.join(workingDir, repoOptions.path || 'snapshot.json').replace(/"/g, '')
             await fs.writeFile(snapshotFile, JSON.stringify(snapshotExport, null, 4))
 
             // 6. stage file
-            await execPromised(`git add ${snapshotFile}`, { cwd: workingDir })
+            await execPromised(`git add "${snapshotFile}"`, { cwd: workingDir })
 
             // 7. commit
             await execPromised(`git commit -m "Update snapshot\n\nSnapshot updated by FlowFuse Pipeline '${options.pipeline.name.replace(/"/g, '')}', triggered by ${options.user.username.replace(/"/g, '')}" --author="${author}"`, { cwd: workingDir })

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -631,7 +631,7 @@ export default {
     },
     async mounted () {
         // set the stagetype to device group if the last stage is a device group itself (only permit device groups after a device group)
-        if (!this.allowInstanceSelection) {
+        if (!this.allowInstanceSelection && (this.input.stageType === StageType.INSTANCE || this.input.stageType === StageType.DEVICE)) {
             this.input.stageType = StageType.DEVICEGROUP
         }
         if (this.gitReposEnabled) {


### PR DESCRIPTION
Fixes #5419 

## Description

When editing a pipeline stage, the code was enforcing the stage type to be a Group if there was already a group in the pipeline. It is now valid for a GH stage to exist after a device group. This fixings things by only reseting the type if it is invalid.

Also fixes handling snapshot sources with spaces in their name.