### PR TITLE
Improve the grid layout of the Blueprint tiles

### DIFF
--- a/frontend/src/components/multi-step-forms/instance/steps/BlueprintStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/BlueprintStep.vue
@@ -18,7 +18,7 @@
                             >
                                 <h3>{{ $categoryName }}</h3>
                                 <hr class="my-3">
-                                <ul class="ff-blueprint-tiles flex gap-5 flex-wrap">
+                                <ul class="ff-blueprint-tiles grid sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-5">
                                     <li v-for="(blueprint, $key) in category" :key="$key" class="tile">
                                         <BlueprintTile
                                             :blueprint="blueprint"
@@ -184,7 +184,9 @@ export default {
 
         .ff-blueprint-tiles {
             .ff-blueprint-tile {
-                width: 280px;
+                max-width: 280px;
+                width: 100%;
+                height: 100%;
             }
         }
     }

--- a/test/e2e/frontend/cypress/tests-ee/blueprints/blueprints.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/blueprints/blueprints.spec.js
@@ -116,11 +116,12 @@ describe('FlowForge - Blueprints', () => {
         // select the second blueprint
         cy.get('[data-group="blueprints"]')
             .eq(1)
+            .find('[data-el="blueprint-tile"]')
             .first()
             .click()
 
         // check our newly selected blueprint is now selected
-        cy.get('[data-el="blueprint-tile"].active').contains(multipleBlueprints.blueprints[2].name)
+        cy.get('[data-el="blueprint-tile"].active').contains(multipleBlueprints.blueprints[1].name)
     })
 
     it('are included in the POST request when creating an Instance', () => {


### PR DESCRIPTION
## Description

<img width="1728" alt="Screenshot 2025-05-12 at 12 47 35" src="https://github.com/user-attachments/assets/1a05e9a8-fd1d-4658-aed8-c071dc6d8d23" />

Ensures the full width of the area is used, introduced dynamic grid sizings based on screen size, and consistency in heights of the tiles.

## Related Issue(s)

Closes #5529 