### PR TITLE
Fix editing pipeline stage when a device group exists in later stages

### DIFF
--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -126,15 +126,9 @@ module.exports = {
             } else {
                 // hosted/remote instance
                 // If a device group is set before this stage, that is an error
-                const nonDeviceGroupStagesPrior = priorStages.filter(s => (s.DeviceGroups?.length ?? 0) > 0)
-                if (nonDeviceGroupStagesPrior.length > 0) {
+                const deviceGroupStagesPrior = priorStages.filter(s => (s.DeviceGroups?.length ?? 0) > 0)
+                if (deviceGroupStagesPrior.length > 0) {
                     throw new PipelineControllerError('invalid_input', 'This stage cannot contain an instance as a Device Group is set in a prior stage', 400)
-                }
-                // If any device group exists after this stage, they must all be device groups
-                const deviceGroupStagesLater = laterStages.filter(s => (s.DeviceGroups?.length ?? 0) > 0)
-                const nonDeviceGroupStagesLater = laterStages.filter(s => (s.DeviceGroups?.length ?? 0) === 0)
-                if (deviceGroupStagesLater.length > 0 && nonDeviceGroupStagesLater.length > 0) {
-                    throw new PipelineControllerError('invalid_input', 'This stage can only contain Device Group stages', 400)
                 }
             }
 

--- a/test/unit/forge/ee/routes/api/pipeline_spec.js
+++ b/test/unit/forge/ee/routes/api/pipeline_spec.js
@@ -774,6 +774,42 @@ describe('Pipelines API', function () {
         })
 
         describe('With a new instance', function () {
+            it('Should be possible to change stage when a group is present later in the chain', async function () {
+                // Setup a pipeline with A (instance) -> B (device) -> C (device group)
+                // and then change A to D (instanceTwo)
+
+                const pipelineId = TestObjects.pipeline.hashid
+
+                // add a device stage
+                const stage2 = await TestObjects.factory.createPipelineStage({ name: 'stage-two', deviceId: TestObjects.deviceOne.id, source: TestObjects.stageOne.hashid, action: 'use_active_snapshot' }, TestObjects.pipeline)
+
+                // add a device group stage at the end of the pipeline
+                const newDeviceGroup = await TestObjects.factory.createApplicationDeviceGroup({ name: 'device-group-s3' }, app.application)
+                await TestObjects.factory.createPipelineStage({ name: 'stage-three', deviceGroupId: newDeviceGroup.hashid, source: stage2.hashid, action: 'use_latest_snapshot' }, TestObjects.pipeline)
+                // add a device group stage at the end of the pipeline
+
+                // get id of stage to modify
+                const stageId = TestObjects.stageOne.hashid
+
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/pipelines/${pipelineId}/stages/${stageId}`,
+                    payload: {
+                        instanceId: TestObjects.instanceTwo.id
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+
+                })
+
+                const body = await response.json()
+
+                body.should.have.property('id')
+                body.should.have.property('instances')
+                body.instances.should.have.length(1)
+                body.instances[0].should.have.property('name', 'instance-two')
+
+                response.statusCode.should.equal(200)
+            })
             it('Should unassign the old instance and assign the new one', async function () {
                 const pipelineId = TestObjects.pipeline.hashid
                 const stageId = TestObjects.stageOne.hashid


### PR DESCRIPTION
closes #5487

## Description

Updates the pipeline validation logic to permit stage alteration when a device group is present further down the chain and adds a new test case to ensure avoid regression.

### New test (test written TDD to ensure it failed before fix)
```
  Pipelines API
    Update Pipeline Stage
      With a new instance
        ✔ Should be possible to change stage when a group is present later in the chain (61ms)
```

## Related Issue(s)

#5487

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

