### PR TITLE
Set 30second SQL timeout

### DIFF
--- a/forge/ee/lib/tables/drivers/postgres-localfs.js
+++ b/forge/ee/lib/tables/drivers/postgres-localfs.js
@@ -57,6 +57,7 @@ module.exports = {
             const escapedDatabaseName = libPg.pg.escapeIdentifier(team.hashid)
             await this._adminClient.query(`CREATE DATABASE ${escapedDatabaseName}`)
             await this._adminClient.query(`REVOKE connect ON DATABASE ${escapedDatabaseName} FROM PUBLIC;`)
+            await this._adminClient.query(`ALTER DATABASE ${escapedDatabaseName} SET statement_timeout='30s'`)
             const teamClient = libPg.newClient({ ...this._options.database, database: team.hashid })
             const password = generatePassword()
             try {

--- a/forge/ee/lib/tables/drivers/postgres-supavisor.js
+++ b/forge/ee/lib/tables/drivers/postgres-supavisor.js
@@ -65,6 +65,7 @@ module.exports = {
                 const escapedDatabaseName = libPg.pg.escapeIdentifier(team.hashid)
                 await this._adminClient.query(`CREATE DATABASE ${escapedDatabaseName}`)
                 await this._adminClient.query(`REVOKE connect ON DATABASE ${escapedDatabaseName} FROM PUBLIC;`)
+                await this._adminClient.query(`ALTER DATABASE ${escapedDatabaseName} SET statement_timeout='30s'`)
                 const teamClient = libPg.newClient({ ...this._options.backend, database: team.hashid })
                 try {
                     await teamClient.connect()


### PR DESCRIPTION
fixes #6090

## Description

<!-- Describe your changes in detail -->

Enforces 30second max statement runtime for new databases

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#6090

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

