### PR TITLE
ci: Enable rate limits on prestaging environments

### DIFF
--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -19,7 +19,12 @@ forge:
     requests:
       cpu: 100m
       memory: 16Mi
-
+  rate_limits:
+    enabled: true
+    global: false
+    max: 600
+    maxAnonymous: 10
+    timeWindow: 30000
 
 postgresql:
   persistence:


### PR DESCRIPTION
## Description

This pull request adds `forge.rate_limit` configuration to the values files used during pre-staging environment deployment. Configuration values matches thes from staging environment.

## Related Issue(s)

closes https://github.com/FlowFuse/CloudProject/issues/757

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

