### PR TITLE
Grant timeline access to viewer roles

### DIFF
--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -126,7 +126,7 @@ const Permissions = {
      */
 
     // Projects
-    'project:history': { description: 'View Hosted Instances project history', role: Roles.Member },
+    'project:history': { description: 'View Hosted Instances project history', role: Roles.Viewer },
 
     // Application
     'application:bom': { description: 'Get the Application Bill of Materials', role: Roles.Owner },

--- a/test/unit/forge/ee/routes/api/project_spec.js
+++ b/test/unit/forge/ee/routes/api/project_spec.js
@@ -405,14 +405,14 @@ describe('Projects API (EE)', function () {
             body.should.have.property('count')
             body.should.have.property('timeline')
         })
-        it('Viewer should not be able to access project history (403)', async function () {
+        it('Viewer should be able to access project history (200)', async function () {
             // 403: Forbidden - The user does not have permission to access the resource
             const response = await app.inject({
                 method: 'GET',
                 url: `/api/v1/projects/${TestObjects.instanceOne.id}/history`,
                 cookies: { sid: TestObjects.tokens.dave }
             })
-            response.statusCode.should.equal(403)
+            response.statusCode.should.equal(200)
         })
         it('Non member should not be able to access project history (404)', async function () {
             // 404: Not Found - The requested resource could not be found

--- a/test/unit/forge/ee/routes/deviceHistory/deviceHistory_spec.js
+++ b/test/unit/forge/ee/routes/deviceHistory/deviceHistory_spec.js
@@ -142,14 +142,14 @@ describe('Devices API (EE)', function () {
             body.should.have.property('count')
             body.should.have.property('timeline')
         })
-        it('Viewer should not be able to access project history (403)', async function () {
+        it('Viewer should be able to access project history (200)', async function () {
         // 403: Forbidden - The user does not have permission to access the resource
             const response = await app.inject({
                 method: 'GET',
                 url: `/api/v1/devices/${TestObjects.device.hashid}/history`,
                 cookies: { sid: TestObjects.tokens.dave }
             })
-            response.statusCode.should.equal(403)
+            response.statusCode.should.equal(200)
         })
         it('Non member should not be able to access project history (404)', async function () {
         // 404: Not Found - The requested resource could not be found


### PR DESCRIPTION
## Description

viewer roles did not have access to the timeline even though they have access to instances/devices audit log and snapshots list, the very things that make up the timeline view

This addresses that

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/4481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

