### PR TITLE
Do not trigger stripe checkout if upgrading active team

### DIFF
--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -52,7 +52,7 @@
                     </template>
                     <div class="flex gap-x-4">
                         <template v-if="!isContactRequired">
-                            <ff-button v-if="!billingEnabled || billingDisabledForSelectedTeamType" :disabled="!formValid" data-action="change-team-type" @click="updateTeam()">
+                            <ff-button v-if="!billingEnabled || !billingMissing" :disabled="!formValid" data-action="change-team-type" @click="updateTeam()">
                                 Change team type
                             </ff-button>
                             <ff-button v-else :disabled="!formValid" data-action="setup-team-billing" @click="setupBilling()">


### PR DESCRIPTION
Fixes #5893 

If a team already has billing setup, we should not be directing them back to stripe as this can lead to duplicate subscription objects.
