### PR TITLE
Filter instances and devices counts based on their application context

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -653,7 +653,7 @@ module.exports = {
                     }
 
                     const statesMap = {}
-                    const findAll = this.findAll({
+                    const findAll = await this.findAll({
                         include: [
                             {
                                 model: M.Application,
@@ -674,8 +674,9 @@ module.exports = {
                         }
                     })
 
-                    findAll.filter((project) => {
-                        return app.hasPermission(membership, 'project:read', { applicationId: project.Application.hashid })
+                    findAll.filter((device) => {
+                        const context = device.Application ? { applicationId: device.Application.hashid } : {}
+                        return app.hasPermission(membership, 'project:read', context)
                     }).forEach(res => {
                         const state = Controllers.Project.getLatestProjectState(res.id) ?? res.state
                         statesMap[state] = (statesMap[state] || 0) + 1

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -658,7 +658,7 @@ module.exports = {
                         ]
                     })
                 },
-                countByState: async (states, teamId, applicationId) => {
+                countByState: async (states, teamId, applicationId, membership) => {
                     if (typeof teamId === 'string') {
                         teamId = M.Team.decodeHashid(teamId)
 
@@ -677,6 +677,12 @@ module.exports = {
 
                     const statesMap = {}
                     const results = await this.findAll({
+                        include: [
+                            {
+                                model: M.Application,
+                                attributes: ['hashid', 'id']
+                            }
+                        ],
                         where: states.length > 0
                             ? {
                                 [Op.or]: states.map(state => ({
@@ -691,7 +697,9 @@ module.exports = {
                             }
                     })
 
-                    results.forEach(res => {
+                    results.filter((project) => {
+                        return app.hasPermission(membership, 'project:read', { applicationId: project.Application.hashid })
+                    }).forEach(res => {
                         const state = Controllers.Project.getLatestProjectState(res.id) ?? res.state
                         statesMap[state] = (statesMap[state] || 0) + 1
                     })

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -658,7 +658,8 @@ module.exports = {
                         ]
                     })
                 },
-                countByState: async (states, teamId, applicationId, membership) => {
+                countByState: async (states, team, applicationId, membership) => {
+                    let teamId = team.id
                     if (typeof teamId === 'string') {
                         teamId = M.Team.decodeHashid(teamId)
 
@@ -697,7 +698,13 @@ module.exports = {
                             }
                     })
 
+                    const platformRbacEnabled = app.config.features.enabled('rbacApplication')
+                    const teamRbacEnabled = team.TeamType.getFeatureProperty('rbacApplication', false)
+
                     results.filter((project) => {
+                        if ((!platformRbacEnabled && !teamRbacEnabled)) {
+                            return true
+                        }
                         return app.hasPermission(membership, 'project:read', { applicationId: project.Application.hashid })
                     }).forEach(res => {
                         const state = Controllers.Project.getLatestProjectState(res.id) ?? res.state

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -371,6 +371,9 @@ module.exports = async function (app) {
         if (projects) {
             if (!request.session?.User?.admin && request.teamMembership && request.teamMembership.permissions?.applications) {
                 projects = projects.filter(projects => {
+                    // todo improve filtering/query because by filtering post query, the limit request attribute is redundant because we're initially
+                    //  finding n results but then filtering ones that might not match the permission schema so
+                    //  we might be returning less than n results as initially requested
                     return app.hasPermission(request.teamMembership, 'project:read', { applicationId: app.db.models.Application.encodeHashid(projects.ApplicationId) })
                 })
             }

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -1094,7 +1094,7 @@ module.exports = async function (app) {
                 : app.db.models.Device
             const membership = await request.session.User.getTeamMembership(request.team.id)
 
-            const stateCounters = await model.countByState(request.query.state, request.team.id, request.query.applicationId, membership) ?? []
+            const stateCounters = await model.countByState(request.query.state, request.team, request.query.applicationId, membership) ?? []
             const response = {}
 
             stateCounters.forEach(res => {

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -1092,8 +1092,9 @@ module.exports = async function (app) {
             const model = request.query.instanceType === 'hosted'
                 ? app.db.models.Project
                 : app.db.models.Device
+            const membership = await request.session.User.getTeamMembership(request.team.id)
 
-            const stateCounters = await model.countByState(request.query.state, request.team.id, request.query.applicationId) ?? []
+            const stateCounters = await model.countByState(request.query.state, request.team.id, request.query.applicationId, membership) ?? []
             const response = {}
 
             stateCounters.forEach(res => {

--- a/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
@@ -11,7 +11,7 @@
                 />
             </li>
             <li v-if="hasMore" class="device-wrapper flex">
-                <team-link :to="{name: 'TeamDevices'}" class="device-tile has-more hover:text-indigo-700">
+                <team-link :to="{name: 'TeamDevices'}" class="device-tile has-more hover:text-indigo-700" data-el="has-more">
                     <span>{{ instancesLeft }} More</span>
                     <span>
                         <ChevronRightIcon class="ff-icon ff-icon-sm" />

--- a/test/e2e/frontend/cypress/tests-ee/rbac/rbac-contextual.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/rbac/rbac-contextual.spec.js
@@ -49,7 +49,7 @@ describe('FlowFuse - RBAC Contextual permissions', () => {
         })
 
         // dashboard
-        it.only('should not have restricted remote instances listed on the dashboard page', () => {
+        it('should not have restricted remote instances listed on the dashboard page', () => {
             cy.get('[data-el="dashboard-section-hosted"]').within(() => {
                 // todo: this test is failing because the dashboard is not loading properly
                 // out of 6 teams with 1 instance each, one team has restricted role, for another viewer role

--- a/test/e2e/frontend/cypress/tests-ee/rbac/rbac-contextual.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/rbac/rbac-contextual.spec.js
@@ -49,19 +49,18 @@ describe('FlowFuse - RBAC Contextual permissions', () => {
         })
 
         // dashboard
-        it('should not have restricted remote instances listed on the dashboard page', () => {
+        it.only('should not have restricted remote instances listed on the dashboard page', () => {
             cy.get('[data-el="dashboard-section-hosted"]').within(() => {
                 // todo: this test is failing because the dashboard is not loading properly
                 // out of 6 teams with 1 instance each, one team has restricted role, for another viewer role
                 // resulting in 4 running, 0 error, 0 stopped
                 // should display 3 instance tiles
                 // should display has more with one more available
-
-                // cy.get('[data-state="running"]').contains('4')
+                cy.get('[data-state="running"]').contains('4')
                 cy.get('[data-state="error"]').contains('0')
                 cy.get('[data-state="stopped"]').contains('0')
-                // cy.get('[data-el="instance-tile"]').should('have.length', 3)
-                // cy.get('[data-el="has-more"]').contains('Show 1 more')
+                cy.get('[data-el="instance-tile"]').should('have.length', 1)
+                cy.get('[data-el="has-more"]').contains('3 More')
             })
             cy.get('[data-el="dashboard-section-remote"]').within(() => {
                 // todo: this test is failing because the dashboard is not loading properly
@@ -72,9 +71,9 @@ describe('FlowFuse - RBAC Contextual permissions', () => {
 
                 cy.get('[data-state="running"]').contains('0')
                 cy.get('[data-state="error"]').contains('0')
-                // cy.get('[data-state="stopped"]').contains('8')
-                // cy.get('[data-el="device-tile"]').should('have.length', 3)
-                // cy.get('[data-el="has-more"]').contains('Show 5 more')
+                cy.get('[data-state="stopped"]').contains('10')
+                cy.get('[data-el="device-tile"]').should('have.length', 1)
+                cy.get('[data-el="has-more"]').contains('9 More')
             })
         })
         it('should not have restricted hosted instances listed on the dashboard page', () => {

--- a/test/unit/forge/db/models/Device_spec.js
+++ b/test/unit/forge/db/models/Device_spec.js
@@ -563,7 +563,6 @@ describe('Device model', function () {
             // increase license limits
             app.license.defaults.devices = 20
             app.license.defaults.instances = 20
-            
             // Load TeamType association for TestObjects.team1
             await app.TestObjects.team1.reload({ include: [{ model: app.db.models.TeamType }] })
         })

--- a/test/unit/forge/db/models/Project_spec.js
+++ b/test/unit/forge/db/models/Project_spec.js
@@ -498,7 +498,6 @@ describe('Project model', function () {
             const instance7 = await app.db.models.Project.create({ name: 'p7', type: '', url: '', state: 'running', TeamId: numericTeamId, ApplicationId: numericApp2Id })
             const instance8 = await app.db.models.Project.create({ name: 'p8', type: '', url: '', state: 'suspended', TeamId: numericTeamId, ApplicationId: numericApp2Id })
 
-            const hashedTeamId = app.db.models.Team.encodeHashid(team.id)
             const hashedAppId = app.db.models.Application.encodeHashid(application1.id)
 
             const result = await app.db.models.Project.countByState(states, team, hashedAppId, null)
@@ -547,7 +546,6 @@ describe('Project model', function () {
             const instance7 = await app.db.models.Project.create({ name: 'p7', type: '', url: '', state: 'running', TeamId: numericTeamId, ApplicationId: numericApp2Id })
             const instance8 = await app.db.models.Project.create({ name: 'p8', type: '', url: '', state: 'stopped', TeamId: numericTeamId, ApplicationId: numericApp2Id })
 
-            const hashedTeamId = app.db.models.Team.encodeHashid(team.id)
             const hashedAppId = app.db.models.Application.encodeHashid(application1.id)
 
             const result = await app.db.models.Project.countByState(states, team, hashedAppId, null)

--- a/test/unit/forge/db/models/Project_spec.js
+++ b/test/unit/forge/db/models/Project_spec.js
@@ -353,20 +353,26 @@ describe('Project model', function () {
     })
 
     describe('Counting Projects by State', function () {
-        beforeEach(() => {
+        beforeEach(async () => {
             app.license.defaults.teams = 20
+            app.license.defaults.instances = 20
+
+            // Load TeamType association for TestObjects.team1
+            await app.TestObjects.team1.reload({ include: [{ model: app.db.models.TeamType }] })
         })
         it('should count projects grouped by state with valid states and a string TeamId', async function () {
             const states = ['running', 'stopped']
 
             const team = await app.db.models.Team.create({ name: 'Test Team', TeamTypeId: 1 })
+            // Load the TeamType association so the team has the getFeatureProperty method
+            await team.reload({ include: [{ model: app.db.models.TeamType }] })
             const numericTeamId = team.id
 
             const instance1 = await app.db.models.Project.create({ name: 'p1', type: '', url: '', state: 'running', TeamId: numericTeamId })
             const instance2 = await app.db.models.Project.create({ name: 'p2', type: '', url: '', state: 'stopped', TeamId: numericTeamId })
             const instance3 = await app.db.models.Project.create({ name: 'p3', type: '', url: '', state: 'running', TeamId: numericTeamId })
 
-            const result = await app.db.models.Project.countByState(states, team.id)
+            const result = await app.db.models.Project.countByState(states, team, null, null)
 
             result.should.deepEqual([
                 { state: 'running', count: 2 },
@@ -381,11 +387,13 @@ describe('Project model', function () {
 
         it('should count projects with no state filter (only by TeamId)', async function () {
             const team = await app.db.models.Team.create({ name: 'Test Team', TeamTypeId: 1 })
+            // Load the TeamType association so the team has the getFeatureProperty method
+            await team.reload({ include: [{ model: app.db.models.TeamType }] })
 
             const instance1 = await app.db.models.Project.create({ name: 'p4', type: '', url: '', state: 'idle', TeamId: team.id })
             const instance2 = await app.db.models.Project.create({ name: 'p5', type: '', url: '', state: 'running', TeamId: team.id })
 
-            const result = await app.db.models.Project.countByState([], team.id)
+            const result = await app.db.models.Project.countByState([], team, null, null)
 
             result.should.deepEqual([
                 { state: 'idle', count: 1 },
@@ -403,8 +411,9 @@ describe('Project model', function () {
                 name: 'Test Team',
                 TeamTypeId: 1
             })
+            await team.reload({ include: [{ model: app.db.models.TeamType }] })
 
-            const result = await app.db.models.Project.countByState(states, team.id)
+            const result = await app.db.models.Project.countByState(states, team, null, null)
 
             result.should.eql([])
 
@@ -412,14 +421,14 @@ describe('Project model', function () {
         })
 
         it('should handle errors gracefully when an invalid teamId is provided', async function () {
-            const teamId = 'invalidTeamId'
+            const invalidTeam = { id: 'invalidTeamId' }
 
             try {
-                await app.db.models.Project.countByState(['running'], teamId)
+                await app.db.models.Project.countByState(['running'], invalidTeam, null, null)
                 should.fail('Expected an error to be thrown')
             } catch (err) {
                 err.should.be.an.Error()
-                err.message.should.match(/invalid.+teamId/i)
+                err.message.should.match(/invalid.*teamId/i)
             }
         })
 
@@ -427,15 +436,15 @@ describe('Project model', function () {
             const states = ['running', 'stopped']
 
             const team = await app.db.models.Team.create({ name: 'Test Team', TeamTypeId: 1 })
+            // Load the TeamType association so the team has the getFeatureProperty method
+            await team.reload({ include: [{ model: app.db.models.TeamType }] })
             const numericTeamId = team.id
 
             const instance1 = await app.db.models.Project.create({ name: 'p1', type: '', url: '', state: 'running', TeamId: numericTeamId })
             const instance2 = await app.db.models.Project.create({ name: 'p2', type: '', url: '', state: 'stopped', TeamId: numericTeamId })
             const instance3 = await app.db.models.Project.create({ name: 'p3', type: '', url: '', state: 'running', TeamId: numericTeamId })
 
-            const hashedTeamId = app.db.models.Team.encodeHashid(team.id)
-
-            const result = await app.db.models.Project.countByState(states, hashedTeamId)
+            const result = await app.db.models.Project.countByState(states, team, null, null)
 
             result.should.deepEqual([
                 { state: 'running', count: 2 },
@@ -450,10 +459,11 @@ describe('Project model', function () {
 
         it('should handle invalid string ApplicationId', async () => {
             const team = await app.db.models.Team.create({ name: 'Test Team', TeamTypeId: 1 })
-            const hashedTeamId = app.db.models.Team.encodeHashid(team.id)
+            // Load the TeamType association so the team has the getFeatureProperty method
+            await team.reload({ include: [{ model: app.db.models.TeamType }] })
 
             try {
-                await app.db.models.Project.countByState([], hashedTeamId, 'invalid-application-id')
+                await app.db.models.Project.countByState([], team, 'invalid-application-id', null)
                 should.fail('Expected an error to be thrown')
             } catch (err) {
                 err.should.be.an.Error()
@@ -468,6 +478,8 @@ describe('Project model', function () {
             const states = ['running', 'stopped']
 
             const team = await app.db.models.Team.create({ name: 'Test Team', TeamTypeId: 1 })
+            // Load the TeamType association so the team has the getFeatureProperty method
+            await team.reload({ include: [{ model: app.db.models.TeamType }] })
             const numericTeamId = team.id
 
             const application1 = await app.db.models.Application.create({ name: 'App 1', TeamId: numericTeamId })
@@ -489,7 +501,7 @@ describe('Project model', function () {
             const hashedTeamId = app.db.models.Team.encodeHashid(team.id)
             const hashedAppId = app.db.models.Application.encodeHashid(application1.id)
 
-            const result = await app.db.models.Project.countByState(states, hashedTeamId, hashedAppId)
+            const result = await app.db.models.Project.countByState(states, team, hashedAppId, null)
 
             result.should.deepEqual([
                 { state: 'running', count: 2 },
@@ -515,6 +527,8 @@ describe('Project model', function () {
             const states = []
 
             const team = await app.db.models.Team.create({ name: 'Test Team', TeamTypeId: 1 })
+            // Load the TeamType association so the team has the getFeatureProperty method
+            await team.reload({ include: [{ model: app.db.models.TeamType }] })
             const numericTeamId = team.id
 
             const application1 = await app.db.models.Application.create({ name: 'App 1', TeamId: numericTeamId })
@@ -536,7 +550,7 @@ describe('Project model', function () {
             const hashedTeamId = app.db.models.Team.encodeHashid(team.id)
             const hashedAppId = app.db.models.Application.encodeHashid(application1.id)
 
-            const result = await app.db.models.Project.countByState(states, hashedTeamId, hashedAppId)
+            const result = await app.db.models.Project.countByState(states, team, hashedAppId, null)
 
             result.should.deepEqual([
                 { count: 2, state: 'running' },


### PR DESCRIPTION
## Description

filters out instances and devices for the dashboard counters dependent on their application permission context

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/pull/6052

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

