### PR TITLE
Remove warning about depricated schema on startup

### DIFF
--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -307,7 +307,10 @@ module.exports = async function (app) {
                 id: { type: 'string' }
             },
             response: {
-                201: {},
+                201: {
+                    type: 'null',
+                    description: 'empty response'
+                },
                 '4xx': {
                     $ref: 'APIError'
                 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Seen in the Staging startup logs:

```
(node:1) [FSTDEP021] DeprecationWarning: You are using the deprecated json shorthand schema on route /api/v1/user/tokens/:id. Specify full object schema instead. It will be removed in `fastify@v5`
(Use `node --trace-deprecation ...` to show where the warning was created)
```

this should remove the warning

Context

https://github.com/fastify/fastify/issues/4833

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

