### PR TITLE
Clear redirectUrl when hitting the oauth account/complete route

### DIFF
--- a/frontend/src/pages/account/AccessRequestEditor.vue
+++ b/frontend/src/pages/account/AccessRequestEditor.vue
@@ -15,7 +15,7 @@
 
 <script>
 import { ArrowSmRightIcon, TemplateIcon } from '@heroicons/vue/solid'
-import { mapState } from 'vuex'
+import { mapState, useStore } from 'vuex'
 
 export default {
     name: 'AccessRequest',
@@ -27,6 +27,9 @@ export default {
         ...mapState('account', ['user', 'team'])
     },
     mounted () {
+        const store = useStore()
+        // If we've got here, remove any redirect url to prevent further unexpected redirects to this route
+        store.dispatch('account/setRedirectUrl', null)
         window.location.href = `/account/complete/${this.$router.currentRoute.value.params.id}`
     }
 }


### PR DESCRIPTION
We have seen occasions where a user is redirected to `/account/complete/ABCDEF/editor` after logging in and presented with a JSON formatted error.

This route is part of the OAuth flow used to authenticate access to the editor; a user should only be redirected there as part of opening the editor.

I haven't been able to track all of the handling of `redirectUrl` within the vue store, but it was clear the redirectUrl wasn't being cleared when it was this particular URL - as this view bounces the user straight on via a window.location update.

This PR adds an explicit clear of the redirectUrl to prevent it being reaccessed later.

My steps to reproduce this issue are quite involved and requires an SSO setup

1. Start logged out - incognito browser ideally
2. Enter URL for an instance editor
3. Login via SSO - you'll get redirected back to the editor
4. Logout of Node-RED - you'll get redirected back to the forge app
5. Login again via SSO
6. Logout of the forge app
7. You are redirected to the incorrect `/account/complete/...` page

With this fix, the incorrect redirect doesn't happen.

I doubt this is the exact sequence users are going through to hit this, but it is the sequence I found to reliably do so. Given the reports all point at an unexpected redirect to `/account/complete...`... then I'm pretty sure this will fix it for those cases as well.
