### PR TITLE
Do not fall through to error case after successful SAML login

### DIFF
--- a/forge/ee/routes/sso/auth.js
+++ b/forge/ee/routes/sso/auth.js
@@ -179,6 +179,7 @@ module.exports = fp(async function (app, opts) {
                     redirectTo = '/account/settings'
                 }
                 reply.redirect(redirectTo)
+                return
             } else {
                 // Invalid session - user is suspended or similar
                 reply.redirect('/')


### PR DESCRIPTION
Fixes #5856 

Adds a missing return to avoid falling through to logging an invalid error.