### PR TITLE
Add migration check GH action

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -1,0 +1,52 @@
+name: Check DB migrations
+
+on:
+  push:
+    branches:
+      - main
+      - maintenance
+  pull_request:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const { execSync } = require('child_process')
+            let firstCommit
+            let lastCommit
+            if (context.eventName === 'push') {
+              firstCommit='HEAD^1'
+              lastCommit='HEAD'
+            } else if (context.eventName === 'pull_request') {
+              firstCommit=context.payload.pull_request.base.sha
+              lastCommit=context.payload.pull_request.head.sha
+            } else {
+              throw new Error('Unsupported event')
+            }
+            // Get the list of files modified
+            const rawFiles = execSync(`git diff --name-only --diff-filter=d "${firstCommit}" "${lastCommit}"`).toString()
+            // Filter for migration files
+            const files = rawFiles.split('\n').filter(f => /^forge\/db\/migrations\/2.*\.js$/.test(f))
+            if (files.length > 0) {
+              console.log('Modified migration files:')
+              files.forEach(f => console.log(` - ${f}`))
+              // Check they are the last files present in the directory
+              const fs = require('fs')
+              const path = require('path')
+              const migrationDir = path.join(process.cwd(), 'forge', 'db', 'migrations')
+              // Get all migration files
+              const allFiles = fs.readdirSync(migrationDir).filter(f => /^2.*\.js$/.test(f)).sort()
+              // Check the last N files are the ones added by the PR
+              const lastFiles = allFiles.slice(-files.length)
+              const invalidFiles = files.filter(f => !lastFiles.includes(path.basename(f)))
+              if (invalidFiles.length > 0) {
+                core.setFailed('Migrations added out of order')
+              }
+            }


### PR DESCRIPTION
## Description

This PR adds a GH action that will check the files modified by a PR (or merge to main) for any new DB migrations. If it finds any, it checks they are the last migrations in the list. This will help prevent merging a PR with a DB migration with an out of date name.

Have tested this a lot in a personal repository. Once we're happy with it, we will add it as a blocker before any deploys are done.

