### PR TITLE
Make Team & TeamType optional for TeamBroker Clients

### DIFF
--- a/forge/comms/v2AuthRoutes.js
+++ b/forge/comms/v2AuthRoutes.js
@@ -124,7 +124,7 @@ module.exports = async function (app) {
         } else {
             if (app.license.active()) {
                 const parts = request.body.username.split('@')
-                const user = await app.db.models.TeamBrokerClient.byUsername(parts[0], parts[1])
+                const user = await app.db.models.TeamBrokerClient.byUsername(parts[0], parts[1], false)
                 if (user) {
                     const acls = JSON.parse(user.acls)
                     for (const acl in acls) {

--- a/forge/db/models/TeamBrokerClient.js
+++ b/forge/db/models/TeamBrokerClient.js
@@ -43,19 +43,15 @@ module.exports = {
     finders: function (M) {
         return {
             static: {
-                byUsername: async (username, teamHashId) => {
+                byUsername: async (username, teamHashId, includeTeam = true) => {
                     let teamId = teamHashId
                     if (typeof teamHashId === 'string') {
                         teamId = M.Team.decodeHashid(teamHashId)
                     }
+                    const incTeam = includeTeam ? { model: M.Team, include: { model: M.TeamType } } : undefined
                     return this.findOne({
                         where: { username, TeamId: teamId },
-                        include: {
-                            model: M.Team,
-                            include: {
-                                model: M.TeamType
-                            }
-                        }
+                        include: incTeam
                     })
                 },
                 byTeam: async (teamHashId, pagination = {}, where = {}) => {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This is to reduce the database load for checking ACLs by removing the join to get the Team and TeamType

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

