### PR TITLE
Hide application user access actions from team members without permissions

### DIFF
--- a/frontend/src/pages/application/Settings/UserAccess.vue
+++ b/frontend/src/pages/application/Settings/UserAccess.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-data-table :columns="columns" :rows="members" :search="searchTerm" :show-search="true">
-        <template #context-menu="{row}">
+        <template v-if="hasPermission('team:user:change-role')" #context-menu="{row}">
             <ff-list-item data-action="edit-token" label="Edit Permissions" @click="editUserPermissions(row)" />
         </template>
     </ff-data-table>


### PR DESCRIPTION
## Description

Restricts application user access actions to team member roles checks only to align with the backend API

## Related Issue(s)

n/a

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

