### PR TITLE
Fix check on snapshot id in device status update

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -55,7 +55,7 @@ module.exports = {
                 // Update the activeSnapshotId if valid and not already set
                 const snapshotId = app.db.models.ProjectSnapshot.decodeHashid(state.snapshot)
                 // hashid.decode returns an array of values, not the raw value.
-                if (snapshotId?.length > 0 && snapshotId !== device.activeSnapshotId) {
+                if (snapshotId?.length > 0 && snapshotId[0] !== device.activeSnapshotId) {
                     // Check to see if snapshot exists
                     if (await app.db.models.ProjectSnapshot.count({ where: { id: snapshotId }, limit: 1 }) > 0) {
                         device.set('activeSnapshotId', snapshotId[0])


### PR DESCRIPTION
Part of #5805 

When a device checks in, the code checks to see if the reported snapshot matches the known active snapshot. If they differ, it checks that the reported snapshot still exists and if so, updates the device's `activeSnapshotId`.

However, the check on whether they differ was comparing a decoded hashid with the raw id - ie `[123] !== 123` - causing it to always think they differ. This led to the snapshot existence check to be performed on *every* checkin.

This fixes the comparison and will remove an unnecessary db operation when devices checkin.