### PR TITLE
 Improve recently modified remote instances sorting

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -6,7 +6,7 @@ const crypto = require('crypto')
 
 const SemVer = require('semver')
 
-const { col, fn, DataTypes, Op, where } = require('sequelize')
+const { col, fn, DataTypes, Op, where, literal } = require('sequelize')
 
 const Controllers = require('../controllers')
 const { buildPaginationSearchClause } = require('../utils')
@@ -405,6 +405,14 @@ module.exports = {
                                 }
                             } else if (key === 'instance') {
                                 order.unshift([M.Project, 'name', pagination.order[key] || 'ASC'])
+                            } else if (key === 'state-priority') {
+                                order.unshift([literal(`
+                                    CASE
+                                        WHEN Device.state IN ('error', 'crashed') THEN 1
+                                        WHEN Device.state IN ('running', 'safe', 'protected', 'warning') THEN 2
+                                        WHEN Device.state IS NULL OR Device.state IN ('stopped', 'offline', 'unknown', '') THEN 3
+                                    END
+                                `), 'ASC'])
                             } else {
                                 order.unshift([key, pagination.order[key] || 'ASC'])
                             }

--- a/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
@@ -110,7 +110,7 @@ export default {
                 limit = 3
                 this.hasMore = true
             }
-            return teamAPI.getTeamDevices(this.team.id, null, limit, null, { })
+            return teamAPI.getTeamDevices(this.team.id, null, limit, null, { sort: 'state-priority' })
                 .then((res) => {
                     this.devices = res.devices
                 })


### PR DESCRIPTION
## Description

Sort instances first by their state in the following order: Error, Running, Suspended.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5671

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

