### PR TITLE
Throttle notifications sent to Device Group members

### DIFF
--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -622,7 +622,8 @@ module.exports = {
             // updates.push('targetSnapshotId', originalSnapshotId, targetDeviceGroup.targetSnapshotId)
             // await app.auditLog.Team.team.device.updated(user, null, targetDeviceGroup.Team, targetDeviceGroup, updates)
 
-            await app.db.controllers.DeviceGroup.sendUpdateCommand(targetDeviceGroup)
+            // Send the update command asynchronously
+            app.db.controllers.DeviceGroup.sendUpdateCommand(targetDeviceGroup)
         } catch (err) {
             throw new PipelineControllerError('unexpected_error', `Error during deploy: ${err.toString()}`, 500, { cause: err })
         }

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -598,6 +598,11 @@ module.exports = {
             // store original value for later audit log
             // const originalSnapshotId = targetDeviceGroup.targetSnapshotId // TODO: implement device audit logs
 
+            // Get the devices for the group
+            const devices = await targetDeviceGroup.getDevices()
+            // Get a list of the ids
+            const deviceIds = devices.length ? devices.map(d => d.id) : []
+
             // start a transaction
             const transaction = await app.db.sequelize.transaction()
             try {
@@ -607,8 +612,10 @@ module.exports = {
                 // Update the targetSnapshotId on the device group
                 await targetDeviceGroup.update({ targetSnapshotId: sourceSnapshot.id }, { transaction })
 
-                // update all devices targetSnapshotId
-                await app.db.models.Device.update({ targetSnapshotId: sourceSnapshot.id }, { where: { DeviceGroupId: targetDeviceGroup.id }, transaction })
+                if (deviceIds.length > 0) {
+                    // update all devices targetSnapshotId
+                    await app.db.models.Device.update({ targetSnapshotId: sourceSnapshot.id }, { where: { id: deviceIds }, transaction })
+                }
                 // commit the transaction
                 await transaction.commit()
             } catch (error) {

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -643,6 +643,9 @@ module.exports = async function (app) {
         } catch (err) {
             if (repliedEarly) {
                 console.warn('Deploy failed, but response already sent', err)
+                if (err.cause) {
+                    console.warn(err.cause.stack)
+                }
             } else {
                 if (err instanceof ControllerError) {
                     return reply

--- a/test/unit/forge/ee/routes/api/applicationDeviceGroups_spec.js
+++ b/test/unit/forge/ee/routes/api/applicationDeviceGroups_spec.js
@@ -1115,6 +1115,9 @@ describe('Application Device Groups API', function () {
                 // add 2 of the devices to the group
                 await app.db.controllers.DeviceGroup.updateDeviceGroupMembership(deviceGroup, { addDevices: [device1of3.id, device2of3.id] })
 
+                // Let the commands get flushed out asynchronously
+                await new Promise(resolve => setTimeout(resolve, 100))
+
                 // reset the mock call history
                 app.comms.devices.sendCommand.resetHistory()
 
@@ -1131,6 +1134,9 @@ describe('Application Device Groups API', function () {
 
                 // should succeed
                 response.statusCode.should.equal(200)
+
+                // Sending commands is done asynchronously. Add a small delay to let them finish
+                await new Promise(resolve => setTimeout(resolve, 200))
 
                 // check 3 devices got an update request
                 app.comms.devices.sendCommand.callCount.should.equal(3)
@@ -1172,6 +1178,9 @@ describe('Application Device Groups API', function () {
                 await deviceGroupOne.save()
                 await app.db.models.PipelineStageDeviceGroup.update({ targetSnapshotId: snapshot.id }, { where: { PipelineStageId: pipelineDeviceGroupsStageTwo.id } })
 
+                // Sending commands is done asynchronously. Add a small delay to let them finish
+                await new Promise(resolve => setTimeout(resolve, 200))
+
                 // reset the mock call history
                 app.comms.devices.sendCommand.resetHistory()
 
@@ -1187,6 +1196,9 @@ describe('Application Device Groups API', function () {
 
                 // should succeed
                 response.statusCode.should.equal(200)
+
+                // Sending commands is done asynchronously. Add a small delay to let them finish
+                await new Promise(resolve => setTimeout(resolve, 200))
 
                 // check both devices got an update request
                 app.comms.devices.sendCommand.callCount.should.equal(2)


### PR DESCRIPTION
## Description

When a large DeviceGroup is deployed to in a pipeline, we are sending the notifications out to all group members at the same time. Those devices all then call home to pull down their snapshot at the same time. This can cause an unexpected loaded on the system if the group is large.

To mitigate this behaviour, this PR throttles the notifications to devices in the group - sending them in batches of 10 with a 5s delay between each batch. This balances the timeliness of deployment against the triggered load on the system.

We are setting up a benchmark test for this in staging to see if we need to tune the batch size/delay numbers.