### PR TITLE
The DELETE request should return code 204 instead of 201

### DIFF
--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -307,7 +307,7 @@ module.exports = async function (app) {
                 id: { type: 'string' }
             },
             response: {
-                201: {
+                204: {
                     type: 'null',
                     description: 'empty response'
                 },
@@ -324,7 +324,7 @@ module.exports = async function (app) {
                 updates.push('id', request.params.id)
                 await app.auditLog.User.user.pat.deleted(request.session.User, null, updates)
                 await token.destroy()
-                reply.code(201).send()
+                reply.code(204).send()
                 return
             }
             reply.code(404).send({ code: 'not_found', error: 'Not Found' })

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -929,7 +929,7 @@ describe('User API', async function () {
                 url: '/api/v1/user/tokens/' + testTokens[0].id,
                 cookies: { sid: TestObjects.tokens.alice }
             })
-            response.statusCode.should.equal(201)
+            response.statusCode.should.equal(204)
         })
         it('Delete a missing Token', async function () {
             const response = await app.inject({


### PR DESCRIPTION
## Description

The 201 code is used to indicate that a resource has been created. Since this is a DELETE request, this code is incorrect and should be replaced with 204 because no body is sent.

Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/201

## Related Issue(s)

None

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

