### PR TITLE
API for assistant inline code completion

### DIFF
--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -157,6 +157,132 @@ module.exports = async function (app) {
         }
     })
     /**
+     * Endpoint for FIM (fill-in-the-middle) code completion requests
+     * For now, this is simply a relay to an external assistant service
+     * In the future, we may decide to bring that service inside the core or
+     * use an alternative means of accessing it.
+     * @name /api/v1/assistant/fim/:nodeModule/:nodeType
+     * @static
+     * @memberof forge.routes.api.assistant
+     */
+    app.post('/fim/:nodeModule/:nodeType', {
+        config: {
+            rateLimit: app.config.rate_limits
+                ? {
+                    hook: 'preHandler', // apply the rate as a preHandler so that session is available
+                    max: 60, // max requests per window. Since the assistant plugin debounces requests, this should minimise risk of overuse without impacting user experience
+                    timeWindow: 30000, // 30 seconds window
+                    keyGenerator: (request) => {
+                        return request.ownerId || request.ip
+                    }
+                }
+                : false
+        },
+        schema: {
+            hide: true, // dont show in swagger
+            params: {
+                nodeModule: { type: 'string' },
+                nodeType: { type: 'string' }
+            },
+            body: {
+                type: 'object',
+                properties: {
+                    // The prompt to send to the assistant (required)
+                    prompt: { type: 'string' },
+                    // A correlation id for the transaction (required)
+                    transactionId: { type: 'string' },
+                    // Additional context for the completion (optional)
+                    context: { type: 'object', additionalProperties: true }
+                },
+                required: ['prompt', 'transactionId']
+            },
+            response: {
+                200: {
+                    type: 'object',
+                    additionalProperties: true
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    },
+    async (request, reply) => {
+        // Check license and tier - FIM is only available for certain tiers
+        const isLicensed = app.license?.active() || false
+        const licenseType = isLicensed ? (app.license.get('dev') ? 'DEV' : 'EE') : 'CE'
+        const tier = isLicensed ? app.license.get('tier') : null
+        const fimTiers = [
+            'teams', // AKA "pro" tier
+            'enterprise'
+        ]
+        if (!fimTiers.includes(tier) && licenseType !== 'DEV') {
+            return reply.code(403).send({ code: 'forbidden', error: 'Forbidden' })
+        }
+
+        const nodeModule = request.params.nodeModule
+        const nodeType = request.params.nodeType
+        const supported = [
+            { nodeModule: 'node-red', nodeName: 'function' },
+            { nodeModule: '@flowfuse/node-red-dashboard', nodeName: 'ui-template' },
+            { nodeModule: '@flowfuse/nr-tables-nodes', nodeName: 'tables-query' }
+        ]
+        if (supported.findIndex(item => item.nodeModule === nodeModule && item.nodeName === nodeType) === -1) {
+            // unsupported node
+            return reply.code(400).send({ code: 'not_supported', error: 'Not Supported' })
+        }
+
+        // if this is a `flowfuse-tables-query` lets see if tables are enabled and try to get the schema hints
+        let tablesCacheKey = null
+        if (nodeModule === '@flowfuse/nr-tables-nodes' && nodeType === 'tables-query') {
+            const tablesFeatureEnabled = app.config.features.enabled('tables') && request.team.TeamType.getFeatureProperty('tables', false)
+            tablesCacheKey = tablesFeatureEnabled && request.team.hashid + '/tables/schema'
+            if (tablesCacheKey) {
+                if (!tablesSchemaCache.has(tablesCacheKey)) {
+                    const { getTablesHints } = require('../../lib/assistant.js')
+                    const creds = await app.tables.getDatabases(request.team)
+                    if (creds && creds.length) {
+                        const database = creds[0] // Get the first database
+                        try {
+                            // Get the DDL
+                            const schemaData = await getTablesHints(app, request.team, database.hashid)
+                            tablesSchemaCache.set(tablesCacheKey, schemaData)
+                        } catch (error) {
+                            tablesSchemaCache.set(tablesCacheKey, '')
+                        }
+                    }
+                }
+            }
+        }
+
+        // post to the assistant service /fim/:nodeModule/:nodeType endpoint
+        try {
+            let isTeamOnTrial
+            if (app.billing && request.team.getSubscription) {
+                const subscription = await request.team.getSubscription()
+                isTeamOnTrial = subscription ? subscription.isTrial() : null
+            }
+            const data = { ...request.body }
+            if (tablesCacheKey) {
+                data.context = data.context || {}
+                data.context.tablesSchema = tablesSchemaCache.get(tablesCacheKey)
+            }
+
+            const method = `fim/${encodeURIComponent(nodeModule)}/${encodeURIComponent(nodeType)}`
+            const response = await app.db.controllers.Assistant.invokeLLM(method, data, {
+                teamHashId: request.team.hashid,
+                instanceType: request.ownerType,
+                instanceId: request.ownerId,
+                additionalHeaders: request.headers,
+                isTeamOnTrial
+            })
+
+            reply.send(response.data)
+        } catch (error) {
+            reply.code(error.response?.status || 500).send({ code: error.response?.data?.code || 'unexpected_error', error: error.response?.data?.error || error.message })
+        }
+    })
+    /**
      * Endpoint for assistant methods
      * For now, this is simply a relay to an external assistant service
      * In the future, we may decide to bring that service inside the core or

--- a/forge/routes/api/assistant.js
+++ b/forge/routes/api/assistant.js
@@ -56,6 +56,39 @@ module.exports = async function (app) {
     })
 
     /**
+     * Endpoint to provide setup instructions to the assistant
+     * This is called when the backend part of the plugin loads
+     * @name /api/v1/assistant/settings
+     * @static
+     * @memberof forge.routes.api.assistant
+     */
+    app.get('/settings', {
+        schema: {
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        inlineCompletions: {
+                            type: 'boolean'
+                        }
+                    }
+                }
+            }
+        }
+    }, async (_request, reply) => {
+        const options = {}
+        const isLicensed = app.license.active() || false
+        const licenseType = isLicensed ? (app.license.get('dev') ? 'DEV' : 'EE') : 'CE'
+        const tier = isLicensed ? app.license.get('tier') : null
+        const completionsTiers = [
+            'teams', // AKA "pro" tier
+            'enterprise'
+        ]
+        options.inlineCompletions = completionsTiers.includes(tier) || licenseType === 'DEV'
+        reply.send(options)
+    })
+
+    /**
      * Endpoint to serve static assets
      * This is used to serve static assets required by the assistant plugin
      * namely, the models and vocabulary files (typically < 1MB in total).


### PR DESCRIPTION
## Description

- Added settings endpoint to Assistant API
  - GET /api/v1/assistant/settings
  - This permits the assistant to retrieve settings for a specific device or project to understand if it can use inline code completions
- Added fim code completion service endpoint
  - POST /api/v1/assistant/fim/:nodeModule/:nodeType
  - This route is very similar to the generic /api/v1/assistant/:method route except for 2 differences:
    - It requires the nodeModule and nodeType to be specified in the URL - so we know exactly which node is requesting the completion and can apply logic specific to that node
    - It has a much higher rate limit (60 requests per 30 minute window) - because code completions are expected to be used more frequently
- Added tests for new fim service endpoint
- Added tests for new settings endpoint

### Tests added `test/unit/forge/routes/api/assistant_spec.js`
```
▼ Assistant API
  ▼ service enabled
    ▼ service tests
      ▼ fim code completion service
        ✔ anonymous cannot access
        ✔ random token cannot access
        ✔ user token can not access
        ✔ device token can access
        ✔ instance token can access
        ✔ fails when prompt is not supplied
        ✔ fails when transactionId is not supplied
        ✔ fails when transactionId is mismatched
        ✔ contains owner info in headers for an instance
        ✔ contains owner info in headers for a device
        ✔ should include tables hints in context and cache it for subsequent requests
        ✔ should fetch fresh tables context hints after cache expiration
        ✔ should fail for unlicensed requests
        ✔ should fail for non pro/enterprise tier requests
    ▼ settings endpoint
      ✔ should return settings for device
      ✔ should return settings for project
      ✔ should fail for unauthorized requests
      ✔ should have inlineCompletions enabled for pro tier team
      ✔ should have inlineCompletions enabled for enterprise tier team
      ✔ should have inlineCompletions disabled for starter team
```

## Related Issue(s)

closes #5978

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

