### PR TITLE
Remove double port from FF Tables creds

### DIFF
--- a/frontend/src/pages/team/Tables/Table/components/TableCredentials.vue
+++ b/frontend/src/pages/team/Tables/Table/components/TableCredentials.vue
@@ -19,7 +19,7 @@
                         <dt>Port</dt>
                         <dd>{{ database.credentials.port }}</dd>
                     </div>
-                    <div class="flex item">
+                    <div v-if="database.credentials.ssl" class="flex item">
                         <dt>SSL</dt>
                         <dd>{{ database.credentials.ssl }}</dd>
                     </div>
@@ -40,10 +40,6 @@
                     <div class="flex item">
                         <dt>Password:</dt>
                         <dd>{{ database.credentials.password }}</dd>
-                    </div>
-                    <div class="flex item">
-                        <dt>Port</dt>
-                        <dd>{{ database.credentials.port }}</dd>
                     </div>
                 </dl>
             </div>


### PR DESCRIPTION
## Description

Port number was shown twice, and only show SSL if required.

Before:
<img width="2864" height="368" alt="image" src="https://github.com/user-attachments/assets/40b2d67b-c1e3-48b9-bd02-96629e7dd86f" />


After:
<img width="2864" height="368" alt="image" src="https://github.com/user-attachments/assets/de2f5e4c-f25f-4cfb-b94c-67beb150a48b" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

