### PR TITLE
Fix clipped or overflowing ff-tooltip

### DIFF
--- a/frontend/src/ui-components/directives/Tooltip.js
+++ b/frontend/src/ui-components/directives/Tooltip.js
@@ -1,4 +1,4 @@
-function renderTooltip (el, binding, vnode) {
+function renderTooltip (el, binding) {
     el.classList.add('ff-tooltip-container')
 
     let posClass = 'ff-tooltip-right'
@@ -6,16 +6,79 @@ function renderTooltip (el, binding, vnode) {
         posClass = 'ff-tooltip-' + binding.arg
     }
 
-    const span = document.createElement('span')
-    span.className = `ff-tooltip ${posClass}`
-    span.innerHTML = binding.value
+    let tooltip = null
+    let tooltipTimeout = null
 
-    el.appendChild(span)
+    const createTooltip = () => {
+        tooltip = document.createElement('div')
+        tooltip.className = `ff-tooltip ${posClass}`
+        tooltip.innerHTML = binding.value
+        tooltip.style.position = 'absolute'
+        tooltip.style.zIndex = '9999' // Ensure it stays above other elements
+
+        document.body.appendChild(tooltip)
+
+        // Position the tooltip relative to the element
+        const rect = el.getBoundingClientRect()
+        switch (posClass) {
+        case 'ff-tooltip-top':
+            tooltip.style.left = (rect.left + rect.width / 2) + 'px'
+            tooltip.style.top = rect.top - (tooltip.offsetHeight + 15) + 'px'
+            break
+        case 'ff-tooltip-bottom':
+            tooltip.style.left = (rect.left + rect.width / 2) + 'px'
+            tooltip.style.top = (rect.bottom + 15) + 'px'
+            break
+        case 'ff-tooltip-left':
+            tooltip.style.left = rect.left - (tooltip.offsetWidth + 15) + 'px'
+            tooltip.style.top = (rect.top + rect.height / 2 - tooltip.offsetHeight / 2) + 'px'
+            break
+        case 'ff-tooltip-right':
+        default:
+            tooltip.style.left = (rect.right + 15) + 'px'
+            tooltip.style.top = (rect.top + rect.height / 2 - tooltip.offsetHeight / 2) + 'px'
+        }
+
+        // Use requestAnimationFrame to allow the DOM to render first
+        requestAnimationFrame(() => {
+            tooltip.classList.add('ff-tooltip--visible')
+        })
+    }
+
+    const removeTooltip = () => {
+        if (tooltip) {
+            // Use requestAnimationFrame to allow the DOM to render first
+            requestAnimationFrame(() => {
+                tooltip.classList.remove('ff-tooltip--visible')
+            })
+
+            setTimeout(() => {
+                tooltip.remove()
+                tooltip = null
+            }, 500)
+        }
+    }
+
+    const onMouseEnter = () => {
+        clearTimeout(tooltipTimeout)
+        tooltipTimeout = setTimeout(createTooltip, 250)
+    }
+
+    const onMouseLeave = () => {
+        clearTimeout(tooltipTimeout)
+        tooltipTimeout = setTimeout(removeTooltip, 250)
+    }
+
+    el.addEventListener('mouseenter', onMouseEnter)
+    el.addEventListener('mouseleave', onMouseLeave)
+
+    // Store references for cleanup
+    el._tooltip = { onMouseEnter, onMouseLeave, removeTooltip }
 }
 
 const directive = {
     name: 'ff-tooltip',
-    mounted: (el, binding) => {
+    mounted (el, binding) {
         if (!binding.value) {
             return
         }
@@ -26,21 +89,23 @@ const directive = {
     },
     updated (el, binding) {
         if (binding.value) {
-            const tooltips = el.getElementsByClassName('ff-tooltip')
-            if (tooltips.length) {
-                // update existing tooltip
-                tooltips[0].innerHTML = binding.value
+            // Replace tooltip content if already present
+            const tooltip = document.querySelector('.ff-tooltip')
+            if (tooltip) {
+                tooltip.innerHTML = binding.value
             } else {
-                // render a new tooltip
                 renderTooltip(el, binding)
             }
         } else {
-            // remove all tooltips
-            const tooltips = el.getElementsByClassName('ff-tooltip')
-            for (let i = 0; i < tooltips.length; i++) {
-                tooltips[i].remove()
-            }
+            el._tooltip?.removeTooltip()
         }
+    },
+    unmounted (el) {
+        el._tooltip?.removeTooltip()
+        el.removeEventListener('mouseenter', el._tooltip?.onMouseEnter)
+        el.removeEventListener('mouseleave', el._tooltip?.onMouseLeave)
+        delete el._tooltip
     }
 }
+
 export default directive

--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -1117,6 +1117,7 @@ $countdown_size: 20px;
   z-index: 100;
   font-weight: normal; // prevent parent overriding if embedded in hX
   white-space: nowrap;
+  height: fit-content;
   background-color: black;
   color: white;
   padding: 3px 12px;
@@ -1126,8 +1127,6 @@ $countdown_size: 20px;
   transition: 0.3s opacity;
   -webkit-transition: 0.3s opacity;
   &.ff-tooltip-right {
-    top: -3px;
-    left: calc(100% + 9px);
     &::after {
       content: " ";
       position: absolute;
@@ -1140,8 +1139,6 @@ $countdown_size: 20px;
     }
   }
   &.ff-tooltip-left {
-    top: -3px;
-    right: calc(100% + 9px);
     &::after {
       content: " ";
       position: absolute;
@@ -1154,8 +1151,6 @@ $countdown_size: 20px;
     }
   }
   &.ff-tooltip-top {
-    bottom: calc(100% + 9px);
-    left: 50%;
     transform: translateX(-50%);
     &::after {
       content: " ";
@@ -1169,8 +1164,6 @@ $countdown_size: 20px;
     }
   }
   &.ff-tooltip-bottom {
-    top: calc(100% + 9px);
-    left: 50%;
     transform: translateX(-50%);
     &::after {
       content: " ";
@@ -1182,6 +1175,9 @@ $countdown_size: 20px;
       border-style: solid;
       border-color: transparent transparent black transparent;
     }
+  }
+  &--visible {
+    opacity: 1;
   }
 }
 .ff-tooltip-container {


### PR DESCRIPTION
## Description

- prevented the ff-tooltip from getting clipped or overflowing by 'teleporting' it to the html body, similarly to the combobox/listbox options.
- preserved the ability to manually position the tooltip
- added a debouncer to prevent multiple tooltips from spawning when hovering rapidly over an element

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5537

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

