### PR TITLE
Fix multi step duplication cold start

### DIFF
--- a/frontend/src/components/multi-step-forms/MultiStepForm.vue
+++ b/frontend/src/components/multi-step-forms/MultiStepForm.vue
@@ -23,6 +23,7 @@
                     v-bind="currentStep.bindings"
                     v-model="payload"
                     @step-updated="$emit('step-updated', $event, currentStepKey)"
+                    @go-to-step="selectStep"
                 />
             </transition>
         </section>

--- a/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
@@ -1,0 +1,196 @@
+<template>
+    <MultiStepForm
+        ref="multiStepForm"
+        :steps="formSteps"
+        :starting-step="2"
+        :disable-next-step="shouldDisableNextStep"
+        :loading-overlay="formLoading"
+        :loading-overlay-text="loadingText"
+        :showFooter="false"
+        last-step-label="Create Instance"
+        @previous-step-state-changed="$emit('previous-step-state-changed', $event)"
+        @next-step-state-changed="$emit('next-step-state-changed', $event)"
+        @next-step-label-changed="$emit('next-step-label-changed', $event)"
+        @submit="onSubmit"
+        @step-updated="updateForm"
+    />
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+import instanceApi from '../../../api/instances.js'
+import teamApi from '../../../api/team.js'
+import Alerts from '../../../services/alerts.js'
+import MultiStepForm from '../MultiStepForm.vue'
+
+import ApplicationStep from './steps/ApplicationStep.vue'
+
+import DuplicationStep from './steps/DuplicationStep.vue'
+import InstanceStep from './steps/InstanceStep.vue'
+
+const INSTANCE_SLUG = 'instance'
+const APPLICATION_SLUG = 'application'
+const DUPLICATION_SLUG = 'duplication'
+
+export default {
+    name: 'MultiStepDuplicateInstanceForm',
+    components: { MultiStepForm },
+    props: {
+    },
+    emits: ['instance-created', 'previous-step-state-changed', 'next-step-state-changed', 'next-step-label-changed'],
+    data () {
+        return {
+            applications: [],
+            form: {
+                [APPLICATION_SLUG]: { },
+                [INSTANCE_SLUG]: { },
+                [DUPLICATION_SLUG]: { }
+            },
+            formLoading: false,
+            instance: null,
+            loadingText: '',
+            errors: {
+
+            }
+        }
+    },
+    computed: {
+        ...mapState('account', ['team']),
+        formSteps () {
+            return [
+                {
+                    sliderTitle: 'Application',
+                    component: ApplicationStep,
+                    bindings: {
+                        slug: APPLICATION_SLUG,
+                        applications: this.applications,
+                        state: this.form[APPLICATION_SLUG]
+                    }
+                },
+                {
+                    sliderTitle: 'Instance',
+                    component: InstanceStep,
+                    bindings: {
+                        slug: INSTANCE_SLUG,
+                        state: this.form[INSTANCE_SLUG].input
+                    }
+                },
+                {
+                    sliderTitle: 'Overview',
+                    component: DuplicationStep,
+                    bindings: {
+                        slug: DUPLICATION_SLUG,
+                        state: this.form[DUPLICATION_SLUG],
+                        instance: this.instance,
+                        instanceSelection: this.form[INSTANCE_SLUG].input ?? {},
+                        applicationSelection: this.form[APPLICATION_SLUG] ?? {},
+                        applications: this.applications
+                    }
+                }
+            ]
+        },
+        shouldDisableNextStep () {
+            let flag = false
+            Object.keys(this.form).forEach(key => {
+                if (this.form[key].hasErrors) {
+                    flag = true
+                }
+            })
+            return flag
+        }
+    },
+    watch: {
+
+    },
+    mounted () {
+        this.getApplications()
+            .then(() => this.getInstance())
+            .then(() => this.prefillForm())
+            .catch(e => e)
+            .finally(() => {
+                this.loading = false
+            })
+    },
+    methods: {
+        updateForm (payload) {
+            this.form = { ...this.form, ...payload }
+        },
+        async onSubmit () {
+            this.loadingText = 'Creating a new Instance'
+            this.formLoading = true
+            const payload = {
+                applicationId: this.form[APPLICATION_SLUG].selection.id,
+                name: this.form[INSTANCE_SLUG].input.name,
+                projectType: this.form[INSTANCE_SLUG].input.instanceType,
+                stack: this.form[INSTANCE_SLUG].input.nodeREDVersion,
+                template: this.form[INSTANCE_SLUG].input.template,
+                sourceProject: {
+                    id: this.instance.id,
+                    options: { ...(this.form[DUPLICATION_SLUG]?.copyParts ?? {}) }
+                }
+            }
+
+            return instanceApi.create(payload)
+                .then((instance) => this.$emit('instance-created', instance))
+                .catch(err => {
+                    const error = err.response.data.error
+
+                    if (error) {
+                        Alerts.emit('Failed to create instance: ' + error, 'warning', 7500)
+                    } else {
+                        Alerts.emit('Failed to create instance')
+                        console.error(err)
+                    }
+                })
+                .finally(() => {
+                    this.loadingText = ''
+                    this.formLoading = false
+                })
+        },
+        goToNextStep () {
+            this.$refs.multiStepForm.nextStep()
+        },
+        goToPreviousStep () {
+            this.$refs.multiStepForm.previousStep()
+        },
+        async getApplications () {
+            const data = await teamApi.getTeamApplications(this.team.id)
+            this.applications = data.applications.map((a) => {
+                return {
+                    label: a.name,
+                    description: a.description,
+                    value: a.id,
+                    id: a.id,
+                    counters: {
+                        instances: a.instances.length,
+                        devices: a.devices.length
+                    }
+                }
+            })
+        },
+        async getInstance () {
+            this.instance = await instanceApi.getInstance(this.$route.params.id)
+        },
+        prefillForm () {
+            const input = {
+                instanceType: this.instance.projectType.id,
+                name: this.instance.name + '-COPY',
+                nodeREDVersion: this.instance.stack.id,
+                template: this.instance.template.id
+            }
+
+            this.form[INSTANCE_SLUG].input = input
+            if (this.instance.application) {
+                this.form[APPLICATION_SLUG].selection = {
+                    id: this.instance.application.id
+                }
+            }
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+
+</style>

--- a/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
@@ -22,6 +22,7 @@ import { mapState } from 'vuex'
 import instanceApi from '../../../api/instances.js'
 import teamApi from '../../../api/team.js'
 import Alerts from '../../../services/alerts.js'
+import NameGenerator from '../../../utils/name-generator/index.js'
 import MultiStepForm from '../MultiStepForm.vue'
 
 import ApplicationStep from './steps/ApplicationStep.vue'
@@ -175,7 +176,7 @@ export default {
         prefillForm () {
             const input = {
                 instanceType: this.instance.projectType.id,
-                name: this.instance.name + '-COPY',
+                name: NameGenerator(),
                 nodeREDVersion: this.instance.stack.id,
                 template: this.instance.template.id
             }

--- a/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
@@ -102,16 +102,27 @@ export default {
         }
     },
     watch: {
-
-    },
-    mounted () {
-        this.getApplications()
-            .then(() => this.getInstance())
-            .then(() => this.prefillForm())
-            .catch(e => e)
-            .finally(() => {
-                this.loading = false
-            })
+        instance: {
+            immediate: true,
+            handler (instance) {
+                if (!instance) {
+                    this.getInstance()
+                        .then(() => {
+                            // workaround for the fact that the team might not be loaded,
+                            // eg team not
+                            if (!this.team) {
+                                return this.$store.dispatch('account/setTeam', this.instance.team.slug)
+                            }
+                        })
+                        .then(() => this.getApplications())
+                        .then(() => this.prefillForm())
+                        .catch(e => e)
+                        .finally(() => {
+                            this.loading = false
+                        })
+                }
+            }
+        }
     },
     methods: {
         updateForm (payload) {
@@ -172,6 +183,7 @@ export default {
         },
         async getInstance () {
             this.instance = await instanceApi.getInstance(this.$route.params.id)
+            console.log(this.instance)
         },
         prefillForm () {
             const input = {

--- a/frontend/src/components/multi-step-forms/instance/steps/DuplicationStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/DuplicationStep.vue
@@ -15,21 +15,8 @@
                                 </ff-button>
                             </div>
                         </div>
-                        <p>{{ selectedApplication.label }}</p>
-                        <p v-if="selectedApplication.description">{{ selectedApplication.description }}</p>
-                    </div>
-
-                    <div class="form-group">
-                        <div class="title">
-                            <label>Instance Type</label>
-                            <div class="actions">
-                                <ff-button v-ff-tooltip="'Edit'" size="small" kind="tertiary" @click="goToStep(1)">
-                                    <PencilIcon class="ff-icon ff-icon-sm" />
-                                </ff-button>
-                            </div>
-                        </div>
-                        <p>{{ selectedInstanceType.name }}</p>
-                        <p>{{ selectedInstanceType.description }}</p>
+                        <p data-el="application-name">{{ selectedApplication.label }}</p>
+                        <p v-if="selectedApplication.description" data-el="application-description">{{ selectedApplication.description }}</p>
                     </div>
 
                     <div class="form-group">
@@ -44,7 +31,20 @@
                                 </ff-button>
                             </div>
                         </div>
-                        <p>{{ instanceSelection.name }}</p>
+                        <p data-el="instance-name">{{ instanceSelection.name }}</p>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="title">
+                            <label>Instance Type</label>
+                            <div class="actions">
+                                <ff-button v-ff-tooltip="'Edit'" size="small" kind="tertiary" @click="goToStep(1)">
+                                    <PencilIcon class="ff-icon ff-icon-sm" />
+                                </ff-button>
+                            </div>
+                        </div>
+                        <p data-el="instance-type-name">{{ selectedInstanceType.name }}</p>
+                        <p data-el="instance-type-description">{{ selectedInstanceType.description }}</p>
                     </div>
 
                     <div class="form-group">
@@ -56,7 +56,7 @@
                                 </ff-button>
                             </div>
                         </div>
-                        <p>{{ selectedNodeRedVersion.label }}</p>
+                        <p data-el="node-red-version">{{ selectedNodeRedVersion?.label }}</p>
                     </div>
 
                     <div v-if="instanceTemplates.length > 1" class="form-group">
@@ -68,7 +68,7 @@
                                 </ff-button>
                             </div>
                         </div>
-                        <p>{{ selectedTemplate.name }}</p>
+                        <p data-el="template-name">{{ selectedTemplate.name }}</p>
                     </div>
 
                     <div class="form-group">

--- a/frontend/src/components/multi-step-forms/instance/steps/DuplicationStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/DuplicationStep.vue
@@ -1,0 +1,297 @@
+<template>
+    <section class="ff-duplication-step text-center flex flex-col gap-4 pt-6" data-step="duplication">
+        <h2>Duplication Overview</h2>
+
+        <div class="max-w-2xl m-auto text-left">
+            <transition name="fade" mode="out-in">
+                <ff-loading v-if="loading" message="Loading data..." />
+                <div v-else class="flex flex-col gap-7" data-el="duplicate-wrapper">
+                    <div class="form-group">
+                        <div class="title">
+                            <label>Application</label>
+                            <div class="actions">
+                                <ff-button v-ff-tooltip="'Edit'" size="small" kind="tertiary" @click="goToStep(0)">
+                                    <PencilIcon class="ff-icon ff-icon-sm" />
+                                </ff-button>
+                            </div>
+                        </div>
+                        <p>{{ selectedApplication.label }}</p>
+                        <p v-if="selectedApplication.description">{{ selectedApplication.description }}</p>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="title">
+                            <label>Instance Type</label>
+                            <div class="actions">
+                                <ff-button v-ff-tooltip="'Edit'" size="small" kind="tertiary" @click="goToStep(1)">
+                                    <PencilIcon class="ff-icon ff-icon-sm" />
+                                </ff-button>
+                            </div>
+                        </div>
+                        <p>{{ selectedInstanceType.name }}</p>
+                        <p>{{ selectedInstanceType.description }}</p>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="title">
+                            <label>Instance Name</label>
+                            <div class="actions">
+                                <ff-button v-ff-tooltip="'Generate a new name'" size="small" kind="tertiary" @click="generateName">
+                                    <RefreshIcon class="ff-icon ff-icon-sm" />
+                                </ff-button>
+                                <ff-button v-ff-tooltip="'Edit'" size="small" kind="tertiary" @click="goToStep(1)">
+                                    <PencilIcon class="ff-icon ff-icon-sm" />
+                                </ff-button>
+                            </div>
+                        </div>
+                        <p>{{ instanceSelection.name }}</p>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="title">
+                            <label>Node RED Version</label>
+                            <div class="actions">
+                                <ff-button v-ff-tooltip="'Edit'" size="small" kind="tertiary" @click="goToStep(1)">
+                                    <PencilIcon class="ff-icon ff-icon-sm" />
+                                </ff-button>
+                            </div>
+                        </div>
+                        <p>{{ selectedNodeRedVersion.label }}</p>
+                    </div>
+
+                    <div v-if="instanceTemplates.length > 1" class="form-group">
+                        <div class="title">
+                            <label>Template</label>
+                            <div class="actions">
+                                <ff-button v-ff-tooltip="'Edit'" size="small" kind="tertiary" @click="goToStep(1)">
+                                    <PencilIcon class="ff-icon ff-icon-sm" />
+                                </ff-button>
+                            </div>
+                        </div>
+                        <p>{{ selectedTemplate.name }}</p>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="title">
+                            <label>Select the components to copy from '{{ instance?.name }}'</label>
+                        </div>
+                        <ExportInstanceComponents id="exportSettings" v-model="copyParts" class="mt-2" />
+                    </div>
+
+                    <div v-if="features.billing" class="my-5 text-left" style="padding: 0 60px;">
+                        <InstanceChargesTable
+                            :project-type="selectedInstanceType"
+                            :subscription="subscription"
+                            :trialMode="isTrialProjectSelected"
+                            :prorationMode="team?.type?.properties?.billing?.proration"
+                        />
+                    </div>
+                </div>
+            </transition>
+        </div>
+    </section>
+</template>
+
+<script>
+import { PencilIcon, RefreshIcon } from '@heroicons/vue/outline'
+import { mapState } from 'vuex'
+
+import billingApi from '../../../../api/billing.js'
+import instanceTypesApi from '../../../../api/instanceTypes.js'
+import stacksApi from '../../../../api/stacks.js'
+import templatesApi from '../../../../api/templates.js'
+
+import ExportInstanceComponents from '../../../../pages/instance/components/ExportImportComponents.vue'
+import InstanceChargesTable from '../../../../pages/instance/components/InstanceChargesTable.vue'
+import FfButton from '../../../../ui-components/components/Button.vue'
+import NameGenerator from '../../../../utils/name-generator/index.js'
+
+import FfLoading from '../../../Loading.vue'
+
+export default {
+    name: 'DuplicationStep',
+    components: { FfButton, InstanceChargesTable, ExportInstanceComponents, FfLoading, PencilIcon, RefreshIcon },
+    props: {
+        applications: {
+            required: true,
+            type: Array
+        },
+        slug: {
+            required: true,
+            type: String
+        },
+        state: {
+            required: false,
+            type: Object,
+            default: () => ({})
+        },
+        instance: {
+            required: true,
+            type: [Object, null]
+        },
+        instanceSelection: {
+            required: true,
+            type: Object
+        },
+        applicationSelection: {
+            required: true,
+            type: Object
+        }
+    },
+    emits: ['step-updated', 'go-to-step'],
+    setup (props) {
+        const initialState = props.state
+        return { initialState }
+    },
+    data () {
+        return {
+            copyParts: {
+                flows: true,
+                credentials: true,
+                nodes: true,
+                envVars: 'all'
+            },
+            instanceTemplates: [],
+            loading: true,
+            nodeRedVersions: [],
+            subscription: null
+        }
+    },
+    computed: {
+        ...mapState('account', ['team', 'features']),
+        isTrialProjectSelected () {
+            //  - Team is in trial mode, and
+            //  - Team billing is not configured, or
+            //  - team billing is configured, but they still have an available
+            //     trial instance to create, and they have selected the trial
+            //     instance type
+            return this.team?.billing?.trial && (
+                !this.team.billing?.active || (
+                    this.team.billing.trialProjectAllowed &&
+                    this.selectedProjectType?.id === this.settings['user:team:trial-mode:projectType']
+                )
+            )
+        },
+        selectedInstanceType () {
+            if (this.instanceSelection.instanceType) {
+                return this.instanceTypes.find(type => type.id === this.instanceSelection.instanceType)
+            }
+            return null
+        },
+        selectedNodeRedVersion () {
+            if (this.instanceSelection.nodeREDVersion) {
+                return this.nodeRedVersions.find(version => version.id === this.instanceSelection.nodeREDVersion)
+            }
+            return null
+        },
+        selectedTemplate () {
+            if (this.instanceSelection.template) {
+                return this.instanceTemplates.find(template => template.id === this.instanceSelection.template)
+            }
+            return null
+        },
+        selectedApplication () {
+            if (this.applicationSelection?.selection?.id) {
+                return this.applications.find(app => app.id === this.applicationSelection.selection.id)
+            }
+            return null
+        }
+    },
+    watch: {
+        copyParts: {
+            immediate: true,
+            handler (value) {
+                this.$emit('step-updated', {
+                    [this.slug]: {
+                        copyParts: value
+                    }
+                })
+            }
+        }
+    },
+    async mounted () {
+        this.getSubscription()
+            .then(() => this.getInstanceTypes())
+            .then(() => this.getNodeRedVersions())
+            .then(() => this.getTemplates())
+            .catch(e => e)
+            .finally(() => {
+                this.loading = false
+            })
+    },
+    methods: {
+        async getInstanceTypes () {
+            const instanceTypes = await instanceTypesApi.getInstanceTypes()
+
+            this.instanceTypes = instanceTypes.types ?? []
+        },
+        async getSubscription () {
+            if (this.features?.billing && !this.team?.billing?.unmanaged && !this.team?.type.properties?.billing?.disabled) {
+                try {
+                    this.subscription = await billingApi.getSubscriptionInfo(this.team?.id)
+                } catch (err) {
+                    if (err.response?.data?.code === 'not_found') {
+                        // This team has no subscription.
+                        if (!this.team.billing?.trial || this.team.billing?.trialEnded) {
+                            throw err
+                        }
+                    }
+                }
+            }
+        },
+        async getNodeRedVersions () {
+            const versions = await stacksApi.getStacks(null, null, null, this.instanceSelection.instanceType)
+
+            this.nodeRedVersions = versions.stacks
+                .filter(version => version.active)
+                .map(version => { return { ...version, value: version.id, label: version.label || version.name } })
+        },
+        getTemplates () {
+            return templatesApi.getTemplates()
+                .then((response) => {
+                    this.instanceTemplates = response.templates.filter(template => template.active)
+                })
+        },
+        goToStep (stepKey) {
+            this.$emit('go-to-step', stepKey)
+        },
+        generateName () {
+            // intended prop mutation to allow easy instance name generation without leaving the page
+            // eslint-disable-next-line vue/no-mutating-props
+            this.instanceSelection.name = NameGenerator()
+        }
+    }
+}
+</script>
+
+<style lang="scss">
+.ff-duplication-step {
+    .form-group {
+        .title {
+            margin-bottom: 5px;
+            padding-bottom: 5px;
+            border-bottom: 1px solid $ff-grey-200;
+            display: flex;
+            justify-content: space-between;
+
+            label {
+
+                font-weight: 500;
+            }
+
+            .actions {
+                display: flex;
+                gap: 5px;
+            }
+        }
+        p {
+            margin-top: 5px;
+
+            &:nth-of-type(2) {
+                color: $ff-grey-500;
+                font-style: italic;
+            }
+        }
+    }
+}
+</style>

--- a/frontend/src/components/multi-step-forms/instance/steps/DuplicationStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/DuplicationStep.vue
@@ -207,17 +207,22 @@ export default {
                     }
                 })
             }
+        },
+        team: {
+            immediate: true,
+            handler (team) {
+                if (team) {
+                    this.getSubscription()
+                        .then(() => this.getInstanceTypes())
+                        .then(() => this.getNodeRedVersions())
+                        .then(() => this.getTemplates())
+                        .catch(e => e)
+                        .finally(() => {
+                            this.loading = false
+                        })
+                }
+            }
         }
-    },
-    async mounted () {
-        this.getSubscription()
-            .then(() => this.getInstanceTypes())
-            .then(() => this.getNodeRedVersions())
-            .then(() => this.getTemplates())
-            .catch(e => e)
-            .finally(() => {
-                this.loading = false
-            })
     },
     methods: {
         async getInstanceTypes () {

--- a/frontend/src/pages/application/routes.js
+++ b/frontend/src/pages/application/routes.js
@@ -19,7 +19,6 @@ import ApplicationPipelineStageEdit from './PipelineStage/edit.vue'
 import ApplicationPipelines from './Pipelines.vue'
 import ApplicationSettings from './Settings.vue'
 import ApplicationSnapshots from './Snapshots.vue'
-import ApplicationCreateInstance from './createInstance.vue'
 import ApplicationIndex from './index.vue'
 
 export default [
@@ -152,28 +151,8 @@ export default [
             }
         ]
     },
-    { // sunsetting, use application-create-instance for creation
-        path: ':id/instances/create',
-        name: 'ApplicationCreateInstance',
-        component: ApplicationCreateInstance,
-        props: route => ({
-            sourceInstanceId: route.query.sourceInstanceId
-        }),
-        meta: {
-            title: 'Application - Instances - Create',
-            menu: {
-                type: 'back',
-                backTo: ({ query, params }) => {
-                    return {
-                        label: 'Back',
-                        to: { name: 'ApplicationInstances', params, query }
-                    }
-                }
-            }
-        }
-    },
     {
-        path: ':id/instances/create-step',
+        path: ':id/instances/create',
         name: 'application-create-instance',
         component: ApplicationCreateInstanceMultiStep,
         meta: {

--- a/frontend/src/pages/instance/DuplicateInstance.vue
+++ b/frontend/src/pages/instance/DuplicateInstance.vue
@@ -1,0 +1,71 @@
+<template>
+    <ff-page>
+        <template #header>
+            <ff-page-header title="Instances">
+                <template #context>
+                    Let's get your new Node-RED instance setup in no time.
+                </template>
+                <template #tools>
+                    <section class="flex gap-3">
+                        <ff-button
+                            class="flex-1"
+                            kind="secondary"
+                            :disabled="!form.previousButtonState"
+                            data-el="previous-step"
+                            @click="$refs.multiStepForm.goToPreviousStep()"
+                        >
+                            Back
+                        </ff-button>
+                        <ff-button
+                            class="flex-1 whitespace-nowrap"
+                            :disabled="form.nextButtonState"
+                            data-el="next-step"
+                            @click="$refs.multiStepForm.goToNextStep()"
+                        >
+                            {{ form.nextStepLabel }}
+                        </ff-button>
+                    </section>
+                </template>
+            </ff-page-header>
+        </template>
+
+        <MultiStepDuplicateInstanceForm
+            ref="multiStepForm"
+            last-step-label="Create Instance"
+            @instance-created="onInstanceCreated"
+            @previous-step-state-changed="form.previousButtonState = $event"
+            @next-step-state-changed="form.nextButtonState = $event"
+            @next-step-label-changed="form.nextStepLabel = $event"
+        />
+    </ff-page>
+</template>
+
+<script>
+import MultiStepDuplicateInstanceForm from '../../components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue'
+
+export default {
+    name: 'DuplicateInstance',
+    components: { MultiStepDuplicateInstanceForm },
+    data () {
+        return {
+            form: {
+                nextButtonState: false,
+                previousButtonState: false,
+                nextStepLabel: 'Next'
+            }
+        }
+    },
+    methods: {
+        onInstanceCreated (instance) {
+            this.$router.push({
+                name: 'instance-overview',
+                params: { id: instance.id }
+            })
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+
+</style>

--- a/frontend/src/pages/instance/Settings/Danger.vue
+++ b/frontend/src/pages/instance/Settings/Danger.vue
@@ -53,7 +53,16 @@
                     </div>
                 </div>
                 <div class="min-w-fit flex-shrink-0">
-                    <ff-button kind="secondary" data-nav="copy-project" @click="showDuplicateInstanceDialog()">Duplicate Instance</ff-button>
+                    <ff-button
+                        kind="secondary"
+                        data-nav="copy-project"
+                        :to="{
+                            name: 'instance-duplicate',
+                            params: { id: instance.id, team_slug: team.slug },
+                        }"
+                    >
+                        Duplicate Instance
+                    </ff-button>
                 </div>
             </div>
         </template>
@@ -188,13 +197,6 @@ export default {
         },
         showChangeStackDialog () {
             this.$refs.changeStackDialog.show(this.instance)
-        },
-        showDuplicateInstanceDialog () {
-            this.$router.push({
-                name: 'ApplicationCreateInstance',
-                params: { id: this.instance.application.id, team_slug: this.team.slug },
-                query: { sourceInstanceId: this.instance.id }
-            })
         },
         showImportInstanceDialog () {
             this.$refs.importInstanceDialog.show(this.instance)

--- a/frontend/src/pages/instance/routes.js
+++ b/frontend/src/pages/instance/routes.js
@@ -5,6 +5,7 @@
 import InstanceAssets from './Assets.vue'
 import InstanceAuditLog from './AuditLog.vue'
 import InstanceRemoteInstances from './Devices.vue'
+import DuplicateInstance from './DuplicateInstance.vue'
 import InstanceLogs from './Logs.vue'
 import InstanceOverview from './Overview.vue'
 import InstanceSettings from './Settings/index.vue'
@@ -89,14 +90,27 @@ export default [
     },
     {
         path: '/instance/:id/:remaining*',
-        redirect: to => {
-            return { name: 'instance-overview', params: { id: to.params.id } }
-        },
-        name: 'Instance',
-        component: Instance,
-        meta: {
-            title: 'Instance - Overview'
-        },
-        children
+        children: [
+            {
+                path: '',
+                redirect: to => {
+                    return { name: 'instance-overview', params: { id: to.params.id } }
+                },
+                name: 'Instance',
+                component: Instance,
+                meta: {
+                    title: 'Instance - Overview'
+                },
+                children
+            },
+            {
+                path: 'duplicate',
+                name: 'instance-duplicate',
+                component: DuplicateInstance,
+                meta: {
+                    title: 'Instance - Duplicate'
+                }
+            }
+        ]
     }
 ]

--- a/test/e2e/frontend/cypress/tests/instances.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances.spec.js
@@ -196,14 +196,12 @@ describe('FlowForge - Instances', () => {
     })
 
     it('can be copied', () => {
-        // TODO needs work as currently lands user on Project Overview rather than Index View
         cy.intercept('GET', '/api/*/projects/*').as('getInstance')
         cy.intercept('POST', '/api/*/projects').as('createProject')
-        cy.intercept('GET', '/api/*/applications/*/instances').as('getApplicationInstances')
 
         cy.visit('/')
 
-        navigateToInstance('ATeam', 'instance-1-1')
+        navigateToInstance('ATeam', 'instance-1-2')
 
         cy.wait('@getInstance')
 
@@ -211,22 +209,36 @@ describe('FlowForge - Instances', () => {
         cy.get('[data-nav="general"]').click()
         cy.get('[data-nav="copy-project"]').click()
 
+        cy.get('[data-step="duplication"]').should('exist')
+
         // Does not use same name
         cy.get('[data-form="project-name"] input').should(($input) => {
             const projectName = $input.val()
             expect(projectName).not.to.be.equal('instance-1-1')
         })
 
-        cy.get('[data-action="create-project"]').click()
+        cy.get('[data-el="application-name"]').contains('application-1')
+
+        // not present if the application doesn't have a description
+        cy.get('[data-el="application-description"]').should('not.exist')
+
+        cy.get('[data-el="instance-name"]').should('not.contain', 'instance-1-2')
+
+        cy.get('[data-el="instance-type-name"]').contains('type1')
+        cy.get('[data-el="instance-type-description"]').contains('project type description')
+
+        cy.get('[data-el="node-red-version"]').contains('stack 2')
+        cy.get('[data-el="template-name"]').contains('template1')
+
+        cy.get('[data-el="next-step"]').click()
+
         cy.wait('@createProject')
-
-        cy.wait('@getApplicationInstances')
-
-        cy.get('[data-el="cloud-instances"] tr:last').click()
-
         cy.wait('@getInstance')
 
-        cy.contains('type1 / stack 1')
+        cy.contains('Application: application-1')
+
+        cy.contains('type1 / stack 2')
+        cy.contains('template1')
     })
 
     it('can be created', () => {

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -74,7 +74,7 @@ module.exports = async function (settings = {}, config = {}) {
     // Platform Setup
     const template = await factory.createProjectTemplate({ name: 'template1' }, userAlice)
     const stack = await factory.createStack({ name: 'stack1', label: 'stack 1' }, projectType)
-    await factory.createStack({ name: 'stack2', label: 'stack 2' }, projectType)
+    const stack2 = await factory.createStack({ name: 'stack2', label: 'stack 2' }, projectType)
 
     // Unused templates and project types
     await factory.createProjectTemplate({ name: 'template2' }, userAlice)
@@ -137,7 +137,7 @@ module.exports = async function (settings = {}, config = {}) {
     // Application and Instances
     const application1 = await factory.createApplication({ name: 'application-1' }, team1)
     await factory.createInstance({ name: 'instance-1-1' }, application1, stack, template, projectType)
-    await factory.createInstance({ name: 'instance-1-2' }, application1, stack, template, projectType, { start: false })
+    await factory.createInstance({ name: 'instance-1-2' }, application1, stack2, template, projectType, { start: false })
 
     /// Team 2
     const team2 = await factory.createTeam({ name: 'BTeam' })


### PR DESCRIPTION
## Description

Accessing the duplicate instance form via url does not preload the team.

Altered the way the duplicate instance form mounts by first loading the instance, getting and setting the team to that instance's team as we don't have anything else to go by

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5351

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

