### PR TITLE
ci: Ensure NR instances have unique names across all pre-staging environments

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -62,7 +62,7 @@ get_latest_image_tag() {
 }
 
 create_suspended_instance() {
-  local INSTANCE_NAME=$1
+  local INSTANCE_NAME=$1-$PR_NUMBER
   local TEAM_APPLICATION_ID=$2
   echo "Creating suspended $INSTANCE_NAME@$TEAM_APPLICATION_ID instance"
   INSTANCE_ID=$(curl -ks -XPOST \


### PR DESCRIPTION
## Description

This pull request updates the `initial-setup.sh` script to ensure that every Node-RED instance deployed across the whole cluster has unique name.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

