### PR TITLE
Add a new project-status permission that allows dashboard users to query instance status

### DIFF
--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -41,6 +41,7 @@ const Permissions = {
     'project:create': { description: 'Create Project', role: Roles.Owner },
     'project:delete': { description: 'Delete Project', role: Roles.Owner },
     'project:read': { description: 'View a Project', role: Roles.Viewer },
+    'project:status': { description: 'View a Project', role: Roles.Dashboard },
     'project:transfer': { description: 'Transfer Project', role: Roles.Owner },
     'project:change-status': { description: 'Start/Stop Project', role: Roles.Owner },
     'project:edit': { description: 'Edit Project Settings', role: Roles.Owner },

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -1283,7 +1283,7 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.project
      */
     app.get('/:instanceId/status', {
-        preHandler: app.needsPermission('project:read'),
+        preHandler: app.needsPermission('project:status'),
         schema: {
             summary: 'Get the live status of an instance',
             tags: ['Instances', 'Live State'],

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -2785,7 +2785,7 @@ describe('Project API', function () {
             result.meta.should.have.property('state', 'unknown')
         })
 
-        it('should return 403 if user does not have project:read permission', async function () {
+        it('should return 200 if the user has the project:status permission', async function () {
             const instance = await app.factory.createInstance(
                 { name: generateProjectName() },
                 TestObjects.ApplicationC,
@@ -2801,7 +2801,7 @@ describe('Project API', function () {
                 cookies: { sid: TestObjects.tokens.evan }
             })
 
-            response.statusCode.should.equal(403)
+            response.statusCode.should.equal(200)
         })
 
         it('should return 404 if user is not part of that team', async function () {


### PR DESCRIPTION
## Description

Relaxing the status check endpoint permissions to allow dashboard users to query an instance's status to prevent the dashboard button from being permanently disabled

## Related Issue(s)

introduced by https://github.com/FlowFuse/flowfuse/pull/5746
closes https://github.com/FlowFuse/flowfuse/issues/5807

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

