### PR TITLE
Handle instance creation failure garacefully when creating new applications 

### DIFF
--- a/frontend/src/components/multi-step-forms/instance/steps/ApplicationStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/ApplicationStep.vue
@@ -74,7 +74,6 @@
                     v-model="input.createInstance"
                     containerClass="none"
                     wrapper-class="flex-col"
-                    placeholder="Application Description"
                     data-form="create-instance"
                     type="checkbox"
                 >

--- a/frontend/src/components/multi-step-forms/instance/steps/InstanceStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/InstanceStep.vue
@@ -8,13 +8,14 @@
 
             <div class="ff-instance-name ff-input-wrapper flex flex-col gap-1">
                 <label class="mb-1">Name</label>
-                <div class="ff-input-wrapper flex gap-3 items-center">
+                <div class="ff-input-wrapper flex gap-3 items-center relative mb-4">
                     <ff-text-input
                         v-model="input.name"
                         label="instance-name"
                         :error="errors.name"
                         data-el="instance-name"
                     />
+                    <span v-if="errors.name" class="absolute left-4 top-9 text-red-600 text-sm" data-el="instance-name-error">{{ errors.name }}</span>
                     <ff-button kind="secondary" @click="refreshName">
                         <template #icon>
                             <RefreshIcon />
@@ -112,16 +113,16 @@
                     </div>
                 </div>
             </transition>
-            <!-- Billing details -->
-            <div v-if="features.billing" class="my-5 text-left">
-                <InstanceChargesTable
-                    :project-type="selectedInstanceType"
-                    :subscription="subscription"
-                    :trialMode="isTrialProjectSelected"
-                    :prorationMode="team?.type?.properties?.billing?.proration"
-                />
-            </div>
         </form>
+        <!-- Billing details -->
+        <div v-if="features.billing" class="my-5 text-left" style="padding: 0 60px;">
+            <InstanceChargesTable
+                :project-type="selectedInstanceType"
+                :subscription="subscription"
+                :trialMode="isTrialProjectSelected"
+                :prorationMode="team?.type?.properties?.billing?.proration"
+            />
+        </div>
     </section>
 </template>
 
@@ -143,13 +144,27 @@ import FeatureUnavailableToTeam from '../../../banners/FeatureUnavailableToTeam.
 
 export default {
     name: 'InstanceStep',
-    components: { InstanceChargesTable, FeatureUnavailableToTeam, RefreshIcon, CheckCircleIcon, Loading, InstanceCreditBanner, FfListbox, FfTextInput },
+    components: {
+        InstanceChargesTable,
+        FeatureUnavailableToTeam,
+        RefreshIcon,
+        CheckCircleIcon,
+        Loading,
+        InstanceCreditBanner,
+        FfListbox,
+        FfTextInput
+    },
     props: {
         slug: {
             required: true,
             type: String
         },
         state: {
+            required: false,
+            type: Object,
+            default: () => ({})
+        },
+        initialErrors: {
             required: false,
             type: Object,
             default: () => ({})
@@ -170,10 +185,10 @@ export default {
                 template: this.initialState.template ?? null
             },
             errors: {
-                name: null,
-                instanceType: null,
-                nodeREDVersion: null,
-                template: null
+                name: this.initialErrors.name ?? null,
+                instanceType: this.initialErrors.instanceType ?? null,
+                nodeREDVersion: this.initialErrors.nodeREDVersion ?? null,
+                template: this.initialErrors.template ?? null
             },
             nodeRedVersions: [],
             instanceTypes: [],
@@ -304,8 +319,7 @@ export default {
                     }
                 })
             },
