### PR TITLE
Encrypted hidden env vars when exporting snapshots

### DIFF
--- a/forge/ee/db/models/PipelineStageGitRepo.js
+++ b/forge/ee/db/models/PipelineStageGitRepo.js
@@ -156,6 +156,7 @@ module.exports = {
                             token: gitToken.token,
                             url: this.url,
                             branch: this.pullBranch || this.branch,
+                            credentialSecret: this.credentialSecret,
                             path: sourceFilename
                         }, options)
                         // snapshotContent is a JSON representation of the snapshot. We need to convert it to a


### PR DESCRIPTION
Fixes https://github.com/FlowFuse/security/issues/105

## Description

This ensures any hidden env vars in a snapshot are encrypted when the snapshot is exported. The values are encrypted with the snapshot credential secret - the same key used to encrypt the flow credentials.

The import snapshot path is also updated to decrypt the values on import.


