### PR TITLE
Allow a team to setup billing at current team tier without contact

### DIFF
--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -152,7 +152,9 @@ export default {
         isContactRequired () {
             return this.billingEnabled &&
                    !this.user.admin &&
-                   this.input.teamType && this.input.teamType.properties?.billing?.requireContact
+                   this.input.teamType &&
+                   this.input.teamTypeId !== this.team.type.id &&
+                   this.input.teamType.properties?.billing?.requireContact
         },
         isSelectionAvailable () {
             if (this.input.teamTypeId) {


### PR DESCRIPTION
The 'requireContact' flag used to direct a user to sales for particular team tiers should only apply when *changing* the team tier.

In the case that a user's subscription has expired for some reason, the existing logic doesn't let them self-service the renewal.

With this fix, they can access stripe checkout on a 'require contact' tier if they aren't changing tier.