### PR TITLE
Ensure template-provided hidden env vars are not cleared on update

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -422,14 +422,19 @@ module.exports = async function (app) {
             // Merge the settings into the existing values
             const currentProjectSettings = await request.project.getSetting(KEY_SETTINGS) || {}
             if (newSettings.env && Array.isArray(newSettings.env)) {
-                newSettings.env = newSettings.env.map(env => {
+                newSettings.env = newSettings.env.filter(env => {
                     // hidden env vars are received as empty strings so we'll replace the empty string with the previous value,
                     // allowing them to be overwritten when needed
                     if (Object.prototype.hasOwnProperty.call(env, 'hidden') && env.hidden && !env.value.length) {
                         const previousValue = currentProjectSettings.env.find(e => e.name === env.name)
+                        if (!previousValue) {
+                            // this is a hidden env var with no value provided and no instance-level value. This
+                            // means it has come from the template and we should not add it to the instance
+                            return false
+                        }
                         env.value = previousValue.value
                     }
-                    return env
+                    return true
                 })
             }
             const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings)

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -176,9 +176,13 @@ export default {
                     // This is a value that cannot be overwritten, so skip it
                     return
                 } else if (field.policy && field.value === this.templateEnvValues[field.name]) {
-                    // This is a template value that can be overwritten. Check
-                    // if the value matches template - if so, skip adding it
-                    return
+                    // This is a template value that can be overwritten.
+                    // If not hidden and the value matches the template, skip adding it.
+                    // Otherise, if hidden, send the value back and let the runtime work
+                    // out whether to add/update it to the instance level settings
+                    if (!field.hidden) {
+                        return
+                    }
                 }
                 settings.env.push({
                     name: field.name,


### PR DESCRIPTION
Fixes #5750 

Template provided hidden env vars were being lost when the instance settings were updated.

The front-end had logic to not send back Template level env vars whose value had not changed. However, in the case of hidden env vars, this meant the value wasn't been sent back at all - so the instance would lose any value it had set for the var.

This fixes it by sending back template-level hidden env vars regardless of their value, and have the backend workout if it represents an add/update for a value at the instance level, or leave it alone.