-            deep: true,
-            immediate: true
+            deep: true
         },
         'input.instanceType' () {
             this.input.nodeREDVersion = null

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -91,6 +91,7 @@ import Product from '../../services/product.js'
 
 import ObjectProperties from './Brokers/Hierarchy/components/schema/ObjectProperties.vue'
 
+// eslint-disable-next-line vue/one-component-per-file
 export default {
     name: 'ChangeTeamType',
     components: {

--- a/frontend/src/pages/team/createApplication.vue
+++ b/frontend/src/pages/team/createApplication.vue
@@ -71,7 +71,6 @@ export default {
     },
     methods: {
         onApplicationCreated (payload) {
-            console.log(payload)
             this.$router.push({ name: 'Application', params: { id: payload.application.id } })
         }
     }

--- a/frontend/src/pages/team/createApplication.vue
+++ b/frontend/src/pages/team/createApplication.vue
@@ -33,7 +33,7 @@
             ref="multiStepForm" :applications="[]"
             :show-instance-follow-up="!isFreeTeamType"
             last-step-label="Create Application"
-            @form-success-application="onApplicationCreated"
+            @form-success="onApplicationCreated"
             @previous-step-state-changed="form.previousButtonState = $event"
             @next-step-state-changed="form.nextButtonState = $event"
             @next-step-label-changed="form.nextStepLabel = $event"
@@ -70,8 +70,9 @@ export default {
         ...mapGetters('account', ['isFreeTeamType'])
     },
     methods: {
-        onApplicationCreated (application) {
-            this.$router.push({ name: 'Application', params: { id: application.id } })
+        onApplicationCreated (payload) {
+            console.log(payload)
+            this.$router.push({ name: 'Application', params: { id: payload.application.id } })
         }
     }
 }

--- a/frontend/src/pages/team/createInstance.vue
+++ b/frontend/src/pages/team/createInstance.vue
@@ -35,7 +35,7 @@
             v-else
             ref="multiStepForm"
             :applications="applications"
-            @form-success-instance="onInstanceCreated"
+            @form-success="onInstanceCreated"
             @previous-step-state-changed="form.previousButtonState = $event"
             @next-step-state-changed="form.nextButtonState = $event"
             @next-step-label-changed="form.nextStepLabel = $event"
@@ -135,8 +135,8 @@ export default {
                 }
             })
         },
-        onInstanceCreated (instance) {
-            return this.$router.push({ name: 'instance-overview', params: { id: instance.id } })
+        onInstanceCreated (payload) {
+            return this.$router.push({ name: 'instance-overview', params: { id: payload.instance.id } })
         }
     }
 }

--- a/test/e2e/frontend/cypress/tests/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications.spec.js
@@ -209,7 +209,7 @@ describe('FlowForge - Applications', () => {
         cy.get('[data-action="open-editor"]').should('exist')
     })
 
