### PR TITLE
Run the e2e smtp servers only when configured to do so

### DIFF
--- a/test/e2e/frontend/cypress/support/commands.js
+++ b/test/e2e/frontend/cypress/support/commands.js
@@ -169,6 +169,26 @@ Cypress.Commands.add('clearBrowserData', () => {
     })
 })
 
+Cypress.Commands.add('isEmailEnabled', () => {
+    cy.login('alice', 'aaPassword')
+
+    cy.visit('/admin/settings/email')
+
+    // wait for the page to render
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(2000)
+
+    // eslint-disable-next-line cypress/require-data-selectors
+    return cy.get('body').then(($body) => {
+        const isDisabled = $body.text().includes('Email is not currently configured for the platform.')
+
+        cy.logout()
+        cy.clearBrowserData()
+
+        return cy.wrap(!isDisabled)
+    })
+})
+
 // Convenience commands that use an admin user to change global platform settings
 Cypress.Commands.add('adminEnableSignUp', () => {
     cy.login('alice', 'aaPassword')

--- a/test/e2e/frontend/cypress/tests-ee/landing/deploy-blueprint.js
+++ b/test/e2e/frontend/cypress/tests-ee/landing/deploy-blueprint.js
@@ -63,15 +63,22 @@ function prefillMultiStepInstanceForm () {
 }
 
 describe('FlowFuse - Deploy Blueprint', () => {
-    before(() => {
+    before(function () {
+        cy.isEmailEnabled()
+            .then((isEnabled) => {
+                if (!isEnabled) {
+                    this.skip()
+                }
+            })
+
         cy.adminEnableSignUp()
         cy.adminEnableTeamAutoCreate()
     })
 
-    // after(() => {
-    //     cy.adminDisableSignUp()
-    //     cy.adminDisableTeamAutoCreate()
-    // })
+    after(() => {
+        cy.adminDisableSignUp()
+        cy.adminDisableTeamAutoCreate()
+    })
 
     describe('Users with accounts', () => {
         describe('And authenticated', () => {

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -109,65 +109,71 @@ describe('FlowFuse platform admin users', () => {
         cy.get('[data-el="banner-device-as-admin"]').should('exist')
     })
 
-    it('can enable sign up', function () {
-        cy.isEmailEnabled()
-            .then((isEnabled) => {
-                if (!isEnabled) {
-                    this.skip()
-                }
-            })
+    describe('with platform email enabled', () => {
+        before(function () {
+            cy.isEmailEnabled()
+                .then((isEnabled) => {
+                    if (!isEnabled) {
+                        this.skip()
+                    }
+                })
+        })
 
-        cy.intercept('GET', '/api/*/settings').as('getSettings')
-        cy.intercept('POST', '/account/logout').as('logout')
+        beforeEach(() => {
+            cy.login('alice', 'aaPassword')
+            cy.home()
+        })
 
-        cy.visit('/admin/settings/general')
-        cy.wait('@getSettings')
+        after(() => {
+            cy.adminDisableSignUp()
+        })
 
-        // enable sign up
-        cy.get('[data-el="enable-signup"] [data-el="form-row-title"]').click()
+        it('can enable sign up', () => {
+            cy.intercept('GET', '/api/*/settings').as('getSettings')
+            cy.intercept('POST', '/account/logout').as('logout')
 
-        cy.get('[data-action="save-settings"]').click()
+            cy.visit('/admin/settings/general')
+            cy.wait('@getSettings')
 
-        cy.logout()
+            // enable sign up
+            cy.get('[data-el="enable-signup"] [data-el="form-row-title"]').click()
 
-        cy.visit('/')
+            cy.get('[data-action="save-settings"]').click()
 
-        cy.get('[data-action="sign-up"]').click()
+            cy.logout()
 
-        cy.url().should('include', '/account/create')
+            cy.visit('/')
 
-        cy.get('[data-el="banner-text"]').should('not.exist')
-        cy.get('[data-el="splash"]').should('not.exist')
-    })
+            cy.get('[data-action="sign-up"]').click()
 
-    it('can customise the content of the "Sign Up" screen', function () {
-        cy.isEmailEnabled()
-            .then((isEnabled) => {
-                if (!isEnabled) {
-                    this.skip()
-                }
-            })
+            cy.url().should('include', '/account/create')
 
-        cy.intercept('GET', '/api/*/settings').as('getSettings')
+            cy.get('[data-el="banner-text"]').should('not.exist')
+            cy.get('[data-el="splash"]').should('not.exist')
+        })
 
-        cy.visit('/admin/settings/general')
-        cy.wait('@getSettings')
+        it('can customise the content of the "Sign Up" screen', () => {
+            cy.intercept('GET', '/api/*/settings').as('getSettings')
 
-        cy.get('[data-el="banner"]').type('this is banner')
-        cy.get('[data-el="splash"]').type('<h1>Welcome to FlowForge</h1>')
+            cy.visit('/admin/settings/general')
+            cy.wait('@getSettings')
 
-        cy.get('[data-action="save-settings"]').click()
+            cy.get('[data-el="banner"]').type('this is banner')
+            cy.get('[data-el="splash"]').type('<h1>Welcome to FlowForge</h1>')
 
-        cy.logout()
+            cy.get('[data-action="save-settings"]').click()
 
-        cy.visit('/')
+            cy.logout()
 
-        cy.get('[data-action="sign-up"]').click()
+            cy.visit('/')
 
-        cy.url().should('include', '/account/create')
+            cy.get('[data-action="sign-up"]').click()
 
-        cy.get('[data-el="banner-text"]').contains('this is banner')
-        cy.get('[data-el="splash"]').contains('Welcome to FlowForge')
+            cy.url().should('include', '/account/create')
+
+            cy.get('[data-el="banner-text"]').contains('this is banner')
+            cy.get('[data-el="splash"]').contains('Welcome to FlowForge')
+        })
     })
 })
 

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -109,7 +109,14 @@ describe('FlowFuse platform admin users', () => {
         cy.get('[data-el="banner-device-as-admin"]').should('exist')
     })
 
-    it('can enable sign up', () => {
+    it('can enable sign up', function () {
+        cy.isEmailEnabled()
+            .then((isEnabled) => {
+                if (!isEnabled) {
+                    this.skip()
+                }
+            })
+
         cy.intercept('GET', '/api/*/settings').as('getSettings')
         cy.intercept('POST', '/account/logout').as('logout')
 
@@ -133,7 +140,14 @@ describe('FlowFuse platform admin users', () => {
         cy.get('[data-el="splash"]').should('not.exist')
     })
 
-    it('can customise the content of the "Sign Up" screen', () => {
+    it('can customise the content of the "Sign Up" screen', function () {
+        cy.isEmailEnabled()
+            .then((isEnabled) => {
+                if (!isEnabled) {
+                    this.skip()
+                }
+            })
+
         cy.intercept('GET', '/api/*/settings').as('getSettings')
 
         cy.visit('/admin/settings/general')

--- a/test/e2e/frontend/test_environment_ee.js
+++ b/test/e2e/frontend/test_environment_ee.js
@@ -39,7 +39,7 @@ if (fs.existsSync(configPath)) {
             enabled: true,
             debug: true,
             smtp: {
-                host: 'localhost',
+                host: process.env.SMTP_HOST,
                 port: process.env.SMTP_PORT,
                 secure: false,
                 debug: true

--- a/test/e2e/frontend/test_environment_ee.js
+++ b/test/e2e/frontend/test_environment_ee.js
@@ -14,27 +14,28 @@ const app = require('./environments/standard')
 const FF_UTIL = require('flowforge-test-utils')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
 
-const configFile = fs.readFileSync(path.join(process.cwd(), 'etc', 'flowforge.local.yml'), 'utf8')
-let emailConfig = null
+const configPath = path.join(process.cwd(), 'etc', 'flowforge.local.yml')
+let e2eConfig = null
 
-if (configFile) {
-    emailConfig = yaml.parse(configFile).e2e
+if (fs.existsSync(configPath)) {
+    const configFile = fs.readFileSync(configPath, 'utf8')
+    e2eConfig = yaml.parse(configFile).e2e
 }
 
 ;(async function () {
     const PORT = 3002
-    let smtpConfig
+    let emailConfig
 
-    if (emailConfig && emailConfig.email && emailConfig.email.ee && emailConfig.email.ee.enabled) {
+    if (e2eConfig && e2eConfig.email && e2eConfig.email.ee && e2eConfig.email.ee.enabled) {
         const smtp = require('./environments/smtp')
 
         await smtp({
-            smtpPort: emailConfig.email.ee.smtp.port,
-            webPort: emailConfig.email.ee.smtp.web_port
+            smtpPort: e2eConfig.email.ee.smtp.port,
+            webPort: e2eConfig.email.ee.smtp.web_port
         })
-        smtpConfig = emailConfig.email.ee
+        emailConfig = e2eConfig.email.ee
     } else {
-        smtpConfig = {
+        emailConfig = {
             enabled: true,
             debug: true,
             smtp: {
@@ -66,7 +67,7 @@ if (configFile) {
                 }
             }
         },
-        email: smtpConfig,
+        email: emailConfig,
         broker: {
             url: ':test:',
             teamBroker: {

--- a/test/e2e/frontend/test_environment_os.js
+++ b/test/e2e/frontend/test_environment_os.js
@@ -30,7 +30,7 @@ if (fs.existsSync(configPath)) {
             enabled: true,
             debug: true,
             smtp: {
-                host: 'localhost',
+                host: process.env.SMTP_HOST,
                 port: process.env.SMTP_PORT,
                 secure: false,
                 debug: true

--- a/test/e2e/frontend/test_environment_os.js
+++ b/test/e2e/frontend/test_environment_os.js
@@ -8,10 +8,11 @@ const yaml = require('yaml')
 
 const app = require('./environments/standard.js')
 
-const configFile = fs.readFileSync(path.join(process.cwd(), 'etc', 'flowforge.local.yml'), 'utf8')
+const configPath = path.join(process.cwd(), 'etc', 'flowforge.local.yml')
 let e2eConfig = null
 
-if (configFile) {
+if (fs.existsSync(configPath)) {
+    const configFile = fs.readFileSync(configPath, 'utf8')
     e2eConfig = yaml.parse(configFile).e2e
 }
 


### PR DESCRIPTION
## Description

- added a new isEmailEnabled cypress command that checks if email is configured
- skipping tests that need email config when not configured locally
- running smtp containers only if configured in the yml file

Smtp containers will run only if the following configuration is present in the `etc/flowforge.local.yml file`:
```yml
...
e2e:
  email:
    os:
      enabled: false
      debug: true
      smtp:
        host: localhost
        port: 1025
        web_port: 8025
        secure: false
    ee:
      enabled: true
      debug: true
      smtp:
        host: localhost
        port: 1026
        web_port: 8026
        secure: false
...
```
This allows a granular approach to testing

## Related Issue(s)

docs update https://github.com/FlowFuse/website/pull/3188

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

