### PR TITLE
Add logging of device status checkins

### DIFF
--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -93,6 +93,7 @@ class DeviceCommsHandler {
                 // TODO: log invalid device
                 return
             }
+            const startTime = Date.now()
             try {
                 const payload = JSON.parse(status.status)
                 await this.app.db.controllers.Device.updateState(device, payload)
@@ -145,7 +146,9 @@ class DeviceCommsHandler {
                 if (sendUpdateCommand) {
                     await this.app.db.controllers.Device.sendDeviceUpdateCommand(device)
                 }
+                this.app.log.info({ msg: 'Device status update', device: deviceId, team: device.Team?.hashid, sendUpdateCommand, responseTime: Date.now() - startTime })
             } catch (err) {
+                this.app.log.info({ msg: 'Device status update error', device: deviceId, team: device.Team?.hashid, responseTime: Date.now() - startTime, err: err.message })
                 // Not a JSON payload - ignore
                 if (err instanceof SyntaxError) {
                     return

--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -100,6 +100,7 @@ class DeviceCommsHandler {
 
                 if (payload === null) {
                     // This device is busy updating - don't interrupt it
+                    this.app.log.info({ msg: 'Device status update - null status', device: deviceId, team: device.Team?.hashid, responseTime: Date.now() - startTime })
                     return
                 }
 


### PR DESCRIPTION
Part of #5782 

Adds logging around the device status checkin handling. As this comes via MQTT, it is not otherwise logged.

The log output will identify the device, team, whether an update was sent back and the overall time to handle the update (in ms). If the case of an error, the error message is logged.

When running with pretty print on, the output looks like:
```
[2025-07-21T09:41:17.887Z] INFO: Device status update {"device":"O65j96mX8e","team":"XGxvbKL57q","sendUpdateCommand":false,"responseTime":4}
```

When running without pretty print:

```
{"level":"INFO","time":"2025-07-21T09:44:54.849Z","msg":"Device status update","device":"O65j96mX8e","team":"XGxvbKL57q","sendUpdateCommand":false,"responseTime":3}
```