### PR TITLE
Add support for Git Pull in pipeline

### DIFF
--- a/docs/user/devops-pipelines.md
+++ b/docs/user/devops-pipelines.md
@@ -69,7 +69,6 @@ There are four types of stage to chose from:
 4. **Git Repository** - a remote GitHub repository.
     -  This stage currently only supports:
        - Repositories hosted on GitHub.com
-       - Pushing snapshots to the repostitory; pulling snapshots back from the respository will be added in a future release
 
 ### Actions
 
@@ -104,7 +103,15 @@ When a Device Group stage is triggered, it will push the current active snapshot
 
 #### Git Repository stage
 
-Currently, the Git Repository stage can only be the last stage of a pipeline. It supports pushing a snapshot to the git repository, but support for pulling it back will come in a future release.
+Git Repository stages can be used to push and pull snapshots from a GitHub hosted repository. The stage can be configured with
+the branch to push/pull from as well as the filename to use for the snapshot.
+
+If a filename is not configured, it will generate the filename when pushing to the repository based on the name of Instance, Device
+or Device Group that provided the snapshot.
+
+When pulling from a repository, if the stage has not previously been used to push to the repository, the filename is a required property.
+
+It is also possible to configure the stage with different branches for the push and pull actions. This enables a GitHub-based review process as part of the pipeline; using a Pull Request process to review and approve the changes before merging between the two branches.
 
 #### Deploy to Devices
 

