### PR TITLE
Do not include full flow content in blueprint collection api

### DIFF
--- a/forge/ee/db/views/FlowTemplate.js
+++ b/forge/ee/db/views/FlowTemplate.js
@@ -11,7 +11,6 @@ module.exports = function (app) {
             icon: { type: 'string' },
             order: { type: 'number' },
             default: { type: 'boolean' },
-            flows: { type: 'object', additionalProperties: true },
             createdAt: { type: 'string' },
             updatedAt: { type: 'string' },
             externalUrl: { type: 'string' }
@@ -27,7 +26,6 @@ module.exports = function (app) {
             icon: blueprint.icon,
             order: blueprint.order,
             default: blueprint.default,
-            flows: blueprint.flows,
             createdAt: blueprint.createdAt,
             updatedAt: blueprint.updatedAt,
             externalUrl: blueprint.externalUrl

--- a/forge/ee/routes/flowBlueprints/index.js
+++ b/forge/ee/routes/flowBlueprints/index.js
@@ -34,7 +34,6 @@ module.exports = async function (app) {
         } else if (request.query.filter === 'inactive') {
             filter = { active: false }
         }
-
         if (request.query.team) {
             const team = await app.db.models.Team.byId(request.query.team)
             if (!team) {
@@ -45,7 +44,7 @@ module.exports = async function (app) {
             reply.send(flowTemplates)
         } else {
             // get all flow templates - typically for administration purposes
-            const flowTemplates = await app.db.models.FlowTemplate.getAll(paginationOptions, filter)
+            const flowTemplates = await app.db.models.FlowTemplate.getAll(paginationOptions, filter, { includeFlows: false })
             flowTemplates.blueprints = flowTemplates.templates.map(ft => app.db.views.FlowTemplate.flowBlueprintSummary(ft))
             reply.send(flowTemplates)
         }
@@ -291,7 +290,7 @@ module.exports = async function (app) {
                 }
             }
         }, async (request, reply) => {
-            const flowTemplates = await app.db.models.FlowTemplate.getAll({}, { active: true })
+            const flowTemplates = await app.db.models.FlowTemplate.getAll({}, { active: true }, { includeFlows: true })
             const modified = flowTemplates.templates.map(bp => app.db.views.FlowTemplate.flowBlueprintExport(bp, true))
             reply.send({
                 blueprints: modified,

--- a/frontend/src/components/dialogs/AssetDetailDialog.vue
+++ b/frontend/src/components/dialogs/AssetDetailDialog.vue
@@ -20,6 +20,8 @@
 
 import FlowRenderer from '@flowfuse/flow-renderer'
 
+import BlueprintAPI from '../../api/flowBlueprints.js'
+
 export default {
     name: 'FlowViewerDialog',
     props: {
@@ -30,7 +32,13 @@ export default {
     },
     setup () {
         return {
-            show (payload) { // accepts blueprints, snapshots and libraries
+            async show (payload) { // accepts blueprints, snapshots and libraries
+                // If there is no flows property, but there is a category property, we assume this is a blueprint
+                // and try to load the content dynamically
+                if (!payload.flows && Object.hasOwn(payload, 'category')) {
+                    const blueprint = await BlueprintAPI.getFlowBlueprint(payload.id)
+                    payload.flows = blueprint.flows
+                }
                 this.mode = 'view'
                 this.$refs.dialog.show()
                 this.payload = payload


### PR DESCRIPTION
## Description

This removes the `flows` property from the `/api/v1/flow-blueprints`  api response, and modifies the db lookup to not return it either.

This property is only used when previewing the contents of a blueprint; and we have an api in place to load the contents of an individual blueprint. This updates the AssetDetailDialog component to dynamically load the blueprint content if needed.

I have verified the `export-public` endpoint does still do the right thing and includes the flows/modules properties as expected.