### PR TITLE
Parametrize the team projects API endpoint

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -490,7 +490,15 @@ module.exports = {
                         include
                     })
                 },
-                byTeam: async (teamIdOrHash, { query = null, instanceId = null, includeAssociations = true, includeSettings = false } = {}) => {
+                byTeam: async (teamIdOrHash, {
+                    query = null,
+                    instanceId = null,
+                    includeAssociations = true,
+                    includeSettings = false,
+                    includeMeta = false,
+                    limit = null,
+                    orderByMostRecentFlows = false
+                } = {}) => {
                     let teamId = teamIdOrHash
                     if (typeof teamId === 'string') {
                         teamId = M.Team.decodeHashid(teamId)
@@ -529,8 +537,23 @@ module.exports = {
                         })
                     }
 
+                    if (includeMeta) {
+                        include.push({
+                            model: M.StorageFlow,
+                            attributes: ['id', 'updatedAt', 'flow', 'ProjectId']
+                        })
+                    }
+
                     const queryObject = {
                         include
+                    }
+
+                    if (limit !== null) {
+                        queryObject.limit = limit
+                    }
+
+                    if (includeMeta && orderByMostRecentFlows) {
+                        queryObject.order = [[{ model: M.StorageFlow }, 'updatedAt', 'DESC']]
                     }
 
                     if (instanceId) {
@@ -541,6 +564,7 @@ module.exports = {
                             { [Op.like]: `%${query.toLowerCase()}%` }
                         )
                     }
+
                     return this.findAll(queryObject)
                 },
                 getProjectTeamId: async (id) => {


### PR DESCRIPTION
## Prerequisites 

child of https://github.com/FlowFuse/flowfuse/pull/5619

please do not merge after review

## Description

Adds support for query parameters to the /team/projects API endpoint, enabling result limiting, sorting by most recent flow update, and inclusion of instance metadata.

This query is resource-intensive, hence the need for a result limit. Despite being marked as deprecated, this endpoint remains the only one that allows retrieval of a team's instances.

The ability to include instance metadata—while adding overhead—eliminates the need for the frontend to make a separate API call just to fetch the same data with the meta key (as currently done on the Applications page). This functionality should always be used with a query limit to control load.

This change also complements the performance improvements discussed in [FlowFuse issue #5520](https://github.com/FlowFuse/flowfuse/issues/5520). Currently, we query /team/projects, then loop through the results to make a second call for each instance—just to get the meta key. This is inefficient, especially as we’re loading all instances client-side and filtering there, instead of server-side.

Once deployed, this enhancement supports step 2 of [this comment](https://github.com/FlowFuse/flowfuse/issues/5520#issuecomment-2944496670): limiting instance results and moving search/filtering to the backend. Both endpoints will now return all required data, including meta.

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5600

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

