### PR TITLE
Update bulk device api for granular rbac

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -243,8 +243,9 @@ module.exports = {
      * @param {*} team - User's team
      * @param {Array<string>} deviceIds - Array of device hashids
      * @param {*} user - User performing the deletion (required for audit logging)
+     * @param {*} teamMembership - Team membership of the user performing the deletion (required for rbac checks)
      */
-    bulkDelete: async function (app, team, deviceIds, user) {
+    bulkDelete: async function (app, team, deviceIds, user, teamMembership) {
         if (!deviceIds || !Array.isArray(deviceIds) || deviceIds.length === 0) {
             throw new ControllerError('invalid_input', 'No devices specified', 400)
         }
@@ -254,9 +255,32 @@ module.exports = {
         const ids = idsDecoded.map(id => id && Array.isArray(id) ? id[0] : null).filter(id => id)
 
         // find all where id in ids
-        const devices = await app.db.models.Device.findAll({ where: { id: ids } })
+        const devices = await app.db.models.Device.findAll({
+            where: { id: ids },
+            include: {
+                model: app.db.models.Project,
+                attributes: ['id', 'ApplicationId']
+            }
+        })
         if (devices.length === 0) {
             throw new ControllerError('not_found', 'No devices found', 404)
+        }
+
+        if (!user.admin && teamMembership && teamMembership.permissions?.applications) {
+            // The requesting user has granular application permissions - we need to check that they have
+            // permission to delete all devices
+            const applicationIds = new Set()
+            devices.forEach(d => {
+                if (d.ApplicationId) {
+                    applicationIds.add(d.ApplicationId)
+                } else if (d.Project && d.Project.ApplicationId) {
+                    applicationIds.add(d.Project.ApplicationId)
+                }
+            })
+            const applicationBlocked = Array.from(applicationIds).some(id => !app.hasPermission(teamMembership, 'team:device:bulk-delete', { applicationId: app.db.models.Application.encodeHashid(id) }))
+            if (applicationBlocked) {
+                throw new ControllerError('invalid_input', 'Invalid input', 400)
+            }
         }
 
         // ensure all devices are part of the same team
@@ -279,7 +303,7 @@ module.exports = {
         teamLogger.team.device.bulkDeleted(user, null, team, devices)
     },
 
-    moveDevices: async function (app, deviceIds, targetApplicationId, targetInstanceId, user) {
+    moveDevices: async function (app, deviceIds, targetApplicationId, targetInstanceId, user, teamMembership) {
         // target is either a project or an application
         if (targetApplicationId && targetInstanceId) {
             throw new ControllerError('invalid_input', 'Target must be either an application or an instance', 400)
@@ -317,6 +341,29 @@ module.exports = {
         }
         if (devices.some(d => d.TeamId !== team.id)) {
             throw new ControllerError('invalid_input', 'All devices must belong to the same team', 400)
+        }
+
+        // Perform RBAC check if enabled
+        if (!user.admin && teamMembership && teamMembership.permissions?.applications) {
+            // Get the list of affected appliction ids
+            const applicationIds = new Set()
+            if (assignToApplication) {
+                applicationIds.add(assignToApplication.id)
+            }
+            if (assignToProject) {
+                applicationIds.add(assignToProject.ApplicationId)
+            }
+            devices.forEach(d => {
+                if (d.ApplicationId) {
+                    applicationIds.add(d.ApplicationId)
+                } else if (d.Project && d.Project.ApplicationId) {
+                    applicationIds.add(d.Project.ApplicationId)
+                }
+            })
+            const applicationBlocked = Array.from(applicationIds).some(id => !app.hasPermission(teamMembership, 'team:device:bulk-edit', { applicationId: app.db.models.Application.encodeHashid(id) }))
+            if (applicationBlocked) {
+                throw new ControllerError('invalid_input', 'Invalid input', 400)
+            }
         }
 
         // Prepare the updates

--- a/forge/routes/api/teamDevices.js
+++ b/forge/routes/api/teamDevices.js
@@ -435,7 +435,7 @@ module.exports = async function (app) {
         try {
             /** @type {typeof import('../../db/controllers/Device.js')} */
             const deviceController = app.db.controllers.Device
-            await deviceController.bulkDelete(request.team, request.body?.devices, request.session?.User)
+            await deviceController.bulkDelete(request.team, request.body?.devices, request.session?.User, request.teamMembership)
             reply.send({ status: 'okay' })
         } catch (err) {
             return handleError(err, reply)
@@ -491,7 +491,7 @@ module.exports = async function (app) {
                 throw new ControllerError('invalid_input', 'Invalid device id', 400)
             }
             if (request.body.instance !== undefined || request.body.application !== undefined) {
-                const updatedDevices = await deviceController.moveDevices(request.body.devices, request.body.application, request.body.instance, request.session?.User)
+                const updatedDevices = await deviceController.moveDevices(request.body.devices, request.body.application, request.body.instance, request.session?.User, request.teamMembership)
                 updatedDevices.devices = updatedDevices.devices.map(d => app.db.views.Device.device(d))
                 reply.send(updatedDevices)
             } else {

--- a/forge/routes/api/teamDevices.js
+++ b/forge/routes/api/teamDevices.js
@@ -435,7 +435,9 @@ module.exports = async function (app) {
         try {
             /** @type {typeof import('../../db/controllers/Device.js')} */
             const deviceController = app.db.controllers.Device
-            await deviceController.bulkDelete(request.team, request.body?.devices, request.session?.User, request.teamMembership)
+            const applicationRBACEnabled = app.config.features.enabled('rbacApplication') && request.team.TeamType.getFeatureProperty('rbacApplication', false)
+            // Only pass through the teamMembership object if application RBAC is enabled
+            await deviceController.bulkDelete(request.team, request.body?.devices, request.session?.User, applicationRBACEnabled ? request.teamMembership : null)
             reply.send({ status: 'okay' })
         } catch (err) {
             return handleError(err, reply)
@@ -491,7 +493,9 @@ module.exports = async function (app) {
                 throw new ControllerError('invalid_input', 'Invalid device id', 400)
             }
             if (request.body.instance !== undefined || request.body.application !== undefined) {
-                const updatedDevices = await deviceController.moveDevices(request.body.devices, request.body.application, request.body.instance, request.session?.User, request.teamMembership)
+                const applicationRBACEnabled = app.config.features.enabled('rbacApplication') && request.team.TeamType.getFeatureProperty('rbacApplication', false)
+                // Only pass through the teamMembership object if application RBAC is enabled
+                const updatedDevices = await deviceController.moveDevices(request.body.devices, request.body.application, request.body.instance, request.session?.User, applicationRBACEnabled ? request.teamMembership : null)
                 updatedDevices.devices = updatedDevices.devices.map(d => app.db.views.Device.device(d))
                 reply.send(updatedDevices)
             } else {

--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -75,7 +75,7 @@ describe('Team Devices API', function () {
 
         const defaultTeamTypeProperties = app.defaultTeamType.properties
         defaultTeamTypeProperties.features = defaultTeamTypeProperties.features || {}
-        defaultTeamTypeProperties.features.applicationRBAC = true
+        defaultTeamTypeProperties.features.rbacApplication = true
         app.defaultTeamType.properties = defaultTeamTypeProperties
         await app.defaultTeamType.save()
 
@@ -945,6 +945,8 @@ describe('Team Devices API', function () {
                 TestObjects.rbacDevice4 = await app.factory.createDevice({ name: 'device rbac 4', type: 'Application Assigned (allowed)' }, TestObjects.BTeam, null, TestObjects.BTeamApplication4)
             }
             before(async function () {
+                // Enable platform RBAC
+                app.config.features.register('rbacApplication', true, false)
                 TestObjects.BTeamApplication3 = await app.factory.createApplication({ name: 'application-3' }, TestObjects.BTeam)
                 TestObjects.BTeamApplication4 = await app.factory.createApplication({ name: 'application-4' }, TestObjects.BTeam)
 


### PR DESCRIPTION
Part of #5745 

Updates the `/api/v1/team/:teamId/devices/bulk` end points to apply granular rbac checks.

For delete
  - verifies none of the devices are currently assigned (directly, or via their instance) to a blocked application.

For update
  - verifies none of the devices are currently assigned (directly, or via their instance) to a blocked application.
 - verifies the target application/instance are not blocked