### PR TITLE
Enhance the latest known project state

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -10,6 +10,8 @@ const { KEY_SETTINGS } = require('../models/ProjectSettings')
  */
 const inflightProjectState = { }
 
+const latestProjectState = { }
+
 const inflightDeploys = new Set()
 
 module.exports = {
@@ -545,7 +547,7 @@ module.exports = {
     },
 
     /**
-     * Imports settings, flows and credentials from a project export object
+     * Imports settings, flows, and credentials from a project export object
      *
      * @param {*} app
      * @param {*} project
@@ -688,6 +690,56 @@ module.exports = {
         const modules = flowBlueprint.modules || {}
         for (const [moduleName, version] of Object.entries(modules)) {
             await app.db.controllers.Project.addProjectModule(instance, moduleName, version)
+        }
+    },
+
+    /**
+     * Retrieves the latest state of a specified project.
+     *
+     * @param {string|Number} projectId - The unique identifier of the project whose latest state is to be retrieved.
+     * @returns {string} The latest state of the specified project.
+     */
+    getLatestProjectState: function (app, projectId) {
+        return latestProjectState[projectId]
+    },
+
+    /**
+     * Updates the state of the latest project for a given project ID.
+     *
+     * @function
+     * @param {string|number} projectId - The unique identifier of the project whose state is being updated.
+     * @param {any} state - The new state to be assigned to the project.
+     */
+    setLatestProjectState: function (app, projectId, state) {
+        latestProjectState[projectId] = state
+    },
+
+    /**
+     * Clears the latest project state for a specific project.
+     *
+     * This function deletes the entry in the `latestProjectState` object corresponding
+     * to the provided project's ID. The state deletion is context-specific to the project
+     * and associated application.
+     *
+     * @param {String|Number} projectId - The project id whose latest state should be cleared.
+     */
+    clearLatestProjectState: function (app, projectId) {
+        delete latestProjectState[projectId]
+    },
+
+    /**
+     * Updates the latest project state for the specified app and project based on the given state.
+     * If the state is 'running' or 'stopped', it clears the latest driver state.
+     * Otherwise, it sets the latest driver state to the new value.
+     *
+     * @param {String|Number} projectId - The project id related to the driver state update.
+     * @param {string} state - The new state to update, can be 'running', 'stopped', or other valid states.
+     */
+    updateLatestProjectState: function (app, projectId, state) {
+        if (['running', 'stopped'].includes(state)) {
+            this.clearLatestProjectState(app, projectId)
+        } else {
+            this.setLatestProjectState(app, projectId, state)
         }
     }
 }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -1320,6 +1320,50 @@ module.exports = async function (app) {
         })
     })
 
+    app.post('/:instanceId/update-state', {
+        preHandler: (request, reply, done) => {
+            // check accessToken is project scope
+            // (ownerId already checked at top-level preHandler)
+            if (request.session.ownerType !== 'project') {
+                reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+            } else {
+                done()
+            }
+        },
+        schema: {
+            summary: 'Update the live status of an instance',
+            tags: ['Instances', 'Live State'],
+            params: {
+                type: 'object',
+                required: ['instanceId'],
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            body: {
+                type: 'object',
+                required: ['state'],
+                properties: {
+                    state: { type: 'string' },
+                    hashId: { type: 'string' }
+                }
+            },
+            response: {
+                202: {
+                    type: 'object',
+                    properties: {}
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        app.db.Controller.Project.updateLatestProjectState(request.params.instanceId, request.body.state)
+
+        reply.code(202).send()
+    })
+
     /**
      * Merge env vars from 2 arrays.
      *


### PR DESCRIPTION
## Description

First part of mitigating incorrect state counters when retrieving aggregated instance counters.

- Added a new in-memory `latestProjectState` map in the Project Controller to track live project state.
  - tracks non-definitive states (excluding `running` and `stopped`) so we can output relevant state counters when querying a team's instances grouped by state.
  - the reason why we track only non-definitive states is because when an instance is in a definitive state we can rely on the state stored in the database (the desired state)
- Use the `latestProjectState` map when retrieving aggregated data in the Project's `countByState` method.
  - the live state is updated only when the underlying driver checks the instance state which means that the `liveState` endpoint still needs to be triggered by users at some point to get up-to-date data, otherwise it might return stale data
- Exposed an API endpoint that allows instances to update their state to mitigate the above drawback.

This is not a foolproof approach. As it stands, the `latestProjectState` map is cleared on each CI deployment. In the long run, we should move this to an in-memory data store so its values persist across deployments. Nonetheless, with the follow-up task on the `nr-launcher`, which will update the instance state on specific events as they occur,  this is definitely a step up from what we have now.

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/5721

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

