### PR TITLE
Tighter rate limit than default for Team Invite resend

### DIFF
--- a/forge/routes/api/teamInvitations.js
+++ b/forge/routes/api/teamInvitations.js
@@ -226,6 +226,16 @@ module.exports = async function (app) {
      * POST [/api/v1/teams/:teamId/invitations]/:invitationId
      */
     app.post('/:invitationId', {
+        config: {
+            rateLimit: app.config.rate_limits
+                ? {
+                    max: 1, // Allow one resend per minute
+                    timeWindow: 60000,
+                    keyGenerator: app.config.rate_limits.keyGenerator,
+                    hard: true
+                }
+                : false
+        },
         schema: {
             summary: 'Resend an invitation',
             tags: ['Team Invitations'],


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Enforce once per minute resend on Team invite if rateLimiting enabled.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

