### PR TITLE
docs: Add `Check the Device Agent service status` paragraph

### DIFF
--- a/docs/device-agent/install/device-agent-installer.md
+++ b/docs/device-agent/install/device-agent-installer.md
@@ -151,7 +151,6 @@ Services are named per-port, for example `flowfuse-device-agent-1880`. On macOS,
 sudo systemctl start flowfuse-device-agent-<port>
 sudo systemctl stop flowfuse-device-agent-<port>
 sudo systemctl restart flowfuse-device-agent-<port>
-sudo systemctl status flowfuse-device-agent-<port>
 ```
 
 #### Linux (SysVinit)
@@ -160,7 +159,6 @@ sudo systemctl status flowfuse-device-agent-<port>
 sudo service flowfuse-device-agent-<port> start
 sudo service flowfuse-device-agent-<port> stop
 sudo service flowfuse-device-agent-<port> restart
-sudo service flowfuse-device-agent-<port> status
 ```
 
 #### Linux (OpenRC)
@@ -169,7 +167,6 @@ sudo service flowfuse-device-agent-<port> status
 sudo rc-service flowfuse-device-agent-<port> start
 sudo rc-service flowfuse-device-agent-<port> stop
 sudo rc-service flowfuse-device-agent-<port> restart
-sudo rc-service flowfuse-device-agent-<port> status
 ```
 
 #### macOS (launchd)
@@ -178,7 +175,6 @@ sudo rc-service flowfuse-device-agent-<port> status
 sudo launchctl start com.flowfuse.device-agent-<port>
 sudo launchctl stop com.flowfuse.device-agent-<port>
 sudo launchctl kickstart -k system/com.flowfuse.device-agent-<port>
-sudo launchctl print system/com.flowfuse.device-agent-<port>
 ```
 
 #### Windows (Service Control)
@@ -186,11 +182,13 @@ sudo launchctl print system/com.flowfuse.device-agent-<port>
 ```bash
 sc.exe start flowfuse-device-agent-<port>
 sc.exe stop flowfuse-device-agent-<port>
-sc.exe query flowfuse-device-agent-<port>
 ```
 
 
 ### Check the Device Agent service status
+
+You can check the status of the Device Agent service to verify if it is running correctly or to diagnose any issues. 
+The status command provides information about the current state of the service, including whether it is active, inactive, or failed.
 
 #### Linux (systemd)
 


### PR DESCRIPTION
## Description

This pull request adds the `Check the Device Agent service status` paragraph into the Device Agent Installer documenation page.
Additionaly, it decrease paragraph levels to not show them in the paragraph menu. 

## Related Issue(s)

https://github.com/FlowFuse/device-agent/issues/512

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

