### PR TITLE
Fix combobox selector behavior when losing focus

### DIFF
--- a/frontend/src/ui-components/components/form/ComboBox.vue
+++ b/frontend/src/ui-components/components/form/ComboBox.vue
@@ -120,7 +120,7 @@ export default {
                     }
 
                     return opt === this.modelValue
-                }) ?? null
+                })
             },
             set (val) {
                 let payload = val?.[this.valueKey] ?? val
@@ -158,9 +158,12 @@ export default {
     },
     methods: {
         compareOptions (modelValue, optionValue) {
-            return this.returnModel
-                ? modelValue?.[this.valueKey] === optionValue?.[this.valueKey]
-                : modelValue === optionValue?.[this.valueKey]
+            if (!modelValue) return
+
+            modelValue = modelValue?.[this.valueKey] ?? modelValue
+            optionValue = optionValue?.[this.valueKey] ?? optionValue
+
+            return modelValue === optionValue
         }
     }
 }

--- a/frontend/src/ui-components/components/form/ComboBox.vue
+++ b/frontend/src/ui-components/components/form/ComboBox.vue
@@ -158,7 +158,7 @@ export default {
     },
     methods: {
         compareOptions (modelValue, optionValue) {
-            if (!modelValue) return
+            if (modelValue == null) return
 
             modelValue = modelValue?.[this.valueKey] ?? modelValue
             optionValue = optionValue?.[this.valueKey] ?? optionValue

--- a/frontend/src/ui-components/components/form/ComboBox.vue
+++ b/frontend/src/ui-components/components/form/ComboBox.vue
@@ -120,7 +120,7 @@ export default {
                     }
 
                     return opt === this.modelValue
-                })
+                }) ?? null
             },
             set (val) {
                 let payload = val?.[this.valueKey] ?? val


### PR DESCRIPTION
## Description

From the combobox [docs](https://headlessui.com/v1/vue/combobox#binding-objects-as-values):
> When binding objects as values, it's important to make sure that you use the same instance of the object as both the value of the Combobox as well as the corresponding ComboboxOption, otherwise they will fail to be equal and cause the combobox to behave incorrectly.

I was not careful when reading the docs and writing the `compareOptions` method used by the combobox to compare options.

Because it couldn't figure out if it had a selected value it auto selected whichever option was active at the moment of closing, which was always the first one in the list if you wouldn't interact with the keyboard.

Tested locally, it should be able to correctly deduce the selected option from a list of objects or a list of primitives.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5488

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

