### PR TITLE
Fix lint warning caused by missing default prop value

### DIFF
--- a/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DeviceTile.vue
@@ -77,7 +77,8 @@ export default {
         },
         application: { // required for deviceActionsMixin fetchData
             required: false,
-            type: Object
+            type: Object,
+            default: null
         },
         minimalView: {
             type: Boolean,


### PR DESCRIPTION
## Description

Fixes lint warning caused by missing default prop value

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

