### PR TITLE
Scroll the side menu when needed

### DIFF
--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -717,6 +717,7 @@ $nav_height: 60px;
         left: 0;
         background: $ff-color--context-menu;
         border-right: 1px solid $ff-color--border;
+        overflow: auto;
 
         .ff-main-navigation {
             .ff-menu-groups {


### PR DESCRIPTION
## Description

Allow the side menu to scroll when needed. On tablets or similar devices some modes might require the sidebar to scroll, dependent on resolution.

https://github.com/user-attachments/assets/bf846940-8040-4bc0-8ae1-b1d585070041


## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/5535

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

