### PR TITLE
Fix clipped kebab menu

### DIFF
--- a/frontend/src/components/version-history/timeline/TimelineEvent.vue
+++ b/frontend/src/components/version-history/timeline/TimelineEvent.vue
@@ -24,7 +24,7 @@
                 </div>
             </div>
             <div class="actions">
-                <ff-kebab-menu v-if="snapshotExists" ref="kebab" menu-align="right">
+                <ff-kebab-menu v-if="snapshotExists" ref="kebab">
                     <ff-list-item
                         :disabled="!hasPermission('project:snapshot:rollback')"
                         label="Restore Snapshot"

--- a/frontend/src/ui-components/components/KebabMenu.vue
+++ b/frontend/src/ui-components/components/KebabMenu.vue
@@ -1,21 +1,25 @@
 <template>
-    <div class="ff-kebab-menu" :class="{'active': open}" data-el="kebab-menu">
-        <!-- using this v-if hack in order to enable both
-        the button and click-outside to work when closing the menu -->
+    <div ref="trigger" class="ff-kebab-menu" :class="{'active': open}" data-el="kebab-menu">
         <DotsVerticalIcon v-if="!open" @click.stop="openOptions" />
         <DotsVerticalIcon v-if="open" @click.stop="closeOptions" />
-        <template v-if="open">
-            <ul :ref="menuOpening" v-click-outside="closeOptions" class="ff-kebab-options"
-                :class="'ff-kebab-options--' + menuAlign"
+        <teleport to="body">
+            <ul v-if="open && visible"
+                ref="menu"
+                v-click-outside="closeOptions"
+                class="ff-kebab-options"
+                :style="{
+                    position: 'fixed',
+                    top: position.top + 'px',
+                    left: position.left + 'px'
+                }"
             >
                 <slot></slot>
             </ul>
-        </template>
+        </teleport>
     </div>
 </template>
 
 <script>
-
 import { DotsVerticalIcon } from '@heroicons/vue/solid'
 
 export default {
@@ -23,65 +27,65 @@ export default {
     components: {
         DotsVerticalIcon
     },
-    props: {
-        // eslint-disable-next-line vue/prop-name-casing
-        'menu-align': {
-            type: String,
-            default: 'right'
-        }
-    },
     data () {
         return {
             open: false,
-            openEvent: null,
-            viewport: {
-                width: window.innerWidth,
-                height: window.innerHeight
-            },
-            mouse: {
-                x: 0,
-                y: 0
+            visible: true,
+            position: {
+                top: 0,
+                left: 0
             }
         }
     },
+    mounted () {
+        window.addEventListener('resize', this.updatePosition)
+        window.addEventListener('scroll', this.updatePosition, true)
+    },
+    beforeUnmount () {
+        window.removeEventListener('resize', this.updatePosition)
+        window.removeEventListener('scroll', this.updatePosition, true)
+    },
     methods: {
-        openOptions (event) {
-            // update the viewport variable - BEFORE opening the menu
-            this.viewport.width = window.innerWidth
-            this.viewport.height = window.innerHeight
-
-            // update the mouse position - BEFORE opening the menu
-            this.mouse.x = event.clientX
-            this.mouse.y = event.clientY
-
-            // open the menu - this will cause the menu to render and the ref to be come available
-            // which will in-turn trigger the menuOpening method
-            this.open = !this.open
+        openOptions () {
+            this.open = true
+            this.$nextTick(this.updatePosition)
         },
         closeOptions () {
-            this.openEvent = null
             this.open = false
         },
-        menuOpening (el) {
-            // get the height of the menu el
-            const menu = {
-                width: el.offsetWidth,
-                height: el.offsetHeight
+        updatePosition () {
+            if (!this.$refs.trigger || !this.$refs.menu) return
+            const rect = this.$refs.trigger.getBoundingClientRect()
+            const menu = this.$refs.menu
+            const { width, height } = menu.getBoundingClientRect()
+
+            const vw = window.innerWidth
+            const vh = window.innerHeight
+
+            // Default positions
+            let top = rect.bottom + window.scrollY
+            let left = rect.left + window.scrollX
+
+            // Try flipping vertically
+            if (top + height > window.scrollY + vh && rect.top - height >= 0) {
+                top = rect.top + window.scrollY - height
             }
 
-            // check if the menu would be out of the viewport
-            const left = this.mouse.x + menu.width + 20 > this.viewport.width // + 20 for padding
-            const top = this.mouse.y + menu.height + 20 > this.viewport.height // + 20 for padding
-
-            // if the menu would be out of the viewport, nudge it in a negative direction
-            // (menu is positioned absolute, so we only need to change the top/left values as a negative offset)
-            if (left && this.menuAlign !== 'right') {
-                el.style.left = '-' + menu.width + 'px'
+            // Try flipping horizontally
+            if (left + width > window.scrollX + vw && rect.right - width >= 0) {
+                left = rect.right + window.scrollX - width
             }
 
-            if (top) {
-                el.style.top = '-' + menu.height + 'px'
-            }
+            this.position = { top, left }
+
+            // Determine visibility of trigger
+            const triggerFullyVisible = (
+                rect.top >= 0 &&
+                rect.left >= 0 &&
+                rect.bottom <= vh &&
+                rect.right <= vw
+            )
+            this.visible = triggerFullyVisible
         }
     }
 }

--- a/frontend/src/ui-components/components/data-table/DataTableRow.vue
+++ b/frontend/src/ui-components/components/data-table/DataTableRow.vue
@@ -28,7 +28,7 @@
             </div>
         </ff-data-table-cell>
         <ff-data-table-cell v-if="hasContextMenu" style="width: 50px" @click="$refs.kebab.openOptions()">
-            <ff-kebab-menu ref="kebab" menu-align="right">
+            <ff-kebab-menu ref="kebab">
                 <slot name="context-menu" :row="data" message="hello world" />
             </ff-kebab-menu>
         </ff-data-table-cell>


### PR DESCRIPTION
## Description

Fixes kebab-menu clipping when overflowing by teleporting the kebab options to the body (similar to the listbox changes made in https://github.com/FlowFuse/flowfuse/pull/5427)
Removes the need for a prop to hardcoded options position and aligns automatically
Makes the options sticky to the element opening it
Closes the options if the triggering element is completely hidden.

## Related Issue(s)

fixes https://github.com/FlowFuse/flowfuse/issues/5313

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

