### PR TITLE
Alter the duplicate instance page breadcrumbs

### DIFF
--- a/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
@@ -38,6 +38,10 @@ export default {
     name: 'MultiStepDuplicateInstanceForm',
     components: { MultiStepForm },
     props: {
+        instance: {
+            type: Object,
+            required: true
+        }
     },
     emits: ['instance-created', 'previous-step-state-changed', 'next-step-state-changed', 'next-step-label-changed'],
     data () {
@@ -49,7 +53,6 @@ export default {
                 [DUPLICATION_SLUG]: { }
             },
             formLoading: false,
-            instance: null,
             loadingText: '',
             errors: {
 
@@ -106,7 +109,6 @@ export default {
     },
     mounted () {
         this.getApplications()
-            .then(() => this.getInstance())
             .then(() => this.prefillForm())
             .catch(e => e)
             .finally(() => {
@@ -169,9 +171,6 @@ export default {
                     }
                 }
             })
-        },
-        async getInstance () {
-            this.instance = await instanceApi.getInstance(this.$route.params.id)
         },
         prefillForm () {
             const input = {

--- a/frontend/src/pages/instance/DuplicateInstance.vue
+++ b/frontend/src/pages/instance/DuplicateInstance.vue
@@ -1,7 +1,18 @@
 <template>
     <ff-page>
         <template #header>
-            <ff-page-header title="Instances">
+            <ff-page-header>
+                <template #breadcrumbs>
+                    <ff-nav-breadcrumb v-if="team" class="whitespace-nowrap" :to="{name: 'Instances', params: {team_slug: team.slug}}">
+                        Instances
+                    </ff-nav-breadcrumb>
+                    <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'instance-settings', params: {team_slug: team.slug, id: instance.id}}">
+                        {{ instance.name }}
+                    </ff-nav-breadcrumb>
+                    <ff-nav-breadcrumb class="whitespace-nowrap">
+                        Duplicate
+                    </ff-nav-breadcrumb>
+                </template>
                 <template #context>
                     Let's get your new Node-RED instance setup in no time.
                 </template>
@@ -30,8 +41,10 @@
         </template>
 
         <MultiStepDuplicateInstanceForm
+            v-if="instance"
             ref="multiStepForm"
             last-step-label="Create Instance"
+            :instance="instance"
             @instance-created="onInstanceCreated"
             @previous-step-state-changed="form.previousButtonState = $event"
             @next-step-state-changed="form.nextButtonState = $event"
@@ -41,6 +54,9 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
+import instanceApi from '../../api/instances.js'
 import MultiStepDuplicateInstanceForm from '../../components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue'
 
 export default {
@@ -52,8 +68,15 @@ export default {
                 nextButtonState: false,
                 previousButtonState: false,
                 nextStepLabel: 'Next'
-            }
+            },
+            instance: null
         }
+    },
+    computed: {
+        ...mapState('account', ['team'])
+    },
+    mounted () {
+        this.getInstance()
     },
     methods: {
         onInstanceCreated (instance) {
@@ -61,6 +84,9 @@ export default {
                 name: 'instance-overview',
                 params: { id: instance.id }
             })
+        },
+        async getInstance () {
+            this.instance = await instanceApi.getInstance(this.$route.params.id)
         }
     }
 }


### PR DESCRIPTION
## Prerequisites
child of https://github.com/FlowFuse/flowfuse/pull/5499

## Description

Altered the duplicate instance breadcrumbs to align with the rest of the app, needed to extract instance fetching data outside the form in order to not pass data upwards.

This will fit in nicely with a next step that will allow the page to cold mount properly.

## Related Issue(s)

part of

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

