### PR TITLE
Aligned the create team enterprise form wit the billing upgrade form

### DIFF
--- a/frontend/src/composables/Hubspot.js
+++ b/frontend/src/composables/Hubspot.js
@@ -1,0 +1,49 @@
+import { defineComponent } from 'vue'
+
+import ObjectProperties from '../pages/team/Brokers/Hierarchy/components/schema/ObjectProperties.vue'
+import Dialog from '../services/dialog.js'
+
+export function useHubspotHelper () {
+    const talkToSalesCalendarModal = (user) => {
+        Dialog.show({
+            header: 'Talk to sales to Upgrade to Enterprise',
+            kind: 'primary',
+            boxClass: 'ff-dialog-box--wide',
+            confirmLabel: 'Close',
+            canBeCanceled: false,
+            is: {
+                // eslint-disable-next-line vue/one-component-per-file
+                component: defineComponent({
+                    components: { ObjectProperties },
+                    computed: {
+                        url () {
+                            const url = new URL('flowfuse/book-a-demo-call', 'https://meetings-eu1.hubspot.com')
+                            url.searchParams.set('embed', true)
+                            url.searchParams.set('firstName', user.name.split(' ')[0])
+                            url.searchParams.set('lastName', user.name.split(' ')[1] ?? '')
+                            url.searchParams.set('email', user.email)
+
+                            return url.toString()
+                        }
+                    },
+                    mounted () {
+                        // Create and inject the HubSpot script tag
+                        const script = document.createElement('script')
+                        script.type = 'text/javascript'
+                        script.src = 'https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js'
+                        script.async = true
+                        document.body.appendChild(script)
+                    },
+                    template: `
+                            <p>Unlock advanced features, dedicated support, and enterprise scale capabilities. Schedule a call to discuss your needs.</p>
+                            <div class="meetings-iframe-container" :data-src="url"></div>
+                          `
+                })
+            }
+        })
+    }
+
+    return {
+        talkToSalesCalendarModal
+    }
+}

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -1,7 +1,7 @@
 <template>
     <ff-page>
         <ff-loading v-if="loading" message="Updating Team..." />
-        <div v-else class="m-auto">
+        <div v-else>
             <form class="space-y-6">
                 <div>
                     <FormHeading>Change your team type</FormHeading>
@@ -76,7 +76,6 @@
 
 <script>
 import { ChevronLeftIcon } from '@heroicons/vue/outline'
-import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
 
 import billingApi from '../../api/billing.js'
@@ -84,18 +83,21 @@ import instanceTypesApi from '../../api/instanceTypes.js'
 import teamApi from '../../api/team.js'
 import teamTypesApi from '../../api/teamTypes.js'
 import FormHeading from '../../components/FormHeading.vue'
+import { useHubspotHelper } from '../../composables/Hubspot.js'
 
 import Alerts from '../../services/alerts.js'
-import Dialog from '../../services/dialog.js'
 import Product from '../../services/product.js'
