### PR TITLE
Fix table renderings

### DIFF
--- a/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsList.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsList.vue
@@ -8,8 +8,12 @@
             <p>Select a table to get going!</p>
         </div>
 
-        <div v-else-if="selectedTable && selectedTable.schema" class="content">
-            <ff-data-table :columns="columns" :rows="rows" />
+        <div v-else-if="selectedTable && selectedTable.schema" class="content overflow-auto h-full">
+            <ff-data-table
+                :columns="columns" :rows="rows"
+                class="h-full overflow-auto"
+                tableClass="table-auto overflow-auto"
+            />
         </div>
 
         <div v-else class="no-content w-full h-full flex justify-center items-center text-gray-400">
@@ -19,8 +23,10 @@
 </template>
 
 <script>
-import { defineComponent } from 'vue'
+import { defineComponent, markRaw } from 'vue'
 import { mapActions, mapGetters, mapState } from 'vuex'
+
+import TextCell from './table-cells/text-cell.vue'
 
 export default defineComponent({
     name: 'RowsList',
@@ -29,26 +35,22 @@ export default defineComponent({
         ...mapGetters('product/tables', ['selectedTable']),
         ...mapState('account', ['team']),
         columns () {
-            return (this.selectedTable?.schema ?? []).map(row => {
+            return (this.selectedTable?.schema ?? []).map((row) => {
                 return {
                     key: row.name,
-                    html: `<span>${row.name}</span> <span class="text-gray-400">${row.type}</span>`,
+                    html: `<span >${row.name}</span> <span class="text-gray-400">${row.type}</span>`,
                     sortable: true,
-                    style: {
-                        width: '32px',
-                        'max-width': '35px'
+                    component: {
+                        is: this.getTableComponent(row.type)
                     },
                     tableCellClass: 'truncate',
-                    tableLabelClass: 'truncate'
+                    tableLabelClass: 'truncate',
+                    headerClass: 'sticky top-0'
                 }
             })
         },
         rows () {
             return (this.selectedTable?.data ?? [])
-                .map(row => {
-                    // console.log(Object.entries(row))
-                    return row
-                })
         }
     },
     watch: {
@@ -70,7 +72,21 @@ export default defineComponent({
         this.updateTableSelection(null)
     },
     methods: {
-        ...mapActions('product/tables', ['getTableSchema', 'getTableData', 'updateTableSelection'])
+        ...mapActions('product/tables', ['getTableSchema', 'getTableData', 'updateTableSelection']),
+        getTableComponent (type) {
+            const componentMap = {
+                text: TextCell
+            }
+
+            if (Object.prototype.hasOwnProperty.call(componentMap, type)) {
+                return componentMap[type]
+            } else {
+                return markRaw({
+                    props: ['row-value'],
+                    template: '<span class="truncate">{{rowValue}}</span>'
+                })
+            }
+        }
     }
 })
 </script>
@@ -79,6 +95,7 @@ export default defineComponent({
 #rows-list {
     height: 100%;
     width: 100%;
+    overflow: auto;
 
     .header {
         border-bottom: 1px solid $ff-color--border;

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/components/table-cells/text-cell.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/components/table-cells/text-cell.vue
@@ -1,0 +1,73 @@
+<template>
+    <div class="text-cell">
+        <pre v-if="!isTooLong" class="value whitespace-pre-wrap">{{ isJson || rowValue }}</pre>
+        <span
+            v-else title="View more..."
+            class="cursor-pointer text-indigo-500 hover:text-indigo-700"
+            @click="openDetailedView"
+        >
+            View more..
+        </span>
+    </div>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+
+import Dialog from '../../../../../../../services/dialog.js'
+export default defineComponent({
+    name: 'text-cell',
+    props: {
+        rowValue: {
+            required: true,
+            type: String
+        },
+        column: {
+            required: true,
+            type: String
+        }
+    },
+    computed: {
+        isJson () {
+            try {
+                return JSON.stringify(JSON.parse(this.rowValue), null, 2)
+            } catch (e) {
+                return false
+            }
+        },
+        isTooLong () {
+            return this.rowValue.length > 50
+        }
+    },
+    methods: {
+        openDetailedView () {
+            let html = ''
+            if (this.isJson) {
+                html = `<pre class="break-words overflow-auto py-3">${this.isJson}</pre>`
+            } else {
+                html = `<code class="whitespace-normal break-words block">${this.rowValue}</code>`
+            }
+            Dialog.show({
+                header: `${this.column} value`,
+                kind: 'primary',
+                html,
+                confirmLabel: 'OK',
+                canBeCanceled: false
+            }, async () => {
+            })
+        }
+    }
+})
+</script>
+
+<style scoped lang="scss">
+.text-cell {
+    overflow: auto;
+    max-height: 3rem;
+
+    .value {
+        background: none;
+        border: none;
+    }
+}
+</style>

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/index.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/index.vue
@@ -34,6 +34,7 @@ export default defineComponent({
     gap: 15px;
     height: 100%;
     width: 100%;
+    overflow: auto;
 
     #tables-list {
         border-right: 1px solid $ff-color--border;

--- a/frontend/src/ui-components/components/data-table/DataTable.vue
+++ b/frontend/src/ui-components/components/data-table/DataTable.vue
@@ -12,7 +12,7 @@
                 <slot name="actions" />
             </div>
         </div>
-        <table class="ff-data-table--data">
+        <table class="ff-data-table--data" :class="tableClass ?? ''">
             <slot name="table">
                 <thead>
                     <!-- HEADERS -->
@@ -23,8 +23,8 @@
                             </ff-data-table-cell>
                             <ff-data-table-cell
                                 v-for="(col, $index) in columns" :key="$index"
-                                :class="[sort.key === col.key ? 'sorted' : '', col.sortable ? 'sortable' : ''].concat(col.class)"
-                                :style="col.style"
+                                :class="[sort.key === col.key ? 'sorted' : '', col.sortable ? 'sortable' : '', col.headerClass ?? ''].concat(col.class)"
+                                :style="col.headerStyle ?? col.style"
                                 @click="sortBy(col, $index)"
                             >
                                 <!-- Internal div required to have flex w/sorting icons -->
@@ -208,6 +208,11 @@ export default {
             required: false,
             default: false,
             type: Boolean
+        },
+        tableClass: {
+            required: false,
+            default: '',
+            type: String
         }
     },
     emits: ['update:search', 'load-more', 'row-selected', 'update:sort', 'rows-checked'],

--- a/frontend/src/ui-components/components/data-table/DataTableRow.vue
+++ b/frontend/src/ui-components/components/data-table/DataTableRow.vue
@@ -12,7 +12,12 @@
                                 @mouseup="handleMouseUp"
             >
                 <template v-if="col.component">
-                    <component :is="col.component.is" v-bind="{...col.component.extraProps ?? {}, ...getCellData(data, col)}" />
+                    <component :is="col.component.is"
+                               :column="col.key"
+                               :style="col.style"
+                               v-bind="{...col.component.extraProps ?? {}, ...getCellData(data, col)}"
+                               :row-value="lookupProperty(data, col.key)"
+                    />
                 </template>
                 <template v-else-if="!isBool(lookupProperty(data, col.key))">
                     {{ lookupProperty(data, col.key) }}
@@ -89,7 +94,7 @@ export default {
                 return data
             }
         },
-        lookupProperty (obj, property) {
+        lookupProperty (obj, property = '') {
             const parts = property.split('.')
             if (parts.length === 1) {
                 return obj[property]


### PR DESCRIPTION
## Description

Better handling of tables with long column names and long values.

- added extra configuration to the ff-table to allow setting custom classes on the table itself and table header columns to allow sticky headers
- added a method to open each type of value in a distinct way, currently only text values are handled differently in that they can be parsed into json values or rendered as plain text (long values are replaced with a CTA to open the value in a modal)
- bound the col value to dynamic components for ease of rendering


https://github.com/user-attachments/assets/ad83bb21-1a73-4f61-b6bf-e816805a1fbf

we do not support the retrieval of more than 10 results, I manually altered the endpoint just to showcase the sticky header

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/5718

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

