### PR TITLE
Account: Make it easier/clearer to delete account

### DIFF
--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -286,14 +286,25 @@ export default {
                 text: 'Are you sure you want to delete this team? This cannot be undone. All Instances and resources within this team will be removed.',
                 confirmLabel: 'Delete Team'
             }, async () => {
-                teamApi.deleteTeam(teamId).then(() => {
-                    alerts.emit('Team successfully deleted', 'confirmation')
-                    // refresh teams
-                    this.$store.dispatch('account/refreshTeams')
-                }).catch(err => {
-                    alerts.emit('Problem deleting team', 'warning')
-                    console.warn(err)
-                })
+                teamApi.deleteTeam(teamId)
+                    .then(() => {
+                        alerts.emit('Team successfully deleted', 'confirmation')
+                        // refresh teams
+                        return this.$store.dispatch('account/refreshTeams')
+                    }).then(() => {
+                        const activeTeam = this.$store.getters['account/team']
+                        // check if the active team is one deleted
+                        if (activeTeam?.id === teamId) {
+                            const teams = this.$store.getters['account/teams']
+                            if (teams.length > 0) {
+                                // get another team
+                                this.$store.dispatch('account/setTeam', teams[0].slug)
+                            }
+                        }
+                    }).catch(err => {
+                        alerts.emit('Problem deleting team', 'warning')
+                        console.warn(err)
+                    })
             })
         },
         selectTeam (team) {

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -102,7 +102,7 @@ export default {
         teams () {
             const currentUser = this.$store.getters['account/user']
             const teams = this.$store.getters['account/teams']
-            const teamOptions = teams.map(team => {
+            const teamOptions = teams?.map(team => {
                 if (team.id === currentUser.defaultTeam) {
                     this.defaultTeamName = team.name
                 }
@@ -124,8 +124,8 @@ export default {
             })
         },
         canDeleteAccount () {
-            for (let i = 0; i < this.teams.length; i++) {
-                if (!this.ownerCounts[this.teams[i].id] || this.ownerCounts[this.teams[i].id] === 1) {
+            for (let i = 0; i < this.teams?.length; i++) {
+                if (!this.ownerCounts[this.teams[i].id] || (this.ownerCounts[this.teams[i].id] === 1 && this.teams[i].owner)) {
                     return false
                 }
             }
@@ -163,7 +163,7 @@ export default {
     },
     mounted () {
         // get the members for each team, and check the owner count
-        this.teams.forEach(team => {
+        this.teams?.forEach(team => {
             if (team.memberCount !== 1) {
                 teamApi.getTeamMembers(team.id)
                     .then(data => {
@@ -227,7 +227,7 @@ export default {
                         }, 800)
                     }
                     this.user = response
-                    this.teams.forEach(team => {
+                    this.teams?.forEach(team => {
                         if (team.id === this.user.defaultTeam) {
                             this.defaultTeamName = team.label
                         }

--- a/frontend/src/pages/account/index.vue
+++ b/frontend/src/pages/account/index.vue
@@ -7,7 +7,7 @@
                 <div class="text-l text-gray-400">{{ user.username }}</div>
             </div>
         </div>
-        <div class="text-sm mt-4 sm:mt-8">
+        <div class="mt-4 sm:mt-8">
             <router-view />
         </div>
     </ff-page>

--- a/test/e2e/frontend/cypress/tests/admin/offboarding.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin/offboarding.spec.js
@@ -54,6 +54,7 @@ describe('FlowFuse - Team Membership', () => {
         cy.visit('account/settings') // go to admin settings
 
         cy.wait(['@getSettings'])
+        cy.wait(['@getTeamMembers'])
 
         cy.get('[data-action="delete-account"]').click()
 
@@ -82,6 +83,7 @@ describe('FlowFuse - Team Membership', () => {
         cy.visit('account/settings') // go to admin settings
 
         cy.wait(['@getSettings'])
+        cy.wait(['@getTeamMembers'])
 
         cy.get('[data-action="delete-account"]').click()
         cy.get('[data-action="dialog-confirm"]').click()


### PR DESCRIPTION
## Description

- As discussed in the issue, we now list the teams that a user is part of, permit the user to delete the team from here, and then drive the `:disabled` state by whether they actually can delete their account. 

<img width="1774" height="710" alt="image" src="https://github.com/user-attachments/assets/58c1b8e9-9742-48a7-a782-9bae1de307ab" />

## Related Issue(s)

Closes #5935 