### PR TITLE
Fix overflowing device last seen badge

### DIFF
--- a/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
@@ -12,6 +12,7 @@
 import { ExclamationCircleIcon } from '@heroicons/vue/outline'
 
 import DeviceStatus from '../../../services/device-status.js'
+import daysSince from '../../../utils/daysSince.js'
 
 export default {
     name: 'DeviceLastSeenBadge',
@@ -25,7 +26,7 @@ export default {
             if (!this.lastSeenAt) {
                 return 'never'
             } else {
-                return this.lastSeenSince || 'unknown'
+                return daysSince(this.lastSeenAt, true) || 'unknown'
             }
         }
     },


### PR DESCRIPTION
## Description

Fix the badge overflowing by using the short form of the daysSince util

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4656

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

