### PR TITLE
Hide applications device tile kebab menu for unauthorized users

### DIFF
--- a/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
@@ -19,18 +19,20 @@
         </div>
         <div class="actions">
             <FinishSetupButton v-if="neverConnected" :device="device" />
-            <ff-kebab-menu v-else>
+            <ff-kebab-menu v-else-if="shouldDisplayKebabMenu">
                 <ff-list-item
+                    v-if="hasPermission('device:edit')"
                     label="Edit Details"
                     @click.stop="$emit('device-action',{action: 'edit', id: device.id})"
                 />
                 <ff-list-item
-                    v-if="(displayingTeam || displayingApplication)"
+                    v-if="(displayingTeam || displayingApplication) && hasPermission('device:edit')"
                     label="Remove from Application"
                     data-action="device-remove-from-application"
                     @click.stop="$emit('device-action',{action: 'removeFromApplication', id: device.id})"
                 />
                 <ff-list-item
+                    v-if="hasPermission('device:edit')"
                     kind="danger"
                     label="Regenerate Configuration"
                     @click.stop="$emit('device-action',{action: 'updateCredentials', id: device.id})"
@@ -49,6 +51,7 @@
 <script>
 import FinishSetupButton from '../../../../../components/FinishSetup.vue'
 import StatusBadge from '../../../../../components/StatusBadge.vue'
+import usePermissions from '../../../../../composables/Permissions.js'
 import AuditMixin from '../../../../../mixins/Audit.js'
 import deviceActionsMixin from '../../../../../mixins/DeviceActions.js'
 import permissionsMixin from '../../../../../mixins/Permissions.js'
@@ -75,14 +78,18 @@ export default {
         }
     },
     emits: ['device-action'],
+    setup () {
+        const { hasPermission } = usePermissions()
+
+        return { hasPermission }
+    },
     computed: {
         neverConnected () {
             return !this.device.lastSeenAt
-        }
-    },
-    methods: {
-        finishSetup () {
-            this.deviceAction('updateCredentials')
+        },
+        shouldDisplayKebabMenu () {
+            return this.hasPermission('device:edit') ||
+            this.hasPermission('device:delete')
         }
     }
 }

--- a/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
@@ -80,7 +80,6 @@ export default {
     emits: ['device-action'],
     setup () {
         const { hasPermission } = usePermissions()
-        
         return { hasPermission }
     },
     computed: {


### PR DESCRIPTION
## Description

Hide the kebab menu for users that don't have the `device:edit` permission, basically for users that have member and viewer roles. This was done to align the ui with backend restrictions

![image](https://github.com/user-attachments/assets/5cb0d0ac-a267-4e2a-aef8-dd3c75df046c)

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/4481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

