### PR TITLE
Default to the Instance Type's default stack if the original instance’s stack is deprecated

### DIFF
--- a/frontend/src/components/multi-step-forms/instance/steps/DuplicationStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/DuplicationStep.vue
@@ -152,6 +152,7 @@ export default {
                 envVars: 'all'
             },
             instanceTemplates: [],
+            instanceTypes: [],
             loading: true,
             nodeRedVersions: [],
             subscription: null
@@ -245,6 +246,13 @@ export default {
             this.nodeRedVersions = versions.stacks
                 .filter(version => version.active)
                 .map(version => { return { ...version, value: version.id, label: version.label || version.name } })
+
+            if (!this.nodeRedVersions.find(v => v.id === this.instanceSelection.nodeREDVersion)) {
+                // intended prop mutation to allow the node RED version to default to the selected instance type nodeRED version
+                // if not available (either deleted or deprecated)
+                // eslint-disable-next-line vue/no-mutating-props
+                this.instanceSelection.nodeREDVersion = this.selectedInstanceType.defaultStack
+            }
         },
         getTemplates () {
             return templatesApi.getTemplates()


### PR DESCRIPTION
## Description

This update migrates functionality from the original implementation.

Previously, when duplicating instances with deprecated or deleted Node-RED versions (stacks), the frontend would display a blank Node-RED version in the overview tab—even though the backend correctly defaulted to the instance type's stack version.

This fix ensures that the frontend now reflects the same default behavior as the backend.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5351

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

