### PR TITLE
Unused device email reminder frequency revision

### DIFF
--- a/forge/housekeeper/tasks/deviceUnusedReminder.js
+++ b/forge/housekeeper/tasks/deviceUnusedReminder.js
@@ -11,7 +11,7 @@ module.exports = {
     schedule: `${randomInt(0, 59)} 7 * * *`,
     run: async function (app) {
         // If a team has 1 or more devices but none of them have ever been online, then email
-        // the "team owner(s)" about the device(s) that are younger than 2 weeks old since creation
+        // the "team owner(s)" about the device(s) that are ~24h old and ~5 days old since creation
 
         const unusedDevices = await app.db.models.Device.findAll({
             where: {
@@ -31,12 +31,27 @@ module.exports = {
             }
         })
 
-        const fourteenDaysAgo = new Date()
-        fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14)
-        fourteenDaysAgo.setHours(0, 0, 0, 0)
-        const recentUnusedDevices = unusedDevices.filter(device => {
-            return device.createdAt >= fourteenDaysAgo
-        })
+        // The goal is to remind users about unused devices at 24h and around 5 days
+        // Since this schedule only runs every 24h between 7 and 8 am UTC, we need to
+        // make some choices as to what to include and when.
+        // To find a reasonable balance, we will create two filters:
+        // 1. window 1 - between 42h and 18h ago
+        // 2. window 2 - between 5.5d and 4.5d ago
+        // Any device that was created within these timeframes will be included
+
+        const now = Date.now()
+        const window1a = new Date(now - 42 * 60 * 60 * 1000) // set to 42 hours ago
+        const window1b = new Date(now - 18 * 60 * 60 * 1000) // set to 18 hours ago
+        const window2a = new Date(now - 5.5 * 24 * 60 * 60 * 1000) // set to 5.5 days ago
+        const window2b = new Date(now - 4.5 * 24 * 60 * 60 * 1000) // set to 4.5 days ago
+
+        const filter1 = (device) => device.createdAt >= window1a && device.createdAt <= window1b
+        const filter2 = (device) => device.createdAt >= window2a && device.createdAt <= window2b
+
+        const devicesInWindow1 = unusedDevices.filter(filter1)
+        const devicesInWindow2 = unusedDevices.filter(filter2)
+
+        const recentUnusedDevices = [...devicesInWindow1, ...devicesInWindow2]
         if (recentUnusedDevices.length === 0) {
             return // No unused devices found
         }

--- a/test/unit/forge/housekeeper/tasks/deviceUnusedReminder_spec.js
+++ b/test/unit/forge/housekeeper/tasks/deviceUnusedReminder_spec.js
@@ -6,17 +6,49 @@ const unusedDeviceReminderTask = require('../../../../../forge/housekeeper/tasks
 
 const setup = require('../setup')
 
+async function forceUpdateDeviceCreatedAt (device, date) {
+    // Ref: https://github.com/sequelize/sequelize/issues/3759#issuecomment-1580202535
+    device.changed('createdAt', true)
+    device.set('createdAt', date || new Date('2000-01-01T00:00:00Z'), { raw: true })
+    await device.save({ silent: true, fields: ['createdAt'] })
+    await device.reload()
+}
+
 describe('Device Unused Reminder Task', function () {
+    // PREMISE:
+    // Add 4 devices, 2 of which will trigger email reminders
+    // * Device1 is ~1d old  - should send email
+    // * Device2 is ~3d old  - should NOT send email
+    // * Device3 is ~5d old  - should send email
+    // * Device4 is ~6d old  - should NOT send email
+
     /** @type {import('../setup').TestApplication} */
     let app
+    let device1 // defaults to being created ~1d ago
+    let device2 // defaults to being created ~3d ago
+    let device3 // defaults to being created ~5d ago
+    let device4 // defaults to being created ~6d ago
 
     before(async function () {
         app = await setup()
+    })
+
+    beforeEach(async function () {
         sinon.stub(app.postoffice, 'send').callsFake(() => {
             return Promise.resolve()
         })
         sinon.stub(app.log, 'info')
         sinon.stub(app.log, 'warn')
+        device1 = await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
+        device2 = await app.factory.createDevice({ name: 'app-dev-2' }, app.team, null, app.application)
+        device3 = await app.factory.createDevice({ name: 'app-dev-3' }, app.team, null, app.application)
+        device4 = await app.factory.createDevice({ name: 'app-dev-4' }, app.team, null, app.application)
+
+        const now = Date.now()
+        await forceUpdateDeviceCreatedAt(device1, new Date(now - 1 * 24 * 60 * 60 * 1000)) // ~1d ago
+        await forceUpdateDeviceCreatedAt(device2, new Date(now - 3 * 24 * 60 * 60 * 1000)) // ~3d ago
+        await forceUpdateDeviceCreatedAt(device3, new Date(now - 5 * 24 * 60 * 60 * 1000)) // ~5d ago
+        await forceUpdateDeviceCreatedAt(device4, new Date(now - 6 * 24 * 60 * 60 * 1000)) // ~6d ago
     })
 
     after(async function () {
@@ -32,37 +64,22 @@ describe('Device Unused Reminder Task', function () {
         // unsuspend alice
         app.user.suspended = false
         await app.user.save()
-        // reset spies
-        app.log.warn.reset()
-        app.postoffice.send.resetHistory()
+        sinon.restore()
     })
 
-    async function forceUpdateDeviceCreatedAt (device, date) {
-        device.changed('createdAt', true)
-        device.set('createdAt', date || new Date('2000-01-01T00:00:00Z'), { raw: true })
-        await device.save({ silent: true, fields: ['createdAt'] })
-        await device.reload()
-    }
-
     it('should not send email if there are no devices', async function () {
+        // delete all devices
+        await app.db.models.Device.destroy({ where: {} })
         // run the task
         await unusedDeviceReminderTask.run(app)
         // check that send was not called
         app.postoffice.send.called.should.be.false()
     })
 
-    it('should send email for unused devices created less than 14 days ago', async function () {
-        // create a new device and add it to team
-        const device1 = await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
-        const device2 = await app.factory.createDevice({ name: 'app-dev-2' }, app.team, null, app.application)
-        const device3 = await app.factory.createDevice({ name: 'app-dev-3' }, app.team, null, app.application)
-
-        // Force device3 to be created before 14 days ago. Ref: https://github.com/sequelize/sequelize/issues/3759#issuecomment-1580202535
-        await forceUpdateDeviceCreatedAt(device3, device3.createdAt.getDate() - 16)
-
+    it('should send email for unused devices created less than ~24h and ~5d days ago', async function () {
         // run the task
         await unusedDeviceReminderTask.run(app)
-        // check that send was called twice (once for each device created less than 14 days ago)
+        // check that send was called twice (once for device created ~24h ago and once for device created ~5 days ago)
         app.postoffice.send.calledTwice.should.be.true()
 
         app.postoffice.send.firstCall.args[0].should.be.an.Object()
@@ -78,16 +95,14 @@ describe('Device Unused Reminder Task', function () {
         app.postoffice.send.secondCall.args[0].email.should.equal('alice@example.com')
         app.postoffice.send.secondCall.args[1].should.equal('DeviceUnusedReminder')
         app.postoffice.send.secondCall.args[2].should.be.an.Object()
-        app.postoffice.send.secondCall.args[2].should.have.property('url', `${app.config.base_url}/device/${device2.hashid}`)
+        app.postoffice.send.secondCall.args[2].should.have.property('url', `${app.config.base_url}/device/${device3.hashid}`)
         app.postoffice.send.secondCall.args[2].should.have.property('teamName', 'ATeam')
-        app.postoffice.send.secondCall.args[2].deviceName.should.have.property('text', 'app-dev-2')
-        app.postoffice.send.secondCall.args[2].deviceName.should.have.property('html', 'app-dev-2')
+        app.postoffice.send.secondCall.args[2].deviceName.should.have.property('text', 'app-dev-3')
+        app.postoffice.send.secondCall.args[2].deviceName.should.have.property('html', 'app-dev-3')
     })
 
     it('should not send email if team has any used devices', async function () {
-        // create a new device and add it to team
-        const device1 = await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
-        await app.factory.createDevice({ name: 'app-dev-2' }, app.team, null, app.application)
+        // set lastSeenAt to now
         device1.lastSeenAt = new Date()
         await device1.save()
 
@@ -97,12 +112,23 @@ describe('Device Unused Reminder Task', function () {
         app.postoffice.send.called.should.be.false()
     })
 
-    it('should not send email if unused devices were created more than 14 days ago', async function () {
-        // create a new device and add it to team
-        const device1 = await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
-        const device2 = await app.factory.createDevice({ name: 'app-dev-2' }, app.team, null, app.application)
-        await forceUpdateDeviceCreatedAt(device1, device1.createdAt.getDate() - 16)
-        await forceUpdateDeviceCreatedAt(device2, device2.createdAt.getDate() - 16)
+    it('should not send email if unused devices were just created ~12h ago', async function () {
+        const now = Date.now()
+        await forceUpdateDeviceCreatedAt(device1, new Date(now - 2 * 60 * 60 * 1000)) // ~2 hours ago
+        await forceUpdateDeviceCreatedAt(device2, new Date(now - 12 * 60 * 60 * 1000)) // ~12 hours ago
+        await forceUpdateDeviceCreatedAt(device3, new Date(now - 17 * 60 * 60 * 1000)) // ~17 hours ago
+
+        // run the task
+        await unusedDeviceReminderTask.run(app)
+        // check that send was not called
+        app.postoffice.send.called.should.be.false()
+    })
+
+    it('should not send email if unused devices were created more than 6 days ago', async function () {
+        const now = Date.now()
+        await forceUpdateDeviceCreatedAt(device1, new Date(now - 6 * 24 * 60 * 60 * 1000)) // ~6 days ago
+        await forceUpdateDeviceCreatedAt(device2, new Date(now - 7 * 24 * 60 * 60 * 1000)) // ~7 days ago
+        await forceUpdateDeviceCreatedAt(device3, new Date(now - 28 * 24 * 60 * 60 * 1000)) // ~28 days ago
 
         // run the task
         await unusedDeviceReminderTask.run(app)
@@ -111,6 +137,10 @@ describe('Device Unused Reminder Task', function () {
     })
 
     it('should not send email for unused devices where team is suspended', async function () {
+        // set lastSeenAt on a teamA device to now to prevent emails in that team
+        device1.lastSeenAt = new Date()
+        await device1.save()
+
         // create team b and bob
         const teamB = await app.factory.createTeam({ name: 'BTeam' })
         const userBob = await app.factory.createUser({
@@ -120,7 +150,8 @@ describe('Device Unused Reminder Task', function () {
             password: 'bbPassword'
         })
         await teamB.addUser(userBob, { through: { role: app.factory.Roles.Roles.Owner } })
-        await app.factory.createDevice({ name: 'app-dev-1' }, teamB, null, app.application)
+        const device = await app.factory.createDevice({ name: 'app-dev-1' }, teamB, null, app.application)
+        await forceUpdateDeviceCreatedAt(device, new Date(Date.now() - 24 * 60 * 60 * 1000)) // ~1 day ago
 
         // suspend team b
         teamB.suspended = true
@@ -133,6 +164,10 @@ describe('Device Unused Reminder Task', function () {
     })
 
     it('should not send email for unused devices to users who are suspended', async function () {
+        // leave only 1 device (the 24h old one)
+        await device2.destroy()
+        await device3.destroy()
+
         // add new owner to team
         const userBob = await app.factory.createUser({
             username: 'bob',
@@ -140,22 +175,21 @@ describe('Device Unused Reminder Task', function () {
             email: 'bob@example.com',
             password: 'bbPassword'
         })
+        await app.team.addUser(userBob, { through: { role: app.factory.Roles.Roles.Owner } })
         userBob.suspended = true
         await userBob.save()
-        await app.team.addUser(userBob, { through: { role: app.factory.Roles.Roles.Owner } })
-        await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
 
         // run the task
         await unusedDeviceReminderTask.run(app)
 
-        // check that only alice was sent an email
+        // check that only alice was sent a single email for the remaining 24h old device
         app.postoffice.send.calledOnce.should.be.true()
         app.postoffice.send.firstCall.args[0].should.be.an.Object()
         app.postoffice.send.firstCall.args[0].email.should.equal('alice@example.com')
     })
 
     it('should not send any emails when all users are suspended', async function () {
-        const device = await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
+        // const device = await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
 
         // suspend all users in the team
         app.user.suspended = true
@@ -165,12 +199,13 @@ describe('Device Unused Reminder Task', function () {
         app.postoffice.send.called.should.be.false()
 
         // should have logged a message ~ No active team owners found for device <hashid> (<name>) in team <hashid> (<name>)
-        app.log.warn.calledWith(`No active team owners found for device ${device.hashid} (app-dev-1) in team ${app.team.hashid} (${app.team.name})`).should.be.true()
+        app.log.warn.calledWith(`No active team owners found for device ${device1.hashid} (app-dev-1) in team ${app.team.hashid} (${app.team.name})`).should.be.true()
+        app.log.warn.calledWith(`No active team owners found for device ${device2.hashid} (app-dev-2) in team ${app.team.hashid} (${app.team.name})`).should.be.false()
+        app.log.warn.calledWith(`No active team owners found for device ${device3.hashid} (app-dev-3) in team ${app.team.hashid} (${app.team.name})`).should.be.true()
+        app.log.warn.calledWith(`No active team owners found for device ${device4.hashid} (app-dev-4) in team ${app.team.hashid} (${app.team.name})`).should.be.false()
     })
 
     it('should not send any email when team trial has ended', async function () {
-        await app.factory.createDevice({ name: 'app-dev-1' }, app.team, null, app.application)
-
         // stub app.db.models.Subscription.byTeamId so that it returns a subscription with trialStatus = ENDED
         sinon.stub(app.db.models.Subscription, 'byTeamId').callsFake(async () => {
             return {


### PR DESCRIPTION
## Description

This pull request updates the logic and tests for sending reminder emails about unused devices. The change is to shift from sending emails every 24h for unused devices that are "less than 14 days old" - to - 2x windows at ~24 hours and ~5 days after device creation. The tests are also refactored and expanded to match the new logic, ensuring correct behaviour for various device ages and team/user states.


### Details

#### As a reminder, this is the old (previously agreed rules) updated for the new time windows.

- Device Criteria: Emails are sent for devices that have never been online ([lastSeenAt](vscode-file://vscode-app/c:/Users/sdmcl/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is null) and were created within specific time windows:
   - Window 1: Devices created between 42 hours ago and 18 hours ago (approximately 24 hours old).
   - Window 2: Devices created between 5.5 days ago and 4.5 days ago (approximately 5 days old).
- Team Criteria: The team must have only unused devices (no devices in the team have ever been online). If any device in the team has a [lastSeenAt](vscode-file://vscode-app/c:/Users/sdmcl/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) value, no emails are sent for that team.
- Recipients: Emails are sent to all active team owners (users with the "Owner" role who are not suspended).
- Frequency: The task runs once per day, scheduled randomly between 7:00 and 8:00 AM UTC.


#### When Emails Are NOT Sent

- If there are no devices at all.
- If the team has any devices that have been online (even one).
- If devices are too new (created less than 18 hours ago) or too old (created more than 6 days ago, outside the defined windows).
- If the team is suspended.
- If all team owners are suspended (a warning is logged for each affected device).
- If the team's trial has ended (for licensed instances with billing enabled).

#### Additional Notes

- Emails are sent individually for each qualifying device to each eligible owner.

## Related Issue(s)

#5865

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

