### PR TITLE
Clarify that Device Agent installs Node-RED

### DIFF
--- a/docs/device-agent/introduction.md
+++ b/docs/device-agent/introduction.md
@@ -19,6 +19,8 @@ The FlowFuse platform can be used to manage Node-RED Remote Instances running on
 
 By installing the FlowFuse Device Agent, you can securely connect your hardware to FlowFuse in order to manage and deploy Node-RED flows remotely.
 
+**Note:** The FlowFuse Device Agent will install Node-RED when the agent receives a snapshot to run from FlowFuse.
+
 In order to connect your device to FlowFuse, and to allow FlowFuse to manage it, you'll need to do the following steps:
 
 - [Quick Start Guide](/docs/device-agent/quickstart.md) - Install on a device and remotely edit through FlowFuse Cloud.


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Adds a note in the FlowFuse device agent documentation introduction that Node-RED is installed by FlowFuse device agent.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

None

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

