### PR TITLE
Enable `instanceResources` and `gitIntegration` on pre-staging

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -296,7 +296,9 @@ curl -ks -w "\n" -XPOST \
                         "staticAssets":true,
                         "bom":true,
                         "projectHistory":true,
-                        "teamBroker":true
+                        "teamBroker":true,
+                        "gitIntegration": true,
+                        "instanceResources":true
                     },
                     "instances": {
                         "'"$projectTypeId"'": {


### PR DESCRIPTION
## Description

This pull request enables `gitIntegration` and `instanceResources` features for enterprise team for pre-staging environments.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5571

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

