### PR TITLE
Ensure SSO managed memberships cannot be modified

### DIFF
--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -291,6 +291,26 @@ module.exports.init = async function (app) {
         }
         return false
     }
+
+    /**
+     * Checks to see if the user's membership of the specified team is managed by SSO\
+     * @param {User} user The user object
+     * @param {Team} team The team object
+     * @returns {boolean} True if the membership is managed by SSO
+     */
+    async function isUserMembershipManaged (user, team) {
+        // Checks to see if the user's membership of the specified team is managed by SSO
+        // 1. check if the user's email is managed by SSO
+        const provider = await app.db.models.SAMLProvider.forEmail(user.email)
+        if (provider) {
+            const options = provider.getOptions()
+            if (options.groupAllTeams || (options.groupTeams || []).includes(team.slug)) {
+                return true
+            }
+        }
+        return false
+    }
+
     /**
      * Update a user's team memberships according to the SAML Assertions
      * received when they logged in.
@@ -580,6 +600,7 @@ module.exports.init = async function (app) {
         isSSOEnabledForEmail,
         getProviderOptions,
         getProviderForEmail,
-        updateTeamMembership
+        updateTeamMembership,
+        isUserMembershipManaged
     }
 }

--- a/forge/routes/api/teamMembers.js
+++ b/forge/routes/api/teamMembers.js
@@ -27,6 +27,14 @@ module.exports = async function (app) {
                     }
                     request.userRole = await request.user.getTeamMembership(request.params.teamId)
                 }
+                if (app.config.features.enabled('sso')) {
+                    if (await app.sso.isUserMembershipManaged(request.user, request.team)) {
+                        // The user's membership for this team is sso managed - do not allow api changes to be applied
+                        reply.code(400).send({ code: 'invalid_request', error: 'Cannot modify team membershipt for an SSO managed user' })
+                        // eslint-disable-next-line no-useless-return
+                        return
+                    }
+                }
             } catch (err) {
                 console.error(err)
                 reply.code(404).send({ code: 'not_found', error: 'Not Found' })


### PR DESCRIPTION
This ensures that a user's team membership that is managed via SSO cannot be modified via the local api. The SSO Group remains single source of truth