### PR TITLE
Add timestamptz default now()

### DIFF
--- a/forge/ee/lib/tables/drivers/postgres-localfs.js
+++ b/forge/ee/lib/tables/drivers/postgres-localfs.js
@@ -256,6 +256,8 @@ module.exports = {
                             column += `DEFAULT ${parseFloat(column.default)}`
                         } else if (col.type === 'boolean') {
                             column += `DEFAULT ${column.default === 'true'}`
+                        } else if (col.type === 'timestamptz') {
+                            column += 'DEFAULT NOW()'
                         }
                     }
                     if (i + 1 !== columns.length) {

--- a/forge/ee/lib/tables/drivers/postgres-supavisor.js
+++ b/forge/ee/lib/tables/drivers/postgres-supavisor.js
@@ -329,6 +329,8 @@ module.exports = {
                             column += `DEFAULT ${parseFloat(column.default)}`
                         } else if (col.type === 'boolean') {
                             column += `DEFAULT ${column.default === 'true'}`
+                        } else if (col.type === 'timestamptz') {
+                            column += 'DEFAULT NOW()'
                         }
                     }
                     if (i + 1 !== columns.length) {


### PR DESCRIPTION
part of #5886

## Description

<!-- Describe your changes in detail -->
Allows a default of `NOW()` to be used for columns with type `timestamptz`

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#5886

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

