### PR TITLE
Extract the device manual install step into a separate component

### DIFF
--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -35,7 +35,7 @@
                     button (size difference is caused by odd padding in the toggle button, which though not visible
                     is still there and affects the button height in this div group)
                 -->
-                <div class="space-x-2 flex align-center" style="height: 34px;">
+                <div class="flex gap-2 align-center" style="height: 34px;">
                     <template v-if="isDevModeAvailable">
                         <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" :disabled="disableModeToggle" :disabledReason="disableModeToggleReason" @mode-change="setDeviceMode" />
                         <button v-if="!isVisitingAdmin" v-ff-tooltip:left="!editorAvailable ? 'You can edit flows directly when Developer Mode is enabled, and your Edge Instance is connected.' : 'Open Edge Instance Editor'" data-action="open-editor" class="ff-btn transition-fade--color ff-btn--secondary ff-btn-icon h-9" :disabled="!editorAvailable" @click="openTunnel(true)">

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -11,7 +11,7 @@
                         be able to reconnect until it has been given its new configuration.
                     </p>
                 </template>
-                <template v-if="hasCredentials">
+                <template v-else>
                     <template v-if="otc">
                         <label class="block font-bold mb-2">Install Device Agent</label>
                         <div class="mb-4">
@@ -86,40 +86,11 @@
 
                         <details class="mt-4">
                             <summary class="mt-6 cursor-pointer">Show manual setup instructions</summary>
-                            <p class="mt-4">
-                                Place the below configuration on your device.
-                                See the <a href="https://flowfuse.com/docs/device-agent/" target="_blank">Device Agent documentation</a> for instructions on how to do this.
-                            </p>
-                            <pre class="overflow-auto text-xs font-light p-4 my-2 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
-                            <div class="flex flex-row justify-end space-x-2 -mt-1">
-                                <ff-button kind="tertiary" size="small" class="ml-4" @click="downloadCredentials()">
-                                    <template #icon-right><DocumentDownloadIcon /></template>
-                                    <span class="">Download</span>
-                                </ff-button>
-                                <ff-button kind="tertiary" size="small" @click="copy(credentials)">
-                                    <template #icon-right><ClipboardCopyIcon /></template>
-                                    <span class="">Copy</span>
-                                </ff-button>
-                            </div>
+                            <ManualInstall class="mt-4" :credentials="credentials" :device="device" />
                         </details>
                     </template>
-                    <template v-else>
-                        <p>
-                            Place the below configuration on your device.
-                            See the <a href="https://flowfuse.com/docs/device-agent/" target="_blank">Device Agent documentation</a> for instructions on how to do this.
-                        </p>
-                        <pre class="overflow-auto text-xs font-light p-4 my-2 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
-                        <div class="flex flex-row justify-end space-x-2 -mt-1">
-                            <ff-button kind="tertiary" size="small" class="ml-4" @click="downloadCredentials()">
-                                <template #icon-right><DocumentDownloadIcon /></template>
-                                <span class="">Download</span>
-                            </ff-button>
-                            <ff-button kind="tertiary" size="small" @click="copy(credentials)">
-                                <template #icon-right><ClipboardCopyIcon /></template>
-                                <span class="">Copy</span>
-                            </ff-button>
-                        </div>
-                    </template>
+
+                    <ManualInstall v-else :credentials="credentials" :device="device" />
                 </template>
             </form>
         </template>
@@ -136,23 +107,23 @@
 </template>
 
 <script>
-// import devicesApi from '../../../../api/devices'
-import { ClipboardCopyIcon, DocumentDownloadIcon } from '@heroicons/vue/outline'
+import { ClipboardCopyIcon } from '@heroicons/vue/outline'
 import { mapState } from 'vuex'
 
 import deviceApi from '../../../../api/devices.js'
 import LinuxIcon from '../../../../assets/icons/linux.svg'
 import MacOSIcon from '../../../../assets/icons/macos.svg'
 import WindowsIcon from '../../../../assets/icons/windows.svg'
-import { downloadData } from '../../../../composables/Download.js'
 import clipboardMixin from '../../../../mixins/Clipboard.js'
 import Alerts from '../../../../services/alerts.js'
+
+import ManualInstall from './components/DeviceCredentialsDialog/ManualInstall.vue'
 
 export default {
     name: 'DeviceCredentialsDialog',
     components: {
-        ClipboardCopyIcon,
-        DocumentDownloadIcon
+        ManualInstall,
+        ClipboardCopyIcon
     },
     mixins: [clipboardMixin],
     props: ['team'],
@@ -168,9 +139,6 @@ export default {
         }
     },
     methods: {
-        downloadCredentials () {
-            downloadData(this.credentials, `device-${this.device.id}.yml`)
-        },
         async regenerateCredentials () {
             const creds = await deviceApi.generateCredentials(this.device.id)
             this.device.credentials = creds

--- a/frontend/src/pages/team/Devices/dialogs/components/DeviceCredentialsDialog/ManualInstall.vue
+++ b/frontend/src/pages/team/Devices/dialogs/components/DeviceCredentialsDialog/ManualInstall.vue
@@ -1,0 +1,63 @@
+<template>
+    <section>
+        <p>
+            Place the below configuration on your device.
+            See the <a href="https://flowfuse.com/docs/device-agent/" target="_blank">Device Agent documentation</a> for instructions on how to do this.
+        </p>
+        <pre class="overflow-auto text-xs font-light p-4 my-2 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
+        <div class="flex flex-row justify-end space-x-2 -mt-1">
+            <ff-button kind="tertiary" size="small" class="ml-4" @click="downloadCredentials()">
+                <template #icon-right><DocumentDownloadIcon /></template>
+                <span class="">Download</span>
+            </ff-button>
+            <ff-button kind="tertiary" size="small" @click="copy(credentials)">
+                <template #icon-right><ClipboardCopyIcon /></template>
+                <span class="">Copy</span>
+            </ff-button>
+        </div>
+    </section>
+</template>
+
+<script>
+import { ClipboardCopyIcon, DocumentDownloadIcon } from '@heroicons/vue/outline'
+
+import { downloadData } from '../../../../../../composables/Download.js'
+import clipboardMixin from '../../../../../../mixins/Clipboard.js'
+import Alerts from '../../../../../../services/alerts.js'
+
+export default {
+    name: 'ManualInstall',
+    components: {
+        ClipboardCopyIcon,
+        DocumentDownloadIcon
+    },
+    mixins: [clipboardMixin],
+    props: {
+        credentials: {
+            type: String,
+            required: true
+        },
+        device: {
+            type: Object,
+            required: true
+        }
+    },
+    methods: {
+        copy (text) {
+            this.copyToClipboard(text).then(() => {
+                Alerts.emit('Copied to Clipboard.', 'confirmation')
+            }).catch((err) => {
+                console.warn('Clipboard write permission denied: ', err)
+                Alerts.emit('Clipboard write permission denied.', 'warning')
+            })
+        },
+        downloadCredentials () {
+            downloadData(this.credentials, `device-${this.device.id}.yml`)
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+
+</style>


### PR DESCRIPTION
## Description

Extracted the common device manual install step into a separate, reusable component

Also fixes a modal overlay rightwards shift due to improper spacing on the device page:
before:
![image](https://github.com/user-attachments/assets/989a5c26-9d7a-411b-b5bd-401edfa100c6)

after:
![image](https://github.com/user-attachments/assets/31d3adf1-5599-4271-9915-f4c2c6b62902)


## Related Issue(s)

part of https://github.com/FlowFuse/device-agent/issues/411#issuecomment-2963848019

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

