### PR TITLE
Make the new HomePage tiles interactive

### DIFF
--- a/frontend/src/pages/team/Home/components/InstanceStat.vue
+++ b/frontend/src/pages/team/Home/components/InstanceStat.vue
@@ -65,7 +65,7 @@ export default {
 <style scoped lang="scss">
 .ff-stat {
     border: 1px solid transparent;
-    transition: ease-in-out .3s;
+    transition: ease-in-out .15s;
     will-change: border-color;
 
     &:hover {

--- a/frontend/src/pages/team/Home/components/InstanceStat.vue
+++ b/frontend/src/pages/team/Home/components/InstanceStat.vue
@@ -1,5 +1,9 @@
 <template>
-    <div class="rounded-md flex-1 p-3" :class="[`bg-${accent}-50`, `text-${accent}-500`]">
+    <div
+        class="rounded-md flex-1 p-3"
+        :class="[`bg-${accent}-50`, `text-${accent}-500`, 'cursor-pointer']"
+        @click="clicked()"
+    >
         <label class="block">{{ title }}</label>
         <span class="counter font-bold text-4xl">{{ counter }}</span>
     </div>
@@ -24,6 +28,7 @@ export default {
             type: Number
         }
     },
+    emits: ['clicked'],
     computed: {
         ...mapGetters('account', ['team']),
         accent () {
@@ -32,7 +37,7 @@ export default {
                 return 'green'
             case 'error':
                 return 'red'
-            case 'not-running':
+            case 'stopped':
             default:
                 return 'gray'
             }
@@ -43,23 +48,15 @@ export default {
                 return 'Running'
             case 'error':
                 return 'Error'
-            case 'not-running':
+            case 'stopped':
             default:
                 return 'Not Running'
             }
-        },
-        apiStates () {
-            switch (this.state) {
-            case 'running':
-                return ['starting', 'importing',
-                    'connected', 'info', 'success', 'pushing', 'pulling',
-                    'loading', 'installing', 'safe', 'protected', 'running', 'warning']
-            case 'error':
-                return ['error', 'crashed']
-            case 'not-running':
-            default:
-                return ['stopping', 'restarting', 'suspending', 'rollback', 'stopped', 'suspended', '']
-            }
+        }
+    },
+    methods: {
+        clicked () {
+            this.$emit('clicked', { type: this.type, state: this.state })
         }
     }
 }

--- a/frontend/src/pages/team/Home/components/InstanceStat.vue
+++ b/frontend/src/pages/team/Home/components/InstanceStat.vue
@@ -1,7 +1,7 @@
 <template>
     <div
-        class="rounded-md flex-1 p-3"
-        :class="[`bg-${accent}-50`, `text-${accent}-500`, 'cursor-pointer']"
+        class="ff-stat rounded-md flex-1 p-3 cursor-pointer"
+        :class="[`bg-${accent}-50`, `text-${accent}-500`, accent]"
         @click="clicked()"
     >
         <label class="block">{{ title }}</label>
@@ -63,5 +63,21 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.ff-stat {
+    border: 1px solid transparent;
+    transition: ease-in-out .3s;
+    will-change: border-color;
 
+    &:hover {
+        &.green {
+            border-color: $ff-green-500;
+        }
+        &.red {
+            border-color: $ff-red-500;
+        }
+        &.gray {
+            border-color: $ff-grey-500;
+        }
+    }
+}
 </style>

--- a/frontend/src/pages/team/Home/index.vue
+++ b/frontend/src/pages/team/Home/index.vue
@@ -186,7 +186,7 @@ export default {
         },
         onStatClick (payload) {
             const searchQuery = Object.prototype.hasOwnProperty.call(this.statesMap, payload.state)
-                ? this.statesMap[payload.state].join('|')
+                ? this.statesMap[payload.state].join(' | ')
                 : ''
             const name = payload.type === 'hosted' ? 'Instances' : 'TeamDevices'
 

--- a/frontend/src/pages/team/Home/index.vue
+++ b/frontend/src/pages/team/Home/index.vue
@@ -22,15 +22,15 @@
                             <div class="flex gap-2 mb-5">
                                 <InstanceStat
                                     :counter="instanceStats.running"
-                                    state="running" type="hosted" @clicked="onGlanceClick"
+                                    state="running" type="hosted" @clicked="onStatClick"
                                 />
                                 <InstanceStat
                                     :counter="instanceStats.error"
-                                    state="error" type="hosted" @clicked="onGlanceClick"
+                                    state="error" type="hosted" @clicked="onStatClick"
                                 />
                                 <InstanceStat
                                     :counter="instanceStats.stopped"
-                                    state="not-running" type="hosted" @clicked="onGlanceClick"
+                                    state="stopped" type="hosted" @clicked="onStatClick"
                                 />
                             </div>
 
@@ -45,15 +45,15 @@
                             <div class="flex gap-2 mb-5">
                                 <InstanceStat
                                     :counter="deviceStats.running"
-                                    state="running" type="remote" @clicked="onGlanceClick"
+                                    state="running" type="remote" @clicked="onStatClick"
                                 />
                                 <InstanceStat
                                     :counter="deviceStats.error"
-                                    state="error" type="remote" @clicked="onGlanceClick"
+                                    state="error" type="remote" @clicked="onStatClick"
                                 />
                                 <InstanceStat
-                                    :counter="deviceStats.stopped
-                                    " state="not-running" type="remote" @clicked="onGlanceClick"
+                                    :counter="deviceStats.stopped"
+                                    state="stopped" type="remote" @clicked="onStatClick"
                                 />
                             </div>
 
@@ -105,29 +105,9 @@ export default {
         return {
             loading: true,
             logEntries: [],
-            instances: [
-                { id: 1, name: 'something-foo', url: 'https://reddit.com', meta: { state: 'running' } },
-                { id: 3, name: 'something-foo', url: 'https://reddit.com', meta: { state: 'suspended' } },
-                {
-                    id: 2,
-                    name: 'another-bar',
-                    url: 'http:/google.com',
-                    meta: { state: 'running' },
-                    settings: {
-                        dashboard2UI: '/dashboard'
-                    }
-                }
-            ],
+            instances: [],
             instanceStateCounts: {},
-            devices: [
-                { id: 1, name: 'foo-this', url: 'https://reddit.com', meta: { state: 'running' } },
-                {
-                    id: 2,
-                    name: 'bar-that',
-                    url: 'http:/google.com',
-                    meta: { state: 'running' }
-                }
-            ],
+            devices: [],
             deviceStateCounts: {},
             statesMap: {
                 running: ['starting', 'importing', 'connected', 'info', 'success', 'pushing', 'pulling', 'loading',
@@ -204,7 +184,14 @@ export default {
                     this.logEntries = response.log
                 })
         },
-        onGlanceClick (payload) {},
+        onStatClick (payload) {
+            const searchQuery = Object.prototype.hasOwnProperty.call(this.statesMap, payload.state)
+                ? this.statesMap[payload.state].join('|')
+                : ''
+            const name = payload.type === 'hosted' ? 'Instances' : 'TeamDevices'
+
+            this.$router.push({ name, query: { searchQuery } })
+        },
         getInstanceStateCounts () {
             return TeamAPI.getTeamInstanceCounts(this.team.id, [], 'hosted')
                 .then(res => {

--- a/frontend/src/pages/team/Home/index.vue
+++ b/frontend/src/pages/team/Home/index.vue
@@ -113,7 +113,7 @@ export default {
                 running: ['starting', 'importing', 'connected', 'info', 'success', 'pushing', 'pulling', 'loading',
                     'installing', 'safe', 'protected', 'running', 'warning'],
                 error: ['error', 'crashed'],
-                stopped: ['stopping', 'restarting', 'suspending', 'rollback', 'stopped', 'suspended', 'unknown']
+                stopped: ['stopping', 'restarting', 'suspending', 'rollback', 'stopped', 'suspended', 'offline', 'unknown']
             }
         }
     },


### PR DESCRIPTION
## Prerequisites
child of https://github.com/FlowFuse/flowfuse/pull/5676 - required to preform multi-term searches

## Description

- Added click-based navigation for the homepage stats, redirecting users to either the hosted-instances remote-instances pages with the appropriate query/search terms
- Refactored state handling for clarity and consistency.
- Removed leftover mock data and streamlined methods for better maintainability.

https://github.com/user-attachments/assets/2da5b61f-cec0-4667-9d79-b8f5e5ff4308

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5660

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

