### PR TITLE
Fix stale topic state by re-evaluating computed prop on topics refresh

### DIFF
--- a/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
+++ b/frontend/src/pages/team/Brokers/Hierarchy/TopicHierarchy/index.vue
@@ -116,11 +116,6 @@ export default {
             filterTerm: ''
         }
     },
-    watch: {
-        topics () {
-            console.log(123)
-        }
-    },
     computed: {
         ...mapGetters('account', ['featuresCheck']),
         ...mapGetters('product', ['brokerExpandedTopics']),


### PR DESCRIPTION
## Description

Fixes a bug where, after logging in and opening the brokers page, expanding a topic and then refreshing the topics list causes the expanded state to be lost.

The fix seems redundant but it forces the `expandedTopics` computed prop to re-evaluate when the `topics` prop is updated.

the hierarchy getter is using the `checkIfTopicOpen` method to pre-set a topic's open state which in turn is using the `expandedTopics` computed property which is serving stale data.

How to reproduce:
1. logout (in order to clear localStorage)
2. login
3. navigate to the brokers page, expand a series of topics
4. refresh the topics list (expanded topics were initially reverted to their closed state)

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5211

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

