### PR TITLE
Add more context to the snapshot selector in the pipeline stages

### DIFF
--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -56,14 +56,27 @@
                     <FormRow data-form="snapshot" containerClass="w-full">
                         Source Snapshot
                         <template #input>
-                            <ff-listbox
+                            <ff-combobox
                                 v-if="hasSnapshots"
                                 v-model="input.selectedSnapshotId"
                                 :options="snapshotOptions"
+                                :extend-search-keys="['description', 'user.username']"
                                 placeholder="Select a snapshot"
                                 data-form="snapshot-select"
                                 class="w-full"
-                            />
+                            >
+                                <template #option="{ option, selected, active }">
+                                    <div class="ff-option-content" :class="{ selected, active }">
+                                        <div class="flex justify-between mb-2">
+                                            <span>{{ option.label }}</span>
+                                            <span v-if="option.user.username" class="text-gray-400">{{ option.user.username }}</span>
+                                        </div>
+                                        <p class="pl-5 text-italic text-gray-400">
+                                            {{ option.description }}
+                                        </p>
+                                    </div>
+                                </template>
+                            </ff-combobox>
                             <div v-else class="error-banner">
                                 There are no snapshots to choose from for this stage's
                                 <template v-if="stage.stageType == StageType.INSTANCE">
@@ -213,7 +226,10 @@ export default {
 
                 return {
                     value: snapshot.id,
-                    label: `${snapshot.name}${isActive ? ' (active)' : ''}`
+                    label: `${snapshot.name}${isActive ? ' (active)' : ''}`,
+                    id: snapshot.id,
+                    description: snapshot?.description ?? null,
+                    user: snapshot?.user ?? null
                 }
             })
         },


### PR DESCRIPTION
## Description

Now that we have the combobox available, we can type search through options.

I extended the combobox to be able to take on multiple search parameters, even on nested keys and also allowed for the customization of its options list.

I swapped the listbox on the pipelines stage selector with the combobox, added the user and description for the user to see when selecting options while also extending the search functionality to search through the username and description.

https://github.com/user-attachments/assets/a838009c-bdcd-46af-8db2-622a5aabb2d8

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/4476

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

