### PR TITLE
chore: Update URLs to the Device Agent Installer download scripts

### DIFF
--- a/frontend/src/pages/team/Devices/dialogs/components/DeviceCredentialsDialog/OtcInstallSection.vue
+++ b/frontend/src/pages/team/Devices/dialogs/components/DeviceCredentialsDialog/OtcInstallSection.vue
@@ -92,16 +92,16 @@ export default {
                 script: {
                     Windows: {
                         title: 'Open an elevated Command Prompt and run:',
-                        command: `powershell -c "irm https://raw.githubusercontent.com/FlowFuse/device-agent/refs/heads/main/installer/get.ps1|iex" && flowfuse-device-agent-installer.exe -o ${this.device.credentials.otc} -u ${this.settings?.base_url}`
+                        command: `powershell -c "irm https://flowfuse.github.io/device-agent/get.ps1|iex" && flowfuse-device-agent-installer.exe -o ${this.device.credentials.otc} -u ${this.settings?.base_url}`
                     },
                     MacOS: {
                         title: 'Open Terminal and run:',
-                        command: '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/FlowFuse/device-agent/refs/heads/main/installer/get.sh)" && \\\n' +
+                        command: '/bin/bash -c "$(curl -fsSL https://flowfuse.github.io/device-agent/get.sh)" && \\\n' +
                                 `./flowfuse-device-agent-installer -o ${this.device.credentials.otc} -u ${this.settings?.base_url}`
                     },
                     Linux: {
                         title: 'Open Terminal and run:',
-                        command: '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/FlowFuse/device-agent/refs/heads/main/installer/get.sh)" && \\\n' +
+                        command: '/bin/bash -c "$(curl -fsSL https://flowfuse.github.io/device-agent/get.sh)" && \\\n' +
                                 `./flowfuse-device-agent-installer -o ${this.device.credentials.otc} -u ${this.settings?.base_url}`
                     }
                 },


### PR DESCRIPTION
## Description

> [!CAUTION]
> This pull request should be merged only once download scripts are publicly available

This pull request changes URLs to the Device Agent Installer 'get' scripts to ones hosted on the GitHub Pages.


## Related Issue(s)

https://github.com/FlowFuse/device-agent/issues/442

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

