### PR TITLE
Add a new instance status endpoint

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -307,18 +307,20 @@ module.exports = {
                     return credentialSecret
                 },
 
-                async liveState () {
-                    let storageFlow = this.StorageFlow
-                    if (storageFlow === undefined) {
-                        app.log.warn(`N+1 warning - Requested live state for instance ${this.id} with no storage flow loaded`)
-                        storageFlow = await M.StorageFlow.byProject(this.id)
-                    }
+                async liveState ({ omitStorageFlows = false } = { }) {
+                    const result = {}
 
                     const inflightState = Controllers.Project.getInflightState(this)
                     const isDeploying = Controllers.Project.isDeploying(this)
 
-                    const result = {
-                        flowLastUpdatedAt: storageFlow?.updatedAt // prop not set if storageFlow not found
+                    if (!omitStorageFlows) {
+                        let storageFlow = this.StorageFlow
+                        if (storageFlow === undefined) {
+                            app.log.warn(`N+1 warning - Requested live state for instance ${this.id} with no storage flow loaded`)
+                            storageFlow = await M.StorageFlow.byProject(this.id)
+                        }
+
+                        result.flowLastUpdatedAt = storageFlow?.updatedAt // prop not set if storageFlow not found
                     }
 
                     if (inflightState) {
@@ -387,44 +389,46 @@ module.exports = {
                         }
                     })
                 },
-                byId: async (id, { includeStorageFlows = false } = {}) => {
-                    const include = [
-                        {
-                            model: M.Team,
-                            attributes: ['hashid', 'id', 'name', 'slug', 'links', 'TeamTypeId', 'suspended']
-                        },
-                        {
-                            model: M.Application,
-                            attributes: ['hashid', 'id', 'name', 'links']
-                        },
-                        {
-                            model: M.ProjectType,
-                            attributes: ['hashid', 'id', 'name']
-                        },
-                        {
-                            model: M.ProjectStack,
-                            attributes: ['hashid', 'id', 'name', 'label', 'links', 'properties', 'replacedBy', 'ProjectTypeId']
-                        },
-                        {
-                            model: M.ProjectTemplate,
-                            attributes: ['hashid', 'id', 'name', 'links', 'settings', 'policy']
-                        },
-                        {
-                            model: M.ProjectSettings,
-                            where: {
-                                [Op.or]: [
-                                    { key: KEY_SETTINGS },
-                                    { key: KEY_HOSTNAME },
-                                    { key: KEY_HA },
-                                    { key: KEY_PROTECTED },
-                                    { key: KEY_CUSTOM_HOSTNAME },
-                                    { key: KEY_HEALTH_CHECK_INTERVAL },
-                                    { key: KEY_DISABLE_AUTO_SAFE_MODE }
-                                ]
+                byId: async (id, { includeStorageFlows = false, barebone = false } = {}) => {
+                    const include = barebone
+                        ? []
+                        : [
+                            {
+                                model: M.Team,
+                                attributes: ['hashid', 'id', 'name', 'slug', 'links', 'TeamTypeId', 'suspended']
                             },
-                            required: false
-                        }
-                    ]
+                            {
+                                model: M.Application,
+                                attributes: ['hashid', 'id', 'name', 'links']
+                            },
+                            {
+                                model: M.ProjectType,
+                                attributes: ['hashid', 'id', 'name']
+                            },
+                            {
+                                model: M.ProjectStack,
+                                attributes: ['hashid', 'id', 'name', 'label', 'links', 'properties', 'replacedBy', 'ProjectTypeId']
+                            },
+                            {
+                                model: M.ProjectTemplate,
+                                attributes: ['hashid', 'id', 'name', 'links', 'settings', 'policy']
+                            },
+                            {
+                                model: M.ProjectSettings,
+                                where: {
+                                    [Op.or]: [
+                                        { key: KEY_SETTINGS },
+                                        { key: KEY_HOSTNAME },
+                                        { key: KEY_HA },
+                                        { key: KEY_PROTECTED },
+                                        { key: KEY_CUSTOM_HOSTNAME },
+                                        { key: KEY_HEALTH_CHECK_INTERVAL },
+                                        { key: KEY_DISABLE_AUTO_SAFE_MODE }
+                                    ]
+                                },
+                                required: false
+                            }
+                        ]
 
                     // Used for instance status
                     if (includeStorageFlows) {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -1270,6 +1270,50 @@ module.exports = async function (app) {
     })
 
     /**
+     * Get the live status of an instance
+     * @name /api/v1/projects/:instanceId/status
+     * @static
+     * @memberof forge.routes.api.project
+     */
+    app.get('/:instanceId/status', {
+        preHandler: app.needsPermission('project:read'),
+        schema: {
+            summary: 'Get the live status of an instance',
+            tags: ['Instances', 'Live State'],
+            params: {
+                type: 'object',
+                required: ['instanceId'],
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        name: { type: 'string' },
+                        id: { type: 'string' },
+                        meta: { type: 'object', additionalProperties: true }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        const instance = await app.db.models.Project.byId(request.params.instanceId, { barebone: true, includeStorageFlows: false })
+
+        const liveState = await instance.liveState({ omitStorageFlows: true })
+
+        return reply.send({
+            id: instance.id,
+            name: instance.name,
+            meta: liveState.meta
+        })
+    })
+
+    /**
      * Merge env vars from 2 arrays.
      *
      * NOTE: When a var is found in both, currentVars will take precedence


### PR DESCRIPTION
## Description

This PR introduces a dedicated endpoint to fetch the status of a single application instance, rather than retrieving the status of **all** instances and devices assigned to an application.

Why:
Currently, the team applications endpoint loads the status of all associated instances and devices, even if the relevant application data hasn’t been requested yet. This results in unnecessary database load and complicates rendering logic, especially as we shift the applications search to the server.

Impact:
This endpoint allows the applications page to query the runtime status (e.g. running/stopped) of a specific instance independently. It avoids bloating the data retrieved through the broader endpoint and makes status queries more targeted and efficient.

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5520

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

