### PR TITLE
Improve recently modified hosted instances sorting

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -556,9 +556,9 @@ module.exports = {
                         queryObject.order = [
                             [literal(`
                                 CASE
-                                    WHEN state = 'error' OR state = 'crashed' THEN 1
-                                    WHEN state = 'running' OR state = 'safe' OR state = 'protected' OR state = 'warning' THEN 2
-                                    WHEN state = 'suspended' OR state = 'stopped' OR state = 'offline' OR state = 'unknown' OR state = '' THEN 3
+                                    WHEN state IN ('error', 'crashed') THEN 1
+                                    WHEN state IN ('running', 'safe', 'protected', 'warning') THEN 2
+                                    WHEN state IS NULL OR state IN ('suspended', 'stopped', 'offline', 'unknown', '') THEN 3
                                     ELSE 4
                                 END
                             `), 'ASC'],


### PR DESCRIPTION
## Description

Sort instances first by their state in the following order: Error, Running, Suspended. 
Within each state group, order them by the timestamp of their most recent flow change, with the most recent first.

applies to hosted instances only.

Due to the fact that retrieving instance statuses is a two-part process, an initial call that fetches the `Project.state` key (via the `/:teamId/projects` endpoint), followed by a secondary call to query the underlying `nr-launcher` layer (via the `projects/:projectId` endpoint), there may be slight discrepancies in the ordering of transitory statuses. 
The initial response might return instances in a certain order based on their state, but by the time the second API call completes, or if an instance transitions from one state to another in the meantime (since we're polling for status changes) — the instance’s status may have changed. 
As a result, the ordering of statuses could become inconsistent.

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5671

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

