### PR TITLE
Highlight search matches when filtering broker topics

### DIFF
--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
@@ -37,6 +37,7 @@
                         :is-last-sibling="key === Object.keys(hierarchy).length-1"
                         :is-root="true"
                         :selected-segment="selectedSegment"
+                        :filter-term="filterTerm"
                         @segment-selected="$emit('segment-selected', $event)"
                         @segment-state-changed="toggleSegmentVisibility"
                     />


### PR DESCRIPTION
## Description

Added highlight functionality on topic segments. The way of doing it seems convoluted, but it's a workaround to using v-html and protect against xss

https://github.com/user-attachments/assets/89f4736c-d110-41da-b363-ece5b47de5fc

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5211

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

