### PR TITLE
Improve visibility of local access of remote instance

### DIFF
--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -32,7 +32,8 @@ module.exports = function (app) {
                 nullable: true,
                 allOf: [{ $ref: 'DeviceGroupSummary' }]
             },
-            nrVersion: { type: 'string' }
+            nrVersion: { type: 'string' },
+            localLoginEnabled: { type: 'boolean' }
         }
     })
 

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -104,6 +104,9 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const result = app.db.views.Device.device(request.device)
+        const securitySettings = await request.device.getSetting('security')
+        result.localLoginEnabled = securitySettings?.localAuth?.enabled || false
+
         if (request.device.nodeRedVersion) {
             result.nrVersion = request.device.nodeRedVersion
         }

--- a/frontend/src/components/InfoCardRow.vue
+++ b/frontend/src/components/InfoCardRow.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="ff-info-card-row flex items-center">
-        <div class="ff-info-card-row-property w-40 font-medium">
+        <div class="ff-info-card-row-property w-48 font-medium">
             <slot name="property">{{ property }}</slot>
         </div>
         <div class="ff-info-card-row-value">

--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -31,6 +31,20 @@
                         />
                     </template>
                 </InfoCardRow>
+                <InfoCardRow v-if="nrLocalLoginOptionPossible" property="Node-RED Local Login:">
+                    <template #value>
+                        <div class="flex items-center space-x-2">
+                            <StatusBadge
+                                :status="nrLocalLoginEnabled ? 'error' : 'success'"
+                                :text="nrLocalLoginEnabled ? 'enabled' : 'disabled'"
+                                v-ff-tooltip="nrLocalLoginEnabledWarning"
+                            />
+                            <router-link to="settings/security" class="flex items-center">
+                                <CogIcon class="w-5 h-5 text-gray-500" />
+                            </router-link>
+                        </div>
+                    </template>
+                </InfoCardRow>
             </template>
         </InfoCard>
         <InfoCard header="Deployment:">
@@ -108,7 +122,7 @@
 <script>
 
 // utilities
-import { CheckCircleIcon, ExclamationIcon, TemplateIcon, WifiIcon } from '@heroicons/vue/outline'
+import { CheckCircleIcon, CogIcon, ExclamationIcon, TemplateIcon, WifiIcon } from '@heroicons/vue/outline'
 
 // api
 import semver from 'semver'
@@ -128,6 +142,7 @@ export default {
     props: ['device'],
     components: {
         CheckCircleIcon,
+        CogIcon,
         ExclamationIcon,
         WifiIcon,
         InfoCard,
@@ -154,6 +169,14 @@ export default {
         deviceOwnerType: function () {
             return this.device?.ownerType || ''
         },
+        nrLocalLoginEnabled: function () {
+            return this.nrLocalLoginOptionPossible && this.device?.localLoginEnabled
+        },
+        nrLocalLoginOptionPossible: function () {
+            // support for local login was added in 3.2.0
+            // and is only available for application devices
+            return this.deviceOwnerType === 'application' && semver.gte(this.device.agentVersion, '3.2.0')
+        },
         agentVersionWarning: function () {
             if (this.deviceOwnerType === 'application') {
                 if (this.device?.agentVersion && semver.gte(this.device.agentVersion, '1.15.0')) {
@@ -162,6 +185,15 @@ export default {
                 return 'Devices assigned to an application must be version 1.15 or greater in order to receive snapshots and updates'
             }
             return ''
+        },
+        nrLocalLoginEnabledWarning: function () {
+            if (!this.nrLocalLoginOptionPossible) {
+                return ''
+            }
+            if (this.nrLocalLoginEnabled) {
+                return 'Local login is enabled. Users can edit the remote instance flows without using FlowFuse. This is not recommended.'
+            }
+            return 'Local login is disabled. Users must use FlowFuse to edit the remote instance flows. This is the recommended setting.'
         },
         nrVersionWarning: function () {
             if (!this.device?.nrVersion) {

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -590,6 +590,7 @@ describe('Device API', async function () {
             result.should.have.property('type', 'something')
             result.should.have.property('links')
             result.should.have.property('team')
+            result.should.have.property('localLoginEnabled')
             result.should.not.have.property('accessToken')
 
             result.team.should.have.property('id', TestObjects.ATeam.hashid)


### PR DESCRIPTION
closes #5490

## Description

* Adds `localLoginEnabled` to device API response
* Uses this to display status on the device Overview as per owner issue discussion

### Screenshots

#### Old device (no support for local login) - not displayed
![image](https://github.com/user-attachments/assets/d948d30d-059b-433a-b29b-7c89c3a3b05d)

#### Project Assigned Device (no support for local login) - not displayed
![image](https://github.com/user-attachments/assets/3fc4b3be-a3ff-4f0e-b0e0-4023d39977e2)
tr

#### New device with support - disabled
![chrome_n9Fv0moNhr](https://github.com/user-attachments/assets/7eb8d155-05cc-40a6-a4f2-5bbb5e8f1bdb)

#### New device with support - enabled
![chrome_eXHiVU18GR](https://github.com/user-attachments/assets/f1111eeb-f2d4-4675-b988-98198ffb9a2e)


## Related Issue(s)

#5490

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

