### PR TITLE
Retain env var hidden flag metadata within snapshots

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -1,4 +1,5 @@
 const { KEY_SETTINGS, KEY_HEALTH_CHECK_INTERVAL, KEY_DISABLE_AUTO_SAFE_MODE, KEY_SHARED_ASSETS } = require('../../db/models/ProjectSettings')
+const { exportEnvVarObject } = require('../../db/utils')
 const { Roles } = require('../../lib/roles')
 
 const ProjectActions = require('./projectActions')
@@ -840,6 +841,7 @@ module.exports = async function (app) {
         if (settings.settings.env) {
             settings.env = Object.assign({}, settings.settings.env, settings.env)
             delete settings.settings.env
+            settings.env = exportEnvVarObject(settings.env)
         }
 
         const teamType = await request.project.Team.getTeamType()


### PR DESCRIPTION
Fixes https://github.com/FlowFuse/security/issues/106

## Description

Currently the 'hidden' flag on env vars gets stripped when generating a snapshot. This means the env var becomes unhidden when pushed via pipeline.

This PR is part one of addressing this. Some explanation is needed.

We have two different ways of storing env var lists. In Instance settings we use an array:
```
[ { name: 'foo', value: 1 }, { name: 'bar', value: 2, hidden: true }]
```

When generating a snapshot, that gets converts to a key/value object:
```
{
   foo: 1,
   bar: 2
}
```

This is where the `hidden` flag is lost.

This PR addresses it by using a new format for the env-var object in the snapshot:

```
{
   foo: 1,
   bar: { value: 2, hidden: true }
}
```

Existing snapshots will continue to be valid; they have already lost the hidden metadata and we can't restore it.

Hosted/Remote instances do not know how to handle this format, so the endpoints they use to retrieve they settings have been updated to convert back to the plain key/value object without the hidden flag - that's okay because they have no use of the hidden flag, they just need the value.

---

This also lays the ground work for further encryption of the values. The metadata object will be able to contain the encrypted value, and the utility function `exportEnVarObject` added by this PR becomes the place that handles decryption prior to passing to an instance/device. It's a bit more complicated then that, which is why that'll be a separate PR.

---

To Do:

 - [ ] Unit test fixes and updates
 - [ ] Check for any other paths that could be impacted by this change
