### PR TITLE
Auto-advance to Next Step After Application Selection

### DIFF
--- a/frontend/src/components/multi-step-forms/MultiStepForm.vue
+++ b/frontend/src/components/multi-step-forms/MultiStepForm.vue
@@ -24,6 +24,7 @@
                     v-model="payload"
                     @step-updated="$emit('step-updated', $event, currentStepKey)"
                     @go-to-step="selectStep"
+                    @next-step="nextStep"
                 />
             </transition>
         </section>

--- a/frontend/src/components/multi-step-forms/instance/steps/ApplicationStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/ApplicationStep.vue
@@ -125,7 +125,7 @@ export default {
             default: false
         }
     },
-    emits: ['step-updated'],
+    emits: ['step-updated', 'next-step'],
     setup (props) {
         return {
             initialState: props.state
@@ -206,6 +206,7 @@ export default {
                 this.selection = null
             } else {
                 this.selection = application
+                this.$emit('next-step')
             }
         }
     }


### PR DESCRIPTION
## Description

added the ability auto advance to the next step after clicking/selecting the application in the multi-step instance form

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5598

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

