### PR TITLE
Allow blank filename for git stages that are not the first

### DIFF
--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -676,7 +676,7 @@ export default {
             }
         },
         'input.pushPath' (newPushPath, oldPushPath) {
-            if (newPushPath === '') {
+            if (newPushPath === '' && this.isFirstStage) {
                 this.errors.pushPath = 'Please enter a valid filename'
             } else {
                 this.errors.pushPath = ''


### PR DESCRIPTION
The 'snapshot file name' field is optional *if* the pipeline stage is not the first stage. If it is the first stage, the filename is required.

The check for this wasn't taking into account the 'isFirstStage' part of the logic.