### PR TITLE
Fix: add back the missing device sort option to recently modified devices

### DIFF
--- a/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
@@ -110,7 +110,7 @@ export default {
                 limit = 3
                 this.hasMore = true
             }
-            return teamAPI.getTeamDevices(this.team.id, null, limit, null, { })
+            return teamAPI.getTeamDevices(this.team.id, null, limit, null, { sort: 'state-priority' })
                 .then((res) => {
                     this.devices = res.devices
                 })


### PR DESCRIPTION
## Description

Adding back the sort option by state priority to the get recently modified team devices to properly sort them.
The option must have gotten lost through subsequent merges after the main task was reverted.

## Related Issue(s)

initially implemented in https://github.com/FlowFuse/flowfuse/issues/5671

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

