### PR TITLE
Fix RBAC filtering for devices by incorporating project-linked applications

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -697,6 +697,14 @@ module.exports = {
                             {
                                 model: M.Application,
                                 attributes: ['hashid', 'id']
+                            },
+                            {
+                                model: M.Project,
+                                attributes: ['id'],
+                                include: {
+                                    model: M.Application,
+                                    attributes: ['hashid', 'id', 'name']
+                                }
                             }
                         ],
                         where: {
@@ -717,7 +725,9 @@ module.exports = {
                     const teamRbacEnabled = team.TeamType.getFeatureProperty('rbacApplication', false)
                     const rbacEnabled = platformRbacEnabled && teamRbacEnabled
                     findAll.forEach((device) => {
-                        if (rbacEnabled && device.Application && !app.hasPermission(membership, 'device:read', { applicationId: device.Application.hashid })) {
+                        const applicationId = device.Application?.hashid ?? device.Project?.Application?.hashid
+
+                        if (rbacEnabled && applicationId && !app.hasPermission(membership, 'device:read', { applicationId })) {
                             // This device is not accessible to this user, do not include in states map
                             return
                         }


### PR DESCRIPTION
## Description

This PR fixes contextual application filtering in device counters. The issue was caused by a missing nested relation to project.application, which prevented correct filtering

## Related Issue(s)

n/a

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

