### PR TITLE
Email reminder for unused devices 

### DIFF
--- a/forge/housekeeper/index.js
+++ b/forge/housekeeper/index.js
@@ -133,6 +133,7 @@ module.exports = fp(async function (app, _opts) {
     await registerTask(require('./tasks/telemetryMetrics'))
     await registerTask(require('./tasks/expireInvites'))
     await registerTask(require('./tasks/inviteReminder'))
+    await registerTask(require('./tasks/deviceUnusedReminder'))
 
     app.addHook('onReady', async () => {
         let promise = Promise.resolve()

--- a/forge/housekeeper/tasks/deviceUnusedReminder.js
+++ b/forge/housekeeper/tasks/deviceUnusedReminder.js
@@ -17,7 +17,7 @@ module.exports = {
             where: {
                 lastSeenAt: null,
                 TeamId: {
-                    [Op.in]: literal('(SELECT `TeamId` FROM `Devices` GROUP BY `TeamId` HAVING COUNT(*) = SUM(CASE WHEN `lastSeenAt` IS NULL THEN 1 ELSE 0 END))')
+                    [Op.in]: literal('(SELECT "TeamId" FROM "Devices" GROUP BY "TeamId" HAVING COUNT(*) = SUM(CASE WHEN "lastSeenAt" IS NULL THEN 1 ELSE 0 END))')
                 }
             },
             include: {

--- a/forge/housekeeper/tasks/deviceUnusedReminder.js
+++ b/forge/housekeeper/tasks/deviceUnusedReminder.js
@@ -1,0 +1,70 @@
+const { Op, literal } = require('sequelize')
+
+const { Roles } = require('../../lib/roles')
+const { sanitizeText } = require('../../postoffice/utils')
+const { randomInt } = require('../utils')
+
+module.exports = {
+    name: 'deviceUnusedReminder',
+    startup: false,
+    // runs every 24h between 7 and 8 am UTC
+    schedule: `${randomInt(0, 59)} 7 * * *`,
+    run: async function (app) {
+        // If a team has 1 or more devices but none of them have ever been online, then email
+        // the "team owner(s)" about the device(s) that are younger than 2 weeks old since creation
+
+        const unusedDevices = await app.db.models.Device.findAll({
+            where: {
+                lastSeenAt: null,
+                TeamId: {
+                    [Op.in]: literal('(SELECT `TeamId` FROM `Devices` GROUP BY `TeamId` HAVING COUNT(*) = SUM(CASE WHEN `lastSeenAt` IS NULL THEN 1 ELSE 0 END))')
+                }
+            },
+            include: {
+                model: app.db.models.Team,
+                as: 'Team',
+                // only fields we need are name and id
+                attributes: ['id', 'name'],
+                where: {
+                    suspended: false
+                }
+            }
+        })
+
+        const fourteenDaysAgo = new Date()
+        fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14)
+        fourteenDaysAgo.setHours(0, 0, 0, 0)
+        const recentUnusedDevices = unusedDevices.filter(device => {
+            return device.createdAt >= fourteenDaysAgo
+        })
+        if (recentUnusedDevices.length === 0) {
+            return // No unused devices found
+        }
+        const uniqueTeamIds = [...new Set(recentUnusedDevices.map(device => device.TeamId))]
+
+        const teamFilter = {
+            TeamId: {
+                [Op.in]: uniqueTeamIds
+            },
+            role: Roles.Owner
+        }
+        const users = (await app.db.models.TeamMember.findAll({ where: teamFilter, include: app.db.models.User }))
+
+        for (const device of recentUnusedDevices) {
+            const deviceTeamOwners = users.filter(user => user.TeamId === device.TeamId).map(user => user.User)
+            if (!deviceTeamOwners || deviceTeamOwners.length === 0) {
+                app.log.warn(`No team owners found for device ${device.id} in team ${device.TeamId}`)
+                continue // should not happen
+            }
+            deviceTeamOwners.forEach(user => {
+                app.postoffice.send(user, 'DeviceUnusedReminder', {
+                    deviceName: sanitizeText(device.name),
+                    createdOn: device.createdAt.toDateString(),
+                    teamName: device.Team?.name || 'Unnamed Team',
+                    url: `${app.config.base_url}/device/${device.hashid}`,
+                    reminderSentAt: new Date()
+                })
+            })
+        }
+    }
+}

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -3,6 +3,7 @@ const handlebars = require('handlebars')
 const nodemailer = require('nodemailer')
 
 const defaultLayout = require('./layouts/default.js')
+const { sanitizeText } = require('./utils.js')
 
 const templates = {}
 
@@ -128,18 +129,6 @@ module.exports = fp(async function (app, _opts) {
         }
     }
 
-    /**
-     * Generates email-safe versions (both text and html) of a piece of text.
-     * This is intended to make user-provided strings (eg username) that may look
-     * like a URL to not looks like a URL to an email client
-     * @param {String} value
-     */
-    function sanitizeText (value) {
-        return {
-            text: value.replace(/\./g, ' '),
-            html: value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\./g, '<br style="display: none;"/>.')
-        }
-    }
     /**
      * Generates email-safe versions (both text and html) of a log array
      * This is intended to make iso time strings and and sanitized log messages

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -186,6 +186,7 @@ module.exports = fp(async function (app, _opts) {
         const ctaChangeTypeUrl = `${context.url}/settings/change-type`
         const template = templates[templateName] || loadTemplate(templateName)
         const templateContext = { forgeURL, ctaChangeTypeUrl, user, ...context }
+        templateContext.support = /^https:\/\/(app.flowfuse.com|forge.flowfuse.dev)/g.test(forgeURL) ? 'https://flowfuse.com/support/' : null
         templateContext.safeName = sanitizeText(user.name || 'user')
         if (templateContext.teamName) {
             templateContext.teamName = sanitizeText(templateContext.teamName)

--- a/forge/postoffice/templates/DeviceUnusedReminder.js
+++ b/forge/postoffice/templates/DeviceUnusedReminder.js
@@ -1,0 +1,36 @@
+module.exports = {
+    subject: "Your remote instance '{{{ deviceName.text }}}' is ready to be connected...!",
+    text:
+`Hello {{{ safeName.text }}},
+
+Congratulations on creating your remote instance '{{{ deviceName.text }}}' which you can see here: {{{ url }}}!
+
+To access the editor for this instance, you will need to install the Device Agent and connect it to the platform.
+
+The documentation at https://flowfuse.com/docs/device-agent/quickstart/ will guide you through the process (it contains a video walkthrough as well).
+
+{{#if support}}
+If you have trouble with any part of the setup process, feel free to contact support via {{{ support }}}
+{{else}}
+If you have trouble with any part of the setup process, contact support.
+{{/if}}
+
+Best regards,
+
+The FlowFuse Team
+`,
+    html:
+`<p>Hello {{{ safeName.html }}},</p>
+<p>Congratulations on creating your remote instance <a href="{{{ url }}}">"{{{ deviceName.html }}}"</a>!</p>
+<p>To access the editor for this instance, you will need to install the Device Agent and connect it to the platform.</p>
+<p>The <a href="https://flowfuse.com/docs/device-agent/quickstart/">quick start documentation</a> can guide you through the process (it contains a video walkthrough as well).</p>
+{{#if support}}
+<p>If you have trouble with any part of the setup process, feel free to <a href="{{{ support }}}">contact support</a>.</p>
+{{else}}
+<p>If you have trouble with any part of the setup process, contact support.</p>
+{{/if}}
+<p></p>
+<p>Best regards,<br>
+The FlowFuse Team</p>
+`
+}

--- a/forge/postoffice/utils.js
+++ b/forge/postoffice/utils.js
@@ -1,0 +1,16 @@
+/**
+ * Generates email-safe versions (both text and html) of a piece of text.
+ * This is intended to make user-provided strings (eg username) that may look
+ * like a URL to not looks like a URL to an email client
+ * @param {String} value
+ */
+function sanitizeText (value) {
+    return {
+        text: value.replace(/\./g, ' '),
+        html: value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\./g, '<br style="display: none;"/>.')
+    }
+}
+
+module.exports = {
+    sanitizeText
+}

--- a/test/unit/forge/housekeeper/setup.js
+++ b/test/unit/forge/housekeeper/setup.js
@@ -1,0 +1,120 @@
+const TestModelFactory = require('../../../lib/TestModelFactory')
+const StripeMock = require('../../../lib/stripeMock')
+
+const FF_UTIL = require('flowforge-test-utils')
+
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+/**
+ * @typedef TestApplicationExtras
+ * @property {TestModelFactory} factory
+ * @property {Object} defaultTeamType - the default team type created by the test setup
+ * @property {Object} user - the Alice user created by the test setup
+ * @property {Object} stack - stack1 created by the test setup
+ * @property {Object} template - template1 created by the test setup
+ * @property {Object} team - team1 created by the test setup
+ * @property {Object} application - application-1 created by the test setup
+ * @property {Object} project - application-1 created by the test setup
+ * @property {Object} projectType - projectType1 created by the test setup
+ */
+
+/**
+ * @typedef {import('../../../../forge/forge.js').ForgeApplication & TestApplicationExtras} TestApplication
+*/
+
+/**
+ * Set up a test application with a default user, team, stack, project template, and project type.
+ * @param {Object} config
+ * @returns {Promise<TestApplication>}
+ */
+async function setup (config = {}) {
+    config = {
+        housekeeper: false,
+        license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwiZGV2Ijp0cnVlLCJpYXQiOjE2NjI0ODI5ODd9.e8Jeppq4aURwWYz-rEpnXs9RY2Y7HF7LJ6rMtMZWdw2Xls6-iyaiKV1TyzQw5sUBAhdUSZxgtiFH5e_cNJgrUg',
+        billing: {
+            stripe: {
+                key: 1234,
+                new_customer_free_credit: 1000,
+                device_price: 'd123',
+                device_product: 'd456'
+            }
+        },
+        ...config
+    }
+
+    /** @type {TestApplication} */
+    const forge = await FF_UTIL.setupApp(config)
+    await forge.db.models.PlatformSettings.upsert({ key: 'setup:initialised', value: true })
+
+    const factory = new TestModelFactory(forge)
+
+    const userAlice = await factory.createUser({
+        admin: true,
+        username: 'alice',
+        name: 'Alice Skywalker',
+        email: 'alice@example.com',
+        password: 'aaPassword'
+    })
+
+    const team1 = await factory.createTeam({ name: 'ATeam' })
+    await team1.addUser(userAlice, { through: { role: Roles.Owner } })
+
+    if (config.license && config.billing) {
+        await factory.createSubscription(team1)
+    }
+
+    const template = await factory.createProjectTemplate(
+        { name: 'template1', settings: {}, policy: {} },
+        userAlice
+    )
+
+    const projectType = await factory.createProjectType({
+        name: 'projectType1',
+        description: 'default project type',
+        properties: {
+            billingProductId: 'product_123',
+            billingPriceId: 'price_123'
+        }
+    })
+
+    const stack = await factory.createStack({ name: 'stack1' }, projectType)
+
+    const application = await factory.createApplication({ name: 'application-1' }, team1)
+
+    const instance = await factory.createInstance(
+        { name: 'project1' },
+        application,
+        stack,
+        template,
+        projectType,
+        { start: false }
+    )
+
+    forge.factory = factory
+
+    forge.defaultTeamType = await forge.db.models.TeamType.findOne({ where: { id: 1 } })
+    // Need to give the default TeamType permission to use projectType instances
+    const defaultTeamTypeProperties = forge.defaultTeamType.properties
+    defaultTeamTypeProperties.instances = {
+        [projectType.hashid]: { active: true }
+    }
+    forge.defaultTeamType.properties = defaultTeamTypeProperties
+    await forge.defaultTeamType.save()
+
+    forge.user = userAlice
+    forge.team = team1
+    forge.stack = stack
+    forge.template = template
+    forge.projectType = projectType
+    forge.application = application
+    forge.project = forge.instance = instance
+
+    return forge
+}
+
+setup.setupStripe = StripeMock
+setup.resetStripe = () => {
+    delete require.cache[require.resolve('stripe')]
+}
+
+module.exports = setup

--- a/test/unit/forge/housekeeper/tasks/deviceUnusedReminder_spec.js
+++ b/test/unit/forge/housekeeper/tasks/deviceUnusedReminder_spec.js
@@ -1,0 +1,110 @@
+const should = require('should') // eslint-disable-line
+const sinon = require('sinon')
+
+const unusedDeviceReminderTask = require('../../../../../forge/housekeeper/tasks/deviceUnusedReminder')
+
+const setup = require('../setup')
+
+describe('Device Unused Reminder Task', function () {
+    /** @type {import('../setup').TestApplication} */
+    let app
+
+    before(async function () {
+        app = await setup()
+        sinon.stub(app.postoffice, 'send').callsFake(() => {
+            return Promise.resolve()
+        })
+    })
+
+    after(async function () {
+        await app.close()
+    })
+
+    beforeEach(async function () {
+        await app.db.models.Device.destroy({ where: {} })
+        app.postoffice.send.resetHistory()
+    })
+
+    async function forceUpdateDeviceCreatedAt (device, date) {
+        device.changed('createdAt', true)
+        device.set('createdAt', date || new Date('2000-01-01T00:00:00Z'), { raw: true })
+        await device.save({ silent: true, fields: ['createdAt'] })
+        await device.reload()
+    }
+
+    it('should not send email if there are no devices', async function () {
+        // run the task
+        await unusedDeviceReminderTask.run(app)
+        // check that send was not called
+        app.postoffice.send.called.should.be.false()
+    })
+
+    it('should send email for unused devices created less than 14 days ago', async function () {
+        // create a new device and add it to team
+        const device1 = await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
+        const device2 = await app.factory.createDevice({ name: 'app-dev-2' }, app.team, null, app.application)
+        const device3 = await app.factory.createDevice({ name: 'app-dev-3' }, app.team, null, app.application)
+        device1.lastSeenAt = null
+        device2.lastSeenAt = null
+        device3.lastSeenAt = null
+        device3.createdAt = new Date()
+        await device1.save()
+        await device2.save()
+
+        // Force device3 to be created before 14 days ago. Ref: https://github.com/sequelize/sequelize/issues/3759#issuecomment-1580202535
+        await forceUpdateDeviceCreatedAt(device3, device3.createdAt.getDate() - 16)
+
+        // run the task
+        await unusedDeviceReminderTask.run(app)
+        // check that send was called twice (once for each device created less than 14 days ago)
+        app.postoffice.send.calledTwice.should.be.true()
+
+        app.postoffice.send.firstCall.args[0].should.be.an.Object()
+        app.postoffice.send.firstCall.args[0].email.should.equal('alice@example.com')
+        app.postoffice.send.firstCall.args[1].should.equal('DeviceUnusedReminder')
+        app.postoffice.send.firstCall.args[2].should.be.an.Object()
+        app.postoffice.send.firstCall.args[2].should.have.property('url', `${app.config.base_url}/device/${device1.hashid}`)
+        app.postoffice.send.firstCall.args[2].should.have.property('teamName', 'ATeam')
+        app.postoffice.send.firstCall.args[2].deviceName.should.have.property('text', 'app-dev-1')
+        app.postoffice.send.firstCall.args[2].deviceName.should.have.property('html', 'app-dev-1')
+
+        app.postoffice.send.secondCall.args[0].should.be.an.Object()
+        app.postoffice.send.secondCall.args[0].email.should.equal('alice@example.com')
+        app.postoffice.send.secondCall.args[1].should.equal('DeviceUnusedReminder')
+        app.postoffice.send.secondCall.args[2].should.be.an.Object()
+        app.postoffice.send.secondCall.args[2].should.have.property('url', `${app.config.base_url}/device/${device2.hashid}`)
+        app.postoffice.send.secondCall.args[2].should.have.property('teamName', 'ATeam')
+        app.postoffice.send.secondCall.args[2].deviceName.should.have.property('text', 'app-dev-2')
+        app.postoffice.send.secondCall.args[2].deviceName.should.have.property('html', 'app-dev-2')
+    })
+
+    it('should not send email if team has any used devices', async function () {
+        // create a new device and add it to team
+        const device1 = await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
+        const device2 = await app.factory.createDevice({ name: 'app-dev-2' }, app.team, null, app.application)
+        device1.lastSeenAt = new Date()
+        device2.lastSeenAt = null
+        await device1.save()
+        await device2.save()
+
+        // run the task
+        await unusedDeviceReminderTask.run(app)
+        // check that send was not called
+        app.postoffice.send.called.should.be.false()
+    })
+
+    it('should not send email if unused devices were created more than 14 days ago', async function () {
+        // create a new device and add it to team
+        const device1 = await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
+        const device2 = await app.factory.createDevice({ name: 'app-dev-2' }, app.team, null, app.application)
+        device1.lastSeenAt = null
+        device2.lastSeenAt = null
+        await forceUpdateDeviceCreatedAt(device1, device1.createdAt.getDate() - 16)
+        await forceUpdateDeviceCreatedAt(device2, device2.createdAt.getDate() - 16)
+
+        // run the task
+        await unusedDeviceReminderTask.run(app)
+        // check that send was not called
+        app.postoffice.send.called.should.be.false()
+    })
+})


### PR DESCRIPTION
closes #5450
## Description

Sends team owners an email, for each unseen device, every 24h between 0700~0800 when:
* All team devices are unseen (i.e. new user, never connected a device before)
* User is not suspended
* Team is not suspended
* Team trial does not have state `ENDED`
* Only devices that were created <= 14 days ago


### Tests added in line with design discussion [here](https://github.com/FlowFuse/flowfuse/issues/5450#issuecomment-2858231984)
```
▼ Device Unused Reminder Task
  ✔ should not send email if there are no devices
  ✔ should send email for unused devices created less than 14 days ago
  ✔ should not send email if team has any used devices
  ✔ should not send email if unused devices were created more than 14 days ago
  ✔ should not send email for unused devices where team is suspended
  ✔ should not send email for unused devices to users who are suspended
  ✔ should not send any emails when all users are suspended
  ✔ should not send any email when team trial has ended
```

### Results

#### Text Only Email clients will see (self hosted)
```text
Hello steve-mcl,

Congratulations on creating your remote instance 'test-import-on-setup' which you can see here: http://<host>/device/X46Oa5EOab!

To access the editor for this instance, you will need to install the Device Agent and connect it to the platform.

The documentation at https://flowfuse.com/docs/device-agent/quickstart/ will guide you through the process (it contains a video walkthrough as well).

If you have trouble with any part of the setup process, contact support.

Best regards,

The FlowFuse Team
```

#### HTML Email clients will see (self hosted)

![image](https://github.com/user-attachments/assets/446e9435-b562-448b-b4f4-1a9c1a92c1f5)


#### Text Only Email clients will see (FFC/Staging)
```text
Hello steve-mcl,

Congratulations on creating your remote instance 'test-import-on-setup' which you can see here: http://<host>/device/X46Oa5EOab!

To access the editor for this instance, you will need to install the Device Agent and connect it to the platform.

The documentation at https://flowfuse.com/docs/device-agent/quickstart/ will guide you through the process (it contains a video walkthrough as well).

If you have trouble with any part of the setup process, feel free to contact support via https://flowfuse.com/support/

Best regards,

The FlowFuse Team
```

#### HTML Email clients will see (FFC/Staging)

![image](https://github.com/user-attachments/assets/5767c664-448f-4726-a85e-f0bfa34327f2)


## Related Issue(s)

#5450

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

