### PR TITLE
Better logging of git errors

### DIFF
--- a/forge/ee/db/models/PipelineStageGitRepo.js
+++ b/forge/ee/db/models/PipelineStageGitRepo.js
@@ -119,7 +119,12 @@ module.exports = {
 
                             app.log.warn(`Failed to deploy pipeline stage ${M.PipelineStage.encodeHashid(this.PipelineStageId)} (push): ${err.message}`)
                             if (!err.code) {
-                                app.log.error(err)
+                                if (err.cause) {
+                                    // Log the root cause - this is usually a git error
+                                    app.log.error(err.cause)
+                                } else {
+                                    app.log.error(err)
+                                }
                             }
                         }
                     })

--- a/forge/ee/lib/gitops/index.js
+++ b/forge/ee/lib/gitops/index.js
@@ -26,12 +26,16 @@ async function cloneRepository (url, branch, workingDir) {
             result.code = 'invalid_branch'
             throw result
         }
+        let error
         // Fallback - try to extract the 'fatal' line from the output
         const m = /fatal: (.*)/.exec(output)
         if (m) {
-            throw new Error('Failed to clone repository: ' + m[1])
+            error = new Error('Failed to clone repository: ' + m[1])
+        } else {
+            error = new Error('Failed to clone repository')
         }
-        throw new Error('Failed to clone repository')
+        error.cause = err
+        throw error
     }
 }
 
@@ -133,11 +137,15 @@ module.exports.init = async function (app) {
                     result.cause = err
                     throw result
                 }
+                let error
                 const m = /fatal: (.*)/.exec(output)
                 if (m) {
-                    throw new Error('Failed to push repository: ' + m[1])
+                    error = new Error('Failed to push repository: ' + m[1])
+                } else {
+                    error = Error('Failed to push repository')
                 }
-                throw new Error('Failed to push repository')
+                error.cause = err
+                throw error
             }
         } finally {
             if (workingDir) {


### PR DESCRIPTION
Part of #5658 


To properly debug #5658 we need to be capturing the output from the git command. This PR does that.