### PR TITLE
Disable blueprint import in e2e tests to avoid clash

### DIFF
--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -25,6 +25,9 @@ module.exports = async function (settings = {}, config = {}) {
         broker: {
             url: ':test:'
         },
+        blueprintImport: {
+            enabled: false
+        },
         ...config
     }
 


### PR DESCRIPTION
Fixes #5573 