### PR TITLE
Prevent team library api call for unauthorized users

### DIFF
--- a/frontend/src/pages/team/Library/TeamLibrary.vue
+++ b/frontend/src/pages/team/Library/TeamLibrary.vue
@@ -65,6 +65,7 @@ import CodePreviewer from '../../../components/CodePreviewer.vue'
 import EmptyState from '../../../components/EmptyState.vue'
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
 import FlowViewer from '../../../components/flow-viewer/FlowViewer.vue'
+import usePermissions from '../../../composables/Permissions.js'
 import formatDateMixin from '../../../mixins/DateTime.js'
 import featuresMixin from '../../../mixins/Features.js'
 import Alerts from '../../../services/alerts.js'
@@ -83,6 +84,11 @@ export default {
         SectionTopMenu
     },
     mixins: [formatDateMixin, featuresMixin],
+    setup () {
+        const { hasPermission } = usePermissions()
+
+        return { hasPermission }
+    },
     data () {
         return {
             breadcrumbs: [],
@@ -111,14 +117,13 @@ export default {
     computed: {
         ...mapState('account', ['team', 'teamMembership'])
     },
-    created () {
-        this.$watch(
-            () => this.$route.params,
-            () => {
-                this.pathChanged(this.$route.params.entryPath || [])
+    watch: {
+        '$route.params': {
+            immediate: true,
+            handler (params) {
+                this.pathChanged(params.entryPath || [])
             }
-        )
-        this.pathChanged(this.$route.params.entryPath || [])
+        }
     },
     methods: {
         entrySelected (entry) {
@@ -152,7 +157,7 @@ export default {
             this.loadEntry(pathArray.filter((entry) => entry))
         },
         async loadEntry (entryPathArray) {
-            if (!this.isSharedLibraryFeatureEnabled) {
+            if (!this.isSharedLibraryFeatureEnabled || !this.hasPermission('library:entry:list')) {
                 return
             }
 


### PR DESCRIPTION
## Description

- quick refactor, removed watcher initialized in the created method
- add a guard to the loadEntry method to be callable by authorized users only

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/4481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

