### PR TITLE
Ensure name check runs when duplicating an Instance

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -1231,7 +1231,7 @@ module.exports = async function (app) {
             reply.code(400).send({ code: 'invalid_name', error: 'Invalid name' })
             return
         }
-        const safeName = name.trime().toLowerCase()
+        const safeName = name.trim().toLowerCase()
         if (app.db.models.Project.BANNED_NAME_LIST.includes(safeName)) {
             reply.status(409).send({ code: 'invalid_project_name', error: 'name not allowed' })
         }

--- a/frontend/src/api/instances.js
+++ b/frontend/src/api/instances.js
@@ -199,6 +199,11 @@ const checkCustomHostnameStatus = async (instanceId) => {
     })
 }
 
+const nameCheck = async (instanceName) => {
+    return client.post('/api/v1/projects/check-name', { name: instanceName })
+        .then(res => res.data)
+}
+
 export default {
     create,
     getInstance,
@@ -225,5 +230,6 @@ export default {
     disableProtectedMode,
     setCustomHostname,
     clearCustomHostname,
-    checkCustomHostnameStatus
+    checkCustomHostnameStatus,
+    nameCheck
 }

--- a/frontend/src/components/multi-step-forms/instance/MultiStepApplicationsInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepApplicationsInstanceForm.vue
@@ -229,6 +229,8 @@ export default {
                         if (err.response.data.code === 'invalid_project_name') {
                             this.form[INSTANCE_SLUG].errors.name = err.response.data.error
                         }
+                        const error = err.response.data.error
+                        Alerts.emit('Failed to create the application: ' + error, 'warning', 7500)
                     }
 
                     const idx = this.formSteps.findIndex(step => step.sliderTitle === 'Instance')

--- a/frontend/src/components/multi-step-forms/instance/steps/InstanceStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/InstanceStep.vue
@@ -285,16 +285,22 @@ export default {
         'input.name': {
             immediate: true,
             handler: debounce(function (value) {
-                instancesApi.nameCheck(value)
-                    .then(res => {
-                        this.errors.name = null
-                    })
-                    .catch(e => {
-                        this.errors.name = 'Instance name already in use.'
-                    })
+                const allowedCharacters = /^([a-zA-Z0-9-]+)(:\d+)?(\/[^\s<>"'#]*)?$/
+
+                if (allowedCharacters.test(value)) {
+                    instancesApi.nameCheck(value)
+                        .then(res => {
+                            this.errors.name = null
+                        })
+                        .catch(e => {
+                            this.errors.name = 'Instance name already in use.'
+                        })
+                } else {
+                    this.errors.name = 'Invalid character in use.'
+                }
             }, 500)
         },
-        'input.errors': {
+        errors: {
             deep: true,
             handler: function () {
                 this.updateParent()


### PR DESCRIPTION
## Description

Added a new check-name API call, implemented a watcher with a debouncer on the instance name, and slightly styled the name error message to prevent layout shifts when errors are displayed.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5540

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

