### PR TITLE
Minimise Device look up on status update

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -307,13 +307,13 @@ module.exports = {
                 }
             },
             static: {
-                byId: async (id) => {
+                byId: async (id, options = { includeAssociations: true }) => {
                     if (typeof id === 'string') {
                         id = M.Device.decodeHashid(id)
                     }
-                    return this.findOne({
-                        where: { id },
-                        include: [
+                    let include = []
+                    if (options.includeAssociations) {
+                        include = [
                             {
                                 model: M.Team,
                                 attributes: ['hashid', 'id', 'name', 'slug', 'links', 'TeamTypeId']
@@ -330,6 +330,10 @@ module.exports = {
                             { model: M.ProjectSnapshot, as: 'targetSnapshot', attributes: ['id', 'hashid', 'name'] },
                             { model: M.ProjectSnapshot, as: 'activeSnapshot', attributes: ['id', 'hashid', 'name'] }
                         ]
+                    }
+                    return this.findOne({
+                        where: { id },
+                        include
                     })
                 },
                 byTeam: async (teamIdOrHash, { query = null, deviceId = null } = {}) => {

--- a/forge/ee/db/controllers/DeviceGroup.js
+++ b/forge/ee/db/controllers/DeviceGroup.js
@@ -249,7 +249,7 @@ module.exports = {
      * so that they can determine what/if it needs to be updated
      * NOTE: Since device groups only support application owned devices, this will only send updates to application owned devices
      *
-     * To avoid triggering a thundering herd, this will send the updates in batches of 10 devices at a time with
+     * To avoid triggering a thundering herd, this will send the updates in batches of 5 devices at a time with
      * a delay of 5 seconds between each batch.
      * @param {forge.db.models.DeviceGroup} [deviceGroup] A device group to send an "update" command to
      * @param {Number[]} [deviceList] A list of device IDs to send an "update" command to
@@ -294,9 +294,10 @@ module.exports = {
                         })
                     }
 
-                    // Send the commands in batches of 10 with a 5 second delay between each batch
+                    // Send the commands in batches of 5 with a 5 second delay between each batch
                     // This is to avoid telling lots of devices to call home at the same time.
-                    const batchSize = 10
+                    // This is a tactical fix to avoid a thundering herd problem and one we'll need to revisit
+                    const batchSize = 5
                     const delay = 5000
                     let start = 0
                     while (start < commands.length) {


### PR DESCRIPTION
Part of #5805 

This reduces the DB query made when looking up a device as part of the status handling path to *only* touch the Device table.

I've also reduced the batch size for Device Group commands to 5 per 5s, down from 10. This is a short term fix to lighten the load whilst we work on other optimisations.