### PR TITLE
Fix state regeneration when switching between context stores

### DIFF
--- a/frontend/src/store/plugins/storage.plugin.js
+++ b/frontend/src/store/plugins/storage.plugin.js
@@ -62,8 +62,10 @@ function updateVuexFromStorageDriver (store, storageDriver) {
                 targetState = targetState[keys[i]]
             }
 
+            if (Object.prototype.hasOwnProperty.call(targetState, keys[keys.length - 1])) {
             // Merge stored state into the existing module state instead of replacing it
-            Object.assign(targetState[keys[keys.length - 1]], storedState[storeKey])
+                Object.assign(targetState[keys[keys.length - 1]], storedState[storeKey])
+            }
         })
     }
 }


### PR DESCRIPTION
## Description


This fix solves recurring problems when the localStorage cache is rebuilt while working on new Vuex stores or production rllbacks.
<img width="484" height="175" alt="image" src="https://github.com/user-attachments/assets/a2efd6fb-653b-43f0-b628-6b835e9a1e35" />
The above error is accompanied by a full app crash and blank screen.


Use cases:
- Development: When adding new Vuex keys/stores on a feature branch, switching to a branch that doesn’t have them crashes the app. Clearing localStorage fixes it.
- Production rollback: If a rollback removes Vuex keys/stores that users already have in localStorage, the app crashes. Since localStorage is client-side, we can’t clear it remotely.

Why this happens:
- We cache Vuex state in localStorage via storage.plugin. On app load, we restore Vuex from localStorage.
- If localStorage has keys that no longer exist in the current Vuex store (because of a rollback or unfinished dev work), we try to assign data to nonexistent stores/keys, which causes errors.

The fix consists of a basic check when restoring Vuex from localStorage, making sure we only assign data to keys that actually exist in the current store.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

