### PR TITLE
Hide pipeline actionable items and guard routes based on user's permissions

### DIFF
--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -6,11 +6,11 @@
                 <label>
                     {{ pipeline.name }}
                 </label>
-                <div v-ff-tooltip:right="'Edit Pipeline Name'">
+                <div v-if="hasPermission('pipeline:edit')" v-ff-tooltip:right="'Edit Pipeline Name'">
                     <PencilAltIcon v-if="!editing.name" class="ml-4 ff-icon ff-clickable" @click="edit" />
                 </div>
             </div>
-            <div class="flex gap-2">
+            <div v-if="hasPermission('pipeline:delete')" class="flex gap-2">
                 <div v-if="!editing.name" v-ff-tooltip:left="'Delete Pipeline'" data-action="delete-pipeline">
                     <TrashIcon class="ff-icon ff-clickable" @click="deletePipeline" />
                 </div>
@@ -61,6 +61,7 @@ import { mapState } from 'vuex'
 
 import ApplicationAPI from '../../api/application.js'
 import { StageAction, StageType } from '../../api/pipeline.js'
+import usePermissions from '../../composables/Permissions.js'
 
 import Alerts from '../../services/alerts.js'
 import Dialog from '../../services/dialog.js'
@@ -103,6 +104,10 @@ export default {
         }
     },
     emits: ['pipeline-deleted', 'stage-deleted', 'deploy-starting', 'deploy-started', 'stage-deploy-starting', 'stage-deploy-started', 'stage-deploy-failed'],
