### PR TITLE
Blueprint auto import

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -294,7 +294,16 @@ These settings enable per team Node-RED private catalogue generation
 
 Option        | Description
 --------------|------------
-`npmRegistry.enabled` | Enables NPM Registry support. Default: false
+`npmRegistry.enabled` | Enables NPM Registry support. Default: `false`
 `npmRegistry.url` | The URL for the Verdaccio NPM Registry. Default: none
 `npmRegistry.admin.username` | Username for Verdaccio admin user
 `npmRegistry.admin.password` | Password for Verdaccio admin user
+
+
+## BluePrint Updates
+
+For Licenses instances these options control how new BluePrints are imported
+
+`blueprintImport.enabled` | Enables the import of new BluePrints from FlowFuse. Default: `true`
+`blueprintImport.export` | Enables the API endpoint to export the local BluePrints. Default: `false`
+`blueprintImport.url` | The URL to import BluePrints from. Default: `https://app.flowfuse.com/api/v1/flow-blueprints/export-public`

--- a/forge/db/migrations/20250513-01-EE-add-imported-bp-id.js
+++ b/forge/db/migrations/20250513-01-EE-add-imported-bp-id.js
@@ -1,0 +1,20 @@
+/**
+ * Add imported ID to BluePrints
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        await context.addColumn('FlowTemplates', 'importedId', {
+            type: DataTypes.STRING,
+            allowNull: true,
+            defaultValue: null
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/ee/db/views/FlowTemplate.js
+++ b/forge/ee/db/views/FlowTemplate.js
@@ -78,6 +78,7 @@ module.exports = function (app) {
                 items: {
                     type: 'object',
                     properties: {
+                        id: { type: 'string' },
                         name: { type: 'string' },
                         description: { type: 'string' },
                         category: { type: 'string' },
@@ -91,8 +92,8 @@ module.exports = function (app) {
         }
     })
 
-    function flowBlueprintExport (blueprint) {
-        return {
+    function flowBlueprintExport (blueprint, includeId = false) {
+        const returnedBlueprint = {
             name: blueprint.name,
             description: blueprint.description,
             category: blueprint.category,
@@ -100,6 +101,11 @@ module.exports = function (app) {
             flows: blueprint.flows,
             modules: blueprint.modules
         }
+
+        if (includeId) {
+            returnedBlueprint.id = blueprint.hashid
+        }
+        return returnedBlueprint
     }
 
     return {

--- a/forge/ee/routes/flowBlueprints/index.js
+++ b/forge/ee/routes/flowBlueprints/index.js
@@ -272,7 +272,7 @@ module.exports = async function (app) {
     if (app.config.blueprintImport?.export) {
         app.get('/export-public', {
             config: {
-                allowAnonymous: true,
+                allowAnonymous: true
             },
             schema: {
                 summary: 'Export one or more Blueprints',

--- a/forge/ee/routes/flowBlueprints/index.js
+++ b/forge/ee/routes/flowBlueprints/index.js
@@ -294,7 +294,7 @@ module.exports = async function (app) {
                 }
             }
         }, async (request, reply) => {
-            let where = {}
+            let where = { active: true }
             if (request.query.id && typeof request.query.id === 'string') {
                 where = { id: app.db.models.FlowTemplate.decodeHashid(request.query.id)[0] }
             } else if (request.query.id && Array.isArray(request.query.id)) {

--- a/forge/ee/routes/flowBlueprints/index.js
+++ b/forge/ee/routes/flowBlueprints/index.js
@@ -277,9 +277,6 @@ module.exports = async function (app) {
             schema: {
                 summary: 'Export one or more Blueprints',
                 tags: ['Flow Blueprints'],
-                query: {
-                    id: { type: 'array', items: { type: 'string' } }
-                },
                 response: {
                     200: {
                         type: 'object',
@@ -294,15 +291,10 @@ module.exports = async function (app) {
                 }
             }
         }, async (request, reply) => {
-            let where = { active: true }
-            if (request.query.id && typeof request.query.id === 'string') {
-                where = { id: app.db.models.FlowTemplate.decodeHashid(request.query.id)[0] }
-            } else if (request.query.id && Array.isArray(request.query.id)) {
-                where = { id: request.query.id.map(i => app.db.models.FlowTemplate.decodeHashid(i)[0]) }
-            }
-            const flowTemplates = await app.db.models.FlowTemplate.getAll({}, where)
+            const flowTemplates = await app.db.models.FlowTemplate.getAll({}, { active: true })
+            const modified = flowTemplates.templates.map(bp => app.db.views.FlowTemplate.flowBlueprintExport(bp, true))
             reply.send({
-                blueprints: flowTemplates.templates.map(bp => app.db.views.FlowTemplate.flowBlueprintExport(bp)),
+                blueprints: modified,
                 count: flowTemplates.templates.length
             })
         })

--- a/forge/housekeeper/index.js
+++ b/forge/housekeeper/index.js
@@ -133,6 +133,7 @@ module.exports = fp(async function (app, _opts) {
     await registerTask(require('./tasks/telemetryMetrics'))
     await registerTask(require('./tasks/expireInvites'))
     await registerTask(require('./tasks/inviteReminder'))
+    await registerTask(require('./tasks/blueprintImport'))
 
     app.addHook('onReady', async () => {
         let promise = Promise.resolve()

--- a/forge/housekeeper/tasks/blueprintImport.js
+++ b/forge/housekeeper/tasks/blueprintImport.js
@@ -4,24 +4,24 @@ const { randomInt } = require('../utils')
 
 async function fetch (app) {
     try {
-        const url = app.config.blueprintImport.url || "https://flowfuse.com/api/v1/flow-blueprints/export-public"
-        const blueprints = await axios.get(app.config.blueprintImport.url, {})
+        const url = app.config.blueprintImport.url || 'https://flowfuse.com/api/v1/flow-blueprints/export-public'
+        const blueprints = await axios.get(url, {})
         const existingBlueprints = await app.db.models.FlowTemplate.getAll()
         for (const blueprint of blueprints.data.blueprints) {
             const existingBlueprint = existingBlueprints.templates.find(b => b.name === blueprint.name)
             if (existingBlueprint) {
-                console.log(`Blueprint ${blueprint.name} already exists`)
-                //await app.db.models.FlowTemplate.update(existingBlueprint.id, blueprint)
+                app.log.info(`Blueprint ${blueprint.name} already exists`)
+                // await app.db.models.FlowTemplate.update(existingBlueprint.id, blueprint)
             } else {
                 blueprint.order = 0
                 blueprint.default = false
                 blueprint.active = true
-                console.log(`Creating new blueprint ${blueprint.name}`)
+                app.log.info(`Creating new blueprint ${blueprint.name}`)
                 await app.db.models.FlowTemplate.create(blueprint)
             }
         }
     } catch (err) {
-        console.log('Error fetching blueprints', err)
+        app.log.error(`Error fetching blueprints ${err.message}`)
     }
 }
 
@@ -33,7 +33,6 @@ module.exports = {
     // and on a random day of the week.
     schedule: `${randomInt(0, 59)} ${randomInt(0, 23)} * * ${randomInt(0, 6)}`,
     run: async function (app) {
-        console.log('Testing blueprint import')
         if (app.license.active() && app.config.blueprintImport.enabled) {
             await fetch(app)
         }

--- a/forge/housekeeper/tasks/blueprintImport.js
+++ b/forge/housekeeper/tasks/blueprintImport.js
@@ -10,12 +10,21 @@ async function fetch (app) {
         for (const blueprint of blueprints.data.blueprints) {
             const existingBlueprint = existingBlueprints.templates.find(b => b.name === blueprint.name)
             if (existingBlueprint) {
-                app.log.info(`Blueprint ${blueprint.name} already exists, skipping`)
+                app.log.info(`Blueprint ${blueprint.name} already exists, checking if imported`)
                 // await app.db.models.FlowTemplate.update(existingBlueprint.id, blueprint)
+                if (existingBlueprint.importedId === blueprint.id) {
+                    existingBlueprint.modules = blueprint.modules
+                    existingBlueprint.flows = blueprint.flows
+                    existingBlueprint.description = blueprint.description
+                    existingBlueprint.category = blueprint.category
+                    existingBlueprint.icon = blueprint.icon
+                }
             } else {
                 blueprint.order = 0
                 blueprint.default = false
                 blueprint.active = true
+                blueprint.importedId = blueprint.id
+                blueprint.id = undefined
                 app.log.info(`Creating new blueprint ${blueprint.name}`)
                 await app.db.models.FlowTemplate.create(blueprint)
             }

--- a/forge/housekeeper/tasks/blueprintImport.js
+++ b/forge/housekeeper/tasks/blueprintImport.js
@@ -1,0 +1,27 @@
+const axios = require('axios')
+
+const { randomInt } = require('../utils')
+
+async function fetch (app) {
+    try {
+        const url = app.config.blueprintImport.url || "https://flowfuse.com/api/v1/flow-blueprints/export-public"
+        const blueprints = await axios.get(app.config.blueprintImport.url, {})
+        console.log(blueprints.data) 
+    } catch (err) {
+        console.log('Error fetching blueprints', err)
+    }
+}
+
+module.exports = {
+    name: 'blueprintImport',
+    startup: 10000,
+    // Pick a random hour/minute for this task to run at. If the application is
+    // horizontal scaled, this will avoid two instances running at the same time
+    schedule: `${randomInt(0, 59)} ${randomInt(0, 23)} * * *`,
+    run: async function (app) {
+        console.log('Testing blueprint import')
+        if (app.license.active() && app.config.blueprintImport.enabled) {
+            await fetch(app)
+        }
+    }
+}

--- a/forge/housekeeper/tasks/blueprintImport.js
+++ b/forge/housekeeper/tasks/blueprintImport.js
@@ -10,7 +10,7 @@ async function fetch (app) {
         for (const blueprint of blueprints.data.blueprints) {
             const existingBlueprint = existingBlueprints.templates.find(b => b.name === blueprint.name)
             if (existingBlueprint) {
-                app.log.info(`Blueprint ${blueprint.name} already exists`)
+                app.log.info(`Blueprint ${blueprint.name} already exists, skipping`)
                 // await app.db.models.FlowTemplate.update(existingBlueprint.id, blueprint)
             } else {
                 blueprint.order = 0

--- a/forge/housekeeper/tasks/blueprintImport.js
+++ b/forge/housekeeper/tasks/blueprintImport.js
@@ -42,7 +42,7 @@ module.exports = {
     // and on a random day of the week.
     schedule: `${randomInt(0, 59)} ${randomInt(0, 23)} * * ${randomInt(0, 6)}`,
     run: async function (app) {
-        if (app.license.active() && app.config.blueprintImport.enabled) {
+        if (app.license.active() && app.config.blueprintImport?.enabled !== false) {
             await fetch(app)
         }
     }

--- a/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
+++ b/test/unit/forge/ee/routes/api/flowBlueprints_spec.js
@@ -33,7 +33,11 @@ describe('Flow Blueprints API', function () {
     }
 
     before(async function () {
-        app = await setup()
+        app = await setup({
+            blueprintImport: {
+                export: true
+            }
+        })
         sandbox.stub(app.log, 'info')
         sandbox.stub(app.log, 'warn')
         sandbox.stub(app.log, 'error')
@@ -698,6 +702,16 @@ describe('Flow Blueprints API', function () {
             const body = response.json()
             body.should.have.property('count', 1)
             body.blueprints[0].name.should.equal('Default (new)')
+        })
+        it('Public Export with no authentication', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/flow-blueprints/export-public'
+            })
+            const body = response.json()
+            response.should.have.property('statusCode', 200)
+            body.should.have.property('count')
+            body.should.have.property('blueprints')
         })
     })
 })


### PR DESCRIPTION
fixes #5179
## Description

<!-- Describe your changes in detail -->
Adds a Housekeeping task to pull the latest BluePrints from FFC once a week for Licensed self hosted users.

The job runs 30 seconds after startup if a license is active or once a week (on a random day of the week and at a random time) to pull new Blueprints.

Enabled by default, but can be disabled (e.g. for FFC), the default URL to pull the BluePrint Bundle from can be set in the flowforge.yml file and if to enable the export API endpoint (unauthenticated)

```
blueprintImport:
  enabled: true,
  export: true,
  url: http://localhost:3000/api/v1/flow-blueprints/export-public
```

Do not merge until helm and CloudProject changes merged

- [x] Helm https://github.com/FlowFuse/helm/pull/601
- [ ] CloudProject https://github.com/FlowFuse/CloudProject/pull/707

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#5179

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [x] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

