### PR TITLE
Fix new user team creation page

### DIFF
--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -9,11 +9,11 @@
         </template>
         <ff-loading v-if="redirecting" message="Redirecting to Stripe..." />
         <ff-loading v-else-if="loading" message="Creating Team..." />
-        <div v-else :class="presetTeamType ? 'flex flex-col gap-4 sm:flex-row sm:gap-0' : 'space-y-6 mb-5'">
+        <div v-else :class="presetTeamType ? 'flex flex-col gap-4 sm:gap-0' : 'flex flex-col space-y-6 mb-5'">
             <div v-if="presetTeamType" class="w-full">
                 <team-type-tile class="m-auto" :team-type="presetTeamType" :enableCTA="false" />
             </div>
-            <form>
+            <form :class="[presetTeamType ? 'flex flex-col items-center mt-10' : '']">
                 <!-- TeamType Type -->
                 <div v-if="!presetTeamType" class="grid mb-3">
                     <ff-tile-selection v-model="input.teamTypeId">
@@ -26,7 +26,7 @@
                         />
                     </ff-tile-selection>
                 </div>
-                <div v-if="!isContactRequired" class="space-y-3">
+                <div v-if="!isContactRequired" class="space-y-3" :class="{'flex flex-col max-w-md': presetTeamType}">
                     <FormRow id="team" v-model="input.name" :error="errors.name" containerClass="max-w-md">
                         Team Name
                         <template #description>


### PR DESCRIPTION
## Description

Aligned the form and team tile to the center for new users creating their first team. Other flows (creating a new team when already in one, and upgrading a team) remain unchanged.

fix:
![image](https://github.com/user-attachments/assets/7127fb51-23b0-4613-a772-3791a69fd9d0)

other team creation pages:
![image](https://github.com/user-attachments/assets/859f99cf-820d-40e2-b28b-d0819e7a64fc)

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5681

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

