### PR TITLE
Fix team switching race condition from the tables page

### DIFF
--- a/frontend/src/pages/team/Tables/index.vue
+++ b/frontend/src/pages/team/Tables/index.vue
@@ -28,9 +28,9 @@
                 </EmptyState>
             </template>
             <template v-else>
-                <ff-loading v-if="loading" message="Loading Databases..." />
+                <ff-loading v-if="loading || pendingTeamChange" message="Loading Databases..." />
 
-                <router-view v-slot="{ Component }">
+                <router-view v-else v-slot="{ Component }">
                     <transition name="page-fade" mode="out-in">
                         <component
                             :is="Component"
@@ -66,7 +66,7 @@ export default defineComponent({
         }
     },
     computed: {
-        ...mapGetters('account', ['featuresCheck', 'team']),
+        ...mapGetters('account', ['featuresCheck', 'team', 'pendingTeamChange']),
         ...mapState('product/tables', ['databases'])
     },
     watch: {
@@ -87,6 +87,10 @@ export default defineComponent({
         }
     },
     mounted () {
+        if (this.pendingTeamChange) {
+            return
+        }
+
         if (!this.featuresCheck.isTablesFeatureEnabledForPlatform) {
             return this.$router.push({ name: 'Home' })
         }

--- a/frontend/src/store/modules/account/index.js
+++ b/frontend/src/store/modules/account/index.js
@@ -503,7 +503,7 @@ const actions = {
             teamMembership = await teamApi.getTeamUserMembership(team.id)
         }
         state.commit('setTeam', team)
-        state.dispatch('clearOtherStores')
+        await state.dispatch('clearOtherStores')
         state.commit('setTeamMembership', teamMembership)
         state.commit('clearPendingTeamChange')
     },


### PR DESCRIPTION
## Description

- wait for clearOtherStores when switching teams to avoid using stale data
- fix Loading Databases loader rendered at the same time with nested routes
- prevent the tables page mounted method from getting triggered if there's a pending state change to avoid redirection back to the tables page

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5835

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