-
-import ObjectProperties from './Brokers/Hierarchy/components/schema/ObjectProperties.vue'
 
 // eslint-disable-next-line vue/one-component-per-file
 export default {
     name: 'ChangeTeamType',
     components: {
         FormHeading
+    },
+    setup () {
+        const { talkToSalesCalendarModal } = useHubspotHelper()
+
+        return { talkToSalesCalendarModal }
     },
     data () {
         return {
@@ -308,43 +310,7 @@ export default {
             }
         },
         sendContact: async function () {
-            const user = this.user
-            Dialog.show({
-                header: 'Talk to sales to Upgrade to Enterprise',
-                kind: 'primary',
-                boxClass: 'ff-dialog-box--wide',
-                confirmLabel: 'Close',
-                canBeCanceled: false,
-                is: {
-                    // eslint-disable-next-line vue/one-component-per-file
-                    component: defineComponent({
-                        components: { ObjectProperties },
-                        computed: {
-                            url () {
-                                const url = new URL('flowfuse/book-a-demo-call', 'https://meetings-eu1.hubspot.com')
-                                url.searchParams.set('embed', true)
-                                url.searchParams.set('firstName', user.name.split(' ')[0])
-                                url.searchParams.set('lastName', user.name.split(' ')[1] ?? '')
-                                url.searchParams.set('email', user.email)
-
-                                return url.toString()
-                            }
-                        },
-                        mounted () {
-                            // Create and inject the HubSpot script tag
-                            const script = document.createElement('script')
-                            script.type = 'text/javascript'
-                            script.src = 'https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js'
-                            script.async = true
-                            document.body.appendChild(script)
-                        },
-                        template: `
-                            <p>Unlock advanced features, dedicated support, and enterprise scale capabilities. Schedule a call to discuss your needs.</p>
-                            <div class="meetings-iframe-container" :data-src="url"></div>
-                          `
-                    })
-                }
-            })
+            this.talkToSalesCalendarModal(this.user)
         }
     }
 }

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -9,8 +9,8 @@
         </template>
         <ff-loading v-if="redirecting" message="Redirecting to Stripe..." />
         <ff-loading v-else-if="loading" message="Creating Team..." />
-        <div v-else class="m-auto max-w-5xl" :class="presetTeamType ? 'flex flex-col gap-4 sm:flex-row sm:gap-0' : 'space-y-6 max-w-4xl m-auto'">
-            <div v-if="presetTeamType" class="w-full max-w-lg">
+        <div v-else :class="presetTeamType ? 'flex flex-col gap-4 sm:flex-row sm:gap-0' : 'space-y-6 mb-5'">
+            <div v-if="presetTeamType" class="w-full">
                 <team-type-tile class="m-auto" :team-type="presetTeamType" :enableCTA="false" />
             </div>
             <form>
@@ -67,7 +67,7 @@
                         <p>To learn more about our {{ input.teamType?.name }} plan, click below to contact our sales team.</p>
                     </div>
                     <ff-button @click="sendContact()">
-                        Contact Sales
+                        Talk to sales
                     </ff-button>
                 </template>
             </form>
@@ -79,18 +79,22 @@
 import { ChevronLeftIcon, ExternalLinkIcon } from '@heroicons/vue/solid'
 import { mapState } from 'vuex'
 
-import billingApi from '../../api/billing.js'
 import teamApi from '../../api/team.js'
 import teamTypesApi from '../../api/teamTypes.js'
 import teamsApi from '../../api/teams.js'
 import FormRow from '../../components/FormRow.vue'
 
 import TeamTypeTile from '../../components/TeamTypeTile.vue'
-import Alerts from '../../services/alerts.js'
+import { useHubspotHelper } from '../../composables/Hubspot.js'
 import slugify from '../../utils/slugify.js'
 
 export default {
     name: 'CreateTeam',
+    setup () {
+        const { talkToSalesCalendarModal } = useHubspotHelper()
+
+        return { talkToSalesCalendarModal }
+    },
     data () {
         return {
             mounted: false,
@@ -255,15 +259,7 @@ export default {
             }, 200)
         },
         sendContact: async function () {
-            if (this.input.teamType) {
-                billingApi.sendTeamTypeContact(this.user, this.input.teamType, 'Create Team').then(() => {
-                    this.$router.go(-1)
-                    Alerts.emit('Thanks for getting in touch. We will contact you soon regarding your request.', 'info', 15000)
-                }).catch(err => {
-                    Alerts.emit('Something went wrong with the request. Please try again or contact support for help.', 'info', 15000)
-                    console.error('Failed to submit hubspot form: ', err)
-                })
-            }
+            this.talkToSalesCalendarModal(this.user)
         }
     },
     components: {


### PR DESCRIPTION
## Description

- extracted the hubspot modal in a composable to use it in both places.
- minor styling fixes with margin alignment that broke after the full height pages
- aligned tile behavior from the create team page with the tiles from the billing page (full width container, tiles wrapping automatically)

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5330

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

