### PR TITLE
Assistant assets endpoint

### DIFF
--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -11,10 +11,13 @@ const { LRUCache } = require('lru-cache')
  */
 module.exports = async function (app) {
     const assetCache = new LRUCache({
-        max: app.config.assistant?.service?.assetCache?.max || 100,
-        ttl: app.config.assistant?.service?.assetCache?.ttl || 30 * 60 * 1000, // Defaults to 1/2 hour cache for assets - enough to handle bursts
+        max: app.config.assistant?.assetCache?.max || 100,
+        ttl: app.config.assistant?.assetCache?.ttl || 30 * 60 * 1000, // Defaults to 1/2 hour cache for assets - enough to handle bursts
         updateAgeOnGet: false // do not update the age on get, we want it to expire after the original ttl
     })
+
+    // decorate the app with the asset cache
+    app.decorate('assistant', { assetCache })
 
     // Get the assistant service configuration
     const serviceUrl = app.config.assistant?.service?.url

--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -1,4 +1,5 @@
 const { default: axios } = require('axios')
+const { LRUCache } = require('lru-cache')
 
 /**
  * Assistant api routes
@@ -9,6 +10,12 @@ const { default: axios } = require('axios')
  * @memberof forge.routes.api
  */
 module.exports = async function (app) {
+    const assetCache = new LRUCache({
+        max: app.config.assistant?.service?.assetCache?.max || 100,
+        ttl: app.config.assistant?.service?.assetCache?.ttl || 30 * 60 * 1000, // Defaults to 1/2 hour cache for assets - enough to handle bursts
+        updateAgeOnGet: false // do not update the age on get, we want it to expire after the original ttl
+    })
+
     // Get the assistant service configuration
     const serviceUrl = app.config.assistant?.service?.url
     const serviceToken = app.config.assistant?.service?.token
@@ -40,6 +47,82 @@ module.exports = async function (app) {
         }
     })
 
