### PR TITLE
Apply requireContact check to team upgrade

### DIFF
--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -378,6 +378,14 @@ module.exports = async function (app) {
                 response.code(400).send({ code: 'invalid_team_type', error: 'Invalid team type' })
                 return
             }
+            if (targetTeamType.id !== request.team.TeamTypeId) {
+                // This is a *change* in team type. Check the 'contact required' flag
+                if (targetTeamType.getProperty('billing.requireContact', false) && request.session.User && !request.session.User.admin) {
+                    response.code(403).type('application/json').send({ code: 'contact_required', error: 'Contact required for this team type' })
+                    return
+                }
+            }
+
             try {
                 await request.team.checkTeamTypeUpdateAllowed(targetTeamType)
             } catch (err) {


### PR DESCRIPTION
Fixes https://github.com/FlowFuse/security/issues/108

The 'requireContact' check is currently only made in the UI. This extends it to also apply at the API level - to ensure only admin users can action an upgrade to a team tier with 'requireContact' set.