### PR TITLE
Granular RBAC: "Finish Setup" Permissions

### DIFF
--- a/frontend/src/pages/device/components/DeviceLastSeenCell.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenCell.vue
@@ -1,5 +1,5 @@
 <template>
-    <template v-if="neverConnected && hasPermission('device:edit')">
+    <template v-if="neverConnected && hasPermission('device:edit', { application })">
         <ff-button kind="secondary" @click="finishSetup">
             <template #icon-left><ExclamationIcon class="ff-icon" /></template>
             Finish Setup
@@ -39,6 +39,10 @@ export default {
         },
         lastSeenMs: {
             type: Number,
+            default: null
+        },
+        application: {
+            type: Object,
             default: null
         }
     },


### PR DESCRIPTION
## Description

Ensure the `application` scope is passed into the `DeviceLastSeenCell` to show/hide the "Finish Setup" button accordingly.

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/pull/6052