### PR TITLE
Adds support for closing the right drawer when pressing the Escape key

### DIFF
--- a/frontend/src/components/drawers/RightDrawer.vue
+++ b/frontend/src/components/drawers/RightDrawer.vue
@@ -17,6 +17,14 @@ export default {
     computed: {
         ...mapState('ux', ['rightDrawer'])
     },
+    watch: {
+        'rightDrawer.state': {
+            handler (isOpen) {
+                const onEsc = (e) => e.key === 'Escape' && this.closeRightDrawer()
+                isOpen ? window.addEventListener('keydown', onEsc) : window.removeEventListener('keydown', onEsc)
+            }
+        }
+    },
     methods: {
         ...mapActions('ux', ['closeRightDrawer']),
         closeDrawer () {
@@ -25,7 +33,6 @@ export default {
             }
         }
     }
-
 }
 </script>
 


### PR DESCRIPTION
## Description

Added support for closing the right drawer by pressing the escape key by adding/removing a keydown event listener whenever the right rawer is opened/closed

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6009

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

