### PR TITLE
Resource Email improvements

### DIFF
--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -194,8 +194,9 @@ module.exports = fp(async function (app, _opts) {
      */
     async function send (user, templateName, context) {
         const forgeURL = app.config.base_url
+        const ctaChangeTypeUrl = `${context.url}/settings/change-type`
         const template = templates[templateName] || loadTemplate(templateName)
-        const templateContext = { forgeURL, user, ...context }
+        const templateContext = { forgeURL, ctaChangeTypeUrl, user, ...context }
         templateContext.safeName = sanitizeText(user.name || 'user')
         if (templateContext.teamName) {
             templateContext.teamName = sanitizeText(templateContext.teamName)

--- a/forge/postoffice/templates/Crashed-out-of-memory.js
+++ b/forge/postoffice/templates/Crashed-out-of-memory.js
@@ -1,7 +1,7 @@
 module.exports = {
     subject: 'FlowFuse Instance crashed',
     text:
-`Hello {{{ safeName }}},
+`Hello {{{ safeName.text }}},
 
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" has crashed due to an out of memory error.
 
@@ -40,7 +40,7 @@ You can access the instance and its logs here:
 
 `,
     html:
-`<p>Hello {{{ safeName }}},</p>
+`<p>Hello {{{ safeName.html }}},</p>
 <p>Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" has crashed due to an out of memory error.</p>
 
 <p>

--- a/forge/postoffice/templates/Crashed-out-of-memory.js
+++ b/forge/postoffice/templates/Crashed-out-of-memory.js
@@ -11,7 +11,7 @@ This can occur for a number of reasons including:
 - An issue in a third-party library or node
 
 Possible solutions:
-- Selecting a larger instance type
+- Upgrade to a larger instance type
 - Disabling some nodes to identify a problem area
 - When polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion
 - Check your flows for large data structures being held in memory, particularly in context
@@ -53,7 +53,7 @@ This can occur for a number of reasons including:
 
 Possible solutions:
 <ul>
-<li>Selecting a larger instance type</li>
+<li>Upgrade to a larger instance type</li>
 <li>Disabling some nodes to identify a problem area</li>
 <li>When polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion</li>
 <li>Check your flows for large data structures being held in memory, particularly in context</li>

--- a/forge/postoffice/templates/Crashed-out-of-memory.js
+++ b/forge/postoffice/templates/Crashed-out-of-memory.js
@@ -1,21 +1,23 @@
 module.exports = {
     subject: 'FlowFuse Instance crashed',
     text:
-`Hello
+`Hello {{{ safeName }}},
 
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" has crashed due to an out of memory error.
 
 This can occur for a number of reasons including:
-- incorrect instance size for your workload
-- an issue in your flows or functions holding onto memory
-- an issue in a third-party library or node
+- Incorrect instance size for your workload
+- An issue in your flows or functions holding onto memory
+- An issue in a third-party library or node
 
 Possible solutions:
-- try selecting a larger instance type
-- try disabling some nodes to see if the problem settles down after a restart
-- when polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion
-- check your flows for large data structures being held in memory, particularly in context
-- check the issue tracker of your contrib nodes
+- Selecting a larger instance type
+- Disabling some nodes to identify a problem area
+- When polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion
+- Check your flows for large data structures being held in memory, particularly in context
+- Check the issue tracker of your contrib nodes
+
+Upgrade my instance: {{{ ctaChangeTypeUrl }}}
 
 {{#if log.text}}
 ------------------------------------------------------
@@ -38,24 +40,27 @@ You can access the instance and its logs here:
 
 `,
     html:
-`<p>Hello</p>
+`<p>Hello {{{ safeName }}},</p>
 <p>Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" has crashed due to an out of memory error.</p>
 
 <p>
 This can occur for a number of reasons including:
 <ul>
-<li>incorrect instance size for your workload/li>
-<li>an issue in your flows holding onto memory/li>
-<li>an issue in a third-party library or node/li>
+<li>Incorrect instance size for your workload</li>
+<li>An issue in your flows holding onto memory</li>
+<li>An issue in a third-party library or node</li>
 </ul>
 
 Possible solutions:
 <ul>
-<li>try selecting a larger instance type</li>
-<li>try disabling some nodes to see if the problem settles down after a restart</li>
-<li>when polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion</li>
-<li>check your flows for large data structures being held in memory, particularly in context</li>
-<li>check the issue tracker of your contrib nodes</li>
+<li>Selecting a larger instance type</li>
+<li>Disabling some nodes to identify a problem area</li>
+<li>When polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion</li>
+<li>Check your flows for large data structures being held in memory, particularly in context</li>
+<li>Check the issue tracker of your contrib nodes</li>
+</ul>
+
+CTA: <a href="{{{ ctaChangeTypeUrl }}}">Select a larger instance type</a>
 </p>
 
 

--- a/forge/postoffice/templates/Crashed-out-of-memory.js
+++ b/forge/postoffice/templates/Crashed-out-of-memory.js
@@ -60,7 +60,7 @@ Possible solutions:
 <li>Check the issue tracker of your contrib nodes</li>
 </ul>
 
-CTA: <a href="{{{ ctaChangeTypeUrl }}}">Select a larger instance type</a>
+CTA: <a href="{{{ ctaChangeTypeUrl }}}">Upgrade my instance</a>
 </p>
 
 

--- a/forge/postoffice/templates/Crashed-out-of-memory.js
+++ b/forge/postoffice/templates/Crashed-out-of-memory.js
@@ -6,7 +6,7 @@ module.exports = {
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" has crashed due to an out of memory error.
 
 This can occur for a number of reasons including:
-- Incorrect instance size for your workload
+- Needing a larger instance size for your workload
 - An issue in your flows or functions holding onto memory
 - An issue in a third-party library or node
 
@@ -46,7 +46,7 @@ You can access the instance and its logs here:
 <p>
 This can occur for a number of reasons including:
 <ul>
-<li>Incorrect instance size for your workload</li>
+<li>Needing a larger instance size for your workload</li>
 <li>An issue in your flows holding onto memory</li>
 <li>An issue in a third-party library or node</li>
 </ul>

--- a/forge/postoffice/templates/Crashed-uncaught-exception.js
+++ b/forge/postoffice/templates/Crashed-uncaught-exception.js
@@ -1,19 +1,21 @@
 module.exports = {
     subject: 'FlowFuse Instance crashed',
     text:
-`Hello
+`Hello {{{ safeName }}},
 
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" has crashed due to an uncaught exception.
 
 This can occur for a number of reasons including:
-- an issue in your flows or function nodes
-- an issue in a third-party contribution node
-- an issue in Node-RED itself
+- An issue in your flows or function nodes
+- An issue in a third-party contribution node
+- An issue in Node-RED itself
 
 Possible solutions:
-- look out for async function calls in your function nodes that dont have error handling
-- check the issue tracker of the node that caused the crash
-- check the Node-RED issue tracker for similar issues
+- Look out for async function calls in your function nodes that don't have error handling
+- Check the issue tracker of the node that caused the crash
+- Check the Node-RED issue tracker for similar issues
+
+Upgrade my instance: {{{ ctaChangeTypeUrl }}}
 
 {{#if log.text}}
 ------------------------------------------------------
@@ -36,22 +38,25 @@ You can access the instance and its logs here:
 
 `,
     html:
-`<p>Hello</p>
+`<p>Hello {{{ safeName }}},</p>
 <p>Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" has crashed due to an uncaught exception.</p>
 
 <p>
 This can occur for a number of reasons including:
 <ul>
-<li>an issue in your flows or function nodes</li>
-<li>an issue in a third-party contribution node</li>
-<li>an issue in Node-RED itself</li>
+<li>An issue in your flows or function nodes</li>
+<li>An issue in a third-party contribution node</li>
+<li>An issue in Node-RED itself</li>
 </ul>
 
 Possible solutions:
 <ul>
-<li>look out for async function calls in your function nodes that dont have error handling</li>
-<li>check the issue tracker of the node that caused the crash</li>
-<li>check the Node-RED issue tracker for similar issues</li>
+<li>Look out for async function calls in your function nodes that don't have error handling</li>
+<li>Check the issue tracker of the node that caused the crash</li>
+<li>Check the Node-RED issue tracker for similar issues</li>
+</ul>
+
+CTA: <a href="{{{ ctaChangeTypeUrl }}}">Select a larger instance type</a>
 </p>
 
 {{#if log.html}}

--- a/forge/postoffice/templates/Crashed-uncaught-exception.js
+++ b/forge/postoffice/templates/Crashed-uncaught-exception.js
@@ -1,7 +1,7 @@
 module.exports = {
     subject: 'FlowFuse Instance crashed',
     text:
-`Hello {{{ safeName }}},
+`Hello {{{ safeName.text }}},
 
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" has crashed due to an uncaught exception.
 
@@ -38,7 +38,7 @@ You can access the instance and its logs here:
 
 `,
     html:
-`<p>Hello {{{ safeName }}},</p>
+`<p>Hello {{{ safeName.html }}},</p>
 <p>Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" has crashed due to an uncaught exception.</p>
 
 <p>

--- a/forge/postoffice/templates/Crashed-uncaught-exception.js
+++ b/forge/postoffice/templates/Crashed-uncaught-exception.js
@@ -6,11 +6,13 @@ module.exports = {
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" has crashed due to an uncaught exception.
 
 This can occur for a number of reasons including:
+- Needing a larger instance size for your workload
 - An issue in your flows or function nodes
 - An issue in a third-party contribution node
 - An issue in Node-RED itself
 
 Possible solutions:
+- Upgrade to a larger instance type
 - Look out for async function calls in your function nodes that don't have error handling
 - Check the issue tracker of the node that caused the crash
 - Check the Node-RED issue tracker for similar issues
@@ -44,6 +46,7 @@ You can access the instance and its logs here:
 <p>
 This can occur for a number of reasons including:
 <ul>
+<li>Needing a larger instance size for your workload</li>
 <li>An issue in your flows or function nodes</li>
 <li>An issue in a third-party contribution node</li>
 <li>An issue in Node-RED itself</li>
@@ -51,6 +54,7 @@ This can occur for a number of reasons including:
 
 Possible solutions:
 <ul>
+<li>Upgrade to a larger instance type</li>
 <li>Look out for async function calls in your function nodes that don't have error handling</li>
 <li>Check the issue tracker of the node that caused the crash</li>
 <li>Check the Node-RED issue tracker for similar issues</li>

--- a/forge/postoffice/templates/Crashed-uncaught-exception.js
+++ b/forge/postoffice/templates/Crashed-uncaught-exception.js
@@ -56,7 +56,7 @@ Possible solutions:
 <li>Check the Node-RED issue tracker for similar issues</li>
 </ul>
 
-CTA: <a href="{{{ ctaChangeTypeUrl }}}">Select a larger instance type</a>
+CTA: <a href="{{{ ctaChangeTypeUrl }}}">Upgrade my instance</a>
 </p>
 
 {{#if log.html}}

--- a/forge/postoffice/templates/Crashed.js
+++ b/forge/postoffice/templates/Crashed.js
@@ -1,9 +1,22 @@
 module.exports = {
     subject: 'FlowFuse Instance crashed',
     text:
-`Hello
+`Hello {{{ safeName.text }}},
 
 Your FlowFuse Instance "{{{ name }}}"{{#if teamName.text}} in Team "{{{ teamName.text }}}"{{/if}} has crashed.
+
+This can occur for a number of reasons including:
+- Needing a larger instance size for your workload
+- An issue in your flows or function nodes
+- An issue in a third-party contribution node
+- An issue in Node-RED itself
+
+Possible solutions:
+- Look out for async function calls in your function nodes that don't have error handling
+- Check the issue tracker of the node that caused the crash
+- Check the Node-RED issue tracker for similar issues
+
+Upgrade my instance: {{{ ctaChangeTypeUrl }}}
 
 {{#if log.text}}
 ------------------------------------------------------
@@ -26,8 +39,27 @@ You can access the instance and its logs here:
 
 `,
     html:
-`<p>Hello</p>
-<p>Your FlowFuse Instance "{{{ name }}}"{{#if teamName.html}} in Team "{{{ teamName.html }}}"{{/if}} has crashed.</p>
+`<p>Hello {{{ safeName.html }}},</p>
+<p>Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" has crashed.</p>
+
+<p>
+This can occur for a number of reasons including:
+<ul>
+<li>Needing a larger instance size for your workload</li>
+<li>An issue in your flows or function nodes</li>
+<li>An issue in a third-party contribution node</li>
+<li>An issue in Node-RED itself</li>
+</ul>
+
+Possible solutions:
+<ul>
+<li>Look out for async function calls in your function nodes that don't have error handling</li>
+<li>Check the issue tracker of the node that caused the crash</li>
+<li>Check the Node-RED issue tracker for similar issues</li>
+</ul>
+
+CTA: <a href="{{{ ctaChangeTypeUrl }}}">Upgrade my instance</a>
+</p>
 
 {{#if log.html}}
 <p>

--- a/forge/postoffice/templates/Crashed.js
+++ b/forge/postoffice/templates/Crashed.js
@@ -12,6 +12,7 @@ This can occur for a number of reasons including:
 - An issue in Node-RED itself
 
 Possible solutions:
+- Upgrade to a larger instance type
 - Look out for async function calls in your function nodes that don't have error handling
 - Check the issue tracker of the node that caused the crash
 - Check the Node-RED issue tracker for similar issues
@@ -53,6 +54,7 @@ This can occur for a number of reasons including:
 
 Possible solutions:
 <ul>
+<li>Upgrade to a larger instance type</li>
 <li>Look out for async function calls in your function nodes that don't have error handling</li>
 <li>Check the issue tracker of the node that caused the crash</li>
 <li>Check the Node-RED issue tracker for similar issues</li>

--- a/forge/postoffice/templates/InstanceResourceCPUExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceCPUExceeded.js
@@ -1,21 +1,24 @@
 module.exports = {
     subject: 'FlowFuse Instance CPU exceeded 75%',
     text:
-`Hello
+`Hello {{{ safeName }}},
 
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" is using more than 75% of its CPU.
+This can cause degraded performance, errors, and crashes.
 
 This can occur for a number of reasons including:
-- incorrect instance size for your workload
-- an issue in your flows or functions causing high CPU usage
-- an issue in a third-party library or node
+- Needing a larger instance size for your workload
+- An issue in your flows or functions causing high CPU usage
+- An issue in a third-party library or node
 
 Possible solutions:
-- upgrading to a larger instance type
-- try disabling some nodes to see if the problem settles down after a restart
-- check your flows for loops or functions that are causing high CPU usage
-- check the issue tracker of your contrib nodes
-- check the instance logs for clues and errors
+- Select a larger instance type
+- Disabling some nodes to identify a problem area
+- Check your flows for loops or functions that are causing high CPU usage
+- Check the issue tracker of your contrib nodes
+- Check the instance logs for clues and errors
+
+Upgrade my instance: {{{ ctaChangeTypeUrl }}}
 
 {{#if log.text}}
 ------------------------------------------------------
@@ -38,24 +41,30 @@ You can access the instance and its logs here:
 
 `,
     html:
-`<p>Hello</p>
-<p>Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" is using more than 75% of its CPU.</p>
+`<p>Hello {{{ safeName }}},</p>
+<p>
+Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" is using more than 75% of its CPU.
+This can cause degraded performance, errors, and crashes.
+</p>
 
 <p>
 This can occur for a number of reasons including:
 <ul>
-<li>incorrect instance size for your workload</li>
-<li>an issue in your flows or functions holding that are causing high CPU usage</li>
-<li>an issue in a third-party library or node</li>
+<li>Needing a larger instance size for your workload</li>
+<li>An issue in your flows or functions holding that are causing high CPU usage</li>
+<li>An issue in a third-party library or node</li>
 </ul>
 
 Possible solutions:
 <ul>
-<li>try selecting a larger instance type</li>
-<li>try disabling some nodes to see if the problem settles down after a restart</li>
-<li>check your flows for loops or functions that are causing high CPU usage</li>
-<li>check the issue tracker of your contrib nodes</li>
-<li>check the instance logs for clues and errors</li>
+<li>Selecting a larger instance type</li>
+<li>Disabling some nodes to identify a problem area</li>
+<li>Check your flows for loops or functions that are causing high CPU usage</li>
+<li>Check the issue tracker of your contrib nodes</li>
+<li>Check the instance logs for clues and errors</li>
+</ul>
+
+CTA: <a href="{{{ ctaChangeTypeUrl }}}">Select a larger instance type</a>
 </p>
 
 

--- a/forge/postoffice/templates/InstanceResourceCPUExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceCPUExceeded.js
@@ -57,7 +57,7 @@ This can occur for a number of reasons including:
 
 Possible solutions:
 <ul>
-<li>Selecting a larger instance type</li>
+<li>Upgrade to a larger instance type</li>
 <li>Disabling some nodes to identify a problem area</li>
 <li>Check your flows for loops or functions that are causing high CPU usage</li>
 <li>Check the issue tracker of your contrib nodes</li>

--- a/forge/postoffice/templates/InstanceResourceCPUExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceCPUExceeded.js
@@ -51,7 +51,7 @@ This can cause degraded performance, errors, and crashes.
 This can occur for a number of reasons including:
 <ul>
 <li>Needing a larger instance size for your workload</li>
-<li>An issue in your flows or functions holding that are causing high CPU usage</li>
+<li>An issue in your flows or functions causing high CPU usage</li>
 <li>An issue in a third-party library or node</li>
 </ul>
 

--- a/forge/postoffice/templates/InstanceResourceCPUExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceCPUExceeded.js
@@ -12,7 +12,7 @@ This can occur for a number of reasons including:
 - An issue in a third-party library or node
 
 Possible solutions:
-- Select a larger instance type
+- Upgrade to a larger instance type
 - Disabling some nodes to identify a problem area
 - Check your flows for loops or functions that are causing high CPU usage
 - Check the issue tracker of your contrib nodes
@@ -64,7 +64,7 @@ Possible solutions:
 <li>Check the instance logs for clues and errors</li>
 </ul>
 
-CTA: <a href="{{{ ctaChangeTypeUrl }}}">Select a larger instance type</a>
+CTA: <a href="{{{ ctaChangeTypeUrl }}}">Upgrade my instance</a>
 </p>
 
 

--- a/forge/postoffice/templates/InstanceResourceCPUExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceCPUExceeded.js
@@ -1,7 +1,7 @@
 module.exports = {
     subject: 'FlowFuse Instance CPU exceeded 75%',
     text:
-`Hello {{{ safeName }}},
+`Hello {{{ safeName.text }}},
 
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" is using more than 75% of its CPU.
 This can cause degraded performance, errors, and crashes.
@@ -41,7 +41,7 @@ You can access the instance and its logs here:
 
 `,
     html:
-`<p>Hello {{{ safeName }}},</p>
+`<p>Hello {{{ safeName.html }}},</p>
 <p>
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" is using more than 75% of its CPU.
 This can cause degraded performance, errors, and crashes.

--- a/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
@@ -12,7 +12,7 @@ This can occur for a number of reasons including:
 - An issue in a third-party library or node
 
 Possible solutions:
-- Select a larger instance type
+- Upgrade to a larger instance type
 - Disabling some nodes to identify a problem area
 - When polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion
 - Check your flows for large data structures being held in memory, particularly in context
@@ -64,7 +64,7 @@ Possible solutions:
 <li>Check the issue tracker of your contrib nodes</li>
 </ul>
 
-CTA: <a href="{{{ ctaChangeTypeUrl }}}">Select a larger instance type</a>
+CTA: <a href="{{{ ctaChangeTypeUrl }}}">Upgrade my instance</a>
 </p>
 
 {{#if log.html}}

--- a/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
@@ -1,7 +1,7 @@
 module.exports = {
     subject: 'FlowFuse Instance Memory usage exceeded 75%',
     text:
-`Hello {{{ safeName }}},
+`Hello {{{ safeName.text }}},
 
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" is using more than 75% of its available memory.
 This can cause degraded performance, errors, and crashes.
@@ -41,7 +41,7 @@ You can access the instance and its logs here:
 
 `,
     html:
-`<p>Hello {{{ safeName }}},</p>
+`<p>Hello {{{ safeName.html }}},</p>
 <p>
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" is using more than 75% of its available memory.
 This can cause degraded performance, errors, and crashes.

--- a/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
@@ -1,21 +1,24 @@
 module.exports = {
     subject: 'FlowFuse Instance Memory usage exceeded 75%',
     text:
-`Hello
+`Hello {{{ safeName }}},
 
 Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.text }}}" is using more than 75% of its available memory.
+This can cause degraded performance, errors, and crashes.
 
 This can occur for a number of reasons including:
-- incorrect instance size for your workload
-- an issue in your flows or functions holding onto memory
-- an issue in a third-party library or node
+- Needing a larger instance size for your workload
+- An issue in your flows or functions holding onto memory
+- An issue in a third-party library or node
 
 Possible solutions:
-- upgrading to a larger instance type
-- try disabling some nodes to see if the problem settles down after a restart
-- when polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion
-- check your flows for large data structures being held in memory, particularly in context
-- check the issue tracker of your contrib nodes
+- Select a larger instance type
+- Disabling some nodes to identify a problem area
+- When polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion
+- Check your flows for large data structures being held in memory, particularly in context
+- Check the issue tracker of your contrib nodes
+
+Upgrade my instance: {{{ ctaChangeTypeUrl }}}
 
 {{#if log.text}}
 ------------------------------------------------------
@@ -38,26 +41,31 @@ You can access the instance and its logs here:
 
 `,
     html:
-`<p>Hello</p>
-<p>Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" is using more than 75% of its available memory.</p>
+`<p>Hello {{{ safeName }}},</p>
+<p>
+Your FlowFuse Instance "{{{ name }}}" in Team "{{{ teamName.html }}}" is using more than 75% of its available memory.
+This can cause degraded performance, errors, and crashes.
+</p>
 
 <p>
 This can occur for a number of reasons including:
 <ul>
-<li>incorrect instance size for your workload</li>
-<li>an issue in your flows holding onto memory</li>
-<li>an issue in a third-party library or node</li>
+<li>Needing a larger instance size for your workload</li>
+<li>An issue in your flows holding onto memory</li>
+<li>An issue in a third-party library or node</li>
 </ul>
 
 Possible solutions:
 <ul>
-<li>try selecting a larger instance type</li>
-<li>try disabling some nodes to see if the problem settles down after a restart</li>
-<li>when polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion</li>
-<li>check your flows for large data structures being held in memory, particularly in context</li>
-<li>check the issue tracker of your contrib nodes</li>
-</p>
+<li>Selecting a larger instance type</li>
+<li>Disabling some nodes to identify a problem area</li>
+<li>When polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion</li>
+<li>Check your flows for large data structures being held in memory, particularly in context</li>
+<li>Check the issue tracker of your contrib nodes</li>
+</ul>
 
+CTA: <a href="{{{ ctaChangeTypeUrl }}}">Select a larger instance type</a>
+</p>
 
 {{#if log.html}}
 <p>

--- a/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
@@ -57,7 +57,7 @@ This can occur for a number of reasons including:
 
 Possible solutions:
 <ul>
-<li>Selecting a larger instance type</li>
+<li>Upgrade to a larger instance type</li>
 <li>Disabling some nodes to identify a problem area</li>
 <li>When polling external services, ensure you are not polling too frequently as this may cause backpressure leading to memory exhaustion</li>
 <li>Check your flows for large data structures being held in memory, particularly in context</li>


### PR DESCRIPTION
closes #5452

## Description

Implements requested changes requested 

Notable differences:
* Changes were made to all 4 resource emails (not just the CPU alert) _(to keep them inline with one another)_ 
* Also, updated the `crashed` emails to include name and CTA
* USER FIRST NAME is not something we can reliably grep from the username.  It is a singular field in the database. User may have left this default (i.e. same as login user id), entered just "Fred" or "Mr Blogs".
  * Instead, I simply get the value from the user name "as is"
* **Possible solutions** - > "Select a larger instance type" was reworded to "Upgrade to a larger instance type" so that it matches the wording of the CTA (which was "Upgrade my instance")
   * NOTE: We may want to consider moving the CTA link to the text of the **Possible solutions** - > "Select a larger instance type"  list item? (like we do for the log)? 
* In the text version of the Email, we cannot have named URLs so the format for the CTA was tweaked to be "Upgrade my instance: {{{ ctaChangeTypeUrl }}}"
* A few other grammatical issues missed in the first implementation fixed up 


I will add @gstout52 as an additional reviewer so that fine tuning tweaks can be made as inline suggestions.

## Related Issue(s)

#5452

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

