### PR TITLE
Fix: Handle Tooltip Concurrency Issues During Rapid Mouse Events

### DIFF
--- a/frontend/src/ui-components/directives/Tooltip.js
+++ b/frontend/src/ui-components/directives/Tooltip.js
@@ -1,3 +1,5 @@
+import { debounce } from '../../utils/eventHandling.js'
+
 function renderTooltip (el, binding) {
     el.classList.add('ff-tooltip-container')
 
@@ -8,8 +10,11 @@ function renderTooltip (el, binding) {
 
     let tooltip = null
     let tooltipTimeout = null
+    let isTooltipVisible = false
 
     const createTooltip = () => {
+        if (isTooltipVisible) return
+
         tooltip = document.createElement('div')
         tooltip.className = `ff-tooltip ${posClass}`
         tooltip.innerHTML = binding.value
@@ -42,20 +47,24 @@ function renderTooltip (el, binding) {
         // Use requestAnimationFrame to allow the DOM to render first
         requestAnimationFrame(() => {
             tooltip.classList.add('ff-tooltip--visible')
+            isTooltipVisible = true
         })
     }
 
     const removeTooltip = () => {
+        if (!isTooltipVisible) return
+
         if (tooltip) {
             // Use requestAnimationFrame to allow the DOM to render first
             requestAnimationFrame(() => {
                 tooltip.classList.remove('ff-tooltip--visible')
-            })
 
-            setTimeout(() => {
-                tooltip?.remove()
-                tooltip = null
-            }, 500)
+                setTimeout(() => {
+                    tooltip?.remove()
+                    tooltip = null
+                    isTooltipVisible = false
+                }, 500)
+            })
         }
     }
 
@@ -69,8 +78,8 @@ function renderTooltip (el, binding) {
         tooltipTimeout = setTimeout(removeTooltip, 250)
     }
 
-    el.addEventListener('mouseenter', onMouseEnter)
-    el.addEventListener('mouseleave', onMouseLeave)
+    el.addEventListener('mouseenter', debounce(onMouseEnter, 150))
+    el.addEventListener('mouseleave', debounce(onMouseLeave, 150))
 
     // Store references for cleanup
     el._tooltip = { onMouseEnter, onMouseLeave, removeTooltip }


### PR DESCRIPTION
## Description

Fixes concurrency issues by adding a debouncer to the `mouseenter` and `mouseleave` events, and improves the handling of tooltip creation/removal when the tooltip is visible.

## Related Issue(s)

https://flowfuse.sentry.io/issues/6693184225/?environment=production&project=4505958486441984&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

https://flowfuse.sentry.io/issues/6693626063/?environment=production&project=4505958486441984&query=is%3Aunresolved&referrer=issue-stream&stream_index=5

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

