### PR TITLE
Fix styling of team select

### DIFF
--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -23,7 +23,7 @@
                 :key="option.label"
                 :value="option"
                 as="template"
-                class="ff-option"
+                class="ff-option ff-team-selection-option"
                 :class="{'create-new': option.value === 'create-new-team'}"
                 :data-option="option.label"
                 :title="option.label"
@@ -132,37 +132,36 @@ export default {
                 }
             }
         }
+    }
+}
+.ff-options .ff-team-selection-option {
+    background-color: $ff-grey-700;
+    border-color: $ff-grey-800;
+    color: $ff-white;
+    border-bottom: 1px solid #4B5563;
+    display: flex;
+    align-items: center;
+    height: 60px;
 
-        .ff-option {
-            background-color: $ff-grey-700;
-            border-color: $ff-grey-800;
-            color: $ff-white;
-            border-bottom: 1px solid #4B5563;
-            display: flex;
-            align-items: center;
-            height: 60px;
+    &.create-new {
+        background-color: $ff-grey-900;
+    }
 
-            &.create-new {
-                background-color: $ff-grey-900;
-            }
+    .ff-option-content {
+        padding: 16px 16px 16px 22px;
+        display: flex;
+        align-items: center;
+        gap: 15px;
+        width: 100%;
 
-            .ff-option-content {
-                padding: 16px 16px 16px 22px;
-                display: flex;
-                align-items: center;
-                gap: 15px;
-                width: 100%;
-
-                &.selected {
-                    background: $ff-grey-800;
-                }
-            }
-
-            &:hover {
-                background-color: $ff-grey-800;
-                color: $ff-teal-100;
-            }
+        &.selected {
+            background: $ff-grey-800;
         }
+    }
+
+    &:hover {
+        background-color: $ff-grey-800;
+        color: $ff-teal-100;
     }
 }
 


### PR DESCRIPTION
## Description

Team Selection appearance was broken by #5057

<img width="295" alt="image" src="https://github.com/user-attachments/assets/f28a19bf-37eb-45f3-9e73-8da469c81de3" />


This fixes that.

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

