### PR TITLE
Assistant for tables (backend)

### DIFF
--- a/forge/ee/lib/tables/drivers/postgres-localfs.js
+++ b/forge/ee/lib/tables/drivers/postgres-localfs.js
@@ -225,6 +225,33 @@ module.exports = {
             throw new Error(`Failed to retrieve table ${table} for team ${team.hashid}: ${err.message}`)
         }
     },
+    /**
+     * Query data in tables
+     * IMPORTANT: this method is primarily intended for internal usage (like getting AI schema hints)
+     * @param {Object} team - The team object
+     * @param {String} databaseId - The database ID
+     * @param {String} queryText - The SQL query to execute
+     * @param {Array} params - The parameters for the query
+     * @returns {String} - The result(s) of the query
+     * @throws {Error} - If the database does not exist
+     */
+    query: async function (team, databaseId, queryText, params = undefined) {
+        const databaseExists = await this._app.db.models.Table.byId(team.id, databaseId)
+        if (!databaseExists || databaseExists.TeamId !== team.id) {
+            throw new Error(`Database ${databaseId} for team ${team.hashid} does not exist`)
+        }
+        const teamClient = libPg.newClient({ ...this._options.backend, database: team.hashid })
+        try {
+            await teamClient.connect()
+            const result = await teamClient.query(queryText, params)
+            return result
+        } catch (error) {
+            console.error('Error running query:', error)
+            throw error
+        } finally {
+            await teamClient.end()
+        }
+    },
     createTable: async function (team, databaseId, tableName, columns) {
         const databaseExists = await this._app.db.models.Table.byId(team.id, databaseId)
         if (!databaseExists || databaseExists.TeamId !== team.id) {

--- a/forge/ee/lib/tables/drivers/postgres-supavisor.js
+++ b/forge/ee/lib/tables/drivers/postgres-supavisor.js
@@ -291,6 +291,33 @@ module.exports = {
             throw new Error(`Failed to retrieve table ${table} for team ${team.hashid}: ${err.message}`)
         }
     },
+    /**
+     * Query data in tables
+     * IMPORTANT: this method is primarily intended for internal usage (like getting AI schema hints)
+     * @param {Object} team - The team object
+     * @param {String} databaseId - The database ID
+     * @param {String} queryText - The SQL query to execute
+     * @param {Array} params - The parameters for the query
+     * @returns {String} - The result(s) of the query
+     * @throws {Error} - If the database does not exist
+     */
+    query: async function (team, databaseId, queryText, params = undefined) {
+        const databaseExists = await this._app.db.models.Table.byId(team.id, databaseId)
+        if (!databaseExists || databaseExists.TeamId !== team.id) {
+            throw new Error(`Database ${databaseId} for team ${team.hashid} does not exist`)
+        }
+        const teamClient = libPg.newClient({ ...this._options.backend, database: team.hashid })
+        try {
+            await teamClient.connect()
+            const result = await teamClient.query(queryText, params)
+            return result
+        } catch (error) {
+            console.error('Error running query:', error)
+            throw error
+        } finally {
+            await teamClient.end()
+        }
+    },
     createTable: async function (team, databaseId, tableName, columns) {
         const databaseExists = await this._app.db.models.Table.byId(team.id, databaseId)
         if (!databaseExists || databaseExists.TeamId !== team.id) {

--- a/forge/ee/lib/tables/wrapper.js
+++ b/forge/ee/lib/tables/wrapper.js
@@ -46,9 +46,9 @@ module.exports = {
             throw new Error('Database driver does not support destroyDatabase')
         }
     },
-    getTables: async (team, databaseId, paginationOptions) => {
+    getTables: async (team, databaseId, paginationOptions, options) => {
         if (this._driver.getTables) {
-            return this._driver.getTables(team, databaseId)
+            return this._driver.getTables(team, databaseId, paginationOptions, options)
         } else {
             throw new Error('Database driver does not support getTables')
         }
@@ -65,6 +65,23 @@ module.exports = {
             return this._driver.getTableData(team, databaseId, table, paginationOptions)
         } else {
             throw new Error('Database driver does not support getTableData')
+        }
+    },
+    /**
+     * Query data in tables
+     * IMPORTANT: this method is primarily intended for internal usage (like getting AI schema hints)
+     * @param {Object} team - The team object
+     * @param {String} databaseId - The database ID
+     * @param {String} queryText - The SQL query to execute
+     * @param {Array} params - The parameters for the query
+     * @returns {String} - The result(s) of the query
+     * @throws {Error} - If the database does not exist
+     */
+    query: async (team, databaseId, queryText, params) => {
+        if (this._driver.query) {
+            return this._driver.query(team, databaseId, queryText, params)
+        } else {
+            throw new Error('Database driver does not support query')
         }
     },
     createTable: async (team, databaseId, tableName, columns) => {

--- a/forge/lib/assistant.js
+++ b/forge/lib/assistant.js
@@ -1,0 +1,321 @@
+const libPg = require('../ee/lib/tables/drivers/lib/pg.js')
+
+/**
+ * Get a pseudo DDL/schema for `tables`.
+ * IMPORTANT: This function is not meant to be 100% accurate or complete.
+ * It is meant to be _enough_ for describing the structure to an AI assistant.
+ * In particular, the structure of views is NOT included. Instead, they are represented as
+ * CREATE TABLE statements (with columns, types, indexes and comments).
+ * Also, functions, sequences, and other database objects are not included.
+ * @param {Object} app - The Fastify app instance
+ * @param {Object} team - The team object
+ * @param {String} databaseId - The database ID
+ * @returns {String} - The DDL for the specified tables
+ */
+async function getTablesHints (app, team, databaseId) {
+    const columnsQuery = `
+        SELECT
+            c.table_schema,
+            c.table_name,
+            c.column_name,
+            c.data_type,
+            c.udt_name,
+            c.character_maximum_length,
+            c.is_nullable,
+            c.column_default,
+            t.table_type -- This will be 'BASE TABLE' or 'VIEW'
+        FROM
+            information_schema.columns AS c
+        JOIN
+            information_schema.tables AS t
+        ON
+            c.table_schema = t.table_schema
+            AND c.table_name = t.table_name
+        WHERE
+            c.table_schema != 'pg_catalog'
+            AND c.table_schema != 'information_schema'
+        ORDER BY
+            c.table_name,
+            c.ordinal_position;
+    `
+    const columns = await app.tables.query(team, databaseId, columnsQuery)
+
+    const pksQuery = `
+        SELECT
+            tc.table_schema,
+            kcu.table_name,
+            kcu.column_name
+        FROM information_schema.table_constraints AS tc
+        JOIN information_schema.key_column_usage AS kcu
+        ON tc.constraint_name = kcu.constraint_name
+        WHERE
+            tc.constraint_type = 'PRIMARY KEY'
+            AND tc.table_schema != 'pg_catalog'
+            AND tc.table_schema != 'information_schema';
+    `
+    const pks = await app.tables.query(team, databaseId, pksQuery)
+
+    const fksQuery = `
+        SELECT
+            tc.table_schema as from_schema,
+            tc.table_name AS from_table,
+            kcu.column_name AS from_column,
+            ccu.table_schema AS to_schema,
+            ccu.table_name AS to_table,
+            ccu.column_name AS to_column
+        FROM information_schema.table_constraints AS tc
+        JOIN information_schema.key_column_usage AS kcu
+        ON tc.constraint_name = kcu.constraint_name
+        JOIN information_schema.constraint_column_usage AS ccu
+        ON ccu.constraint_name = tc.constraint_name
+        WHERE
+            tc.constraint_type = 'FOREIGN KEY'
+            AND tc.table_schema != 'pg_catalog'
+            AND tc.table_schema != 'information_schema';
+    `
+    const fks = await app.tables.query(team, databaseId, fksQuery)
+
+    const indexesQuery = `
+        SELECT
+            n.nspname AS schema_name,
+            t.relname AS table_name,
+            i.relname AS index_name,
+            to_json(array_agg(a.attname)) AS column_names
+        FROM
+            pg_class t,
+            pg_class i,
+            pg_index ix,
+            pg_attribute a,
+            pg_namespace n
+        WHERE
+            t.oid = ix.indrelid
+            AND i.oid = ix.indexrelid
+            AND a.attrelid = t.oid
+            AND a.attnum = ANY(ix.indkey)
+            AND t.relnamespace = n.oid
+            AND ix.indisprimary = false -- skip prim key index as they will be retrieved in the columns query
+            AND n.nspname != 'pg_catalog'
+            AND n.nspname != 'information_schema'
+        GROUP BY
+            n.nspname,
+            t.relname,
+            i.relname
+        ORDER BY
+            n.nspname,
+            t.relname,
+            i.relname;
+    `
+    const indexes = await app.tables.query(team, databaseId, indexesQuery)
+
+    const commentsQuery = `
+        SELECT
+            n.nspname AS schema_name,
+            c.relname AS table_name,
+            a.attname AS column_name,
+            d.description AS column_comment
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+        JOIN pg_catalog.pg_description d ON d.objoid = a.attrelid AND d.objsubid = a.attnum
+        WHERE
+            n.nspname NOT IN ('pg_catalog', 'information_schema')
+            AND c.relkind IN ('r', 'v') -- 'r' for tables, 'v' for views
+            AND a.attnum > 0 -- Exclude system columns
+        ORDER BY
+            schema_name,
+            table_name,
+            column_name;
+    `
+    const comments = await app.tables.query(team, databaseId, commentsQuery)
+
+    let ddl
+    if (app.config.tables?.driver?.type === 'postgres-supavisor' || app.config.tables?.driver?.type === 'postgres-localfs') {
+        ddl = generatePostgreSqlDdl(columns.rows, pks.rows, fks.rows, indexes.rows, comments.rows)
+    } else {
+        throw new Error('Database Context is not supported for tables driver type')
+    }
+    return ddl
+}
+
+/**
+ * Transforms database query results into a DDL-like schema "good enough" for providing context to an AI.
+ * @param {Array<Object>} columns - The result rows from the columns query.
+ * @param {Array<Object>} pks - The result rows from the primary keys query.
+ * @param {Array<Object>} fks - The result rows from the foreign keys query.
+ * @param {Array<Object>} indexes - The result rows from the indexes query (excl primary keys as they are already included in pks)
+ * @param {Array<Object>} views - The result rows from the views query.
+ * @returns {string} - The generated DDL statements.
+ */
+function generatePostgreSqlDdl (columns, pks, fks, indexes, comments) {
+    const schemaMap = new Map()
+
+    // Step 1: Populate the schema with tables and columns.
+    // NOTE: This will also include views and they will appear to be tables with columns and types.
+    // This simplifies and minimises the DDL, more importantly, it provides better context for the AI.
+    columns.forEach(row => {
+        if (!schemaMap.has(row.table_schema)) {
+            schemaMap.set(row.table_schema, {
+                schemaName: row.table_schema,
+                tableMap: new Map(),
+                viewMap: new Map()
+            })
+        }
+
+        const schema = schemaMap.get(row.table_schema)
+        if (!schema.tableMap.has(row.table_name)) {
+            schema.tableMap.set(row.table_name, {
+                isView: row.table_type === 'VIEW',
+                tableName: row.table_name,
+                columns: [],
+                primaryKeys: [],
+                foreignKeys: [],
+                indexes: []
+            })
+        }
+        const table = schema.tableMap.get(row.table_name)
+        const comment = comments.find(c => c.table_name === row.table_name && c.schema_name === row.table_schema && c.column_name === row.column_name)
+        const col = {
+            columnName: row.column_name,
+            dataType: row.udt_name,
+            isNullable: row.is_nullable === 'YES',
+            defaultValue: row.column_default,
+            comment: comment ? comment.column_comment : ''
+        }
+        if (col.dataType === 'varchar' && row.character_maximum_length) {
+            col.dataType = `${col.dataType}(${row.character_maximum_length})`
+        } else if (col.dataType === 'int8' && /nextval(.*::regclass)/.test(col.defaultValue)) {
+            col.dataType = 'bigserial'
+            col.defaultValue = ''
+        } else if (col.dataType === 'int4' && /nextval(.*::regclass)/.test(col.defaultValue)) {
+            col.dataType = 'serial4'
+            col.defaultValue = ''
+        }
+        table.columns.push(col)
+    })
+
+    // Step 2: Add primary key information.
+    pks.forEach(row => {
+        const schema = schemaMap.get(row.table_schema)
+        if (!schema) return
+        const table = schema.tableMap.get(row.table_name)
+        if (table) {
+            // Add the column name to the primaryKeys array for the table.
+            table.primaryKeys.push(row.column_name)
+
+            // Find the specific column and mark it as a primary key.
+            const column = table.columns.find(c => c.columnName === row.column_name)
+            if (column) {
+                column.isPrimaryKey = true
+            }
+        }
+    })
+
+    // Step 3: Add foreign key information.
+    fks.forEach(row => {
+        const schema = schemaMap.get(row.from_schema)
+        if (!schema) return
+        const table = schema.tableMap.get(row.from_table)
+        if (table) {
+            // Find the specific column and add its FK details.
+            const column = table.columns.find(c => c.columnName === row.from_column)
+            if (column) {
+                column.isForeignKey = true
+                column.references = {
+                    table: row.to_table,
+                    column: row.to_column
+                }
+            }
+        }
+    })
+
+    // Step 4: Add index information.
+    indexes.forEach(row => {
+        const schema = schemaMap.get(row.schema_name)
+        if (!schema) return
+        const table = schema.tableMap.get(row.table_name)
+        if (table) {
+            table.indexes.push({
+                indexName: row.index_name,
+                columnNames: row.column_names // should be an array of strings
+            })
+        }
+    })
+
+    // Convert the Map values back to an array for the final output.
+    const schemas = Array.from(schemaMap.values())
+
+    const ddlTC = []
+    const ddlFK = []
+    const ddlIdx = []
+    const ddlViews = [] // Views
+    const ei = libPg.pg.escapeIdentifier
+    const el = libPg.pg.escapeLiteral
+    schemas.forEach(schema => {
+        const schemaName = ei(schema.schemaName)
+        ddlTC.push(`-- PostgreSQL Schema: ${schemaName}`)
+        const tables = Array.from(schema.tableMap.values())
+        tables.forEach(table => {
+            const tableName = ei(table.tableName)
+            const tableNameFull = `${schemaName}.${tableName}`
+            // generate CREATE TABLE statements with columns, types and PKs.
+            const columns = table.columns.map(col => {
+                let columnDef = `${ei(col.columnName)} ${col.dataType}`
+                if (!col.isNullable && !col.isPrimaryKey) {
+                    columnDef += ' NOT NULL'
+                }
+                if (col.defaultValue) {
+                    columnDef += ` DEFAULT ${col.defaultValue}`
+                }
+                return columnDef
+            })
+
+            // Add primary key constraint at the end of the column list.
+            if (table.primaryKeys.length > 0) {
+                const tableNamePK = ei(table.tableName + '_pkey')
+                const escapedPrimaryKeys = table.primaryKeys.map(pk => {
+                    if (pk && pk.startsWith('"') && pk.endsWith('"')) {
+                        return pk
+                    }
+                    return ei(pk)
+                })
+                const pkDef = `CONSTRAINT ${tableNamePK} PRIMARY KEY (${escapedPrimaryKeys.join(',')})`
+                columns.push(pkDef)
+            }
+
+            const ddlObj = table.isView ? ddlViews : ddlTC
+            if (table.isView) {
+                // The definition for a VIEW is not included as it may be complex.
+                // Instead, the columns and their types are shown to help provide context to the AI
+                ddlObj.push(`-- NOTE: Below, ${tableNameFull} is a VIEW in the DB, it is shown as a regular table for context only.`)
+            }
+
+            ddlObj.push(`CREATE TABLE ${tableNameFull} (\n\t${columns.join(',\n\t')}\n);`)
+            table.columns.forEach(c => {
+                if (c.comment) {
+                    ddlObj.push(`COMMENT ON COLUMN ${tableNameFull}.${ei(c.columnName)} IS ${el(c.comment)};`)
+                }
+            })
+
+            // generate foreign key constraints.
+            table.foreignKeys.forEach(fk => {
+                const fkKeyName = ei(`${table.tableName}_${fk.columnName}_fkey`)
+                const fkColName = ei(fk.columnName)
+                ddlFK.push(`ALTER TABLE ${schemaName}.${tableName} ADD CONSTRAINT ${fkKeyName} FOREIGN KEY (${fkColName}) REFERENCES ${schemaName}.${ei(fk.references.table)}(${ei(fk.references.column)});`)
+            })
+
+            // generate CREATE INDEX statements.
+            table.indexes.forEach(index => {
+                if (index?.indexName && Array.isArray(index?.columnNames) && index.columnNames.length > 0) {
+                    const columnNames = index.columnNames.map(ei).join(',')
+                    ddlIdx.push(`CREATE INDEX ${ei(index.indexName)} ON ${schemaName}.${tableName} (${columnNames});`)
+                }
+            })
+        })
+    })
+    return ddlTC.concat(ddlViews).concat(ddlFK).concat(ddlIdx).join('\n')
+}
+
+module.exports = {
+    getTablesHints,
+    generatePostgreSqlDdl
+}

--- a/forge/lib/assistant.js
+++ b/forge/lib/assistant.js
@@ -260,7 +260,7 @@ function generatePostgreSqlDdl (columns, pks, fks, indexes, comments) {
             // generate CREATE TABLE statements with columns, types and PKs.
             const columns = table.columns.map(col => {
                 let columnDef = `${ei(col.columnName)} ${col.dataType}`
-                if (!col.isNullable && !col.isPrimaryKey) {
+                if (!col.isNullable || col.isPrimaryKey) {
                     columnDef += ' NOT NULL'
                 }
                 if (col.defaultValue) {

--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -15,9 +15,14 @@ module.exports = async function (app) {
         ttl: app.config.assistant?.assetCache?.ttl || 30 * 60 * 1000, // Defaults to 1/2 hour cache for assets - enough to handle bursts
         updateAgeOnGet: false // do not update the age on get, we want it to expire after the original ttl
     })
+    const tablesSchemaCache = new LRUCache({
+        max: app.config.assistant?.tablesSchemaCache?.max || 100,
+        ttl: app.config.assistant?.tablesSchemaCache?.ttl || 5 * 60 * 1000, // Defaults to 5 mins
+        updateAgeOnGet: false // do not update the age on get, we want it to expire after the original ttl
+    })
 
     // decorate the app with the asset cache
-    app.decorate('assistant', { assetCache })
+    app.decorate('assistant', { assetCache, tablesSchemaCache })
 
     // Get the assistant service configuration
     const serviceUrl = app.config.assistant?.service?.url
@@ -170,12 +175,36 @@ module.exports = async function (app) {
 
         const url = `${serviceUrl.replace(/\/+$/, '')}/${method.replace(/^\/+/, '')}`
 
+        // if this is a `flowfuse-tables-query` lets see if tables are enabled and try to get the schema hints
+        const tablesFeatureEnabled = app.config.features.enabled('tables') && request.team.TeamType.getFeatureProperty('tables', false)
+        const isTablesQuery = tablesFeatureEnabled && method === 'flowfuse-tables-query'
+        const tablesCacheKey = request.team.hashid + '/tables/schema'
+        if (isTablesQuery) {
+            const { getTablesHints } = require('../../lib/assistant.js')
+            if (!tablesSchemaCache.has(tablesCacheKey)) {
+                const creds = await app.tables.getDatabases(request.team)
+                if (creds && creds.length) {
+                    const database = creds[0] // Get the first database
+                    try {
+                        // Get the DDL
+                        const schemaData = await getTablesHints(app, request.team, database.hashid)
+                        tablesSchemaCache.set(tablesCacheKey, schemaData)
+                    } catch (error) {
+                        tablesSchemaCache.set(tablesCacheKey, '')
+                    }
+                }
+            }
+        }
+
         // post to the assistant service
         try {
             const headers = await buildRequestHeaders(request)
-            const response = await axios.post(url, {
-                ...request.body
-            }, {
+            const data = { ...request.body }
+            if (isTablesQuery) {
+                data.context = data.context || {}
+                data.context.tablesSchema = tablesSchemaCache.get(tablesCacheKey)
+            }
+            const response = await axios.post(url, data, {
                 headers,
                 timeout: requestTimeout
             })

--- a/test/unit/forge/lib/assistant_spec.js
+++ b/test/unit/forge/lib/assistant_spec.js
@@ -1,0 +1,89 @@
+require('should')
+const sinon = require('sinon')
+
+const assistant = require('../../../../forge/lib/assistant')
+
+describe('assistant.js', function () {
+    describe('generatePostgreSqlDdl', function () {
+        it('should generate DDL for a simple table with PK, FK, index, and comments', function () {
+            const columns = [
+                { table_schema: 'public', table_name: 'users', column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, table_type: 'BASE TABLE', character_maximum_length: null },
+                { table_schema: 'public', table_name: 'users', column_name: 'name', udt_name: 'varchar', is_nullable: 'YES', column_default: null, table_type: 'BASE TABLE', character_maximum_length: 255 },
+                { table_schema: 'public', table_name: 'users', column_name: 'role_id', udt_name: 'int4', is_nullable: 'YES', column_default: null, table_type: 'BASE TABLE', character_maximum_length: null },
+                { table_schema: 'public', table_name: 'roles', column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, table_type: 'BASE TABLE', character_maximum_length: null },
+                { table_schema: 'public', table_name: 'roles', column_name: 'name', udt_name: 'varchar', is_nullable: 'YES', column_default: null, table_type: 'BASE TABLE', character_maximum_length: 100 }
+            ]
+            const pks = [
+                { table_schema: 'public', table_name: 'users', column_name: 'id' },
+                { table_schema: 'public', table_name: 'roles', column_name: 'id' }
+            ]
+            const fks = [
+                { from_schema: 'public', from_table: 'users', from_column: 'role_id', to_schema: 'public', to_table: 'roles', to_column: 'id' }
+            ]
+            const indexes = [
+                { schema_name: 'public', table_name: 'users', index_name: 'users_name_idx', column_names: ['name'] }
+            ]
+            const comments = [
+                { schema_name: 'public', table_name: 'users', column_name: 'id', column_comment: 'User ID' },
+                { schema_name: 'public', table_name: 'users', column_name: 'name', column_comment: 'User name' }
+            ]
+            const ddl = assistant.generatePostgreSqlDdl(columns, pks, fks, indexes, comments)
+            ddl.should.match(/CREATE TABLE "public"\."users"/)
+            ddl.should.match(/"id" int4 NOT NULL/)
+            ddl.should.match(/"name" varchar\(255\)/)
+            ddl.should.match(/"role_id" int4/)
+            ddl.should.match(/CONSTRAINT "users_pkey" PRIMARY KEY \("id"\)/)
+            ddl.should.match(/CREATE INDEX "users_name_idx" ON "public"\."users" \("name"\)/)
+            ddl.should.match(/CREATE TABLE "public"\."roles"/)
+            ddl.should.match(/"id" int4 NOT NULL/)
+            ddl.should.match(/"name" varchar\(100\)/)
+            ddl.should.match(/CONSTRAINT "roles_pkey" PRIMARY KEY \("id"\)/)
+            ddl.should.match(/COMMENT ON COLUMN "public"\."users"\."id" IS 'User ID'/)
+        })
+    })
+
+    describe('getTablesHints', function () {
+        let app, team, databaseId
+        beforeEach(function () {
+            app = {
+                tables: {
+                    query: sinon.stub()
+                },
+                config: {
+                    tables: {
+                        driver: { type: 'postgres-supavisor' }
+                    }
+                }
+            }
+            team = { id: 'team1' }
+            databaseId = 'db1'
+        })
+
+        it('should call app.tables.query with correct queries and return DDL', async function () {
+            // Setup fake query results
+            app.tables.query.onCall(0).resolves({
+                rows: [
+                    { table_schema: 'public', table_name: 'users', column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, table_type: 'BASE TABLE', character_maximum_length: null }
+                ]
+            })
+            app.tables.query.onCall(1).resolves({
+                rows: [
+                    { table_schema: 'public', table_name: 'users', column_name: 'id' }
+                ]
+            })
+            app.tables.query.onCall(2).resolves({ rows: [] }) // fks
+            app.tables.query.onCall(3).resolves({ rows: [] }) // indexes
+            app.tables.query.onCall(4).resolves({ rows: [] }) // comments
+
+            const ddl = await assistant.getTablesHints(app, team, databaseId)
+            ddl.should.match(/CREATE TABLE/)
+            app.tables.query.callCount.should.equal(5)
+        })
+
+        it('should throw if driver type is not supported', async function () {
+            app.config.tables.driver.type = 'sqlite'
+            app.tables.query.resolves({ rows: [] })
+            await assistant.getTablesHints(app, team, databaseId).should.be.rejectedWith('Database Context is not supported for tables driver type')
+        })
+    })
+})


### PR DESCRIPTION
## Description

Hooks into existing assistant method & if the requested method is identified as `flowfuse-tables-query` the database schema DDL is approximated and included in the AI request. Note: this is cached (5 minutes by default) to avoid repeated hits on DB

### Tests:

```
▼ assistant.js
  ▼ generatePostgreSqlDdl
    ✔ should generate DDL for a simple table with PK, FK, index, and comments
  ▼ getTablesHints
    ✔ should call app.tables.query with correct queries and return DDL
    ✔ should throw if driver type is not supported

▼ Assistant API
  ▼ service enabled
    ▼ service tests
      ▼ flowfuse-tables-query service
        ✔ anonymous cannot access
        ✔ random token cannot access
        ✔ user token can not access
        ✔ device token can access
        ✔ instance token can access
        ✔ fails when prompt is not supplied
        ✔ fails when transactionId is not supplied
        ✔ fails when transactionId is mismatched
        ✔ contains owner info in headers for an instance
        ✔ contains owner info in headers for a device
        ✔ should include tables hints in context and cache it for subsequent requests
        ✔ should fetch fresh tables context hints after cache expiration
```


## Related Issue(s)

closes #3648 

## Checklist


 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.
     - https://github.com/FlowFuse/website/issues/3648

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

