### PR TITLE
Fix admins unable to create a team after initial app setup

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -61,6 +61,7 @@ export default {
         ...mapState('account', ['pending', 'user', 'team', 'teams', 'redirectUrlAfterLogin', 'settings']),
         ...mapGetters('account', ['defaultUserTeam']),
         canCreateTeam () {
+            if (this.user.admin) return true
             return Object.prototype.hasOwnProperty.call(this.settings, 'team:create') && this.settings['team:create'] === true
         }
     },


### PR DESCRIPTION
## Description

Fixes the inability for admin users to create a team after the initial app setup.

## Related Issue(s)

introduced by https://github.com/FlowFuse/flowfuse/issues/5766
closes https://github.com/FlowFuse/flowfuse/issues/5841

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

