### PR TITLE
Fix Broker page overflows and remove the topic inspector load more button

### DIFF
--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
@@ -11,7 +11,7 @@
             </template>
         </main-title>
 
-        <div class="space-y-3">
+        <div class="space-y-3 overflow-auto flex flex-col h-full">
             <ff-text-input
                 v-model="filterTerm"
                 class="ff-data-table--search"
@@ -252,13 +252,19 @@ export default {
 
 <style scoped lang="scss">
 .unified-namespace-hierarchy {
-    flex-grow: 1;
-    min-width: 50%;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    overflow: auto;
+
     .topics {
         background: $ff-white;
         padding: 10px;
         border-radius: 6px;
         border: 1px solid $ff-grey-200;
+        overflow: auto;
+        height: 100%;
     }
 }
 </style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
@@ -11,7 +11,7 @@
             </template>
         </main-title>
 
-        <div class="space-y-3 overflow-auto flex flex-col h-full">
+        <div class="space-y-3 overflow-auto flex flex-col">
             <ff-text-input
                 v-model="filterTerm"
                 class="ff-data-table--search"
@@ -265,6 +265,11 @@ export default {
         border: 1px solid $ff-grey-200;
         overflow: auto;
         height: 100%;
+    }
+}
+@media screen and (max-width: $ff-screen-md) {
+    .unified-namespace-hierarchy {
+        min-width: 100%;
     }
 }
 </style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/PayloadSchema.vue
@@ -2,7 +2,7 @@
     <main-title title="Payload Schema" class="mt-1" />
 
     <div class="ff-topic-inspecting">
-        <section class="schema-wrapper">
+        <section class="schema-wrapper flex flex-col overflow-auto h-full">
             <sub-title title="Schema" :icon="CodeBracketSquareIcon">
                 <template v-if="canClearSuggestion" #actions>
                     <span v-ff-tooltip:left="'Clear accepted suggestion'">
@@ -89,5 +89,6 @@ export default {
     padding: 10px;
     border-radius: 6px;
     border: 1px solid $ff-grey-200;
+    overflow: auto;
 }
 </style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicInspector/index.vue
@@ -145,9 +145,11 @@ export default {
 
 <style scoped lang="scss">
 .ff-topic-inspector {
+    display: flex;
+    flex-direction: column;
     flex: 1;
-    min-width: 50%;
+    min-width: 0;
     transition: width 0.3s;
-    overflow: hidden;
+    overflow: auto;
 }
 </style>

--- a/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSchema.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/components/TopicSchema.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="topic-schema" :class="{collapsed: isSchemaCollapsed}">
+    <div class="topic-schema">
         <template v-if="schema === null">
             <p class="text-center opacity-50">
                 No schema defined
@@ -18,10 +18,6 @@
                 <b>Schema</b>:
                 <object-properties v-if="schemaType === 'object'" :properties="schema.properties" />
                 <array-properties v-else-if="schemaType === 'array'" :items="schema.items" />
-                <button v-if="isSchemaCollapsible" class="show-more" @click="isSchemaExtended = !isSchemaExtended">
-                    <template v-if="isSchemaCollapsed">Show More</template>
-                    <template v-else>Show Less</template>
-                </button>
             </section>
         </template>
     </div>
@@ -51,11 +47,7 @@ export default {
                 'object',
                 'array',
                 'bin'
-            ],
-            schemaContainerMaxHeight: 400,
-            schemaContainerHeight: 0,
-            isSchemaExtended: false,
-            resizeObserver: null
+            ]
         }
     },
     computed: {
@@ -85,55 +77,6 @@ export default {
             default:
                 return ''
             }
-        },
-        isSchemaCollapsible () {
-            return this.schemaContainerHeight > this.schemaContainerMaxHeight
-        },
-        isSchemaCollapsed () {
-            if (this.isSchemaExtended === true) {
-                return false
-            }
-            return this.isSchemaCollapsible
-        }
-    },
-    mounted () {
-        this.updateResizeObserver()
-    },
-    updated () {
-        this.updateResizeObserver()
-    },
-    methods: {
-        updateHeight () {
-            return new Promise(resolve => {
-                // we need to schedule the height request before the next repaint to avoid a ResizeObserver loop
-                requestAnimationFrame(() => {
-                    this.schemaContainerHeight = this.$refs.schemaContainer?.scrollHeight || 0
-                })
-                resolve()
-            })
-        },
-        observeHeightChanges () {
-            return new Promise(resolve => {
-                if (!this.$refs.schemaContainer) return
-
-                this.resizeObserver = new ResizeObserver(() => {
-                    this.updateHeight()
-                })
-
-                this.resizeObserver.observe(this.$refs.schemaContainer)
-                resolve()
-            })
-        },
-        updateResizeObserver () {
-            return new Promise((resolve) => {
-                if (this.resizeObserver) {
-                    this.resizeObserver.disconnect()
-                }
-                resolve()
-            })
-                .then(() => this.updateHeight())
-                .then(() => this.observeHeightChanges())
-                .catch(e => e)
         }
     }
 }
@@ -148,7 +91,7 @@ export default {
     padding: 10px 6px;
     font-size: 0.875rem;
     line-height: 1.25rem;
-    overflow: hidden;
+    overflow: auto;
     position: relative;
 
     .topic-schema-unknown {
@@ -158,8 +101,6 @@ export default {
     }
 
     .schema-container {
-        overflow: hidden;
-
         .show-more {
             position: absolute;
             bottom: 0;
@@ -169,6 +110,7 @@ export default {
     }
 
     &.collapsed {
+        overflow: hidden;
         box-shadow: inset 0 -30px 20px -20px rgba(49, 46, 129, 0.2);
         padding-bottom: 35px;
 

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -126,6 +126,8 @@ export default {
     display: flex;
     flex-direction: row;
     gap: 12px;
+    overflow: auto;
+    height: 100%;
 }
 
 @media screen and (max-width: $ff-screen-md) {

--- a/frontend/src/pages/team/Brokers/Hierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/index.vue
@@ -127,7 +127,7 @@ export default {
     flex-direction: row;
     gap: 12px;
     overflow: auto;
-    height: 100%;
+    //height: 100%;
 }
 
 @media screen and (max-width: $ff-screen-md) {


### PR DESCRIPTION
## Description

- Fixes the brokers page overflows and allows scrolling.
- Removed the topic inspector load more button.

The load more button was added to alleviate lacking scrolling functionality and prevent the topic inspector from spreading too far. It was also adding observer watchers on elements and hard coded heights which is unnecessary now that scrolling behavior is restored.

https://github.com/user-attachments/assets/d00f26e3-e037-431a-803a-6fec31218b22

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5298

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

