### PR TITLE
Handle the TeamDeviceCreateDialog state externally to prevent unnecessary api calls

### DIFF
--- a/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
@@ -35,28 +35,17 @@
         </div>
 
         <TeamDeviceCreateDialog
-            v-if="team"
+            v-if="team && deviceEditModalOpened"
             ref="teamDeviceCreateDialog"
             :team="team"
             :teamDeviceCount="teamDeviceCount"
             @device-created="deviceCreated"
             @device-updated="deviceUpdated"
+            @closed="deviceEditModalOpened = false"
         >
             <template #description>
-                <p>
-                    Here, you can add a new device to your
-                    <template v-if="displayingTeam">team.</template>
-                    <template v-if="displayingApplication">application.</template>
-                    <template v-else-if="displayingInstance">application instance.</template>
-                    This will generate a <b>device.yml</b> file that should be
-                    placed on the target device.
-                </p>
                 <p class="my-4">
-                    If you want your device to be automatically registered to an instance, in order to remotely deploy flows, you can use provisioning tokens
-                    in your <ff-team-link :to="{'name': 'TeamSettingsDevices', 'params': {team_slug: team.slug}}">Team Settings</ff-team-link>
-                </p>
-                <p class="my-4">
-                    Further info on Devices can be found
+                    Further info on Remote Instances can be found
                     <a href="https://flowfuse.com/docs/user/devices/" target="_blank">here</a>.
                 </p>
             </template>
@@ -96,7 +85,8 @@ export default {
     emits: ['delete-device'],
     data () {
         return {
-            devices: this.application.devices
+            devices: this.application.devices,
+            deviceEditModalOpened: false
         }
     },
     computed: {
@@ -146,7 +136,8 @@ export default {
             })
         },
         onDeviceAction ({ action, id }) {
-            this.deviceAction(action, id)
+            this.deviceEditModalOpened = true
+            this.$nextTick(() => this.deviceAction(action, id))
         }
     }
 }

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -3,6 +3,7 @@
         ref="dialog" :header="device ? 'Update Remote Instance' : 'Add Remote Instance'"
         :confirm-label="device ? 'Update' : 'Add'" :disable-primary="!formValid" data-el="team-device-create-dialog"
         @confirm="confirm()"
+        @cancel="close"
     >
         <template #default>
             <slot name="description" />
@@ -66,7 +67,7 @@ export default {
             required: true
         }
     },
-    emits: ['deviceUpdated', 'deviceCreating', 'deviceCreated'],
+    emits: ['deviceUpdated', 'deviceCreating', 'deviceCreated', 'closed'],
     setup () {
         return {
             show (device, instance, application, showApplicationsList = false) {
@@ -128,7 +129,7 @@ export default {
                 const currency = price.replace(/[\d.]+/, '')
                 const cost = (Number(price.replace(/[^\d.]+/, '')) || 0) * 100
                 return {
-                    name: 'Device',
+                    name: 'Remote Instance',
                     currency,
                     cost,
                     priceInterval
@@ -180,6 +181,7 @@ export default {
                 devicesApi.updateDevice(this.device.id, opts).then((response) => {
                     this.$emit('deviceUpdated', response)
                     alerts.emit('Device successfully updated.', 'confirmation')
+                    this.close()
                 }).catch(err => {
                     console.error(err.response.data)
                     if (err.response.data) {
@@ -223,6 +225,7 @@ export default {
                             alerts.emit('Device successfully created.', 'confirmation')
                         })
                     }
+                    this.close()
                 }).catch(err => {
                     this.team.deviceCount--
                     this.$emit('deviceCreated', null)
@@ -236,6 +239,9 @@ export default {
                     }
                 })
             }
+        },
+        close () {
+            this.$emit('closed')
         }
     }
 }


### PR DESCRIPTION
## Description

Due to the fact that the TeamDeviceCreateDialog is a wrapper for the ff-dialog means that it's rendered every time it's used in a page (even though it's not visible) but it's created method gets called either way.

This is somewhat problematic on the applications page where the dialog is embedded on each device wrapper for each application, causing it to preform an API call each time an application with the device wrapper is present.

https://github.com/user-attachments/assets/1838bc87-4d7e-4f89-b981-e46ecadc9148

By handling the modal's state externally, we're preventing these calls from being made until the modal is acted upon.

https://github.com/user-attachments/assets/56708edf-123d-41a8-aaf2-92e335652ec0

I also took the liberty to remove some content from the modal which was referring to remote instance creation not editing while also updating the naming from device to remote instance in the billing information section


## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/4481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

