### PR TITLE
Fix inconsistent remote instance status badge color

### DIFF
--- a/frontend/src/pages/device/components/DeviceLastSeenCell.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenCell.vue
@@ -5,7 +5,7 @@
             Finish Setup
         </ff-button>
     </template>
-    <DeviceLastSeenBadge v-else :lastSeenAt="lastSeenAt" :lastSeenSince="lastSeenSince" />
+    <DeviceLastSeenBadge v-else :lastSeenAt="lastSeenAt" :lastSeenSince="lastSeenSince" :lastSeenMs="lastSeenMs" />
 </template>
 
 <script>


### PR DESCRIPTION
## Description

Fixes inconsistent badge coloring due to missing last seen prop passed to the device status badge

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/5483

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

