### PR TITLE
Bypass implicit Permissions mixin dependencies

### DIFF
--- a/frontend/src/components/banners/SubscriptionExpired.vue
+++ b/frontend/src/components/banners/SubscriptionExpired.vue
@@ -28,6 +28,7 @@
 
 <script>
 import { ChevronRightIcon, ExclamationCircleIcon } from '@heroicons/vue/outline'
+import { mapState } from 'vuex'
 
 import permissionsMixin from '../../mixins/Permissions.js'
 
@@ -39,6 +40,7 @@ export default {
     },
     mixins: [permissionsMixin],
     computed: {
+        ...mapState('account', ['team']),
         billingPath () {
             return '/team/' + this.team.slug + '/billing'
         },

--- a/frontend/src/components/banners/TeamSuspended.vue
+++ b/frontend/src/components/banners/TeamSuspended.vue
@@ -13,6 +13,7 @@
 
 <script>
 import { ExclamationCircleIcon } from '@heroicons/vue/outline'
+import { mapState } from 'vuex'
 
 import permissionsMixin from '../../mixins/Permissions.js'
 
@@ -21,6 +22,9 @@ export default {
     components: {
         ExclamationCircleIcon
     },
-    mixins: [permissionsMixin]
+    mixins: [permissionsMixin],
+    computed: {
+        ...mapState('account', ['team'])
+    }
 }
 </script>

--- a/frontend/src/components/banners/TeamTrial.vue
+++ b/frontend/src/components/banners/TeamTrial.vue
@@ -50,7 +50,7 @@ export default {
     },
     mixins: [permissionsMixin],
     computed: {
-        ...mapState('account', ['teamMembership']),
+        ...mapState('account', ['team', 'teamMembership']),
         billingPath () {
             return '/team/' + this.team.slug + '/settings/change-type'
         },

--- a/frontend/src/components/drawers/navigation/MainNav.vue
+++ b/frontend/src/components/drawers/navigation/MainNav.vue
@@ -40,7 +40,7 @@ export default {
     mixins: [permissionsMixin],
     emits: ['option-selected'],
     computed: {
-        ...mapState('account', ['user', 'team', 'teamMembership', 'features', 'notifications']),
+        ...mapState('account', ['user', 'team', 'features', 'notifications']),
         ...mapState('ux', ['mainNav']),
         ...mapGetters('account', ['requiresBilling']),
         ...mapGetters('ux', ['mainNavContexts', 'mainNavContext']),

--- a/frontend/src/components/instance/ActionButton.vue
+++ b/frontend/src/components/instance/ActionButton.vue
@@ -17,8 +17,6 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-
 import InstanceApi from '../../api/instances.js'
 import permissionsMixin from '../../mixins/Permissions.js'
 import ConfirmInstanceDeleteDialog from '../../pages/instance/Settings/dialogs/ConfirmInstanceDeleteDialog.vue'
@@ -44,7 +42,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
         flowActionsDisabled () {
             return !(this.instance.meta && this.instance.meta.state !== 'suspended')
         },

--- a/frontend/src/mixins/Permissions.js
+++ b/frontend/src/mixins/Permissions.js
@@ -1,5 +1,3 @@
-import { mapState } from 'vuex'
-
 import usePermissions from '../composables/Permissions.js'
 
 /**
@@ -9,8 +7,6 @@ import usePermissions from '../composables/Permissions.js'
 // todo in an attempt to sunset the wide use of mixins, the permissions composable should be used instead
 export default {
     computed: {
-        // todo to be removed. A lot of components that use this mixin rely on the state imported here
-        ...mapState('account', ['team', 'teamMembership']),
         isVisitingAdmin () {
             const { isVisitingAdmin } = usePermissions()
             return isVisitingAdmin()

--- a/frontend/src/pages/application/DeviceGroup/Settings/Environment.vue
+++ b/frontend/src/pages/application/DeviceGroup/Settings/Environment.vue
@@ -34,7 +34,6 @@
 
 <script>
 import { ExclamationCircleIcon } from '@heroicons/vue/outline'
-import { mapState } from 'vuex'
 
 import applicationApi from '../../../../api/application.js'
 import permissionsMixin from '../../../../mixins/Permissions.js'
@@ -114,7 +113,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
         unsavedChanges () {
             return this.editable.changed.env
         }

--- a/frontend/src/pages/application/DeviceGroup/Settings/General.vue
+++ b/frontend/src/pages/application/DeviceGroup/Settings/General.vue
@@ -35,8 +35,6 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-
 import ApplicationApi from '../../../../api/application.js'
 import FormHeading from '../../../../components/FormHeading.vue'
 import FormRow from '../../../../components/FormRow.vue'
@@ -74,7 +72,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
         unsavedChanges () {
             return this.deviceGroup ? (this.input.name !== this.deviceGroup.name || this.input.description !== this.deviceGroup.description) : false
         },

--- a/frontend/src/pages/application/DeviceGroup/Settings/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/Settings/index.vue
@@ -43,7 +43,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership', 'team'])
+        ...mapState('account', ['teamMembership'])
     },
     watch: {
         deviceGroup: function (newVal, oldVal) {

--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -162,7 +162,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership']),
+        ...mapState('account', ['teamMembership']),
         ...mapGetters('account', ['featuresCheck']),
         cloudColumns () {
             return [

--- a/frontend/src/pages/application/Settings.vue
+++ b/frontend/src/pages/application/Settings.vue
@@ -49,8 +49,6 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-
 import ApplicationAPI from '../../api/application.js'
 
 import FormHeading from '../../components/FormHeading.vue'
@@ -98,7 +96,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
         formValid () {
             return this.input.projectName
         },

--- a/frontend/src/pages/application/Snapshots.vue
+++ b/frontend/src/pages/application/Snapshots.vue
@@ -59,7 +59,6 @@
 <script>
 import { FilterIcon } from '@heroicons/vue/outline'
 import { markRaw } from 'vue'
-import { mapState } from 'vuex'
 
 import ApplicationApi from '../../api/application.js'
 import SnapshotsApi from '../../api/snapshots.js'
@@ -181,7 +180,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
         snapshotList () {
             return this.snapshots.map(s => {
                 return {

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -56,7 +56,7 @@ export default {
     },
     mixins: [permissionsMixin, applicationMixin, instanceActionsMixin],
     computed: {
-        ...mapState('account', ['features']),
+        ...mapState('account', ['features', 'team']),
         navigation () {
             const routes = [
                 { label: 'Hosted Instances', to: { name: 'ApplicationInstances' }, tag: 'application-overview', icon: ProjectsIcon },

--- a/frontend/src/pages/device/Settings/Danger.vue
+++ b/frontend/src/pages/device/Settings/Danger.vue
@@ -33,7 +33,7 @@ export default {
         FormHeading
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership'])
+        ...mapState('account', ['team'])
     },
     data () {
         return {

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -16,8 +16,6 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-
 import deviceApi from '../../../api/devices.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
 import alerts from '../../../services/alerts.js'
@@ -108,7 +106,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
         isUpdateButtonDisabled () {
             if (this.hasError) return true
             return !this.unsavedChanges

--- a/frontend/src/pages/device/Settings/General.vue
+++ b/frontend/src/pages/device/Settings/General.vue
@@ -208,7 +208,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
+        ...mapState('account', ['team']),
         canChangeNodeRedVersion () {
             return this.deviceOwnerType === 'application' && this.hasPermission('device:edit')
         },

--- a/frontend/src/pages/device/Settings/Palette.vue
+++ b/frontend/src/pages/device/Settings/Palette.vue
@@ -60,8 +60,6 @@
 <script>
 import { PlusSmIcon, XIcon } from '@heroicons/vue/outline'
 
-import { mapState } from 'vuex'
-
 import deviceApi from '../../../api/devices.js'
 import FormHeading from '../../../components/FormHeading.vue'
 import FormRow from '../../../components/FormRow.vue'
@@ -101,7 +99,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
         defaultEnabled () {
             return this.urls.includes(this.defaultCatalogue)
         },

--- a/frontend/src/pages/device/Settings/Security.vue
+++ b/frontend/src/pages/device/Settings/Security.vue
@@ -26,7 +26,6 @@
 
 <script>
 import semver from 'semver'
-import { mapState } from 'vuex'
 
 import deviceApi from '../../../api/devices.js'
 
@@ -85,7 +84,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
         securityOptionsSupported () {
             if (!this.device.agentVersion) {
                 // Device has not called home yet - so we don't know what agent

--- a/frontend/src/pages/device/Settings/index.vue
+++ b/frontend/src/pages/device/Settings/index.vue
@@ -26,7 +26,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership', 'team'])
+        ...mapState('account', ['teamMembership'])
     },
     mounted () {
         if (this.checkAccess()) {

--- a/frontend/src/pages/device/VersionHistory/Snapshots/index.vue
+++ b/frontend/src/pages/device/VersionHistory/Snapshots/index.vue
@@ -211,7 +211,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership', 'features']),
+        ...mapState('account', ['team', 'features']),
         canCreateSnapshot () {
             if (!this.developerMode || this.busy) {
                 return false

--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -119,8 +119,6 @@
 <script>
 import { ExternalLinkIcon, LinkIcon, ServerIcon, TemplateIcon, TrendingUpIcon } from '@heroicons/vue/outline'
 
-import { mapState } from 'vuex'
-
 import InstanceApi from '../../api/instances.js'
 import FormHeading from '../../components/FormHeading.vue'
 import StatusBadge from '../../components/StatusBadge.vue'
@@ -156,7 +154,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership']),
         instanceRunning () {
             return this.instance?.meta?.state === 'running'
         },

--- a/frontend/src/pages/instance/Settings/Alerts.vue
+++ b/frontend/src/pages/instance/Settings/Alerts.vue
@@ -6,7 +6,6 @@
 
 <script>
 import { useRouter } from 'vue-router'
-import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
@@ -55,7 +54,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership', 'features']),
         emailOptions () {
             return [
                 {

--- a/frontend/src/pages/instance/Settings/Danger.vue
+++ b/frontend/src/pages/instance/Settings/Danger.vue
@@ -175,7 +175,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'features', 'teamMembership']),
+        ...mapState('account', ['team', 'features']),
         isLoading () {
             return this.loading.deleting || this.loading.suspend || this.loading.changingStack || this.loading.duplicating || this.loading.settingType
         }

--- a/frontend/src/pages/instance/Settings/Editor.vue
+++ b/frontend/src/pages/instance/Settings/Editor.vue
@@ -56,7 +56,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership']),
+        ...mapState('account', ['team']),
         saveButton () {
             return {
                 visible: true,

--- a/frontend/src/pages/instance/Settings/Environment.vue
+++ b/frontend/src/pages/instance/Settings/Environment.vue
@@ -11,8 +11,6 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-
 import InstanceApi from '../../../api/instances.js'
 import permissionsMixin from '../../../mixins/Permissions.js'
 import Dialog from '../../../services/dialog.js'
@@ -73,7 +71,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
         saveButton () {
             return {
                 visible: this.hasPermission('device:edit-env'),

--- a/frontend/src/pages/instance/Settings/LauncherSettings.vue
+++ b/frontend/src/pages/instance/Settings/LauncherSettings.vue
@@ -28,8 +28,6 @@
 import SemVer from 'semver'
 import { useRouter } from 'vue-router'
 
-import { mapState } from 'vuex'
-
 import InstanceApi from '../../../api/instances.js'
 import FormHeading from '../../../components/FormHeading.vue'
 import FormRow from '../../../components/FormRow.vue'
@@ -69,7 +67,6 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership']),
         unsavedChanges: function () {
             return +this.original.healthCheckInterval !== +this.input.healthCheckInterval ||
                 this.original.disableAutoSafeMode !== this.input.disableAutoSafeMode

--- a/frontend/src/pages/instance/Settings/Palette.vue
+++ b/frontend/src/pages/instance/Settings/Palette.vue
@@ -67,7 +67,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership', 'features']),
+        ...mapState('account', ['team', 'features']),
         catalogFeatureEnabledForTeam () {
             if (!this.features.customCatalogs) {
                 return false

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -114,7 +114,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership', 'settings']),
+        ...mapState('account', ['team', 'settings']),
         projectLauncherCompatible () {
             const launcherVersion = this.project?.meta?.versions?.launcher
             if (!launcherVersion) {

--- a/frontend/src/pages/instance/Settings/index.vue
+++ b/frontend/src/pages/instance/Settings/index.vue
@@ -71,7 +71,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership', 'features', 'settings']),
+        ...mapState('account', ['team', 'features', 'settings']),
         navigation () {
             const canEditProject = this.hasPermission('project:edit')
 

--- a/frontend/src/pages/instance/VersionHistory/Snapshots/index.vue
+++ b/frontend/src/pages/instance/VersionHistory/Snapshots/index.vue
@@ -138,7 +138,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
+        ...mapState('account', ['team']),
         columns () {
             const cols = [
                 {

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -126,7 +126,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership', 'team']),
+        ...mapState('account', ['team']),
         navigation () {
             if (!this.instance.id) return []
             let versionHistoryRoute

--- a/frontend/src/pages/team/AuditLog.vue
+++ b/frontend/src/pages/team/AuditLog.vue
@@ -39,6 +39,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import TeamAPI from '../../api/team.js'
 import FormHeading from '../../components/FormHeading.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
@@ -73,6 +75,7 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['team', 'teamMembership']),
         logScope () {
             return !this.auditFilters.selectedEventScope ? 'application' : 'project' // cannot use 'instance' due to legacy naming
         }

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -108,6 +108,7 @@
 
 import { ExternalLinkIcon } from '@heroicons/vue/outline'
 import { markRaw } from 'vue'
+import { mapState } from 'vuex'
 
 import billingApi from '../../api/billing.js'
 
@@ -183,6 +184,7 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['team']),
         billingSetUp () {
             return !this.missingSubscription && this.team.billing?.active
         },

--- a/frontend/src/pages/team/Brokers/Clients/index.vue
+++ b/frontend/src/pages/team/Brokers/Clients/index.vue
@@ -119,7 +119,7 @@ export default {
         Roles () {
             return Roles
         },
-        ...mapState('account', ['user', 'team', 'teamMembership', 'features']),
+        ...mapState('account', ['user', 'team', 'features']),
         ...mapState('product', {
             clients: state => state.UNS.clients
         }),

--- a/frontend/src/pages/team/Instances.vue
+++ b/frontend/src/pages/team/Instances.vue
@@ -237,7 +237,7 @@ export default {
         }
     },
     computed: {
-        ...mapGetters('account', ['featuresCheck']),
+        ...mapGetters('account', ['featuresCheck', 'team']),
         instances () {
             return Array.from(this.instancesMap.values())
         },

--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -65,7 +65,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['user']),
+        ...mapState('account', ['user', 'team']),
         canEditUser: function () {
             return this.hasPermission('team:user:remove') || this.hasPermission('team:user:change-role')
         },

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -65,7 +65,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['settings'])
+        ...mapState('account', ['settings', 'team', 'teamMembership'])
     },
     watch: {
         teamMembership: 'fetchData',

--- a/frontend/src/pages/team/Members/index.vue
+++ b/frontend/src/pages/team/Members/index.vue
@@ -30,7 +30,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['user'])
+        ...mapState('account', ['user', 'team'])
     },
     watch: {
         teamMembership: 'checkAccess'

--- a/frontend/src/pages/team/Settings/Devices.vue
+++ b/frontend/src/pages/team/Settings/Devices.vue
@@ -57,6 +57,7 @@
 <script>
 import { KeyIcon, PlusSmIcon, TemplateIcon } from '@heroicons/vue/outline'
 import { markRaw } from 'vue'
+import { mapState } from 'vuex'
 
 import teamApi from '../../../api/team.js'
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
@@ -112,6 +113,7 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['team']),
         addEnabled: function () {
             return this.hasPermission('team:device:provisioning-token:create')
         },

--- a/frontend/src/pages/team/Settings/Integrations.vue
+++ b/frontend/src/pages/team/Settings/Integrations.vue
@@ -111,7 +111,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['features']),
+        ...mapState('account', ['features', 'team']),
         ...mapGetters('account', ['featuresCheck']),
         addEnabled: function () {
             return this.hasPermission('team:git:tokens:create')

--- a/frontend/src/pages/team/Settings/index.vue
+++ b/frontend/src/pages/team/Settings/index.vue
@@ -35,7 +35,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['features'])
+        ...mapState('account', ['features', 'team', 'teamMembership'])
     },
     watch: {
         teamMembership: 'checkAccess'


### PR DESCRIPTION
## Description

This is the first step toward removing the permissions mixin entirely. By making component dependencies explicit, we reduce hidden coupling and prevent breakage once the mixin is removed.

- reviewed all components using the permissions mixin
- removed the mixin where possible
- added direct `team`/`teamMembership` imports from the composable layer where needed

We can heavily rely on frontend unit and E2E tests here, since any missing or incorrect handling of `team` and `teamMembership` would immediately break the UI entirely.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5975

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