--- a/forge/db/migrations/20250516-01-EE-add-path-to-pipeline-stage-git-repo.js
+++ b/forge/db/migrations/20250516-01-EE-add-path-to-pipeline-stage-git-repo.js
@@ -1,0 +1,39 @@
+/**
+ * Add PipelineStageGitRepo table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        await context.addColumn('PipelineStageGitRepos', 'pushPath', {
+            type: DataTypes.STRING,
+            default: '',
+            allowNull: true
+        })
+        await context.addColumn('PipelineStageGitRepos', 'lastPushPath', {
+            type: DataTypes.STRING,
+            default: '',
+            allowNull: true
+        })
+        await context.addColumn('PipelineStageGitRepos', 'pullBranch', {
+            type: DataTypes.STRING,
+            default: 'main',
+            allowNull: true
+        })
+        await context.addColumn('PipelineStageGitRepos', 'pullPath', {
+            type: DataTypes.STRING,
+            default: '',
+            allowNull: true
+        })
+        await context.addColumn('PipelineStageGitRepos', 'lastPullAt', {
+            type: DataTypes.DATE,
+            allowNull: true
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -131,17 +131,6 @@ module.exports = {
                     }
                 }
             } else if (options.gitTokenId) {
-                if (orderedStages.length === 0) {
-                    // this should never be reached but here for completeness
-                    throw new PipelineControllerError('invalid_input', 'A Git Repository cannot be the first stage', 400)
-                }
-                // if the first stage is the same as the stage being updated, then it's the first stage
-                if (firstStage && firstStage.id === stage.id) {
-                    throw new PipelineControllerError('invalid_input', 'A Git Repository cannot be the first stage', 400)
-                }
-                if (laterStages && laterStages.length) {
-                    throw new PipelineControllerError('invalid_input', 'This stage cannot be a Git Repository as it is not the last stage', 400)
-                }
                 // TODO: code duplication between here and the create path to validate ownership of the gitToken
                 const gitTokenId = app.db.models.GitToken.decodeHashid(options.gitTokenId)
                 let gitToken
@@ -315,12 +304,6 @@ module.exports = {
             }
         }
 
-        if (options.gitTokenId) {
-            if (stages.length === 0) {
-                throw new PipelineControllerError('invalid_input', 'A Git Repository cannot be the first stage', 400)
-            }
-        }
-
         const transaction = await app.db.sequelize.transaction()
         try {
             const stage = await app.db.models.PipelineStage.create(options, { transaction })
@@ -369,9 +352,10 @@ module.exports = {
         const sourceInstances = await sourceStage.getInstances()
         const sourceDevices = await sourceStage.getDevices()
         const sourceDeviceGroups = await sourceStage.getDeviceGroups()
-        const totalSources = sourceInstances.length + sourceDevices.length + sourceDeviceGroups.length
+        const sourceGitRepo = await sourceStage.getPipelineStageGitRepo()
+        const totalSources = sourceInstances.length + sourceDevices.length + sourceDeviceGroups.length + (sourceGitRepo ? 1 : 0)
         if (totalSources === 0) {
-            throw new PipelineControllerError('invalid_stage', 'Source stage must have at least one instance or device', 400)
+            throw new PipelineControllerError('invalid_stage', 'Source stage must have at least one instance, device, device group or git repo', 400)
         }
         if (totalSources > 1) {
             throw new PipelineControllerError('invalid_stage', 'Deployments are currently only supported for source stages with a single instance or device', 400)
@@ -402,12 +386,17 @@ module.exports = {
         const targetObject = targetInstance || targetDevice || targetDeviceGroup
 
         const sourceType = sourceInstance ? 'instance' : (sourceDevice ? 'device' : (sourceDeviceGroup ? 'device group' : ''))
-        const sourceApplication = await app.db.models.Application.byId(sourceObject.ApplicationId)
-        if (!sourceApplication) {
-            throw new PipelineControllerError('invalid_stage', `Source ${sourceType} must be associated with an application`, 400)
+
+        let sourceApplication
+        // Anything but a git repo must be associated with an application
+        if (sourceObject) {
+            sourceApplication = await app.db.models.Application.byId(sourceObject.ApplicationId)
+            if (!sourceApplication) {
+                throw new PipelineControllerError('invalid_stage', `Source ${sourceType} must be associated with an application`, 400)
+            }
         }
 
-        if (targetObject) {
+        if (sourceObject && targetObject) {
             // Only applies for instance/device/device group targets
             const targetType = targetInstance ? 'instance' : (targetDevice ? 'device' : (targetDeviceGroup ? 'device group' : ''))
             const targetApplication = await app.db.models.Application.byId(targetObject.ApplicationId)
@@ -429,6 +418,7 @@ module.exports = {
             targetDevice,
             sourceDeviceGroup,
             targetDeviceGroup,
+            sourceGitRepo,
             targetGitRepo,
             targetStage
         }

--- a/forge/ee/db/models/PipelineStage.js
+++ b/forge/ee/db/models/PipelineStage.js
@@ -201,7 +201,10 @@ module.exports = {
                     if (existingRepoStage) {
                         existingRepoStage.GitTokenId = GitTokenId
                         existingRepoStage.url = gitOptions.url
-                        existingRepoStage.branch = gitOptions.branch
+                        existingRepoStage.branch = gitOptions.branch || ''
+                        existingRepoStage.pullBranch = gitOptions.pullBranch || ''
+                        existingRepoStage.pushPath = gitOptions.pushPath || ''
+                        existingRepoStage.pullPath = gitOptions.pullPath || ''
                         if (gitOptions.credentialSecret) {
                             existingRepoStage.credentialSecret = gitOptions.credentialSecret
                         }
@@ -210,7 +213,10 @@ module.exports = {
                         await this.createPipelineStageGitRepo({
                             GitTokenId,
                             url: gitOptions.url,
-                            branch: gitOptions.branch,
+                            branch: gitOptions.branch || '',
+                            pullBranch: gitOptions.pullBranch || '',
+                            pushPath: gitOptions.pushPath || '',
+                            pullPath: gitOptions.pullPath || '',
                             credentialSecret: gitOptions.credentialSecret
                         }, options)
                     }

--- a/forge/ee/db/models/PipelineStageGitRepo.js
+++ b/forge/ee/db/models/PipelineStageGitRepo.js
@@ -7,22 +7,55 @@ module.exports = {
             type: DataTypes.STRING,
             allowNull: false
         },
+        // The branch to push updates to
         branch: {
             type: DataTypes.STRING,
             allowNull: false,
             default: 'main'
         },
+        // The branch to pull updates from. Defaults to '', meaning
+        // use the same as 'branch'.
+        pullBranch: {
+            type: DataTypes.STRING,
+            default: ''
+        },
+        // The path to push to in the repo. If blank, derives the name
+        // from the source of the snapshot.
+        pushPath: {
+            type: DataTypes.STRING,
+            default: ''
+        },
+        // The path that was actually pushed to the last time the stage ran.
+        // Allows the pull operation to retrieve the file if it was derived
+        lastPushPath: {
+            type: DataTypes.STRING,
+            default: ''
+        },
+        // When the last push ran
         lastPushAt: {
             type: DataTypes.DATE
         },
+        // The path to pull from. If blank, uses 'lastPushPath'. If that is also
+        // blank, it will fail.
+        pullPath: {
+            type: DataTypes.STRING,
+            default: ''
+        },
+        // When the last pull ran
+        lastPullAt: {
+            type: DataTypes.DATE
+        },
+        // The last status of the stage
         status: {
             type: DataTypes.STRING,
             default: ''
         },
+        // Any message associated with the last status
         statusMessage: {
             type: DataTypes.STRING,
             default: ''
         },
+        // The credential secret to use for export/import of the flows
         credentialSecret: {
             type: DataTypes.STRING,
             default: ''
@@ -60,9 +93,12 @@ module.exports = {
                     setImmediate(async () => {
                         try {
                             const gitToken = await this.getGitToken()
-                            let targetFilename = 'snapshot.json'
+                            let targetFilename = this.pushPath
                             if (options.sourceObject?.name) {
                                 targetFilename = 'snapshot-' + options.sourceObject.name + '.json'
+                            }
+                            if (!targetFilename) {
+                                targetFilename = 'snapshot.json'
                             }
                             await app.gitops.pushToRepository({
                                 token: gitToken.token,
@@ -72,6 +108,7 @@ module.exports = {
                                 path: targetFilename
                             }, snapshot, options)
 
+                            this.lastPushPath = targetFilename
                             this.status = 'success'
                             this.statusMessage = ''
                             await this.save()

--- a/forge/ee/db/models/PipelineStageGitRepo.js
+++ b/forge/ee/db/models/PipelineStageGitRepo.js
@@ -94,7 +94,7 @@ module.exports = {
                         try {
                             const gitToken = await this.getGitToken()
                             let targetFilename = this.pushPath
-                            if (options.sourceObject?.name) {
+                            if (!targetFilename && options.sourceObject?.name) {
                                 targetFilename = 'snapshot-' + options.sourceObject.name + '.json'
                             }
                             if (!targetFilename) {

--- a/forge/ee/db/views/PipelineStage.js
+++ b/forge/ee/db/views/PipelineStage.js
@@ -24,7 +24,11 @@ module.exports = function (app) {
                     gitTokenId: { type: 'string' },
                     url: { type: 'string' },
                     branch: { type: 'string' },
+                    pullBranch: { type: 'string' },
+                    pushPath: { type: 'string' },
+                    pullPath: { type: 'string' },
                     lastPushAt: { type: 'string' },
+                    lastPullAt: { type: 'string' },
                     status: { type: 'string' },
                     statusMessage: { type: 'string' },
                     credentialSecret: { type: 'boolean' }
@@ -60,7 +64,11 @@ module.exports = function (app) {
                 gitTokenId: app.db.models.GitToken.encodeHashid(stage.PipelineStageGitRepo.GitTokenId),
                 url: stage.PipelineStageGitRepo.url,
                 branch: stage.PipelineStageGitRepo.branch,
+                pullBranch: stage.PipelineStageGitRepo.pullBranch,
+                pushPath: stage.PipelineStageGitRepo.pushPath,
+                pullPath: stage.PipelineStageGitRepo.pullPath,
                 lastPushAt: stage.PipelineStageGitRepo.lastPushAt,
+                lastPullAt: stage.PipelineStageGitRepo.lastPullAt,
                 status: stage.PipelineStageGitRepo.status,
                 statusMessage: stage.PipelineStageGitRepo.statusMessage,
                 // Never return the secret - but indicate if one is set

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -255,6 +255,9 @@ module.exports = async function (app) {
                     gitTokenId: { type: 'string' },
                     url: { type: 'string' },
                     branch: { type: 'string' },
+                    pullBranch: { type: 'string' },
+                    pushPath: { type: 'string' },
+                    pullPath: { type: 'string' },
                     credentialSecret: { type: 'string' },
                     source: { type: 'string' }
                 }
@@ -281,6 +284,9 @@ module.exports = async function (app) {
             gitTokenId,
             url,
             branch,
+            pullBranch,
+            pushPath,
+            pullPath,
             credentialSecret
         } = request.body
         let stage
@@ -295,6 +301,9 @@ module.exports = async function (app) {
                 gitTokenId,
                 url,
                 branch,
+                pullBranch,
+                pushPath,
+                pullPath,
                 credentialSecret
             }
             if (request.body.source) {
@@ -359,6 +368,9 @@ module.exports = async function (app) {
                     gitTokenId: { type: 'string' },
                     url: { type: 'string' },
                     branch: { type: 'string' },
+                    pullBranch: { type: 'string' },
+                    pushPath: { type: 'string' },
+                    pullPath: { type: 'string' },
                     credentialSecret: { type: 'string' },
                     source: { type: 'string' }
                 }
@@ -384,6 +396,9 @@ module.exports = async function (app) {
                 gitTokenId: request.body.gitTokenId,
                 url: request.body.url,
                 branch: request.body.branch,
+                pullBranch: request.body.pullBranch,
+                pushPath: request.body.pushPath,
+                pullPath: request.body.pullPath,
                 credentialSecret: request.body.credentialSecret
             }
 
@@ -510,8 +525,10 @@ module.exports = async function (app) {
             const sourceStage = await app.db.models.PipelineStage.byId(
                 request.params.stageId
             )
-
-            if (sourceStage?.action === app.db.models.PipelineStage.SNAPSHOT_ACTIONS.NONE) {
+            // A blank action is okay if the stage is a git repo.
+            // TODO: would it be cleaner to have a GIT Action? Not sure as it only applies to the one stage type.
+            const gitRepo = await sourceStage?.getPipelineStageGitRepo()
+            if (!gitRepo && sourceStage?.sourceStage?.action === app.db.models.PipelineStage.SNAPSHOT_ACTIONS.NONE) {
                 // Nothing to do
                 reply.code(200).send({ status: 'okay' })
                 return
@@ -524,6 +541,7 @@ module.exports = async function (app) {
                 targetDevice,
                 sourceDeviceGroup,
                 targetDeviceGroup,
+                sourceGitRepo,
                 targetGitRepo,
                 targetStage
             } = await app.db.controllers.Pipeline.validateSourceStageForDeploy(
@@ -566,6 +584,11 @@ module.exports = async function (app) {
             } else if (sourceDeviceGroup) {
                 sourceSnapshot = await app.db.controllers.Pipeline.getSnapshotForSourceDeviceGroup(sourceDeviceGroup)
                 sourceDeployed = sourceDeviceGroup
+            } else if (sourceGitRepo) {
+                sourceSnapshot = await sourceGitRepo.pull()
+                if (!sourceSnapshot) {
+                    throw new Error(sourceGitRepo.statusMessage || 'Failed to pull from Git repository')
+                }
             } else {
                 throw new Error('No source device or instance found.')
             }

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -588,7 +588,7 @@ module.exports = async function (app) {
             } else if (sourceGitRepo) {
                 sourceSnapshot = await sourceGitRepo.pull()
                 if (!sourceSnapshot) {
-                    throw new Error(sourceGitRepo.statusMessage || 'Failed to pull from Git repository')
+                    throw new ControllerError('deploy_failed', sourceGitRepo.statusMessage || 'Failed to pull from Git repository')
                 }
             } else {
                 throw new Error('No source device or instance found.')

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -528,7 +528,8 @@ module.exports = async function (app) {
             // A blank action is okay if the stage is a git repo.
             // TODO: would it be cleaner to have a GIT Action? Not sure as it only applies to the one stage type.
             const gitRepo = await sourceStage?.getPipelineStageGitRepo()
-            if (!gitRepo && sourceStage?.sourceStage?.action === app.db.models.PipelineStage.SNAPSHOT_ACTIONS.NONE) {
+
+            if (!gitRepo && sourceStage?.action === app.db.models.PipelineStage.SNAPSHOT_ACTIONS.NONE) {
                 // Nothing to do
                 reply.code(200).send({ status: 'okay' })
                 return

--- a/forge/lib/pipelineValidation.js
+++ b/forge/lib/pipelineValidation.js
@@ -34,7 +34,7 @@ const pipelineStageRules = {
         canBeFirst: true,
         canBeLast: true,
         canPrecede: ['*'],
-        canFollow: ['INSTANCE', 'DEVICE'],
+        canFollow: ['INSTANCE', 'DEVICE', 'GITHUB_REPO'],
         mustBeLast: false,
         canBeMoreThanOne: true
     },
@@ -44,7 +44,7 @@ const pipelineStageRules = {
         canBeFirst: true,
         canBeLast: true,
         canPrecede: ['*'],
-        canFollow: ['INSTANCE', 'DEVICE'],
+        canFollow: ['INSTANCE', 'DEVICE', 'GITHUB_REPO'],
         mustBeLast: false,
         canBeMoreThanOne: true
     },
@@ -54,19 +54,19 @@ const pipelineStageRules = {
         canBeFirst: false,
         canBeLast: true,
         canPrecede: ['DEVICE_GROUP', 'GITHUB_REPO'],
-        canFollow: ['DEVICE_GROUP', 'INSTANCE', 'DEVICE'],
+        canFollow: ['DEVICE_GROUP', 'INSTANCE', 'DEVICE', 'GITHUB_REPO'],
         canBeMoreThanOne: true,
         mustBeLast: false
     },
     GITHUB_REPO: {
         type: 'GITHUB_REPO',
         description: 'Git Repository',
-        canBeFirst: false,
+        canBeFirst: true,
         canBeLast: true,
-        canFollow: ['INSTANCE', 'DEVICE', 'DEVICE_GROUP'],
-        canPrecede: [],
-        mustBeLast: true,
-        canBeMoreThanOne: false
+        canFollow: ['*'],
+        canPrecede: ['*'],
+        mustBeLast: false,
+        canBeMoreThanOne: true
     }
 }
 // freeze the rules so they cannot be modified
@@ -87,7 +87,7 @@ const getPipelineStageRule = (stage) => {
         return pipelineStageRules.DEVICE
     } else if (stage.Instances?.length || stage.instance || stage.stageType === 'instance') {
         return pipelineStageRules.INSTANCE
-    } else if (stage.PipelineStageGitRepo?.gitTokenId || stage.gitRepo?.gitTokenId || stage.stageType === 'git-repo') {
+    } else if (stage.PipelineStageGitRepo?.GitTokenId || stage.gitRepo?.GitTokenId || stage.stageType === 'git-repo') {
         return pipelineStageRules.GITHUB_REPO
     }
     return null

--- a/frontend/src/api/pipeline.js
+++ b/frontend/src/api/pipeline.js
@@ -82,6 +82,9 @@ const addPipelineStage = async (pipelineId, stage) => {
         options.gitTokenId = stage.gitTokenId
         options.url = stage.url
         options.branch = stage.branch
+        options.pullBranch = stage.pullBranch
+        options.pushPath = stage.pushPath
+        options.pullPath = stage.pullPath
         options.credentialSecret = stage.credentialSecret
         delete options.instanceId
         delete options.deviceGroupId

--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -17,6 +17,7 @@
             <AnimIconRestarting v-if="status === 'restarting'" class="w-4 h-4" />
             <AnimIconInstalling v-if="status === 'importing'" class="w-4 h-4" />
             <AnimIconPushing v-if="status === 'pushing'" class="w-4 h-4" />
+            <AnimIconPulling v-if="status === 'pulling'" class="w-4 h-4" />
             <AnimIconStarting v-if="status === 'starting'" class="w-4 h-4" />
             <CloudUploadIcon v-if="status === 'loading'" class="w-4 h-4" />
             <AnimIconInstalling v-if="status === 'installing' || status === 'updating'" class="w-3 h-3" />
@@ -43,6 +44,7 @@ import {
 
 import {
     AnimIconInstalling,
+    AnimIconPulling,
     AnimIconPushing,
     AnimIconRestarting,
     AnimIconStarting
@@ -63,6 +65,7 @@ export default {
         RefreshIcon,
         AnimIconInstalling,
         AnimIconPushing,
+        AnimIconPulling,
         AnimIconRestarting,
         AnimIconStarting
     },

--- a/frontend/src/components/icons-animated/Pulling.vue
+++ b/frontend/src/components/icons-animated/Pulling.vue
@@ -1,0 +1,54 @@
+<template>
+    <div class="ff-icon-anim ff-icon-pulling">
+        <ArrowDownIcon />
+    </div>
+</template>
+
+<script>
+import {
+    ArrowDownIcon
+} from '@heroicons/vue/outline'
+
+export default {
+    name: 'AnimIconPulling',
+    components: {
+        ArrowDownIcon
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+
+.ff-icon-anim {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.ff-icon-pulling {
+    overflow: hidden;
+}
+
+.ff-icon-pulling svg {
+    --anim-time: 0.75s;
+    position: relative;
+    color: currentColor;
+    animation: ff-icon-pulling var(--anim-time) infinite linear;
+    animation-delay: calc(var(--anim-time) / 2);
+}
+
+@keyframes ff-icon-pulling {
+  0% {
+    opacity: 0;
+    transform: translate(0, -100%);
+  }
+  50% {
+    opacity: 1;
+    transform: translate(0, 0);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(0, 100%);
+  }
+}
+</style>

--- a/frontend/src/components/icons-animated/index.js
+++ b/frontend/src/components/icons-animated/index.js
@@ -1,9 +1,11 @@
 import AnimIconInstalling from './Installing.vue'
+import AnimIconPulling from './Pulling.vue'
 import AnimIconPushing from './Pushing.vue'
 import AnimIconRestarting from './Restarting.vue'
 import AnimIconStarting from './Starting.vue'
 
 export {
+    AnimIconPulling,
     AnimIconPushing,
     AnimIconRestarting,
     AnimIconStarting,

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -15,6 +15,9 @@
                 <template v-if="stage.stageType === StageType.DEVICEGROUP">
                     use the group's target snapshot from "{{ stage.name }}" and
                 </template>
+                <template v-else-if="stage.stageType === StageType.GITREPO">
+                    pull the snapshot from the configured Git repository and
+                </template>
                 <template v-else-if="stage.action === StageAction.CREATE_SNAPSHOT">
                     create a new snapshot in "{{ stage.name }}" and
                 </template>
@@ -24,11 +27,11 @@
                 <template v-else-if="stage.action === StageAction.PROMPT">
                     use the snapshot selected below from "{{ stage.name }}" and
                 </template>
-                <template v-if="target?.stageType !== StageType.GITREPO">
-                    copy over all flows, nodes, environment variables and credentials to "{{ target?.name }}".
+                <template v-if="target?.stageType === StageType.GITREPO">
+                    push it to the configured Git repository.
                 </template>
                 <template v-else>
-                    push it to the configured Git repository.
+                    copy over all flows, nodes, environment variables and credentials to "{{ target?.name }}".
                 </template>
             </p>
             <template v-if="target?.stageType === StageType.DEVICEGROUP">
@@ -241,6 +244,9 @@ export default {
             this.$refs.dialog.close()
         },
         fetchData: async function () {
+            if (this.stage.stageType === StageType.GITREPO) {
+                return
+            }
             this.loadingSnapshots = true
 
             if (this.stage.stageType === StageType.DEVICE) {

--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -128,9 +128,7 @@ export default {
             return this.scopedPipeline.name?.length > 0
         },
         addStageAvailable () {
-            return (this.pipeline.stages.length === 0 ||
-                this.pipeline.stages[this.pipeline.stages.length - 1].stageType !== StageType.GITREPO) &&
-                this.hasPermission('pipeline:edit')
+            return this.hasPermission('pipeline:edit')
         },
         stagesWithStates () {
             return this.pipeline.stages.map((stage) => {
@@ -238,10 +236,11 @@ export default {
             return false
         },
         nextStageAvailable (stage, $index) {
-            if (stage.type === StageType.GITREPO) {
-                return false
-            }
             const endofPipeline = ($index >= this.pipeline.stages.length - 1)
+            if (!endofPipeline && stage.stageType === StageType.GITREPO) {
+                // A git repo stage can pull as long as it is not the last stage
+                return true
+            }
             if (stage.action !== StageAction.NONE && !endofPipeline) {
                 // we are mid-pipeline
                 const nextStage = this.pipeline.stages[$index + 1]

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -132,11 +132,23 @@
             <template v-if="stage.stageType == StageType.GITREPO">
                 <div class="ff-pipeline-stage-row">
                     <label>Branch:</label>
-                    <span>{{ stage.gitRepo?.branch || 'main' }}</span>
+                    <div>
+                        <template v-if="!stage.gitRepo?.pullBranch || stage.gitRepo?.pullBranch === stage.gitRepo?.branch">
+                            <div>{{ stage.gitRepo?.branch || 'main' }}</div>
+                        </template>
+                        <template v-else>
+                            <div>{{ stage.gitRepo?.branch || 'main' }} (push)</div>
+                            <div>{{ stage.gitRepo?.pullBranch || 'main' }} (pull)</div>
+                        </template>
+                    </div>
                 </div>
-                <div class="ff-pipeline-stage-row">
+                <div v-if="!isFirstStage" class="ff-pipeline-stage-row">
                     <label>Last Pushed:</label>
                     <span v-ff-tooltip="stage.state?.lastPushAt || stage.gitRepo?.lastPushAt ||'Never'">{{ (stage.state?.lastPushAt || stage.gitRepo?.lastPushAt) ? daysSince((stage.state?.lastPushAt || stage.gitRepo?.lastPushAt)) : 'Never' }}</span>
+                </div>
+                <div class="ff-pipeline-stage-row">
+                    <label>Last Pulled:</label>
+                    <span v-ff-tooltip="stage.state?.lastPullAt || stage.gitRepo?.lastPullAt ||'Never'">{{ (stage.state?.lastPullAt || stage.gitRepo?.lastPullAt) ? daysSince((stage.state?.lastPullAt || stage.gitRepo?.lastPullAt)) : 'Never' }}</span>
                 </div>
                 <div v-if="stage.state?.status" class="ff-pipeline-stage-row">
                     <label>Status:</label>
@@ -148,7 +160,7 @@
                 </div>
             </template>
 
-            <div v-if="playEnabled" class="ff-pipeline-stage-row">
+            <div v-if="playEnabled && stage.stageType !== StageType.GITREPO" class="ff-pipeline-stage-row">
                 <label>Deploy Action:</label>
                 <span>
                     <template v-if="stage.stageType === StageType.DEVICEGROUP">
@@ -258,6 +270,9 @@ export default {
         return { hasPermission }
     },
     computed: {
+        isFirstStage () {
+            return this.stageIndex === 0
+        },
         stageIndex () {
             return this.pipeline.stages.indexOf(this.stage)
         },
@@ -324,7 +339,6 @@ export default {
                 await PipelineAPI.deployPipelineStage(this.pipeline.id, this.stage.id, sourceSnapshot?.id)
             } catch (error) {
                 this.$emit('stage-deploy-failed')
-
                 if (error.response?.data?.error) {
                     return Alerts.emit(error.response.data.error, 'warning')
                 }

--- a/frontend/src/pages/application/PipelineStage/create.vue
+++ b/frontend/src/pages/application/PipelineStage/create.vue
@@ -117,6 +117,9 @@ export default {
                 options.gitTokenId = input.gitTokenId
                 options.url = input.url
                 options.branch = input.branch
+                options.pullBranch = input.pullBranch
+                options.pullPath = input.pullPath
+                options.pushPath = input.pushPath
                 options.credentialSecret = input.credentialSecret
             }
 

--- a/frontend/src/pages/application/PipelineStage/edit.vue
+++ b/frontend/src/pages/application/PipelineStage/edit.vue
@@ -129,6 +129,9 @@ export default {
                 options.gitTokenId = input.gitTokenId
                 options.url = input.url
                 options.branch = input.branch
+                options.pullBranch = input.pullBranch
+                options.pullPath = input.pullPath
+                options.pushPath = input.pushPath
                 if (input.credentialSecret) {
                     // Only pass back a non-blank value. This avoids overwriting
                     // the existing value

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -65,8 +65,6 @@
                     :value="StageType.GITREPO"
                     description=""
                     color="#e46133"
-                    :disabled="isFirstStage"
-                    disabledTooltip="Git Repository stages can only follow an Instance stage"
                 >
                     <template #icon><IconGit /></template>
                 </ff-tile-selection-option>
@@ -164,16 +162,43 @@
                     </template>
                 </FormRow>
                 <FormRow
+                    v-model="input.pushPath"
+                    :error="errors.pushPath"
+                    type="text"
+                    data-form="stage-repo-pushPath"
+                    :placeholder="isFirstStage ? 'e.g. snapshot.json' : 'Generate filename from source stage'"
+                >
+                    <template #default>
+                        Snapshot Filename
+                    </template>
+                    <template #description>
+                        The filename to use for the snapshot. <span v-if="!isFirstStage">If left blank, the name will be generated from the source stage when pushing to the repository.</span>
+                    </template>
+                </FormRow>
+                <FormRow
                     v-model="input.branch"
                     type="text"
                     data-form="stage-repo-branch"
-                    placeholder="e.g. main"
+                    placeholder="default: main"
                 >
                     <template #default>
-                        Repository Branch
+                        Push Branch
                     </template>
                     <template #description>
-                        The branch must already exist on the repository.
+                        The branch to push snapshots to. The branch must already exist on the repository.
+                    </template>
+                </FormRow>
+                <FormRow
+                    v-model="input.pullBranch"
+                    type="text"
+                    data-form="stage-repo-pull-branch"
+                    :placeholder="'default: ' + (input.branch || 'main')"
+                >
+                    <template #default>
+                        Pull Branch
+                    </template>
+                    <template #description>
+                        The branch to pull snapshots from. If not set it will use the Push Branch. The branch must already exist on the repository.
                     </template>
                 </FormRow>
                 <FormRow
@@ -323,6 +348,7 @@ import { StageAction, StageType } from '../../../api/pipeline.js'
 import teamApi from '../../../api/team.js'
 
 import FormRow from '../../../components/FormRow.vue'
+
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
 import IconDeviceGroupSolid from '../../../components/icons/DeviceGroupSolid.js'
 import IconDeviceSolid from '../../../components/icons/DeviceSolid.js'
@@ -388,6 +414,9 @@ export default {
                 gitTokenId: stage.gitRepo?.gitTokenId,
                 url: stage.gitRepo?.url,
                 branch: stage.gitRepo?.branch,
+                pullBranch: stage.gitRepo?.pullBranch,
+                pushPath: stage.gitRepo?.pushPath,
+                pullPath: stage.gitRepo?.pullPath,
                 credentialSecret: stage.gitRepo?.credentialSecret ? '__PLACEHOLDER__' : ''
             },
             newDeviceGroupInput: {
@@ -395,7 +424,8 @@ export default {
                 description: ''
             },
             errors: {
-                url: ''
+                url: '',
+                pushPath: ''
             },
             gitTokens: []
         }
@@ -465,6 +495,8 @@ export default {
                 (this.input.stageType === StageType.GITREPO && (
                     this.input.url !== this.stage.gitRepo?.url ||
                     this.input.branch !== this.stage.gitRepo?.branch ||
+                    this.input.pullBranch !== this.stage.gitRepo?.pullBranch ||
+                    this.input.pushPath !== this.stage.gitRepo?.pushPath ||
                     this.input.gitTokenId !== this.stage.gitRepo?.gitTokenId ||
                     (this.input.credentialSecret !== '' && this.input.credentialSecret !== '__PLACEHOLDER__')
                 ))
@@ -474,13 +506,13 @@ export default {
             return this.formDirty &&
                 (this.input.instanceId || this.input.deviceId || this.input.deviceGroupId || this.input.gitTokenId) &&
                 this.input.name &&
-                (this.input.stageType === StageType.DEVICEGROUP ? true : this.input.action) &&
+                ((this.input.stageType === StageType.DEVICEGROUP || this.input.stageType === StageType.GITREPO) ? true : this.input.action) &&
                 (this.input.stageType === StageType.GITREPO
                     ? (
                         this.input.url &&
                         this.errors.url === '' &&
-                        this.input.branch &&
-                        this.input.credentialSecret
+                        this.input.credentialSecret &&
+                        (!this.isFirstStage || this.input.pushPath !== '')
                     )
                     : true
                 ) &&
@@ -634,6 +666,13 @@ export default {
                 this.errors.url = 'Please enter a valid GitHub repository URL'
             } else {
                 this.errors.url = ''
+            }
+        },
+        'input.pushPath' (newPushPath, oldPushPath) {
+            if (newPushPath === '') {
+                this.errors.pushPath = 'Please enter a valid filename'
+            } else {
+                this.errors.pushPath = ''
             }
         }
     },

--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -251,7 +251,7 @@ export default {
                 this.startPollingForDeviceGroupsDeployStatus()
                 pollingStarted = true
             }
-            if (nextStage.gitRepo?.gitTokenId|| stage.gitRepo?.gitTokenId) {
+            if (nextStage.gitRepo?.gitTokenId || stage.gitRepo?.gitTokenId) {
                 this.startPollingForGitRepoStatus()
                 pollingStarted = true
             }

--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -236,6 +236,8 @@ export default {
             }
             if (stage.gitRepo?.gitTokenId) {
                 clearInterval(this.polling.gitRepos)
+                // Trigger one final update of status to ensure the state is updated
+                this.loadGitRepoStatus()
                 this.gitRepoStatusMap.get(stage.id).isDeploying = false
             }
         },

--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -202,6 +202,16 @@ export default {
             } else {
                 return console.warn('Deployment starting to stage without an instance, device or device group.')
             }
+            if (stage.gitRepo?.gitTokenId) {
+                // This is a pull from the repo
+                this.gitRepoStatusMap.set(stage.id, {
+                    isDeploying: true,
+                    pipeline,
+                    status: 'pulling',
+                    statusMessage: '',
+                    lastPushAt: Date.now()
+                })
+            }
         },
         stageDeployFailed (stage, nextStage, pipeline) {
             if (nextStage.instance?.id) {
@@ -224,17 +234,28 @@ export default {
                 clearInterval(this.polling.gitRepos)
                 this.gitRepoStatusMap.get(nextStage.id).isDeploying = false
             }
+            if (stage.gitRepo?.gitTokenId) {
+                clearInterval(this.polling.gitRepos)
+                this.gitRepoStatusMap.get(stage.id).isDeploying = false
+            }
         },
         startPollingForDeployStatus (stage, nextStage, pipeline) {
+            let pollingStarted = false
             if (nextStage.instance?.id) {
                 this.startPollingForInstanceDeployStatus()
+                pollingStarted = true
             } else if (nextStage.device?.id) {
                 this.startPollingForDeviceDeployStatus()
+                pollingStarted = true
             } else if (nextStage.deviceGroup?.id) {
                 this.startPollingForDeviceGroupsDeployStatus()
-            } else if (nextStage.gitRepo?.gitTokenId) {
+                pollingStarted = true
+            }
+            if (nextStage.gitRepo?.gitTokenId|| stage.gitRepo?.gitTokenId) {
                 this.startPollingForGitRepoStatus()
-            } else {
+                pollingStarted = true
+            }
+            if (!pollingStarted) {
                 return console.warn('Polling started for stage without an instance, device or device group.')
             }
         },
@@ -414,7 +435,7 @@ export default {
                 promises.push(PipelineAPI.getPipelineStage(status.pipeline.id, stageId)
                     .then((stage) => {
                         const currentStatus = this.gitRepoStatusMap.get(stageId)
-                        if (stage.gitRepo?.status === 'pushing') {
+                        if (stage.gitRepo?.status === 'pushing' || stage.gitRepo?.status === 'pulling') {
                             someDeploying = true
                         } else {
                             currentStatus.isDeploying = false

--- a/frontend/src/utils/pipelineValidation.js
+++ b/frontend/src/utils/pipelineValidation.js
@@ -34,7 +34,7 @@ const pipelineStageRules = {
         canBeFirst: true,
         canBeLast: true,
         canPrecede: ['*'],
-        canFollow: ['INSTANCE', 'DEVICE'],
+        canFollow: ['INSTANCE', 'DEVICE', 'GITHUB_REPO'],
         mustBeLast: false,
         canBeMoreThanOne: true
     },
@@ -44,7 +44,7 @@ const pipelineStageRules = {
         canBeFirst: true,
         canBeLast: true,
         canPrecede: ['*'],
-        canFollow: ['INSTANCE', 'DEVICE'],
+        canFollow: ['INSTANCE', 'DEVICE', 'GITHUB_REPO'],
         mustBeLast: false,
         canBeMoreThanOne: true
     },
@@ -54,19 +54,19 @@ const pipelineStageRules = {
         canBeFirst: false,
         canBeLast: true,
         canPrecede: ['DEVICE_GROUP', 'GITHUB_REPO'],
-        canFollow: ['DEVICE_GROUP', 'INSTANCE', 'DEVICE'],
+        canFollow: ['DEVICE_GROUP', 'INSTANCE', 'DEVICE', 'GITHUB_REPO'],
         canBeMoreThanOne: true,
         mustBeLast: false
     },
     GITHUB_REPO: {
         type: 'GITHUB_REPO',
         description: 'Git Repository',
-        canBeFirst: false,
+        canBeFirst: true,
         canBeLast: true,
-        canFollow: ['INSTANCE', 'DEVICE', 'DEVICE_GROUP'],
-        canPrecede: [],
-        mustBeLast: true,
-        canBeMoreThanOne: false
+        canFollow: ['*'],
+        canPrecede: ['*'],
+        mustBeLast: false,
+        canBeMoreThanOne: true
     }
 }
 // freeze the rules so they cannot be modified
@@ -87,7 +87,7 @@ const getPipelineStageRule = (stage) => {
         return pipelineStageRules.DEVICE
     } else if (stage.Instances?.length || stage.instance || stage.stageType === 'instance') {
         return pipelineStageRules.INSTANCE
-    } else if (stage.PipelineStageGitRepo?.gitTokenId || stage.gitRepo?.gitTokenId || stage.stageType === 'git-repo') {
+    } else if (stage.PipelineStageGitRepo?.GitTokenId || stage.gitRepo?.GitTokenId || stage.stageType === 'git-repo') {
         return pipelineStageRules.GITHUB_REPO
     }
     return null

--- a/test/unit/forge/lib/pipelineValidation_spec.js
+++ b/test/unit/forge/lib/pipelineValidation_spec.js
@@ -38,7 +38,7 @@ describe('Pipeline Validation', function () {
                 pls.Instances = stageType === 'instance' ? [{}] : undefined
                 pls.Devices = stageType === 'device' ? [{}] : undefined
                 pls.DeviceGroups = stageType === 'device-group' ? [{}] : undefined
-                pls.PipelineStageGitRepo = stageType === 'git-repo' ? { gitTokenId: 'abc123' } : undefined
+                pls.PipelineStageGitRepo = stageType === 'git-repo' ? { GitTokenId: 'abc123' } : undefined
             }
             if (clientSideProps) {
                 pls.instance = stageType === 'instance' ? {} : undefined
@@ -142,9 +142,9 @@ describe('Pipeline Validation', function () {
                 ;(() => validateStages(stages)).should.throw(/A Device Group Pipeline stage cannot be the first stage/)
             })
 
-            it('should fail: git repo as the first stage', function () {
+            it('should pass: git repo as the first stage', function () {
                 const stages = [createServerSideStage('git-repo')]
-                ;(() => validateStages(stages)).should.throw(/A Git Repository Pipeline stage cannot be the first stage/)
+                validateStages(stages).should.be.true()
             })
 
             it('should fail: device group -> instance', function () {
@@ -165,31 +165,31 @@ describe('Pipeline Validation', function () {
                 ;(() => validateStages(stages)).should.throw(/A Device Group Pipeline stage cannot precede a Remote Instance/)
             })
 
-            it('should fail: git repo -> instance', function () {
+            it('should pass: git repo -> instance', function () {
                 const stages = [
                     createServerSideStage('instance', 'id1', 'Instance 1'),
                     createServerSideStage('git-repo', 'id2', 'Git Repo 1'),
                     createServerSideStage('instance', 'id3', 'Instance 2')
                 ]
-                ;(() => validateStages(stages)).should.throw(/A Git Repository Pipeline stage must be the last stage/)
+                validateStages(stages).should.be.true()
             })
 
-            it('should fail: git repo -> device', function () {
+            it('should pass: git repo -> device', function () {
                 const stages = [
                     createServerSideStage('instance', 'id1', 'Instance 1'),
                     createServerSideStage('git-repo', 'id2', 'Git Repo 1'),
                     createServerSideStage('device', 'id3', 'Device 1')
                 ]
-                ;(() => validateStages(stages)).should.throw(/A Git Repository Pipeline stage must be the last stage/)
+                validateStages(stages).should.be.true()
             })
 
-            it('should fail: git repo -> device group', function () {
+            it('should pass: git repo -> device group', function () {
                 const stages = [
                     createServerSideStage('instance', 'id1', 'Instance 1'),
                     createServerSideStage('git-repo', 'id2', 'Git Repo 1'),
                     createServerSideStage('device-group', 'id3', 'Device Group 1')
                 ]
-                ;(() => validateStages(stages)).should.throw(/A Git Repository Pipeline stage must be the last stage/)
+                validateStages(stages).should.be.true()
             })
         })
         describe('Client Side Pipeline stages', function () {
@@ -282,9 +282,9 @@ describe('Pipeline Validation', function () {
                 ;(() => validateStages(stages)).should.throw(/A Device Group Pipeline stage cannot be the first stage/)
             })
 
-            it('should fail: git repo as the first stage', function () {
+            it('should pass: git repo as the first stage', function () {
                 const stages = [createClientSideStage('git-repo')]
-                ;(() => validateStages(stages)).should.throw(/A Git Repository Pipeline stage cannot be the first stage/)
+                validateStages(stages).should.be.true()
             })
 
             it('should fail: device group -> instance', function () {
@@ -305,31 +305,31 @@ describe('Pipeline Validation', function () {
                 ;(() => validateStages(stages)).should.throw(/A Device Group Pipeline stage cannot precede a Remote Instance/)
             })
 
-            it('should fail: git repo -> instance', function () {
+            it('should pass: git repo -> instance', function () {
                 const stages = [
                     createClientSideStage('instance', 'id1', 'Instance 1'),
                     createClientSideStage('git-repo', 'id2', 'Git Repo 1'),
                     createClientSideStage('instance', 'id3', 'Instance 2')
                 ]
-                ;(() => validateStages(stages)).should.throw(/A Git Repository Pipeline stage must be the last stage/)
+                validateStages(stages).should.be.true()
             })
 
-            it('should fail: git repo -> device', function () {
+            it('should pass: git repo -> device', function () {
                 const stages = [
                     createClientSideStage('instance', 'id1', 'Instance 1'),
                     createClientSideStage('git-repo', 'id2', 'Git Repo 1'),
                     createClientSideStage('device', 'id3', 'Device 1')
                 ]
-                ;(() => validateStages(stages)).should.throw(/A Git Repository Pipeline stage must be the last stage/)
+                validateStages(stages).should.be.true()
             })
 
-            it('should fail: git repo -> device group', function () {
+            it('should pass: git repo -> device group', function () {
                 const stages = [
                     createClientSideStage('instance', 'id1', 'Instance 1'),
                     createClientSideStage('git-repo', 'id2', 'Git Repo 1'),
                     createClientSideStage('device-group', 'id3', 'Device Group 1')
                 ]
-                ;(() => validateStages(stages)).should.throw(/A Git Repository Pipeline stage must be the last stage/)
+                validateStages(stages).should.be.true()
             })
         })
     })


### PR DESCRIPTION
Closes #5415 

## Description

Adds support for a git pipeline stage to pull from a repo.

The commits are ordered as follows:

1. Migration + backend updates to add necessarily properties to the Git pipeline stage model
2. Backend API to do the actual pull + deploy of the pipeline stage
3. UI updates


The git pipeline stage model is updated to include:
 - `pullBranch` - so a pipeline can be configured to push/pull from different branches; enabling a PR-based review workflow. It will default to the existing `branch` property (ie the same for push/pull).
 - `pushPath` - allow the user to specify the filename the snapshot should be saved as. Be default it derives the name from the source stage.
 - `lastPushPath` - the name of the last file pushed. This allows the stage to remember what it last saved, so the pull will know what file to retrieve.
 - `pullPath` - the filename to pull. This is needed if the stage is at the start of a pipeline - as we have no way of knowing what file to pull in that scenario.


The UI constraints around where a Git stage can be have been updated to allow the git stage to be at the start or mid-pipeline.

The stage UI now shows the info on push/pull state:

 - Here the push/pull branches are the same, so we only show it once.

<img width="335" alt="image" src="https://github.com/user-attachments/assets/3392cb66-00a8-42d0-b251-c6d08fe36425" />


- Here the push/pull branches are different, so both are shown.
<img width="358" alt="image" src="https://github.com/user-attachments/assets/1ebdfc89-00ec-4c0a-ac4e-ed6d6bb1da78" />

