### PR TITLE
Double logging for FF Tables create errors

### DIFF
--- a/forge/ee/routes/tables/index.js
+++ b/forge/ee/routes/tables/index.js
@@ -91,6 +91,7 @@ module.exports = async function (app) {
                 return reply.status(409).send({ code: 'already_exists', error: 'Database already exists' })
             } else {
                 // console.log(err)
+                app.log.error(`Create FF tables error ${err.toString()}`)
                 reply.status(500).send({ code: 'unexpected_error', error: 'Failed to create database' })
             }
         }


### PR DESCRIPTION
## Description
Double check for FF Database create errors

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

