### PR TITLE
Reduce the rate of calls to instance name check API

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -1217,7 +1217,7 @@ module.exports = async function (app) {
         config: {
             rateLimit: app.config.rate_limits
                 ? {
-                    max: 5,
+                    max: 6,
                     timeWindow: 30000,
                     keyGenerator: app.config.rate_limits.keyGenerator,
                     hard: true

--- a/frontend/src/api/instances.js
+++ b/frontend/src/api/instances.js
@@ -201,7 +201,6 @@ const checkCustomHostnameStatus = async (instanceId) => {
 
 const nameCheck = async (instanceName) => {
     return client.post('/api/v1/projects/check-name', { name: instanceName })
-        .then(res => res.data)
 }
 
 const getResources = async (instanceId) => {

--- a/frontend/src/components/multi-step-forms/instance/steps/InstanceStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/InstanceStep.vue
@@ -293,12 +293,20 @@ export default {
                             this.errors.name = null
                         })
                         .catch(e => {
-                            this.errors.name = 'Instance name already in use.'
+                            if (e.status === 409) {
+                                if (e.response?.data?.error === 'name in use') {
+                                    this.errors.name = 'Instance name already in use.'
+                                } else if (e.response?.data?.error === 'name not allowed') {
+                                    this.errors.name = 'Instance name not allowed.'
+                                }
+                            } else if (e.status === 429) {
+                                this.errors.name = 'Name check rate limit exceeded'
+                            }
                         })
                 } else {
                     this.errors.name = 'Invalid character in use.'
                 }
-            }, 500)
+            }, 1000)
         },
         errors: {
             deep: true,


### PR DESCRIPTION
fixes #5703

## Description

<!-- Describe your changes in detail -->
This increases the pause time in typing a name before sending to the API (from 500ms to 1000ms).

Also add a different message for the rate limit to the name in use error.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#5703

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

