### PR TITLE
Fix multi-step-form inconsistent behavior when navigating between steps

### DIFF
--- a/frontend/src/components/multi-step-forms/instance/steps/ApplicationStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/ApplicationStep.vue
@@ -193,7 +193,6 @@ export default {
                         errors
                     }
                 })
-                this.$emit('next-step')
             },
             deep: true,
             immediate: true
@@ -231,6 +230,9 @@ export default {
                 this.selection = null
             } else {
                 this.selection = application
+                this.$nextTick(() => {
+                    this.$emit('next-step')
+                })
             }
         }
     }

--- a/frontend/src/components/multi-step-forms/instance/steps/InstanceStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/InstanceStep.vue
@@ -273,6 +273,7 @@ export default {
     },
     watch: {
         input: {
+            immediate: true,
             deep: true,
             handler () {
                 this.updateParent()


### PR DESCRIPTION
## Description

Fixes inconsistent behavior on the multi-step form when navigating between steps:
#### Navigating back to the applications page resulted in a push forward to the next step
- Caused by the next-step event being emitted in the selection watcher, which is triggered every time the application selection is updated — in this case, it was triggered by switching steps.
- The fix moves the automated next-step emitter to the selectApplication method, which is triggered only when a user clicks on an application tile, with a delay so the selection can be updated first.

#### The Next button remained enabled after navigating back to the instance step
- Occurred because the instance step was not re-evaluated when re-mounted and didn’t get a chance to update the parent container that it had errors, which would automatically disable the button.
- The fix evaluates the instance step input immediately upon mount.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5727

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

