### PR TITLE
Add transaction ID mismatch check in assistant API response

### DIFF
--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -120,6 +120,9 @@ module.exports = async function (app) {
                 headers,
                 timeout: requestTimeout
             })
+            if (request.body.transactionId !== response.data.transactionId) {
+                throw new Error('Transaction ID mismatch') // Ensure we are responding to the correct transaction
+            }
             reply.send(response.data)
         } catch (error) {
             reply.code(error.response?.status || 500).send({ code: error.response?.data?.code || 'unexpected_error', error: error.response?.data?.error || error.message })


### PR DESCRIPTION
## Description

Ensure the initiators transaction ID is matched before responding with AI results

### Background
The assistant API in forge is essentially a gateway to the API service hosted externally. To ensure replies are only ever sent to the correct initiator, a random transaction ID is included in each initiation. This PR ensures no response is leaked back to initiator if the transaction ID from the AI processing does not match.

During work on [#33](https://github.com/FlowFuse/node-red/issues/33), this oversight was spotted.

## Related Issue(s)

Part of https://github.com/FlowFuse/node-red/issues/33

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

