### PR TITLE
Add FF exclusive nodes feature flag

### DIFF
--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -31,6 +31,7 @@ module.exports = fp(async function (app, opts) {
             app.decorate('tables', await require('./tables').init(app))
         }
         app.config.features.register('certifiedNodes', true, true)
+        app.config.features.register('ffNodes', true, true)
         app.config.features.register('rbacApplication', true, true)
     }
 

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -351,36 +351,46 @@ module.exports = async function (app) {
         }
 
         // Platform wide catalogue and npm registry
-        const platformNPMEnabled = !!app.config.features.enabled('certifiedNodes') && !!teamType.getFeatureProperty('certifiedNodes', false)
-        if (platformNPMEnabled) {
-            const npmRegURLString = app.settings.get('platform:certifiedNodes:npmRegistryURL')
-            const token = app.settings.get('platform:certifiedNodes:token')
-            const catalogueString = app.settings.get('platform:certifiedNodes:catalogueURL')
-            if (npmRegURLString && token && catalogueString) {
-                const npmRegURL = new URL(npmRegURLString)
-                const catalogue = new URL(catalogueString)
-                if (!response.palette) {
-                    response.palette = {}
+        const platformNPMEnabled = !!app.config.features.enabled('certifiedNodes', false) &&
+                                   !!app.config.features.enabled('ffNodes', false) &&
+                                   !!app.settings.get('platform:ff-npm-registry:token')
+        const certifiedNodesEnabledForTeam = teamType.getFeatureProperty('certifiedNodes', false)
+        const ffNodesEnabledForTeam = teamType.getFeatureProperty('ffNodes', false)
+
+        if (platformNPMEnabled && (certifiedNodesEnabledForTeam || ffNodesEnabledForTeam)) {
+            try {
+                const npmRegURL = new URL(app.settings.get('platform:ff-npm-registry:url') || 'https://registry.flowfuse.com/')
+                const token = app.settings.get('platform:ff-npm-registry:token')
+
+                const certNodesCatalogue = app.settings.get('platform:ff-npm-registry:catalogue:certifiedNodes') || 'https://ff-certified-nodes.flowfuse.cloud/catalogue.json'
+                const ffNodesCatalogue = app.settings.get('platform:ff-npm-registry:catalogue:ffNodes') || 'https://ff-certified-nodes.flowfuse.cloud/ff-catalogue.json'
+
+                // Handle FF Exclusive Nodes
+
+                if (certNodesCatalogue || ffNodesCatalogue) {
+                    // At least one is configured - so initialise the settings
+                    response.palette = response.palette || {}
+                    response.palette.catalogue = response.palette.catalogue || []
                 }
-                if (response.palette?.catalogues) {
-                    response.palette.catalogues
-                        .push(catalogue.toString())
-                } else {
-                    response.palette.catalogues = [
-                        catalogue.toString()
-                    ]
+                function updateSettingsForCatalogue (scope, catalogueString) {
+                    const catalogue = new URL(catalogueString)
+                    response.palette.catalogue.push(catalogue.toString())
+                    const npmrcEntry = `${scope}:registry=${npmRegURL.toString()}\n` +
+                          `//${npmRegURL.host}:_auth="${token}"\n`
+                    if (response.palette.npmrc) {
+                        response.palette.npmrc += '\n' + npmrcEntry
+                    } else {
+                        response.palette.npmrc = npmrcEntry
+                    }
                 }
-                if (response.palette?.npmrc) {
-                    response.palette.npmrc = `${response.palette.npmrc}\n` +
-                        `@flowfuse-certified-nodes:registry=${npmRegURL.toString()}\n` +
-                        `@flowfuse-nodes:registry=${npmRegURL.toString()}\n` +
-                        `//${npmRegURL.host}:_auth="${token}"\n`
-                } else {
-                    response.palette.npmrc =
-                        `@flowfuse-certified-nodes:registry=${npmRegURL.toString()}\n` +
-                        `@flowfuse-nodes:registry=${npmRegURL.toString()}\n` +
-                        `//${npmRegURL.host}:_auth="${token}"\n`
+                if (certifiedNodesEnabledForTeam && certNodesCatalogue) {
+                    updateSettingsForCatalogue('@flowfuse-certified-nodes', certNodesCatalogue)
                 }
+                if (ffNodesEnabledForTeam && ffNodesCatalogue) {
+                    updateSettingsForCatalogue('@flowfuse-nodes', ffNodesCatalogue)
+                }
+            } catch (err) {
+                app.log.error('Failed to configure platform npm registry for device', err)
             }
         }
 

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -89,10 +89,8 @@ module.exports = async function (app) {
                     }
                 })
                 response['platform:stats:token'] = app.settings.get('platform:stats:token')
-                if (app.config.features.enabled('certifiedNodes')) {
-                    response['platform:certifiedNodes:npmRegistryURL'] = app.settings.get('platform:certifiedNodes:npmRegistryURL')
-                    response['platform:certifiedNodes:token'] = app.settings.get('platform:certifiedNodes:token')
-                    response['platform:certifiedNodes:catalogueURL'] = app.settings.get('platform:certifiedNodes:catalogueURL')
+                if (app.config.features.enabled('certifiedNodes') || app.config.features.enabled('ffNodes')) {
+                    response['platform:ff-npm-registry:enabled'] = !!app.settings.get('platform:ff-npm-registry:token')
                 }
             }
             if (app.config.features.enabled('sso') && app.settings.get('platform:sso:google') && app.settings.get('platform:sso:google:clientId')) {

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -71,9 +71,9 @@ module.exports = {
     'platform:sso:google:clientId': null, // Client ID for Google SSO
     'platform:sso:direct': false, // Direct SSO Login
 
-    // Certified Nodes
-    'platform:certifiedNodes:npmRegistryURL': null, // NPM registry URL for certified nodes
-    'platform:certifiedNodes:token': null, // Token for certified nodes
-    'platform:certifiedNodes:catalogueURL': null // Catalogue URL for certified nodes
-
+    // FlowFuse npm registry
+    'platform:ff-npm-registry:url': null,
+    'platform:ff-npm-registry:token': null,
+    'platform:ff-npm-registry:catalogue:certifiedNodes': null,
+    'platform:ff-npm-registry:catalogue:ffNodes': null
 }

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -137,6 +137,7 @@
                     <FormRow v-model="input.properties.features.instanceResources" type="checkbox">Instance Resources</FormRow>
                     <FormRow v-model="input.properties.features.tables" type="checkbox">Tables</FormRow>
                     <FormRow v-model="input.properties.features.certifiedNodes" type="checkbox">Certified Nodes</FormRow>
+                    <FormRow v-model="input.properties.features.ffNodes" type="checkbox">FlowFuse Exclusive Nodes</FormRow>
                     <FormRow v-model="input.properties.features.generatedSnapshotDescription" type="checkbox">Generated Snapshot Descriptions</FormRow>
                     <FormRow v-model="input.properties.features.assistantInlineCompletions" type="checkbox">Assistant Inline Code Completions</FormRow>
                     <FormRow v-model="input.properties.features.rbacApplication" type="checkbox">Application-level RBAC</FormRow>

--- a/frontend/src/pages/admin/routes.js
+++ b/frontend/src/pages/admin/routes.js
@@ -219,7 +219,7 @@ export default [
                 path: 'certified-nodes',
                 component: AdminCertifiedNodes,
                 meta: {
-                    title: 'Admin - Certified Nodes'
+                    title: 'Admin - FlowFuse Nodes'
                 }
             }
         ]

--- a/frontend/src/store/modules/account/index.js
+++ b/frontend/src/store/modules/account/index.js
@@ -205,6 +205,8 @@ const getters = {
 
             // Certified Nodes
             isCertifiedNodesFeatureEnabledForPlatform: !!state.features?.certifiedNodes,
+            // FlowFuse Nodes
+            isFlowFuseNodesFeatureEnabledForPlatform: !!state.features?.ffNodes,
 
             // Static Assets
             isStaticAssetFeatureEnabledForPlatform: !!state.features?.staticAssets,

--- a/frontend/src/store/modules/ux/index.js
+++ b/frontend/src/store/modules/ux/index.js
@@ -132,7 +132,7 @@ const getters = {
                         featureUnavailable: !features.isBlueprintsFeatureEnabledForPlatform
                     },
                     {
-                        label: 'Certified Nodes',
+                        label: 'FlowFuse Nodes',
                         to: { name: 'admin-certified-nodes' },
                         tag: 'admin-certified-nodes',
                         icon: CollectionIcon,


### PR DESCRIPTION
## Description

Splits the cert-nodes feature flag into two - cert nodes and ff-exclusive nodes.

Updates the UI to simplify the configuration. Admins should only need to provide the registry token

<img width="677" height="378" alt="image" src="https://github.com/user-attachments/assets/563ec9c9-a948-4724-be13-5470a17a193b" />

I have renamed the settings we are using as certNodes is now a subset of the full thing. Only impact will be our staging env that'll need the token readding. The settings can be provided via the yaml file under:

-  `platform:ff-npm-registry:url`
- `platform:ff-npm-registry:token`
- `platform:ff-npm-registry:catalogue:certifiedNodes`
- `platform:ff-npm-registry:catalogue:ffNodes`

All except for `token` have the right defaults applied (albeit inline in the code rather than the defaults file... ).

