### PR TITLE
Handle team device create dialog state externally to prevent unnecessary api calls part 2

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -286,7 +286,7 @@ jobs:
   
       - name: Build container image
         id: build
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
           context: .
           file: "./ci/Dockerfile"
@@ -332,7 +332,7 @@ jobs:
           echo "timestamp=$(date +%s)" >> $GITHUB_ENV
 
       - name: Download artifact
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: k8s-forge
           path: /tmp


### PR DESCRIPTION
## Prerequisites

child of https://github.com/FlowFuse/flowfuse/pull/5470

## Description

Due to the fact that the TeamDeviceCreateDialog is a wrapper for the ff-dialog means that it's rendered every time it's used in a page (even though it's not visible) but it's created method gets called either way.

By handling the state externally we're getting rid of a redundant API call on the applications devices

https://github.com/user-attachments/assets/fb7c785a-6d45-4c4f-97cc-6152eb3d3db1

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/4481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

