### PR TITLE
Add an empty state and message to the home page when team creation is disabled

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -6,14 +6,31 @@
             </div>
         </template>
         <ff-page v-else-if="teams.length === 0">
-            <template #header>
+            <template v-if="canCreateTeam" #header>
                 <ff-page-header title="Choose Team Type">
                     <template #context>
                         Choose which team type you'd like to get started with.
                     </template>
                 </ff-page-header>
             </template>
-            <TeamTypeSelection />
+            <TeamTypeSelection v-if="canCreateTeam" />
+            <EmptyState v-else>
+                <template #img>
+                    <img src="../images/empty-states/team-instances.png">
+                </template>
+                <template #header>Team Creation is currently disabled</template>
+                <template #message>
+                    <p>You cannot create a team at the moment because this feature is disabled by an administrator.</p>
+                    <p>
+                        To join a team, you need to be invited by someone who is already a member.
+                    </p>
+                </template>
+                <template #note>
+                    <p>
+                        Administrators can enable user team creation in the platform settings if needed.
+                    </p>
+                </template>
+            </EmptyState>
         </ff-page>
     </main>
 </template>
@@ -22,6 +39,8 @@
 
 import { mapGetters, mapState } from 'vuex'
 
+import EmptyState from '../components/EmptyState.vue'
+
 import FlowFuseLogo from '../components/Logo.vue'
 
 import TeamTypeSelection from '../components/TeamTypeSelection.vue'
@@ -29,6 +48,7 @@ import TeamTypeSelection from '../components/TeamTypeSelection.vue'
 export default {
     name: 'HomePage',
     components: {
+        EmptyState,
         FlowFuseLogo,
         TeamTypeSelection
     },
@@ -38,8 +58,11 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['pending', 'user', 'team', 'teams', 'redirectUrlAfterLogin']),
-        ...mapGetters('account', ['defaultUserTeam'])
+        ...mapState('account', ['pending', 'user', 'team', 'teams', 'redirectUrlAfterLogin', 'settings']),
+        ...mapGetters('account', ['defaultUserTeam']),
+        canCreateTeam () {
+            return Object.prototype.hasOwnProperty.call(this.settings, 'team:create') && this.settings['team:create'] === true
+        }
     },
     watch: {
         team: 'redirectOnLoad',


### PR DESCRIPTION
## Description

Adds an empty-state message for users without teams to avoid the team-selection limbo, when team creation is disabled in platform settings.

![image](https://github.com/user-attachments/assets/120c8acb-9624-4973-9d98-23e401a3d9a8)

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5766

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

