### PR TITLE
Remote 'CTA' text from emails

### DIFF
--- a/forge/postoffice/templates/Crashed-out-of-memory.js
+++ b/forge/postoffice/templates/Crashed-out-of-memory.js
@@ -85,7 +85,6 @@ Logs:
 </p>
 {{/if}}
 
-<p>You can access the instance and its logs here</p>
-<a href="{{{ url }}}">Instance Logs</a>
+<p>You can access the instance and its logs here: <a href="{{{ url }}}">Instance Logs</a></p>
 `
 }

--- a/forge/postoffice/templates/Crashed-uncaught-exception.js
+++ b/forge/postoffice/templates/Crashed-uncaught-exception.js
@@ -84,7 +84,6 @@ Logs:
 </p>
 {{/if}}
 
-<p>You can access the instance and its logs here</p>
-<a href="{{{ url }}}">Instance Logs</a>
+<p>You can access the instance and its logs here: <a href="{{{ url }}}">Instance Logs</a></p>
 `
 }

--- a/forge/postoffice/templates/Crashed.js
+++ b/forge/postoffice/templates/Crashed.js
@@ -84,7 +84,6 @@ Logs:
 </p>
 {{/if}}
 
-<p>You can access the instance and its logs here</p>
-<a href="{{{ url }}}">Instance Logs</a>
+<p>You can access the instance and its logs here: <a href="{{{ url }}}">Instance Logs</a></p>
 `
 }

--- a/forge/postoffice/templates/InstanceResourceCPUExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceCPUExceeded.js
@@ -89,7 +89,7 @@ Logs:
 </p>
 {{/if}}
 
-<p>You can access the instance and its logs here</p>
-<a href="{{{ url }}}">Instance Logs</a>
+<p>You can access the instance and its logs here: <a href="{{{ url }}}">Instance Logs</a></p>
+
 `
 }

--- a/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
+++ b/forge/postoffice/templates/InstanceResourceMemoryExceeded.js
@@ -88,7 +88,7 @@ Logs:
 </p>
 {{/if}}
 
-<p>You can access the instance and its logs here</p>
-<a href="{{{ url }}}">Instance Logs</a>
+<p>You can access the instance and its logs here: <a href="{{{ url }}}">Instance Logs</a></p>
+
 `
 }


### PR DESCRIPTION
## Description

Paraphrasing feedback received on the email content: why does it say CTA?

This PR removes the `CTA:` text from the emails as it doesn't look good and fixes an odd looking line break:

Previous:

<img width="396" height="133" alt="image" src="https://github.com/user-attachments/assets/5b1c33a8-df2f-414f-aeef-ec24cf77a120" />


Updated:

<img width="491" height="122" alt="image" src="https://github.com/user-attachments/assets/1f1aa753-2257-4df7-b665-13e1e184b2e8" />

