### PR TITLE
fix: remove deviceActionsMixin from DeviceTile to fix Edit Details di…

### DIFF
--- a/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
@@ -50,7 +50,6 @@
 import FinishSetupButton from '../../../../../components/FinishSetup.vue'
 import StatusBadge from '../../../../../components/StatusBadge.vue'
 import AuditMixin from '../../../../../mixins/Audit.js'
-import deviceActionsMixin from '../../../../../mixins/DeviceActions.js'
 import permissionsMixin from '../../../../../mixins/Permissions.js'
 import FfKebabMenu from '../../../../../ui-components/components/KebabMenu.vue'
 import DaysSince from '../../../../application/Snapshots/components/cells/DaysSince.vue'
@@ -63,7 +62,7 @@ export default {
         DaysSince,
         FinishSetupButton
     },
-    mixins: [AuditMixin, permissionsMixin, deviceActionsMixin],
+    mixins: [AuditMixin, permissionsMixin],
     props: {
         device: {
             type: Object,
@@ -82,7 +81,7 @@ export default {
     },
     methods: {
         finishSetup () {
-            this.deviceAction('updateCredentials')
+            this.$emit('device-action', { action: 'updateCredentials', id: this.device.id })
         }
     }
 }


### PR DESCRIPTION
DeviceTile was incorrectly including deviceActionsMixin while also emitting device-action events to its parent DevicesWrapper. This caused the 'Update Remote Instance' dialog to fail when clicking 'Edit Details' because DeviceTile tried to access $refs.teamDeviceCreateDialog which doesn't exist in that component.

The fix removes the mixin from DeviceTile since it should only emit events to DevicesWrapper, which properly handles device actions with the correct dialog references.

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/5668 
## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