-    it.only('are not permitted to have a duplicate project name during creation', () => {
+    it('are not permitted to have a duplicate project name during creation', () => {
         cy.request('GET', 'api/v1/teams', { failOnStatusCode: false }).then((response) => {
             let createAppCallCount = 0
             const team = response.body.teams[0]

--- a/test/e2e/frontend/cypress/tests/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications.spec.js
@@ -120,59 +120,58 @@ describe('FlowForge - Applications', () => {
             })
         })
 
-        // todo undo when the instance failing fix is applied
-        // it('handles instance creation failing gracefully', () => {
-        //     const APPLICATION_NAME = `new-application-${Math.random().toString(36).substring(2, 7)}`
-        //     const IN_USE_INSTANCE_NAME = 'instance-1-1'
-        //     const INSTANCE_NAME = `new-instance-${Math.random().toString(36).substring(2, 7)}`
-        //
-        //     cy.request('GET', 'api/v1/teams').then((response) => {
-        //         const team = response.body.teams[0]
-        //
-        //         cy.visit(`/team/${team.slug}/applications/create`)
-        //
-        //         cy.intercept('POST', '/api/*/applications').as('createApplication')
-        //         cy.intercept('POST', '/api/*/projects').as('createInstance')
-        //
-        //         cy.get('[data-el="next-step"]').should('be.disabled')
-        //
-        //         cy.get('[data-form="application-name"] input').clear()
-        //         cy.get('[data-form="application-name"] input').type(APPLICATION_NAME)
-        //
-        //         cy.get('[data-el="next-step"]').should('be.enabled')
-        //         cy.get('[data-el="next-step"]').should('contain', 'Next')
-        //
-        //         cy.get('[data-el="next-step"]').click()
-        //
-        //         cy.get('[data-el="instance-name"] input').clear()
-        //         cy.get('[data-el="instance-name"] input').type(IN_USE_INSTANCE_NAME)
-        //
-        //         cy.get('[data-form="project-type"]').contains('type1').click()
-        //         cy.get('[data-form="project-template"]').contains('template1').click()
-        //
-        //         cy.get('[data-el="node-red-listbox"]').click()
-        //         cy.get('[data-option].ff-option').first().click()
-        //
-        //         cy.get('[data-el="next-step"]').click()
-        //
-        //         cy.wait('@createApplication')
-        //         cy.wait('@createInstance')
-        //
-        //         // check that the user get redirected back to the instance step after failed instance creation
-        //         cy.get('[data-el="instance-step"]').contains('name in use')
-        //         cy.get('[data-el="instance-name-error"]').contains('name in use')
-        //
-        //         cy.get('[data-el="instance-name"] input').clear()
-        //         cy.get('[data-el="instance-name"] input').type(INSTANCE_NAME)
-        //
-        //         cy.get('[data-el="next-step"]').click()
-        //
-        //         cy.wait('@createInstance')
-        //
-        //         cy.contains(APPLICATION_NAME)
-        //         cy.contains(INSTANCE_NAME)
-        //     })
-        // })
+        it('handles instance creation failing gracefully', () => {
+            const APPLICATION_NAME = `new-application-${Math.random().toString(36).substring(2, 7)}`
+            const IN_USE_INSTANCE_NAME = 'instance-1-1'
+            const INSTANCE_NAME = `new-instance-${Math.random().toString(36).substring(2, 7)}`
+
+            cy.request('GET', 'api/v1/teams').then((response) => {
+                const team = response.body.teams[0]
+
+                cy.visit(`/team/${team.slug}/applications/create`)
+
+                cy.intercept('POST', '/api/*/applications').as('createApplication')
+                cy.intercept('POST', '/api/*/projects').as('createInstance')
+
+                cy.get('[data-el="next-step"]').should('be.disabled')
+
+                cy.get('[data-form="application-name"] input').clear()
+                cy.get('[data-form="application-name"] input').type(APPLICATION_NAME)
+
+                cy.get('[data-el="next-step"]').should('be.enabled')
+                cy.get('[data-el="next-step"]').should('contain', 'Next')
+
+                cy.get('[data-el="next-step"]').click()
+
+                cy.get('[data-el="instance-name"] input').clear()
+                cy.get('[data-el="instance-name"] input').type(IN_USE_INSTANCE_NAME)
+
+                cy.get('[data-form="project-type"]').contains('type1').click()
+                cy.get('[data-form="project-template"]').contains('template1').click()
+
+                cy.get('[data-el="node-red-listbox"]').click()
+                cy.get('[data-option].ff-option').first().click()
+
+                cy.get('[data-el="next-step"]').click()
+
+                cy.wait('@createApplication')
+                cy.wait('@createInstance')
+
+                // check that the user get redirected back to the instance step after failed instance creation
+                cy.get('[data-el="instance-step"]').contains('name in use')
+                cy.get('[data-el="instance-name-error"]').contains('name in use')
+
+                cy.get('[data-el="instance-name"] input').clear()
+                cy.get('[data-el="instance-name"] input').type(INSTANCE_NAME)
+
+                cy.get('[data-el="next-step"]').click()
+
+                cy.wait('@createInstance')
+
+                cy.contains(APPLICATION_NAME)
+                cy.contains(INSTANCE_NAME)
+            })
+        })
 
         it('should have a back button', () => {
             cy.request('GET', 'api/v1/teams').then((response) => {
@@ -210,25 +209,82 @@ describe('FlowForge - Applications', () => {
         cy.get('[data-action="open-editor"]').should('exist')
     })
 
-    // todo redo, cannot be fixes easily without fixing the application duplication bug
-    // it('are not permitted to have a duplicate project name during creation', () => {
-    //     cy.request('GET', 'api/v1/teams', { failOnStatusCode: false }).then((response) => {
-    //         const team = response.body.teams[0]
-    //
-    //         cy.visit(`/team/${team.slug}/applications/create`)
-    //
-    //         cy.get('[data-form="application-name"] input').clear()
-    //         cy.get('[data-form="application-name"] input').type(`new-application-${Math.random().toString(36).substring(2, 7)}`)
-    //
-    //         cy.get('[data-form="project-name"] input').clear()
-    //         cy.get('[data-form="project-name"] input').type('instance-1-1')
-    //         cy.get('[data-form="project-type"]').contains('type1').click()
-    //
-    //         cy.get('[data-action="create-project"]').click()
-    //
-    //         cy.get('[data-form="project-name"] [data-el="form-row-error"]').contains('name in use')
-    //     })
-    // })
+    it.only('are not permitted to have a duplicate project name during creation', () => {
+        cy.request('GET', 'api/v1/teams', { failOnStatusCode: false }).then((response) => {
+            let createAppCallCount = 0
+            const team = response.body.teams[0]
+            // we need at least one blueprint to show the blueprints step
+            cy.intercept('GET', '/api/*/flow-blueprints?filter=active&team=*', {
+                meta: {},
+                count: 1,
+                blueprints: [
+                    {
+                        id: 'yJR1DQ9NbK',
+                        active: true,
+                        name: 'My first Blueprint',
+                        description: 'My first team',
+                        category: 'Some other category',
+                        icon: 'cog',
+                        order: 1,
+                        default: false,
+                        externalUrl: 'https://google.com'
+                    }
+                ]
+            }).as('getBlueprints')
+            cy.intercept('POST', '/api/*/applications', req => {
+                createAppCallCount++
+            }).as('createApplication')
+
+            cy.visit(`/team/${team.slug}/applications/create`)
+
+            cy.wait('@getBlueprints')
+
+            cy.get('[data-form="application-name"] input').clear()
+            cy.get('[data-form="application-name"] input').type(`new-application-${Math.random().toString(36).substring(2, 7)}`)
+
+            cy.get('[data-el="next-step"]').click()
+
+            cy.get('[data-el="instance-name"] input').clear()
+            cy.get('[data-el="instance-name"] input').type('instance-1-1')
+            cy.get('[data-form="project-type"]').contains('type1').click()
+            cy.get('[data-form="project-template"]').contains('template1').click()
+
+            cy.get('[data-el="node-red-listbox"]').click()
+            cy.get('[data-option].ff-option').first().click()
+
+            cy.get('[data-el="next-step"]').click()
+
+            cy.get('[data-step="blueprint"]').should('exist')
+
+            cy.get('[data-el="next-step"]').click()
+
+            // checking that the createApp api call was preformed and the application was created
+            cy.wrap(null).then(() => {
+                expect(createAppCallCount).to.eq(1)
+            })
+
+            // should get redirected back to the instance step on failure
+            cy.get('[data-step="instance"]').should('exist')
+
+            cy.get('[data-el="instance-name-error"]').contains('name in use')
+
+            // add a diff in the name
+            cy.get('[data-el="instance-name"] input').type(`-${Math.random().toString(36).substring(2, 7)}`)
+
+            cy.get('[data-el="instance-name-error"]').should('not.exist')
+
+            cy.get('[data-el="next-step"]').click()
+
+            cy.get('[data-step="blueprint"]').should('exist')
+
+            cy.get('[data-el="next-step"]').click()
+
+            // check that createApplication was NOT called a second time
+            cy.wrap(null).then(() => {
+                expect(createAppCallCount).to.eq(1)
+            })
+        })
+    })
 
     it('can be updated', () => {
         const START_ID = Math.random().toString(36).substring(2, 7)

--- a/test/e2e/frontend/cypress/tests/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications.spec.js
@@ -158,7 +158,7 @@ describe('FlowForge - Applications', () => {
                 cy.wait('@createInstance')
 
                 // check that the user get redirected back to the instance step after failed instance creation
-                cy.get('[data-el="instance-step"]').contains('name in use')
+                cy.get('[data-step="instance"]').contains('name in use')
                 cy.get('[data-el="instance-name-error"]').contains('name in use')
 
                 cy.get('[data-el="instance-name"] input').clear()


### PR DESCRIPTION
## Prerequisites

Depends on https://github.com/FlowFuse/flowfuse/pull/5438 

## Description

Fixes a bug that duplicated applications when the application form failed to create an instance using the old form and gracefully handles this scenario using the multi-step-form.

### How to reproduce the initial bug (existent on the old form):
- access the application creation form with instance creation ticked/enabled
- move on to the instance step and fill in the instance name field with a name that's already use d by another instance (causing the form to crash)
- prompted with the fact that the instance name already in use, change the instance name with something unique and create the application
- you'll end up with two applications, only one of them containing the instance with unique name

### Behavior of the multi-step form after #5438 
- after the initial attempt of creating an application with an instance that had a duplicate name, you'd get redirected to the application page and the instance wouldn't have been created
- an error alert would appear with the message that instance name already in use

### Fixed behavior
- after the initial attempt of creating an application with an instance that had a duplicate name, the application would get created and the user will get redirected to the instance step with the instance name marked as having an error
- users can navigate back to the application step but only have access to the newly created application
- users can fix the instance name and follow on with the application creation form
- when completing the entire form, users will be left on the newly created application page with the newly created instance


## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5373

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

