### PR TITLE
fix: close search overlay when tabbing out of search control

### DIFF
--- a/frontend/src/components/global-search/GlobalSearch.vue
+++ b/frontend/src/components/global-search/GlobalSearch.vue
@@ -1,5 +1,8 @@
 <template>
-    <div id="global-search" :class="{focused: isFocused}" data-el="global-search">
+    <div
+        id="global-search" :class="{focused: isFocused}" data-el="global-search" tabindex="-1"
+        @focusout="handleFocusOut"
+    >
         <transition name="fade" mode="out-in">
             <div v-if="isFocused" class="overlay" @click="deFocusSearch" />
         </transition>
@@ -227,6 +230,11 @@ export default {
         handleEscapeKey (event) {
             if (event.key === 'Escape') {
                 this.onEscKeyPress()
+            }
+        },
+        handleFocusOut (event) {
+            if (!event.relatedTarget || !this.$el.contains(event.relatedTarget)) {
+                this.deFocusSearch()
             }
         },
         getData: debounce(async function () {

--- a/frontend/src/components/global-search/GlobalSearch.vue
+++ b/frontend/src/components/global-search/GlobalSearch.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        id="global-search" :class="{focused: isFocused}" data-el="global-search" tabindex="-1"
+        id="global-search" :class="{focused: isFocused}" data-el="global-search"
         @focusout="handleFocusOut"
     >
         <transition name="fade" mode="out-in">


### PR DESCRIPTION
## Description

Fixes #5314 

Added focusout handler to close search overlay when focus moves outside component during tab navigation.

[Screencast from 2025-09-16 13-48-44.webm](https://github.com/user-attachments/assets/cf74c293-9db7-43e1-97c1-6f9a3567a485)


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