+    /**
+     * Endpoint to serve static assets
+     * This is used to serve static assets required by the assistant plugin
+     * namely, the models and vocabulary files (typically < 1MB in total).
+     * Assets are cached in memory to reduce load during bursts.
+     * The assets are fetched from the assistant service and cached for 30 minutes.
+     */
+    app.get('/assets/*', {
+        schema: {
+            hide: true, // dont show in swagger
+            response: {
+                200: {
+                    type: 'string'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        const upstreamPath = request.params['*'] // the path to the asset
+        if (!upstreamPath) {
+            return reply.code(400).send({ code: 'invalid_path', error: 'Invalid asset path' })
+        } else if (upstreamPath.startsWith('/')) {
+            return reply.code(400).send({ code: 'invalid_path', error: 'Asset paths must not start with a slash' })
+        }
+        const targetUrl = new URL(`assets/${upstreamPath}`, serviceUrl).toString() // construct the full URL to the asset
+        const cacheKey = upstreamPath
+        const cachedAsset = assetCache.get(cacheKey)
+        // check if the asset is cached
+        if (cachedAsset) {
+            // FUTURE: add an etag to the cached asset and if the client has an If-None-Match header, check if it matches the cached asset's ETag
+            // If it does, return a 304 Not Modified response
+            // For now, the requester (ff-assistant) does not store the file or ETag so there is no point at this time.
+            // However, if we have a WAF or similar in front of this service, it may add an ETag header to the response
+            // and we can use that to send a 304 Not Modified response
+            reply.code(cachedAsset.statusCode)
+            const responseHeaders = buildAssetResponseHeaders(cachedAsset)
+            for (const headerName in responseHeaders) {
+                reply.header(headerName, responseHeaders[headerName])
+            }
+            return reply.send(cachedAsset.body)
+        }
+
+        // Make a get request for asset to the assistant service
+        try {
+            const headers = await buildRequestHeaders(request)
+            const response = await axios.get(targetUrl, {
+                headers,
+                responseType: 'arraybuffer', // Always get response as a buffer to handle both binary and text/json
+                timeout: requestTimeout,
+                validateStatus: (status) => true // Accept all status codes, we will handle them manually
+            })
+            const responseBody = Buffer.from(response.data)
+
+            // Store the response in cache, including status, headers, and body
+            const assetToCache = {
+                statusCode: response.status, // Axios uses 'status' for status code
+                headers: {
+                    ...response.headers
+                },
+                body: responseBody // This will be a Node.js Buffer
+            }
+            // cache the asset
+            assetCache.set(upstreamPath, assetToCache)
+            const responseHeaders = buildAssetResponseHeaders(response)
+            for (const headerName in responseHeaders) {
+                reply.header(headerName, responseHeaders[headerName])
+            }
+            reply.send(response.data)
+        } catch (error) {
+            if (!reply.sent) {
+                reply.code(error.response?.status || 500).send({ code: error.response?.data?.code || 'unexpected_error', error: error.response?.data?.error || error.message })
+            }
+        }
+    })
     /**
      * Endpoint for assistant methods
      * For now, this is simply a relay to an external assistant service
@@ -135,6 +218,24 @@ module.exports = async function (app) {
         }
         if (request.headers['user-agent']) {
             headers['User-Agent'] = request.headers['user-agent']
+        }
+        return headers
+    }
+
+    function buildAssetResponseHeaders (response) {
+        // A list of headers to pass through from the backend assistant asset service to the client.
+        // They are only added if they are present in the response.
+        // This is to ensure we only pass through headers that are relevant (and avoid passing through sensitive headers).
+        const ASSET_HEADERS_TO_PROXY = [
+            'content-type', 'content-length', 'date', 'expires',
+            'last-modified', 'cache-control', 'vary', 'accept-ranges', 'age'
+        ]
+        const headers = {}
+        const sourceHeaders = response.headers || response // handles both Axios and cached object headers
+        for (const headerName of ASSET_HEADERS_TO_PROXY) {
+            if (sourceHeaders[headerName]) {
+                headers[headerName] = sourceHeaders[headerName]
+            }
         }
         return headers
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
                 "jsonwebtoken": "^9.0.0",
                 "ldapts": "^7.0.12",
                 "lottie-web-vue": "^2.0.7",
+                "lru-cache": "^11.1.0",
                 "marked": "^15.0.7",
                 "mqtt": "^5.1.1",
                 "mqtt-match": "^3.0.0",
@@ -15869,10 +15870,13 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "license": "ISC"
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+            "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/magic-string": {
             "version": "0.30.17",
@@ -16622,6 +16626,12 @@
                 "debug": "^4.3.4",
                 "process-nextick-args": "^2.0.1"
             }
+        },
+        "node_modules/mqtt/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
         },
         "node_modules/ms": {
             "version": "2.1.2",
@@ -18261,6 +18271,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
         },
         "node_modules/path-scurry/node_modules/minipass": {
             "version": "7.0.4",
@@ -35881,9 +35897,9 @@
             "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
         },
         "lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+            "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="
         },
         "magic-string": {
             "version": "0.30.17",
@@ -36410,6 +36426,13 @@
                 "split2": "^4.2.0",
                 "worker-timers": "^7.1.4",
                 "ws": "^8.17.1"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "10.4.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+                    "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+                }
             }
         },
         "mqtt-match": {
@@ -37669,6 +37692,11 @@
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "dependencies": {
+                "lru-cache": {
+                    "version": "10.4.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+                    "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+                },
                 "minipass": {
                     "version": "7.0.4",
                     "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
         "jsonwebtoken": "^9.0.0",
         "ldapts": "^7.0.12",
         "lottie-web-vue": "^2.0.7",
+        "lru-cache": "^11.1.0",
         "marked": "^15.0.7",
         "mqtt": "^5.1.1",
         "mqtt-match": "^3.0.0",


### PR DESCRIPTION
## Description

TLDR;
* Refactors header and config logic for re-use in additional endpoint
* Adds endpoint `/assets/*` to `/api/v1/assistant`
   * Full URL:  `/api/v1/assistant/assets/*`
   * Sets `schema.hide: true` while the feature set grows (same as existing endpoint)
* Adds LRUCache module and asset caching and endpoint 
   * Selected an arborary number of `max: 100` (this could be revised down to something closer to 5 if desired - since we dont have many resources today, but that may change with new features being added)
   * Set `ttl` to 30 mins with a hard expiry (i.e. subsequent `GET` requests will not reset ttl. This is to permit a refresh when new assets are pushed to the upstream resource.
   * Unit tests

### Tests added to `test/unit/forge/routes/api/assistant_spec.js`
```
▼ Assistant API
  ▼ assets endpoint
    ✔ should return 401 for anonymous access
    ✔ should return 401 for random token
    ✔ should return 401 for user token
    ✔ should return 400 for missing asset path
    ✔ should return 400 for asset path starting with slash
    ✔ should handle upstream error
    ✔ should fetch and cache asset for device token
    ✔ should fetch and cache asset for instance token
    ✔ should fetch fresh after cache expiration
```



* ## Related Issue(s)

closes #5722

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

