### PR TITLE
Remove extra info logging when running unused devices housekeeper task

### DIFF
--- a/forge/housekeeper/tasks/deviceUnusedReminder.js
+++ b/forge/housekeeper/tasks/deviceUnusedReminder.js
@@ -51,7 +51,6 @@ module.exports = {
             for (const [teamId, team] of uniqueTeams) {
                 const subscription = await team.getSubscription()
                 if (subscription && subscription.trialStatus === app.db.models.Subscription.TRIAL_STATUS.ENDED) {
-                    app.log.info(`Skip sending unused device reminder to users of team ${team.hashid} (${team.name}) because it is expired`)
                     uniqueTeams.delete(teamId)
                 }
             }

--- a/test/unit/forge/housekeeper/tasks/deviceUnusedReminder_spec.js
+++ b/test/unit/forge/housekeeper/tasks/deviceUnusedReminder_spec.js
@@ -33,7 +33,6 @@ describe('Device Unused Reminder Task', function () {
         app.user.suspended = false
         await app.user.save()
         // reset spies
-        app.log.info.reset()
         app.log.warn.reset()
         app.postoffice.send.resetHistory()
     })
@@ -184,8 +183,5 @@ describe('Device Unused Reminder Task', function () {
 
         // app.db.models.Subscription should have been called with the team id
         app.db.models.Subscription.byTeamId.calledWith(app.team.id).should.be.true()
-
-        // should have logged a message about skipping the team
-        app.log.info.calledWith(`Skip sending unused device reminder to users of team ${app.team.hashid} (${app.team.name}) because it is expired`).should.be.true()
     })
 })


### PR DESCRIPTION
closes #5533 

## Description

Remove app.log.info as per [suggestion](https://github.com/FlowFuse/flowfuse/pull/5513#discussion_r2087194010)

## Related Issue(s)

#5533 
#5513

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

