### PR TITLE
Hide the device Finish setup Call to Action from users without permissions

### DIFF
--- a/frontend/src/pages/device/components/DeviceLastSeenCell.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenCell.vue
@@ -10,7 +10,8 @@
 
 <script>
 import { ExclamationIcon } from '@heroicons/vue/outline'
-import usePermissions from '../../../../../../../../flowfuse/frontend/src/composables/Permissions.js'
+
+import usePermissions from '../../../composables/Permissions.js'
 
 import deviceActionsMixin from '../../../mixins/DeviceActions.js'
 

--- a/frontend/src/pages/device/components/DeviceLastSeenCell.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenCell.vue
@@ -1,5 +1,5 @@
 <template>
-    <template v-if="neverConnected">
+    <template v-if="neverConnected && hasPermission('device:edit')">
         <ff-button kind="secondary" @click="finishSetup">
             <template #icon-left><ExclamationIcon class="ff-icon" /></template>
             Finish Setup
@@ -10,6 +10,7 @@
 
 <script>
 import { ExclamationIcon } from '@heroicons/vue/outline'
+import usePermissions from '../../../../../../../../flowfuse/frontend/src/composables/Permissions.js'
 
 import deviceActionsMixin from '../../../mixins/DeviceActions.js'
 
@@ -39,6 +40,10 @@ export default {
             type: Number,
             default: null
         }
+    },
+    setup () {
+        const { hasPermission } = usePermissions()
+        return { hasPermission }
     },
     computed: {
         neverConnected () {

--- a/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
@@ -18,7 +18,7 @@
             </div>
         </div>
         <div class="actions">
-            <FinishSetupButton v-if="neverConnected" :device="device" />
+            <FinishSetupButton v-if="neverConnected && hasPermission('device:edit')" :device="device" />
             <ff-kebab-menu v-else>
                 <ff-list-item
                     label="Edit Details"
@@ -49,6 +49,7 @@
 <script>
 import FinishSetupButton from '../../../../../components/FinishSetup.vue'
 import StatusBadge from '../../../../../components/StatusBadge.vue'
+import usePermissions from '../../../../../composables/Permissions.js'
 import AuditMixin from '../../../../../mixins/Audit.js'
 import deviceActionsMixin from '../../../../../mixins/DeviceActions.js'
 import permissionsMixin from '../../../../../mixins/Permissions.js'
@@ -75,6 +76,10 @@ export default {
         }
     },
     emits: ['device-action'],
+    setup () {
+        const { hasPermission } = usePermissions()
+        return { hasPermission }
+    },
     computed: {
         neverConnected () {
             return !this.device.lastSeenAt


### PR DESCRIPTION
## Description

Hides the Finish setup button from users without device:edit permission. done for the applications view (device tiles) and the device browser (should impact device listings)

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/4481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

