### PR TITLE
Allow Devices to get FF Tables creds

### DIFF
--- a/forge/ee/routes/tables/index.js
+++ b/forge/ee/routes/tables/index.js
@@ -41,6 +41,11 @@ module.exports = async function (app) {
                 if (project.Team.hashid !== request.team.hashid) {
                     return reply.status(401).send({ code: 'unauthorized', error: 'unauthorized' })
                 }
+            } else if (request.session.ownerType === 'device') {
+                const device = await app.db.models.Device.byId(parseInt(request.session.ownerId))
+                if (!device || device.Team.hashid !== request.team.hashid) {
+                    return reply.status(401).send({ code: 'unauthorized', error: 'unauthorized' })
+                }
             } else {
                 await app.needsPermission('team:database:list')(request, reply, done)
             }

--- a/test/unit/forge/ee/routes/tables/index_spec.js
+++ b/test/unit/forge/ee/routes/tables/index_spec.js
@@ -131,7 +131,7 @@ describe('Tables API', function () {
             method: 'GET',
             url: `/api/v1/teams/${TestObjects.team.hashid}/databases`,
             headers: {
-                'Authorization': `Bearer ${projectTokens.token}`
+                Authorization: `Bearer ${projectTokens.token}`
             }
         })
         response.statusCode.should.equal(200)
@@ -147,7 +147,7 @@ describe('Tables API', function () {
             method: 'GET',
             url: `/api/v1/teams/${TestObjects.team.hashid}/databases`,
             headers: {
-                'Authorization': `Bearer ${deviceToken.token}`
+                Authorization: `Bearer ${deviceToken.token}`
             }
         })
         response.statusCode.should.equal(200)

--- a/test/unit/forge/ee/routes/tables/index_spec.js
+++ b/test/unit/forge/ee/routes/tables/index_spec.js
@@ -4,7 +4,7 @@ const setup = require('../../setup')
 const FF_UTIL = require('flowforge-test-utils')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
 
-describe.only('Tables API', function () {
+describe('Tables API', function () {
     let app
     const TestObjects = { tokens: {} }
 


### PR DESCRIPTION
fixes #5920
## Description

<!-- Describe your changes in detail -->
Adds Device tokens to the allowed list for FF Tables creds.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#5920

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

