### PR TITLE
Select which snapshot to generate ai description against

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -391,6 +391,18 @@ module.exports = {
                         limit: 1
                     })
                     return snapshots[0]
+                },
+                async getLatestDeploySnapshot () {
+                    const snapshots = await this.getProjectSnapshots({
+                        where: {
+                            name: {
+                                [Op.like]: 'Deploy Snapshot - %'
+                            }
+                        },
+                        order: [['createdAt', 'DESC']],
+                        limit: 1
+                    })
+                    return snapshots[0]
                 }
             },
             static: {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -1474,15 +1474,15 @@ module.exports = async function (app) {
             targetSnapshot = (await request.project.getLatestDeploySnapshot()) ?? {}
             break
         default:
-            targetSnapshot = (await app.db.models.ProjectSnapshot.byId(request.body.target)) ?? {}
-            break
-        }
+            targetSnapshot = (await app.db.models.ProjectSnapshot.byId(request.body.target))
 
-        if (!targetSnapshot || Object.keys(targetSnapshot).length === 0) {
-            return reply.code(404).send({
-                code: 'not_found',
-                error: 'Snapshot not found'
-            })
+            if (!targetSnapshot) {
+                return reply.code(404).send({
+                    code: 'not_found',
+                    error: 'Snapshot not found'
+                })
+            }
+            break
         }
 
         const currentSnapshot = await app.db.controllers.ProjectSnapshot.buildSnapshot(

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -1444,6 +1444,7 @@ module.exports = async function (app) {
             },
             body: {
                 type: 'object',
+                required: ['target'],
                 properties: {
                     target: { type: 'string' }
                 }
@@ -1475,6 +1476,13 @@ module.exports = async function (app) {
         default:
             targetSnapshot = (await app.db.models.ProjectSnapshot.byId(request.body.target)) ?? {}
             break
+        }
+
+        if (!targetSnapshot || Object.keys(targetSnapshot).length === 0) {
+            return reply.code(404).send({
+                code: 'not_found',
+                error: 'Snapshot not found'
+            })
         }
 
         const currentSnapshot = await app.db.controllers.ProjectSnapshot.buildSnapshot(

--- a/frontend/src/api/instances.js
+++ b/frontend/src/api/instances.js
@@ -214,8 +214,8 @@ const getResources = async (instanceId) => {
     })
 }
 
-const generateSnapshotDescription = async (instanceId) => {
-    return client.post(`/api/v1/projects/${instanceId}/generate/snapshot-description`, {})
+const generateSnapshotDescription = async (instanceId, { target }) => {
+    return client.post(`/api/v1/projects/${instanceId}/generate/snapshot-description`, { target })
         .then(res => {
             return res.data.data
         })

--- a/frontend/src/api/projectSnapshots.js
+++ b/frontend/src/api/projectSnapshots.js
@@ -63,8 +63,8 @@ const getSnapshot = (instanceId, snapshotId) => {
 /**
  * TODO: Currently hits project API
  */
-const getInstanceSnapshots = (instanceId, cursor, limit) => {
-    const url = paginateUrl(`/api/v1/projects/${instanceId}/snapshots`, cursor, limit)
+const getInstanceSnapshots = (instanceId, cursor, limit, query) => {
+    const url = paginateUrl(`/api/v1/projects/${instanceId}/snapshots`, cursor, limit, query)
     return client.get(url).then(res => {
         res.data.snapshots = res.data.snapshots.map(ss => {
             ss.createdSince = daysSince(ss.createdAt)

--- a/frontend/src/pages/instance/VersionHistory/Snapshots/dialogs/SnapshotCreateDialog.vue
+++ b/frontend/src/pages/instance/VersionHistory/Snapshots/dialogs/SnapshotCreateDialog.vue
@@ -54,7 +54,7 @@
                                 </popover-item>
                                 <popover-item
                                     title="or search for a specific snapshot"
-                                    class="bg-gray-100 hover:bg-gray-100"
+                                    class="bg-gray-100 hover:bg-gray-100 border-t border-gray-200"
                                 >
                                     <template #content>
                                         <div class="flex gap-1 w-full my-2">
@@ -83,7 +83,7 @@
                                             <ff-button
                                                 kind="secondary"
                                                 :disabled="!selectedSnapshot || loadingDescription"
-                                                @click="onPopoverItemClick('custom',close)"
+                                                @click="onPopoverItemClick(selectedSnapshot,close)"
                                             >
                                                 <template #icon>
                                                     <ChevronRightIcon class="ff-icon" />
@@ -189,9 +189,9 @@ export default {
                 })
             }
         },
-        generateDescription () {
+        generateDescription (target) {
             this.loadingDescription = true
-            return instanceApi.generateSnapshotDescription(this.project.id, {})
+            return instanceApi.generateSnapshotDescription(this.project.id, { target })
                 .then(res => {
                     if (!this.input.name.length) {
                         this.input.name = res.name
@@ -216,6 +216,7 @@ export default {
                 })
                 .finally(() => {
                     this.loadingDescription = false
+                    this.selectedSnapshot = null
                 })
         },
         searchSnapshots (query) {

--- a/frontend/src/pages/instance/VersionHistory/Snapshots/dialogs/SnapshotCreateDialog.vue
+++ b/frontend/src/pages/instance/VersionHistory/Snapshots/dialogs/SnapshotCreateDialog.vue
@@ -163,10 +163,7 @@ export default {
             return !this.submitted && !!(this.input.name)
         }
     },
-    mounted () {
-        console.log('SnapshotCreateDialog mounted')
-        console.log(this.featuresCheck)
-    },
+    mounted () { },
     methods: {
         confirm () {
             if (this.formValid) {

--- a/frontend/src/pages/instance/VersionHistory/Snapshots/dialogs/SnapshotCreateDialog.vue
+++ b/frontend/src/pages/instance/VersionHistory/Snapshots/dialogs/SnapshotCreateDialog.vue
@@ -40,7 +40,7 @@
                                     @click="onPopoverItemClick('latest',close)"
                                 >
                                     <template #icon>
-                                        <ChevronLeftIcon class="ff-icon text-indigo-500" />
+                                        <ClockIcon class="ff-icon text-indigo-500" />
                                     </template>
                                 </popover-item>
                                 <popover-item
@@ -102,8 +102,8 @@
 </template>
 <script>
 
-import { CubeTransparentIcon } from '@heroicons/vue/outline'
-import { ChevronLeftIcon, ChevronRightIcon, QuestionMarkCircleIcon } from '@heroicons/vue/solid'
+import { ClockIcon, CubeTransparentIcon } from '@heroicons/vue/outline'
+import { ChevronRightIcon, QuestionMarkCircleIcon } from '@heroicons/vue/solid'
 import { mapGetters } from 'vuex'
 
 import instanceApi from '../../../../../api/instances.js'
@@ -122,8 +122,8 @@ export default {
         FormRow,
         QuestionMarkCircleIcon,
         CubeTransparentIcon,
-        ChevronLeftIcon,
-        ChevronRightIcon
+        ChevronRightIcon,
+        ClockIcon
     },
     props: {
         project: {
@@ -164,6 +164,8 @@ export default {
         }
     },
     mounted () {
+        console.log('SnapshotCreateDialog mounted')
+        console.log(this.featuresCheck)
     },
     methods: {
         confirm () {

--- a/frontend/src/pages/instance/VersionHistory/Snapshots/dialogs/SnapshotCreateDialog.vue
+++ b/frontend/src/pages/instance/VersionHistory/Snapshots/dialogs/SnapshotCreateDialog.vue
@@ -25,13 +25,61 @@
                     </FormRow>
                     <ff-button
                         v-if="featuresCheck.isGeneratedSnapshotDescriptionEnabled" kind="tertiary"
-                        :disabled="loadingDescription" @click="generateDescription"
+                        :disabled="loadingDescription" @click.self="generateDescription"
                     >
                         Generate with AI
                         <template #icon-left>
                             <CubeTransparentIcon class="ff-icon" />
                         </template>
                     </ff-button>
+                    <ff-popover button-text="Generate with AI" button-kind="tertiary">
+                        <template #icon-left>
+                            <CubeTransparentIcon class="ff-icon" />
+                        </template>
+                        <template #panel>
+                            <section>
+                                <popover-item
+                                    title="Use latest snapshot"
+                                    description="Compare with latest snapshot [snapshot name]"
+                                >
+                                    <template #icon>
+                                        <ChevronLeftIcon class="ff-icon text-indigo-500" />
+                                    </template>
+                                </popover-item>
+                                <popover-item
+                                    title="Use latest auto-snapshot"
+                                    description="Compare with the latest auto snapshot: [snapshot name]"
+                                >
+                                    <template #icon>
+                                        <ChevronDoubleLeftIcon class="ff-icon text-indigo-500" />
+                                    </template>
+                                </popover-item>
+                                <popover-item
+                                    title="Use latest deploy snapshot"
+                                    description="Compare with the latest deploy snapshot: [snapshot name]"
+                                >
+                                    <template #icon>
+                                        <PipelineIcon class="ff-icon text-indigo-500" />
+                                    </template>
+                                </popover-item>
+                                <popover-item
+                                    title="or search for a specific snapshot"
+                                    class="bg-gray-50"
+                                >
+                                    <template #content>
+                                        <div class="flex gap-1 w-full my-2">
+                                            <ff-combobox class="flex-1" :options="[]" />
+                                            <ff-button kind="secondary">
+                                                <template #icon>
+                                                    <ChevronRightIcon class="ff-icon" />
+                                                </template>
+                                            </ff-button>
+                                        </div>
+                                    </template>
+                                </popover-item>
+                            </section>
+                        </template>
+                    </ff-popover>
                 </section>
             </form>
         </template>
@@ -40,21 +88,28 @@
 <script>
 
 import { CubeTransparentIcon } from '@heroicons/vue/outline'
-import { QuestionMarkCircleIcon } from '@heroicons/vue/solid'
+import { ChevronDoubleLeftIcon, ChevronLeftIcon, ChevronRightIcon, QuestionMarkCircleIcon } from '@heroicons/vue/solid'
 import { mapGetters } from 'vuex'
 
 import instanceApi from '../../../../../api/instances.js'
 import snapshotApi from '../../../../../api/projectSnapshots.js'
 
 import FormRow from '../../../../../components/FormRow.vue'
+import PipelineIcon from '../../../../../components/icons/Pipelines.js'
 import alerts from '../../../../../services/alerts.js'
+import PopoverItem from '../../../../../ui-components/components/PopoverItem.vue'
 
 export default {
     name: 'SnapshotCreateDialog',
     components: {
+        PopoverItem,
+        PipelineIcon,
         FormRow,
         QuestionMarkCircleIcon,
-        CubeTransparentIcon
+        CubeTransparentIcon,
+        ChevronLeftIcon,
+        ChevronDoubleLeftIcon,
+        ChevronRightIcon
     },
     props: {
         project: {

--- a/frontend/src/ui-components/components.js
+++ b/frontend/src/ui-components/components.js
@@ -11,6 +11,7 @@ import FFListItem from './components/ListItem.vue'
 import FFMarkdownViewer from './components/Markdown.vue'
 import FFNotificationPill from './components/NotificationPill.vue'
 import FFNotificationToast from './components/NotificationToast.vue'
+import FFPopover from './components/Popover.vue'
 import FFSpinner from './components/Spinner.vue'
 import FFDataTable from './components/data-table/DataTable.vue'
 import FFDataTableCell from './components/data-table/DataTableCell.vue'
@@ -67,5 +68,6 @@ export default {
     FFNotificationPill,
     FFNotificationToast,
     // Tabs
-    FFTabs
+    FFTabs,
+    FFPopover
 }

--- a/frontend/src/ui-components/components/Popover.vue
+++ b/frontend/src/ui-components/components/Popover.vue
@@ -1,0 +1,75 @@
+<template>
+    <Popover v-slot="{ open }" class="relative">
+        <PopoverButton ref="trigger"
+                       class="ff-btn ff-btn-icon transition-fade--color"
+                       :class="{...buttonClass, active: open}"
+                       @click="() => { $nextTick(() => { updatePosition(); open = true }) }"
+        >
+            <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
+                <slot name="icon-left"></slot>
+            </span>
+            <span>{{ buttonText }}</span>
+            <span class="ml-2">
+                <ChevronDownIcon class="ff-icon transition-ease" :class="{ 'rotate-180 transform': open }" />
+            </span>
+        </PopoverButton>
+        <teleport to="body">
+            <PopoverPanel
+                v-if="open"
+                class="absolute w-full overflow-auto bg-white  border border-gray-200 rounded-md shadow-md z-[200]"
+                :style="{
+                    top: position.top + 'px',
+                    left: position.left + 'px',
+                    width: position.width + 'px'
+                }"
+            >
+                <slot name="panel" />
+            </PopoverPanel>
+        </teleport>
+    </Popover>
+</template>
+
+<script>
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
+import { ChevronDownIcon } from '@heroicons/vue/solid'
+import { defineComponent } from 'vue'
+
+import BoxOptionsMixin from '../../mixins/BoxOptionsMixin.js'
+
+export default defineComponent({
+    name: 'ff-popover',
+    components: {
+        ChevronDownIcon,
+        Popover,
+        PopoverButton,
+        PopoverPanel
+    },
+    mixins: [BoxOptionsMixin],
+    props: {
+        buttonText: {
+            type: String,
+            required: true
+        },
+        buttonKind: {
+            default: 'primary',
+            type: String // "primary", "secondary", "tertiary"
+        }
+    },
+    computed: {
+        hasIconLeft: function () {
+            return this.$slots['icon-left']
+        },
+        buttonClass () {
+            return {
+                ['ff-btn--' + this.buttonKind]: true,
+                'ff-btn-small': this.buttonKind === 'small',
+                'ff-btn-fwidth': this.buttonKind === 'full-width'
+            }
+        }
+    }
+})
+</script>
+
+<style scoped lang="scss">
+
+</style>

--- a/frontend/src/ui-components/components/Popover.vue
+++ b/frontend/src/ui-components/components/Popover.vue
@@ -3,6 +3,7 @@
         <PopoverButton ref="trigger"
                        class="ff-btn ff-btn-icon transition-fade--color"
                        :class="{...buttonClass, active: open}"
+                       :disabled="disabled"
                        @click="() => { $nextTick(() => { updatePosition(); open = true }) }"
         >
             <span v-if="hasIconLeft" class="ff-btn--icon ff-btn--icon-left">
@@ -54,6 +55,11 @@ export default defineComponent({
         buttonKind: {
             default: 'primary',
             type: String // "primary", "secondary", "tertiary"
+        },
+        disabled: {
+            default: false,
+            required: false,
+            type: Boolean
         }
     },
     computed: {

--- a/frontend/src/ui-components/components/Popover.vue
+++ b/frontend/src/ui-components/components/Popover.vue
@@ -18,9 +18,9 @@
                 v-if="open"
                 class="absolute w-full overflow-auto bg-white  border border-gray-200 rounded-md shadow-md z-[200]"
                 :style="{
-                    top: position.top + 'px',
+                    top: position.top + 10 + 'px',
                     left: position.left + 'px',
-                    width: position.width + 'px'
+                    width: 'fit-content'
                 }"
             >
                 <slot name="panel" />

--- a/frontend/src/ui-components/components/Popover.vue
+++ b/frontend/src/ui-components/components/Popover.vue
@@ -16,6 +16,7 @@
         <teleport to="body">
             <PopoverPanel
                 v-if="open"
+                v-slot="{ close }"
                 class="absolute w-full overflow-auto bg-white  border border-gray-200 rounded-md shadow-md z-[200]"
                 :style="{
                     top: position.top + 10 + 'px',
@@ -23,7 +24,7 @@
                     width: 'fit-content'
                 }"
             >
-                <slot name="panel" />
+                <slot name="panel" :close="close" />
             </PopoverPanel>
         </teleport>
     </Popover>

--- a/frontend/src/ui-components/components/PopoverItem.vue
+++ b/frontend/src/ui-components/components/PopoverItem.vue
@@ -1,0 +1,72 @@
+<template>
+    <div class="popover-item" @click="onClick">
+        <div v-if="hasIcon" class="icon">
+            <slot name="icon" />
+        </div>
+        <div class="content w-full">
+            <div class="title">
+                <h5>{{ title }}</h5>
+            </div>
+            <div v-if="description" class="description">
+                {{ description }}
+            </div>
+            <slot name="content" />
+        </div>
+    </div>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+    name: 'popover-item',
+    props: {
+        title: {
+            type: String,
+            required: true
+        },
+        description: {
+            type: String,
+            required: false,
+            default: null
+        },
+        onClick: {
+            required: false,
+            type: Function,
+            default: () => {}
+        }
+    },
+    computed: {
+        hasIcon: function () {
+            return this.$slots.icon
+        }
+    }
+})
+</script>
+
+<style scoped lang="scss">
+.popover-item {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    padding: 5px;
+    cursor: pointer;
+
+    .icon {
+        padding: 5px;
+    }
+
+    .content {
+        display: flex;
+        flex-direction: column;
+
+        .description {
+            color: $ff-grey-400;
+        }
+    }
+
+    &:hover {
+        background: $ff-grey-100;
+    }
+}
+</style>

--- a/frontend/src/ui-components/components/PopoverItem.vue
+++ b/frontend/src/ui-components/components/PopoverItem.vue
@@ -49,7 +49,7 @@ export default defineComponent({
     display: flex;
     align-items: center;
     gap: 15px;
-    padding: 5px;
+    padding: 10px 20px;
     cursor: pointer;
 
     .icon {

--- a/frontend/src/ui-components/components/form/ComboBox.vue
+++ b/frontend/src/ui-components/components/form/ComboBox.vue
@@ -224,7 +224,6 @@ export default {
     },
     watch: {
         query () {
-            this.$emit('update:query', this.query)
             if (this.fetchRemoteOptions) {
                 this.debouncedFetchRemoteOptions()
             }

--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -1119,7 +1119,7 @@ $countdown_size: 20px;
   position: absolute;
   z-index: 100;
   font-weight: normal; // prevent parent overriding if embedded in hX
-  white-space: nowrap;
+  white-space: preserve-breaks;
   height: fit-content;
   background-color: black;
   color: white;

--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -114,7 +114,7 @@
     background-color: $ff-color--action;
     border: 1px solid $ff-color--action;
     color: $ff-grey-50;
-    &:hover {
+    &:hover, &.active {
       background-color: $ff-color--highlight;
     }
   }
@@ -122,7 +122,7 @@
     background-color: $ff-white;
     color: $ff-color--action;
     border: 1px solid $ff-color--action;
-    &:hover {
+    &:hover, &.active {
       background-color: $ff-color--highlight;
       border-color: $ff-color--highlight;
       color: $ff-white;
@@ -130,7 +130,7 @@
   }
   &--tertiary {
     color: $ff-color--action;
-    &:hover {
+    &:hover, &.active {
       background-color: $ff-color--highlight;
       color: $ff-white;
     }

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -3280,7 +3280,7 @@ describe('Project API', function () {
             const response = await app.inject({
                 method: 'POST',
                 url: `/api/v1/projects/${TestObjects.project1.id}/generate/snapshot-description`,
-                payload: { target: 'latest' },
+                payload: { target: 'some-code' },
                 cookies: { sid: TestObjects.tokens.alice }
             })
 


### PR DESCRIPTION
## Description

Allow for more accurate, context-aware ai-generated snapshot descriptions by letting users select the comparison baseline, including pipeline deploys or any specific snapshot, with a quick-search UI.

- added a new ff popover component which is a wrapper over [headless ui's popover](https://headlessui.com/v1/vue/popover) component
- extended the instances.generateSnapshotDescription api method to accept a target parameter for query searching
- extended the combobox to allow for remote option searching
- replaced single “Generate with AI” button with a popover offering:
  - Use latest manual snapshot
  - Use latest deploy snapshot
  - Search and pick a specific snapshot (combobox with remote search)

- added a new `target` parameter for the snapshot generation endpoint to ingest the target snapshot we would need to compare against
- added a new query `getLatestDeploySnapshot` method to query for the latest deployed snapshot through a pipeline

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5983

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

