### PR TITLE
Add tooltip to 'Members' menu for single-user teams

### DIFF
--- a/frontend/src/store/modules/ux/index.js
+++ b/frontend/src/store/modules/ux/index.js
@@ -340,7 +340,7 @@ const getters = {
                                 }
 
                                 return {
-                                    title: 'Add a team member to get started building!'
+                                    title: 'Add a team member and start collaborating!'
                                 }
                             })()
                         }

--- a/frontend/src/store/modules/ux/index.js
+++ b/frontend/src/store/modules/ux/index.js
@@ -331,7 +331,18 @@ const getters = {
                             },
                             tag: 'team-members',
                             icon: UsersIcon,
-                            disabled: requiresBilling
+                            disabled: requiresBilling,
+                            alert: (() => {
+                                const teamAge = new Date().getTime() - new Date(team.createdAt).getTime()
+                                const fourteenDaysInMs = 14 * 24 * 60 * 60 * 1000
+                                if (team.membersCount === 1 && teamAge > fourteenDaysInMs) {
+                                    return null
+                                }
+
+                                return {
+                                    title: 'Add a team member to get started building!'
+                                }
+                            })()
                         }
                     ]
                 },


### PR DESCRIPTION
## Description

Adds a tooltip to the left nav bar’s 'Members' item to encourage invites. Visible only for teams with one member and less than 14 days old.

![image](https://github.com/user-attachments/assets/5a010c48-37d3-4eb9-997a-1c081e58b1f9)

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5579

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

