### PR TITLE
ci: Rename GHA workflow responsible for container build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,14 +117,14 @@ jobs:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
 
-      - name: Trigger flowforge container build
+      - name: Trigger FlowFuse container build
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
-          workflow: flowforge-container.yml
+          workflow: flowfuse-container.yml
           repo: flowfuse/helm
           ref: main
           token: ${{ steps.generate_token.outputs.token }}
-          inputs: '{"flowforge_ref": "${{ github.ref }}", "flowforge_release_name": "${{ env.release_name }}"}'
+          inputs: '{"flowfuse_ref": "${{ github.ref }}", "flowfuse_release_name": "${{ env.release_name }}"}'
 
   notify-slack:
     name: Notify on failure


### PR DESCRIPTION
## Description

Important: should be merged together with https://github.com/FlowFuse/helm/pull/631

This pull request renames the workflow name which should be triggered after successful package publish in the `Publish` GHA workflow.

## Related Issue(s)

https://github.com/FlowFuse/admin/pull/405

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

