### PR TITLE
Modify device loading logic to get all app devices

### DIFF
--- a/frontend/src/pages/application/Pipeline/index.vue
+++ b/frontend/src/pages/application/Pipeline/index.vue
@@ -63,7 +63,17 @@ export default {
             }
 
             try {
-                this.devices = (await ApplicationApi.getApplicationDevices(this.application.id)).devices
+                // Need to load all devices in the application - which could be more than a single page
+                const devices = []
+                let cursor
+                do {
+                    const deviceData = await ApplicationApi.getApplicationDevices(this.application.id, cursor)
+                    cursor = deviceData?.meta?.next_cursor
+                    if (deviceData?.devices) {
+                        devices.push(deviceData?.devices)
+                    }
+                } while (cursor)
+                this.devices = devices.flat()
             } catch (err) {
                 this.devices = []
                 Alerts.emit('Failed to load Remote Instances', 'warning')


### PR DESCRIPTION
closes #5477  

## Description

Iterate data pages to return full list of remote instances

### Demo showing 350 devices
![chrome_rQt1YHpNwS](https://github.com/user-attachments/assets/0511b35d-daf1-471c-9ae0-c1ffce1af852)


## Related Issue(s)

#5477  

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

