### PR TITLE
UI: Ensure Node-RED Logs render at full width

### DIFF
--- a/frontend/src/pages/instance/components/InstanceLogs.vue
+++ b/frontend/src/pages/instance/components/InstanceLogs.vue
@@ -8,7 +8,7 @@
     <div v-if="!instance.meta || instance.meta.state === 'suspended'" class="flex text-gray-500 justify-center italic mb-4 p-8">
         Logs unavailable
     </div>
-    <div v-else :class="showOfflineBanner ? 'forge-log-offline-background' : ''" class="mx-auto text-xs border bg-gray-800 text-gray-200 rounded p-2 font-mono">
+    <div v-else :class="showOfflineBanner ? 'forge-log-offline-background' : ''" class="w-full mx-auto text-xs border bg-gray-800 text-gray-200 rounded p-2 font-mono">
         <div v-if="prevCursor" class="flex">
             <a class="text-center w-full hover:text-blue-400 cursor-pointer pb-1" @click="loadPrevious">Load earlier...</a>
         </div>


### PR DESCRIPTION
## Description

Ensures the NR Logs render at full width. Problem occurs when there isn't a multi-line entry and the lgos are able to shrink in width, is not linked to, or caused by changes in #5528 so I made it a separate PR.

## Related Issue(s)

Fixes issue found here: https://github.com/FlowFuse/flowfuse/pull/5528#issuecomment-2921897005