### PR TITLE
Prevent users from selecting other applications when duplicating instances

### DIFF
--- a/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepDuplicateInstanceForm.vue
@@ -159,18 +159,21 @@ export default {
         },
         async getApplications () {
             const data = await teamApi.getTeamApplications(this.team.id)
-            this.applications = data.applications.map((a) => {
-                return {
-                    label: a.name,
-                    description: a.description,
-                    value: a.id,
-                    id: a.id,
-                    counters: {
-                        instances: a.instances.length,
-                        devices: a.devices.length
+            this.applications = data.applications
+                .map((a) => {
+                    return {
+                        label: a.name,
+                        description: a.description,
+                        value: a.id,
+                        id: a.id,
+                        counters: {
+                            instances: a.instances.length,
+                            devices: a.devices.length
+                        }
                     }
-                }
-            })
+                })
+                // filter out applications that don't own to the origin instance, @see #5785
+                .filter(app => app.id === this.instance.application.id)
         },
         prefillForm () {
             const input = {


### PR DESCRIPTION
## Description

Fixes oversight on the UI when duplicating instances that permits users to select different applications when duplicating instances when the back end has a check in place that prevents, this allowing to duplicate instances only inside the same application.

The fix filters out available applications other than the source instance application while still allowing users to go back to the applications step. This approach allows for ease of reversal in case things change on the back end.

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5785

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

