### PR TITLE
Fix memberCount typo causing the add members cta to be permanently present

### DIFF
--- a/frontend/src/store/modules/ux/index.js
+++ b/frontend/src/store/modules/ux/index.js
@@ -335,13 +335,13 @@ const getters = {
                             alert: (() => {
                                 const teamAge = new Date().getTime() - new Date(team.createdAt).getTime()
                                 const fourteenDaysInMs = 14 * 24 * 60 * 60 * 1000
-                                if (team.membersCount === 1 && teamAge > fourteenDaysInMs) {
-                                    return null
+                                if (team.memberCount === 1 && teamAge < fourteenDaysInMs) {
+                                    return {
+                                        title: 'Add a team member and start collaborating!'
+                                    }
                                 }
 
-                                return {
-                                    title: 'Add a team member and start collaborating!'
-                                }
+                                return null
                             })()
                         }
                     ]


### PR DESCRIPTION
## Description

A typo on the team properties memberCount causes the add members CTA to be permanently present.

Also reversed the logic so the alert is null by default and shown only when condition is met.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

