### PR TITLE
ci: Enable `generatedSnapshotDescription` feature on pre-staging environments

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -81,7 +81,7 @@ create_suspended_instance() {
   echo "DEBUG: Raw response from API:"
   echo "$RESPONSE"
   echo "DEBUG: Response length: ${#RESPONSE}"
-  
+
   # Check if response is valid JSON before parsing
   if echo "$RESPONSE" | jq . > /dev/null 2>&1; then
     INSTANCE_ID=$(echo "$RESPONSE" | jq -r '.id')
@@ -243,8 +243,8 @@ curl -ks -w "\n" -XPOST \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $INIT_CONFIG_ACCESS_TOKEN" \
 -d '{
-      "name": "Team",
-      "description": "Team type",
+      "name": "Pro",
+      "description": "Pro type",
       "active": true,
       "properties": {
                     "users": {
@@ -357,7 +357,7 @@ starterTeamApplicationId=$(curl -ks -XPOST \
       }' https://$FLOWFUSE_URL/api/v1/applications | jq -r '.id')
 
 ### Create Team Team Application
-echo "Creating Team Team Application"
+echo "Creating Pro Team Application"
 proTeamId=$(get_team_id "Plant Pro")
 proTeamApplicationId=$(curl -ks -XPOST \
   -H 'Content-Type: application/json' \


### PR DESCRIPTION
## Description

This pull request enables `generatedSnapshotDescription` feature on newly created pre-staging environments.

## Related Issue(s)

Closes https://github.com/FlowFuse/CloudProject/issues/847

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

