### PR TITLE
Fix the deployStageDialog selector not overflowing properly

### DIFF
--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -159,7 +159,6 @@ import FormRow from '../FormRow.vue'
 export default {
     name: 'DeployStageDialog',
     components: {
-        FfListbox,
         FormRow
     },
     props: {

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -56,20 +56,14 @@
                     <FormRow data-form="snapshot" containerClass="w-full">
                         Source Snapshot
                         <template #input>
-                            <ff-dropdown
+                            <ff-listbox
                                 v-if="hasSnapshots"
                                 v-model="input.selectedSnapshotId"
+                                :options="snapshotOptions"
                                 placeholder="Select a snapshot"
                                 data-form="snapshot-select"
                                 class="w-full"
-                            >
-                                <ff-dropdown-option
-                                    v-for="snapshot in snapshotOptions"
-                                    :key="snapshot.value"
-                                    :label="snapshot.label"
-                                    :value="snapshot.value"
-                                />
-                            </ff-dropdown>
+                            />
                             <div v-else class="error-banner">
                                 There are no snapshots to choose from for this stage's
                                 <template v-if="stage.stageType == StageType.INSTANCE">
@@ -159,11 +153,13 @@ import DeviceApi from '../../api/devices.js'
 import { StageAction, StageType } from '../../api/pipeline.js'
 import SnapshotApi from '../../api/projectSnapshots.js'
 import SnapshotsApi from '../../api/snapshots.js'
+import FfListbox from '../../ui-components/components/form/ListBox.vue'
 import FormRow from '../FormRow.vue'
 
 export default {
     name: 'DeployStageDialog',
     components: {
+        FfListbox,
         FormRow
     },
     props: {

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -153,7 +153,6 @@ import DeviceApi from '../../api/devices.js'
 import { StageAction, StageType } from '../../api/pipeline.js'
 import SnapshotApi from '../../api/projectSnapshots.js'
 import SnapshotsApi from '../../api/snapshots.js'
-import FfListbox from '../../ui-components/components/form/ListBox.vue'
 import FormRow from '../FormRow.vue'
 
 export default {

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -351,8 +351,11 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
             cy.get('[data-el="deploy-stage-dialog"].ff-dialog-container--open').should('be.visible')
             cy.get('[data-el="deploy-stage-dialog"].ff-dialog-container--open').within(() => {
                 cy.get('[data-form="snapshot-select"]').click()
-                cy.get(`[data-form="snapshot-select"] .ff-dropdown-options:contains("Snapshot 2 for ${PIPELINE_NAME} test")`).click()
+            })
 
+            cy.get(`[data-el="listbox-options"] [data-option="Snapshot 2 for ${PIPELINE_NAME} test"]`).click()
+
+            cy.get('[data-el="deploy-stage-dialog"].ff-dialog-container--open').within(() => {
                 /* eslint-disable cypress/require-data-selectors */
                 cy.get('button.ff-btn.ff-btn--primary').click()
                 /* eslint-enable */


### PR DESCRIPTION
## Description

replaced the ff-dropdown selector with the listbox selector

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5463

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

