### PR TITLE
Ensure Device Node-RED version is populated on status update

### DIFF
--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -141,7 +141,7 @@ class DeviceCommsHandler {
                     // The Settings are incorrect
                     sendUpdateCommand = true
                 }
-                if (Object.hasOwn(payload, 'nodeRedVersion')){
+                if (Object.hasOwn(payload, 'nodeRedVersion')) {
                     let editor = await device.getSetting('editor')
                     if (editor) {
                         editor.nodeRedVersion = payload.nodeRedVersion

--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -141,6 +141,17 @@ class DeviceCommsHandler {
                     // The Settings are incorrect
                     sendUpdateCommand = true
                 }
+                if (Object.hasOwn(payload, 'nodeRedVersion')){
+                    let editor = await device.getSetting('editor')
+                    if (editor) {
+                        editor.nodeRedVersion = payload.nodeRedVersion
+                    } else {
+                        editor = {
+                            nodeRedVersion: payload.nodeRedVersion
+                        }
+                    }
+                    await device.updateSetting('editor', editor)
+                }
 
                 if (sendUpdateCommand) {
                     await this.app.db.controllers.Device.sendDeviceUpdateCommand(device)

--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -141,17 +141,6 @@ class DeviceCommsHandler {
                     // The Settings are incorrect
                     sendUpdateCommand = true
                 }
-                if (Object.hasOwn(payload, 'nodeRedVersion')) {
-                    let editor = await device.getSetting('editor')
-                    if (editor) {
-                        editor.nodeRedVersion = payload.nodeRedVersion
-                    } else {
-                        editor = {
-                            nodeRedVersion: payload.nodeRedVersion
-                        }
-                    }
-                    await device.updateSetting('editor', editor)
-                }
 
                 if (sendUpdateCommand) {
                     await this.app.db.controllers.Device.sendDeviceUpdateCommand(device)

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -104,9 +104,8 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const result = app.db.views.Device.device(request.device)
-        const nrVersion = await request.device.getSetting('editor')
-        if (nrVersion) {
-            result.nrVersion = nrVersion.nodeRedVersion
+        if (request.device.nodeRedVersion) {
+            result.nrVersion = request.device.nodeRedVersion
         }
         // ingress-nginx will set a cookie on /api/v1/devices - which will cannot allow to override
         // that of the device-specific cookie. So clear it out.


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This looks to have got missed at some point, we added the NR version to the Device Overview page, but it needs the status check in data to be stored in the database to work.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