+    setup () {
+        const { hasPermission } = usePermissions()
+        return { hasPermission }
+    },
     data () {
         const pipeline = this.pipeline
         return {

--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -50,6 +50,7 @@
         </div>
         <div v-else class="ff-pipeline-stages">
             <PipelineStage v-if="addStageAvailable" @click="addStage" />
+            <p class="text-center text-gray-400 center w-full">No stages in sight just yet!</p>
         </div>
     </div>
 </template>
@@ -127,8 +128,9 @@ export default {
             return this.scopedPipeline.name?.length > 0
         },
         addStageAvailable () {
-            return this.pipeline.stages.length === 0 ||
-                this.pipeline.stages[this.pipeline.stages.length - 1].stageType !== StageType.GITREPO
+            return (this.pipeline.stages.length === 0 ||
+                this.pipeline.stages[this.pipeline.stages.length - 1].stageType !== StageType.GITREPO) &&
+                this.hasPermission('pipeline:edit')
         },
         stagesWithStates () {
             return this.pipeline.stages.map((stage) => {

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -10,6 +10,7 @@
             </div>
             <div class="ff-pipeline-actions">
                 <span
+                    v-if="hasPermission('pipeline:edit')"
                     v-ff-tooltip:right="'Edit Pipeline Stage'"
                     data-action="stage-edit"
                     @click="edit"
@@ -20,6 +21,7 @@
                     />
                 </span>
                 <span
+                    v-if="hasPermission('pipeline:delete')"
                     v-ff-tooltip:right="'Delete Pipeline Stage'"
                     data-action="stage-delete"
                     @click="deleteStage"
@@ -30,6 +32,7 @@
                     />
                 </span>
                 <span
+                    v-if="hasPermission('pipeline:edit')"
                     v-ff-tooltip:right="'Run Pipeline Stage'"
                     data-action="stage-run"
                     :class="{'ff-disabled': !playEnabled || !pipeline?.id || deploying }"
@@ -191,6 +194,7 @@ import { ExclamationIcon, LockClosedIcon, PencilAltIcon, PlayIcon, PlusCircleIco
 import PipelineAPI, { StageAction, StageType } from '../../api/pipeline.js'
 
 import StatusBadge from '../../components/StatusBadge.vue'
+import usePermissions from '../../composables/Permissions.js'
 import InstanceStatusBadge from '../../pages/instance/components/InstanceStatusBadge.vue'
 
 import Alerts from '../../services/alerts.js'
@@ -248,6 +252,10 @@ export default {
         }
     },
     emits: ['stage-deleted', 'stage-deploy-starting', 'stage-deploy-started', 'stage-deploy-failed'],
+    setup () {
+        const { hasPermission } = usePermissions()
+        return { hasPermission }
+    },
     computed: {
         stageIndex () {
             return this.pipeline.stages.indexOf(this.stage)

--- a/frontend/src/pages/application/Pipeline/create.vue
+++ b/frontend/src/pages/application/Pipeline/create.vue
@@ -52,10 +52,12 @@
 
 <script>
 import { ChevronLeftIcon } from '@heroicons/vue/solid'
+import { mapState } from 'vuex'
 
 import ApplicationsAPI from '../../../api/application.js'
 import FormRow from '../../../components/FormRow.vue'
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
+import usePermissions from '../../../composables/Permissions.js'
 import Alerts from '../../../services/alerts.js'
 
 export default {
@@ -71,6 +73,10 @@ export default {
             required: true
         }
     },
+    setup () {
+        const { hasPermission } = usePermissions()
+        return { hasPermission }
+    },
     data () {
         return {
             icons: {
@@ -84,8 +90,24 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['team']),
         submitEnabled () {
             return this.input.name?.length > 0
+        }
+    },
+    watch: {
+        team: {
+            immediate: true,
+            handler (team) {
+                if (team && !this.hasPermission('pipeline:create')) {
+                    this.$router.replace({
+                        name: 'ApplicationPipelines',
+                        params: {
+                            id: this.application.id
+                        }
+                    })
+                }
+            }
         }
     },
     async mounted () {

--- a/frontend/src/pages/application/Pipeline/index.vue
+++ b/frontend/src/pages/application/Pipeline/index.vue
@@ -15,6 +15,7 @@
 
 <script>
 import ApplicationApi from '../../../api/application.js'
+import usePermissions from '../../../composables/Permissions.js'
 import Alerts from '../../../services/alerts.js'
 
 export default {
@@ -30,6 +31,11 @@ export default {
             required: true
         }
     },
+    setup () {
+        const { hasPermission } = usePermissions()
+
+        return { hasPermission }
+    },
     data: function () {
         return {
             pipeline: null,
@@ -42,7 +48,11 @@ export default {
         '$route.params.pipelineId': 'fetchData'
     },
     async created () {
-        await this.fetchData()
+        if (this.hasPermission('application:pipeline:list')) {
+            await this.fetchData()
+        } else {
+            return this.$router.push({ name: 'Application', params: this.$route.params })
+        }
     },
     methods: {
         async loadPipeline () {

--- a/frontend/src/pages/application/PipelineStage/create.vue
+++ b/frontend/src/pages/application/PipelineStage/create.vue
@@ -14,9 +14,11 @@
 
 <script>
 import { ChevronLeftIcon } from '@heroicons/vue/solid'
+import { mapState } from 'vuex'
 
 import ApplicationAPI from '../../../api/application.js'
 import PipelinesAPI from '../../../api/pipeline.js'
+import usePermissions from '../../../composables/Permissions.js'
 
 import Alerts from '../../../services/alerts.js'
 
@@ -50,12 +52,34 @@ export default {
             required: true
         }
     },
+    setup () {
+        const { hasPermission } = usePermissions()
+        return { hasPermission }
+    },
     data () {
         return {
             icons: {
                 chevronLeft: ChevronLeftIcon
             },
             mounted: false
+        }
+    },
+    computed: {
+        ...mapState('account', ['team'])
+    },
+    watch: {
+        team: {
+            immediate: true,
+            handler (team) {
+                if (team && !this.hasPermission('pipeline:create')) {
+                    this.$router.replace({
+                        name: 'ApplicationPipelines',
+                        params: {
+                            id: this.application.id
+                        }
+                    })
+                }
+            }
         }
     },
     async mounted () {

--- a/frontend/src/pages/application/PipelineStage/edit.vue
+++ b/frontend/src/pages/application/PipelineStage/edit.vue
@@ -18,9 +18,11 @@
 
 <script>
 import { ChevronLeftIcon } from '@heroicons/vue/solid'
+import { mapState } from 'vuex'
 
 import ApplicationAPI from '../../../api/application.js'
 import PipelinesAPI from '../../../api/pipeline.js'
+import usePermissions from '../../../composables/Permissions.js'
 
 import Alerts from '../../../services/alerts.js'
 
@@ -53,6 +55,10 @@ export default {
             required: true
         }
     },
+    setup () {
+        const { hasPermission } = usePermissions()
+        return { hasPermission }
+    },
     data () {
         return {
             icons: {
@@ -60,6 +66,24 @@ export default {
             },
             mounted: false,
             stage: null
+        }
+    },
+    computed: {
+        ...mapState('account', ['team'])
+    },
+    watch: {
+        team: {
+            immediate: true,
+            handler (team) {
+                if (team && !this.hasPermission('pipeline:edit')) {
+                    this.$router.replace({
+                        name: 'ApplicationPipelines',
+                        params: {
+                            id: this.application.id
+                        }
+                    })
+                }
+            }
         }
     },
     async mounted () {

--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -23,6 +23,8 @@
         </template>
         <template #tools>
             <ff-button
+
+                v-if="hasPermission('pipeline:create')"
                 data-action="pipeline-add"
                 :to="{
                     name: 'CreatePipeline',
@@ -150,7 +152,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['features', 'teamMembership']),
+        ...mapState('account', ['features', 'teamMembership', 'team']),
         featureEnabled () {
             return this.features['devops-pipelines']
         }

--- a/frontend/src/pages/team/Pipelines/index.vue
+++ b/frontend/src/pages/team/Pipelines/index.vue
@@ -9,9 +9,20 @@
                     <img alt="info" src="../../../images/pictograms/pipeline_red.png">
                 </template>
                 <template #helptext>
-                    <p>DevOps Pipelines are used to link multiple Node-RED instances together in a deployment pipeline.</p>
-                    <p>This is normally used to define "Development" instances, where you can test your new flows without fear or breaking "Production" environments, and then, when you're ready, deploy your changes with a single click</p>
-                    <p>Get started by choosing an <router-link :to="{name: 'Team'}">Application</router-link> to build your first DevOps Pipeline in.</p>
+                    <p>
+                        DevOps Pipelines are used to link multiple Node-RED instances together in a deployment
+                        pipeline.
+                    </p>
+                    <p>
+                        This is normally used to define "Development" instances, where you can test your new flows
+                        without fear or breaking "Production" environments, and then, when you're ready, deploy your
+                        changes with a single click
+                    </p>
+                    <p>
+                        Get started by choosing an
+                        <router-link :to="{name: 'Team'}">Application</router-link>
+                        to build your first DevOps Pipeline in.
+                    </p>
                 </template>
             </ff-page-header>
         </template>
@@ -81,6 +92,7 @@ import { mapGetters } from 'vuex'
 
 import pipelineAPI from '../../../api/pipeline.js'
 import EmptyState from '../../../components/EmptyState.vue'
+import usePermissions from '../../../composables/Permissions.js'
 
 import TeamPipeline from './components/TeamPipeline.vue'
 
@@ -90,6 +102,11 @@ export default {
         SearchIcon,
         EmptyState,
         TeamPipeline
+    },
+    setup () {
+        const { hasPermission } = usePermissions()
+
+        return { hasPermission }
     },
     data () {
         return {
@@ -115,6 +132,13 @@ export default {
         }
     },
     mounted () {
+        if (!this.hasPermission('application:pipeline:list')) {
+            return this.$router.push({
+                name: 'Applications',
+                params: this.$route.params
+            })
+        }
+
         if (this.featuresCheck.devOpsPipelinesFeatureEnabled) {
             this.getPipelines()
         }

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -812,7 +812,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
 
         cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
             cy.get('[data-el="protected-marker"]').should('exist')
-            cy.get('[data-el="ff-pipeline-stage"]:first [data-action="stage-run"]').should('have.class', 'ff-disabled')
+            cy.get('[data-el="ff-pipeline-stage"]:first [data-action="stage-run"]').should('not.exist')
         })
 
         cy.logout()


### PR DESCRIPTION
## Description

Added route guards to the create and edit pipeline pages based on permissions and also hid the create pipeline button.
Hid the create edit, delete, run stage buttons based on user permissions.
Hid the create stage button from the pipeline rows

https://github.com/user-attachments/assets/d79f6dd4-1b43-4de5-a066-00e0e3b2c2cf

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4695

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

