### PR TITLE
Fix lefthand side bar missing when accessing from a shared link

### DIFF
--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -46,7 +46,6 @@ import FeatureUnavailableToTeam from '../../components/banners/FeatureUnavailabl
 import FileBrowser from '../../components/file-browser/FileBrowser.vue'
 import usePermissions from '../../composables/Permissions.js'
 import featuresMixin from '../../mixins/Features.js'
-import permissionsMixin from '../../mixins/Permissions.js'
 import Alerts from '../../services/alerts.js'
 import { Roles } from '../../utils/roles.js'
 
@@ -60,7 +59,7 @@ export default {
         FeatureUnavailableToTeam,
         FileBrowser
     },
-    mixins: [permissionsMixin, featuresMixin],
+    mixins: [featuresMixin],
     inheritAttrs: false,
     props: {
         instance: {

--- a/frontend/src/pages/instance/Assets.vue
+++ b/frontend/src/pages/instance/Assets.vue
@@ -44,6 +44,7 @@ import AssetsAPI from '../../api/assets.js'
 import FeatureUnavailable from '../../components/banners/FeatureUnavailable.vue'
 import FeatureUnavailableToTeam from '../../components/banners/FeatureUnavailableToTeam.vue'
 import FileBrowser from '../../components/file-browser/FileBrowser.vue'
+import usePermissions from '../../composables/Permissions.js'
 import featuresMixin from '../../mixins/Features.js'
 import permissionsMixin from '../../mixins/Permissions.js'
 import Alerts from '../../services/alerts.js'
@@ -65,6 +66,13 @@ export default {
         instance: {
             required: true,
             type: Object
+        }
+    },
+    setup () {
+        const { hasPermission, hasAMinimumTeamRoleOf } = usePermissions()
+
+        return {
+            hasPermission, hasAMinimumTeamRoleOf
         }
     },
     data () {

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -27,7 +27,6 @@ export default {
     components: {
         TemplateSettingsEnvironment
     },
-    mixins: [permissionsMixin],
     beforeRouteLeave: async function (_to, _from, next) {
         if (this.unsavedChanges) {
             const dialogOpts = {

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -15,7 +15,6 @@ import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
 import usePermissions from '../../../composables/Permissions.js'
-import permissionsMixin from '../../../mixins/Permissions.js'
 import Dialog from '../../../services/dialog.js'
 import TemplateSettingsEnvironment from '../../admin/Template/sections/Environment.vue'
 import {

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -14,6 +14,7 @@
 import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
+import usePermissions from '../../../composables/Permissions.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
 import Dialog from '../../../services/dialog.js'
 import TemplateSettingsEnvironment from '../../admin/Template/sections/Environment.vue'
@@ -53,6 +54,13 @@ export default {
         }
     },
     emits: ['instance-updated', 'save-button-state', 'restart-instance'],
+    setup () {
+        const { hasPermission } = usePermissions()
+
+        return {
+            hasPermission
+        }
+    },
     data () {
         return {
             unsavedChanges: false,

--- a/frontend/src/pages/instance/Settings/LauncherSettings.vue
+++ b/frontend/src/pages/instance/Settings/LauncherSettings.vue
@@ -33,7 +33,7 @@ import { mapState } from 'vuex'
 import InstanceApi from '../../../api/instances.js'
 import FormHeading from '../../../components/FormHeading.vue'
 import FormRow from '../../../components/FormRow.vue'
-import permissionsMixin from '../../../mixins/Permissions.js'
+import usePermissions from '../../../composables/Permissions.js'
 import Alerts from '../../../services/alerts.js'
 import Dialog from '../../../services/dialog.js'
 
@@ -43,7 +43,6 @@ export default {
         FormRow,
         FormHeading
     },
-    mixins: [permissionsMixin],
     inheritAttrs: false,
     props: {
         project: {
@@ -52,6 +51,13 @@ export default {
         }
     },
     emits: ['instance-updated', 'save-button-state', 'restart-instance'],
+    setup () {
+        const { hasPermission } = usePermissions()
+
+        return {
+            hasPermission
+        }
+    },
     data () {
         return {
             mounted: false,

--- a/frontend/src/pages/instance/Settings/index.vue
+++ b/frontend/src/pages/instance/Settings/index.vue
@@ -40,8 +40,8 @@ import { mapState } from 'vuex'
 
 import SectionSideMenu from '../../../components/SectionSideMenu.vue'
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
+import usePermissions from '../../../composables/Permissions.js'
 import instanceActionsMixin from '../../../mixins/InstanceActions.js'
-import permissionsMixin from '../../../mixins/Permissions.js'
 
 export default {
     name: 'InstanceSettings',
@@ -49,7 +49,7 @@ export default {
         SectionTopMenu,
         SectionSideMenu
     },
-    mixins: [permissionsMixin, instanceActionsMixin],
+    mixins: [instanceActionsMixin],
     inheritAttrs: false,
     props: {
         instance: {
@@ -58,6 +58,13 @@ export default {
         }
     },
     emits: ['instance-updated', 'instance-confirm-delete', 'instance-confirm-suspend'],
+    setup () {
+        const { hasPermission } = usePermissions()
+
+        return {
+            hasPermission
+        }
+    },
     data () {
         return {
             sideNavigation: [],

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -111,10 +111,11 @@ export default {
     },
     mixins: [permissionsMixin, instanceMixin, featuresMixin],
     setup () {
-        const { hasPermission } = usePermissions()
+        const { hasPermission, hasAMinimumTeamRoleOf } = usePermissions()
 
         return {
-            hasPermission
+            hasPermission,
+            hasAMinimumTeamRoleOf
         }
     },
     data: function () {

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -87,7 +87,6 @@ import usePermissions from '../../composables/Permissions.js'
 
 import featuresMixin from '../../mixins/Features.js'
 import instanceMixin from '../../mixins/Instance.js'
-import permissionsMixin from '../../mixins/Permissions.js'
 import { Roles } from '../../utils/roles.js'
 
 import ConfirmInstanceDeleteDialog from './Settings/dialogs/ConfirmInstanceDeleteDialog.vue'
@@ -109,7 +108,7 @@ export default {
         InstanceEditorLink,
         LockClosedIcon
     },
-    mixins: [permissionsMixin, instanceMixin, featuresMixin],
+    mixins: [instanceMixin, featuresMixin],
     setup () {
         const { hasPermission, hasAMinimumTeamRoleOf } = usePermissions()
 

--- a/frontend/src/pages/team/AuditLog.vue
+++ b/frontend/src/pages/team/AuditLog.vue
@@ -43,6 +43,7 @@ import TeamAPI from '../../api/team.js'
 import FormHeading from '../../components/FormHeading.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import AuditLogBrowser from '../../components/audit-log/AuditLogBrowser.vue'
+import usePermissions from '../../composables/Permissions.js'
 import permissionsMixin from '../../mixins/Permissions.js'
 import FfListbox from '../../ui-components/components/form/ListBox.vue'
 
@@ -55,6 +56,10 @@ export default {
         SectionTopMenu
     },
     mixins: [permissionsMixin],
+    setup () {
+        const { hasPermission } = usePermissions()
+        return { hasPermission }
+    },
     data () {
         return {
             logEntries: [],

--- a/frontend/src/pages/team/AuditLog.vue
+++ b/frontend/src/pages/team/AuditLog.vue
@@ -39,12 +39,13 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import TeamAPI from '../../api/team.js'
 import FormHeading from '../../components/FormHeading.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import AuditLogBrowser from '../../components/audit-log/AuditLogBrowser.vue'
 import usePermissions from '../../composables/Permissions.js'
-import permissionsMixin from '../../mixins/Permissions.js'
 import FfListbox from '../../ui-components/components/form/ListBox.vue'
 
 export default {
@@ -55,7 +56,6 @@ export default {
         FormHeading,
         SectionTopMenu
     },
-    mixins: [permissionsMixin],
     setup () {
         const { hasPermission } = usePermissions()
         return { hasPermission }
@@ -78,6 +78,7 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['team', 'teamMembership']),
         logScope () {
             return !this.auditFilters.selectedEventScope ? 'application' : 'project' // cannot use 'instance' due to legacy naming
         }


### PR DESCRIPTION
## Description

Fixes the left-hand sidebar not rendering when opening settings via shared/deep links.


- traced the root cause to a race condition where `teamMembership` isn’t loaded yet when the menu first renders, and the menu isn’t re-evaluated after the `/api/v1/teams/<team-id>/user` response arrives
- exposed the permissions functions as direct exports to be used in vuex modules
  - getters must be pure, sync, and only depend on state and other getters
  - vuex re-runs a getter only when it reads reactive state. Using the composable hid that dependency, so vuex couldn't track it
- because I refactored the permission composable and stored `teamMembership` into a prop, i also had to replace the permissions mixin with the composable to preserve reactivity


## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5939

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

