### PR TITLE
Iterate on empty state messaging for new home page tiles

### DIFF
--- a/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
@@ -22,9 +22,9 @@
 
         <div v-else class="no-devices flex flex-col flex-1 justify-center text-gray-500 italic">
             <p class="text-center self-center">
-                This space intentionally left unpopulated.
-                <span class="text-indigo-500 cursor-pointer" @click.stop.prevent="openCreateDialog">Deploy a remote instance</span>
-                to change that.
+                No remote Node-RED Instances found.
+                <span class="text-indigo-500 cursor-pointer" @click.stop.prevent="openCreateDialog">Add a Remote Instance</span>
+                to get started.
             </p>
         </div>
 

--- a/frontend/src/pages/team/Home/components/RecentlyModifiedInstances.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedInstances.vue
@@ -16,9 +16,9 @@
         </ul>
         <div v-else class="no-instances flex flex-col flex-1 justify-center text-gray-500 italic">
             <p class="text-center self-center">
-                This section’s a ghost town.
+                It's looking a little empty.
                 <team-link :to="{name: 'CreateInstance'}" class="text-indigo-500">Create a Hosted Instance</team-link>
-                and break the silence.
+                to get started.
             </p>
         </div>
     </div>


### PR DESCRIPTION
## Description

I'm all for witty empty state's, but they felt a little out of place, so lightened them a little.

### Before

<img width="1451" alt="Screenshot 2025-06-20 at 16 02 39" src="https://github.com/user-attachments/assets/4aa6e470-1715-4275-875d-a8d9eedcb41d" />

### After

<img width="1454" alt="Screenshot 2025-06-20 at 16 01 48" src="https://github.com/user-attachments/assets/3e64e83c-bb05-4b5b-92d1-30325c7437c9" />