### PR TITLE
Shared Cache implementation

### DIFF
--- a/forge/caches/index.js
+++ b/forge/caches/index.js
@@ -1,0 +1,37 @@
+/**
+ * The a pluggable object cache
+ * 
+ *
+ * @namespace cache
+ * @memberof forge
+ */
+
+
+/**
+ * @typedef {Object} forge.Status
+ * @property {string} status
+ */
+const fp = require('fastify-plugin')
+
+const CACHE_DRIVERS = {
+    memory: './memory-cache.js',
+    redis: './redis-cache.js'
+}
+
+module.exports = fp(async function (app, _opts) {
+    const cacheType = app.config.cache?.driver?.type || 'memory'
+    const cacheModule = CACHE_DRIVERS[cacheType]
+    try {
+        const driver = require(cacheModule)
+        await driver.initCache(app.config.cache?.options || {})
+        app.decorate('caches', driver)
+        app.log.info(`Cache driver: ${cacheType}`)
+        app.addHook('onClose', async (_) => {
+            app.log.info('Driver shutdown')
+            await driver.closeCache()
+        })
+    } catch (err) {
+        app.log.error(`Failed to load the cache driver: ${cacheType}`)
+        throw err
+    }
+}, { name: 'app.caches' })

--- a/forge/caches/index.js
+++ b/forge/caches/index.js
@@ -1,11 +1,9 @@
 /**
  * The a pluggable object cache
- * 
  *
  * @namespace cache
  * @memberof forge
  */
-
 
 /**
  * @typedef {Object} forge.Status

--- a/forge/caches/memory-cache.js
+++ b/forge/caches/memory-cache.js
@@ -1,39 +1,45 @@
-async function initCache() {}
+const caches = {}
 
-async function closeCache() {}
+async function initCache () {}
 
-function newCache(options) {
-    return new Cache()
+async function closeCache () {}
+
+function getCache (name, options) {
+    if (!caches[name]) {
+        caches[name] = new Cache(name, options)
+    }
+    return caches[name]
 }
 
 class Cache {
-    constructor (options) {
+    constructor (name, options) {
         this.holder = {}
     }
 
-    async get(key) {
+    async get (key) {
         return this.holder[key]
     }
 
-    async set(key, value) {
-        return this.holder[key] = value
+    async set (key, value) {
+        this.holder[key] = value
+        return value
     }
 
-    async del(key) {
+    async del (key) {
         delete this.holder[key]
     }
 
-    async keys() {
+    async keys () {
         return Object.keys(this.holder)
     }
 
-    async all() {
+    async all () {
         return this.holder
     }
 }
 
 module.exports = {
     initCache,
-    newCache,
+    getCache,
     closeCache
 }

--- a/forge/caches/memory-cache.js
+++ b/forge/caches/memory-cache.js
@@ -1,0 +1,39 @@
+async function initCache() {}
+
+async function closeCache() {}
+
+function newCache(options) {
+    return new Cache()
+}
+
+class Cache {
+    constructor (options) {
+        this.holder = {}
+    }
+
+    async get(key) {
+        return this.holder[key]
+    }
+
+    async set(key, value) {
+        return this.holder[key] = value
+    }
+
+    async del(key) {
+        delete this.holder[key]
+    }
+
+    async keys() {
+        return Object.keys(this.holder)
+    }
+
+    async all() {
+        return this.holder
+    }
+}
+
+module.exports = {
+    initCache,
+    newCache,
+    closeCache
+}

--- a/forge/caches/redis-cache.js
+++ b/forge/caches/redis-cache.js
@@ -1,50 +1,55 @@
 const { createClient } = require('@redis/client')
 
+const caches = {}
+
 let url
 let client
 
 async function initCache (options) {
     url = options.url
     client = createClient()
-    await client.connect({url})
+    await client.connect({ url })
 }
 
-function newCache(options) {
-    return new Cache({client, ...options})
+function getCache (name, options) {
+    if (!caches[name]) {
+        caches[name] = new Cache(name, { client, ...options })
+    }
+    return caches[name]
 }
 
-async function closeCache() {
+async function closeCache () {
     client.close()
 }
 
 class Cache {
-    constructor (options) {
-        this.prefix = options.prefix
+    constructor (name, options) {
+        this.name = name
         this.client = options.client
     }
 
-    async get(key) {
-        return JSON.parse(await this.client.hGet(this.prefix, key))
+    async get (key) {
+        return JSON.parse(await this.client.hGet(this.name, key))
     }
 
-    async set(key, value) {
-        await this.client.hSet(this.prefix, key, JSON.stringify(value))
+    async set (key, value) {
+        await this.client.hSet(this.name, key, JSON.stringify(value))
         return value
     }
 
-    async del(key) {
-        await this.client.hDel(this.prefix, key)
+    async del (key) {
+        await this.client.hDel(this.name, key)
     }
 
-    async keys() {
-        let keys = await this.client.hKeys(this.prefix)
+    async keys () {
+        const keys = await this.client.hKeys(this.name)
         return keys
     }
 
-    async all() {
-        const values = await this.client.hGetAll(this.prefix)
+    async all () {
+        const values = await this.client.hGetAll(this.name)
         const newObj = {}
-        for(const k of Object.keys(values)) {
+        for (const k of Object.keys(values)) {
             newObj[k] = JSON.parse(values[k])
         }
         return newObj
@@ -53,6 +58,6 @@ class Cache {
 
 module.exports = {
     initCache,
-    newCache,
+    getCache,
     closeCache
 }

--- a/forge/caches/redis-cache.js
+++ b/forge/caches/redis-cache.js
@@ -1,0 +1,58 @@
+const { createClient } = require('@redis/client')
+
+let url
+let client
+
+async function initCache (options) {
+    url = options.url
+    client = createClient()
+    await client.connect({url})
+}
+
+function newCache(options) {
+    return new Cache({client, ...options})
+}
+
+async function closeCache() {
+    client.close()
+}
+
+class Cache {
+    constructor (options) {
+        this.prefix = options.prefix
+        this.client = options.client
+    }
+
+    async get(key) {
+        return JSON.parse(await this.client.hGet(this.prefix, key))
+    }
+
+    async set(key, value) {
+        await this.client.hSet(this.prefix, key, JSON.stringify(value))
+        return value
+    }
+
+    async del(key) {
+        await this.client.hDel(this.prefix, key)
+    }
+
+    async keys() {
+        let keys = await this.client.hKeys(this.prefix)
+        return keys
+    }
+
+    async all() {
+        const values = await this.client.hGetAll(this.prefix)
+        const newObj = {}
+        for(const k of Object.keys(values)) {
+            newObj[k] = JSON.parse(values[k])
+        }
+        return newObj
+    }
+}
+
+module.exports = {
+    initCache,
+    newCache,
+    closeCache
+}

--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -56,7 +56,7 @@ class DeviceCommsHandler {
         this.deviceLogHeartbeats = {}
         this.deviceResourcesHeartbeats = {}
         /** @type {Object.<string, typeof CommandResponseMonitor>} */
-        this.inFlightCommands = app.caches.newCache({ prefix: 'device-inflight' })
+        this.inFlightCommands = app.caches.getCache('device-inflight')
         this.deviceLogHeartbeatInterval = -1
         this.deviceResourcesHeartbeatInterval = -1
 

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -8,11 +8,11 @@ const { KEY_SETTINGS } = require('../models/ProjectSettings')
  * is no need to store that in the database. But we do need to know it so the
  * information can be returned on the API.
  */
-const inflightProjectState = 'project-inflightProjectState' // {}
+const inflightProjectState = 'project-inflightProjectState'
 
-const latestProjectState = 'project-latestProjectState' // {}
+const latestProjectState = 'project-latestProjectState'
 
-const inflightDeploys = new Set()
+const inflightDeploys = 'project-inflightDeploys'
 
 module.exports = {
     /**
@@ -40,8 +40,9 @@ module.exports = {
      * @param {*} app
      * @param {*} instance
      */
-    isDeploying: function (app, instance) {
-        return inflightDeploys.has(instance.id)
+    isDeploying: async function (app, instance) {
+        const has = await app.caches.getCache(inflightDeploys).get(instance.id)
+        return has === true
     },
 
     /**
@@ -49,8 +50,8 @@ module.exports = {
      * @param {*} app
      * @param {*} instance
      */
-    setInDeploy: function (app, instance) {
-        inflightDeploys.add(instance.id)
+    setInDeploy: async function (app, instance) {
+        await app.caches.getCache(inflightDeploys).set(instance.id, true)
     },
 
     /**
@@ -59,9 +60,7 @@ module.exports = {
      * @param {*} project
      */
     clearInflightState: async function (app, project) {
-        // delete inflightProjectState[project.id]
         await app.caches.getCache(inflightProjectState).del(project.id)
-        inflightDeploys.delete(project.id)
     },
 
     /**

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -8,9 +8,9 @@ const { KEY_SETTINGS } = require('../models/ProjectSettings')
  * is no need to store that in the database. But we do need to know it so the
  * information can be returned on the API.
  */
-const inflightProjectState = { }
+const inflightProjectState = 'project-inflightProjectState' // {}
 
-const latestProjectState = { }
+const latestProjectState = 'project-latestProjectState' // {}
 
 const inflightDeploys = new Set()
 
@@ -21,8 +21,8 @@ module.exports = {
      * @param {*} project
      * @returns the in-flight state
      */
-    getInflightState: function (app, project) {
-        return inflightProjectState[project.id]
+    getInflightState: async function (app, project) {
+        return await app.caches.getCache(inflightProjectState).get(project.id)
     },
 
     /**
@@ -31,8 +31,8 @@ module.exports = {
      * @param {*} project
      * @param {*} state
      */
-    setInflightState: function (app, project, state) {
-        inflightProjectState[project.id] = state
+    setInflightState: async function (app, project, state) {
+        await app.caches.getCache(inflightProjectState).set(project.id, state)
     },
 
     /**
@@ -58,8 +58,9 @@ module.exports = {
      * @param {*} app
      * @param {*} project
      */
-    clearInflightState: function (app, project) {
-        delete inflightProjectState[project.id]
+    clearInflightState: async function (app, project) {
+        // delete inflightProjectState[project.id]
+        await app.caches.getCache(inflightProjectState).del(project.id)
         inflightDeploys.delete(project.id)
     },
 
@@ -570,7 +571,7 @@ module.exports = {
             throw error
         }
         if (project.state === 'running') {
-            app.db.controllers.Project.setInflightState(project, 'restarting')
+            await app.db.controllers.Project.setInflightState(project, 'restarting')
             project.state = 'running'
             await project.save()
             const result = await app.containers.restartFlows(project)
@@ -699,8 +700,9 @@ module.exports = {
      * @param {string|Number} projectId - The unique identifier of the project whose latest state is to be retrieved.
      * @returns {string} The latest state of the specified project.
      */
-    getLatestProjectState: function (app, projectId) {
-        return latestProjectState[projectId]
+    getLatestProjectState: async function (app, projectId) {
+        return await app.caches.getCache(latestProjectState).get(projectId)
+        // return latestProjectState[projectId]
     },
 
     /**
@@ -710,8 +712,8 @@ module.exports = {
      * @param {string|number} projectId - The unique identifier of the project whose state is being updated.
      * @param {any} state - The new state to be assigned to the project.
      */
-    setLatestProjectState: function (app, projectId, state) {
-        latestProjectState[projectId] = state
+    setLatestProjectState: async function (app, projectId, state) {
+        app.caches.getCache(latestProjectState).set(projectId, state)
     },
 
     /**
@@ -723,8 +725,8 @@ module.exports = {
      *
      * @param {String|Number} projectId - The project id whose latest state should be cleared.
      */
-    clearLatestProjectState: function (app, projectId) {
-        delete latestProjectState[projectId]
+    clearLatestProjectState: async function (app, projectId) {
+        return await app.caches.getCache(latestProjectState).del(projectId)
     },
 
     /**
@@ -733,11 +735,11 @@ module.exports = {
      * @param {String|Number} projectId - The project id related to the driver state update.
      * @param {string} state - The new state to update, can be 'running', 'stopped', or other valid states.
      */
-    updateLatestProjectState: function (app, projectId, state) {
+    updateLatestProjectState: async function (app, projectId, state) {
         if (['running'].includes(state)) {
-            this.clearLatestProjectState(app, projectId)
+            await this.clearLatestProjectState(app, projectId)
         } else {
-            this.setLatestProjectState(app, projectId, state)
+            await this.setLatestProjectState(app, projectId, state)
         }
     }
 }

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -329,7 +329,7 @@ module.exports = {
                     const result = {}
 
                     const inflightState = await Controllers.Project.getInflightState(this)
-                    const isDeploying = Controllers.Project.isDeploying(this)
+                    const isDeploying = await Controllers.Project.isDeploying(this)
 
                     if (!omitStorageFlows) {
                         let storageFlow = this.StorageFlow

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -328,7 +328,7 @@ module.exports = {
                 async liveState ({ omitStorageFlows = false } = { }) {
                     const result = {}
 
-                    const inflightState = Controllers.Project.getInflightState(this)
+                    const inflightState = await Controllers.Project.getInflightState(this)
                     const isDeploying = Controllers.Project.isDeploying(this)
 
                     if (!omitStorageFlows) {
@@ -353,7 +353,7 @@ module.exports = {
                         result.meta = await app.containers.details(this) || { state: 'unknown' }
 
                         if (result.meta.state !== this.state) {
-                            Controllers.Project.setLatestProjectState(this.id, result.meta.state)
+                            await Controllers.Project.setLatestProjectState(this.id, result.meta.state)
                         }
 
                         if (result.meta.versions) {
@@ -713,14 +713,14 @@ module.exports = {
                     const teamRbacEnabled = team.TeamType.getFeatureProperty('rbacApplication', false)
                     const rbacEnabled = platformRbacEnabled && teamRbacEnabled
 
-                    results.forEach((project) => {
+                    for (const project of results) {
                         if (rbacEnabled && !app.hasPermission(membership, 'project:read', { applicationId: project.Application.hashid })) {
                             // This instance is not accessible to this user, do not include in states map
                             return
                         }
-                        const state = Controllers.Project.getLatestProjectState(project.id) ?? project.state
+                        const state = await Controllers.Project.getLatestProjectState(project.id) ?? project.state
                         statesMap[state] = (statesMap[state] || 0) + 1
-                    })
+                    }
 
                     return Object.entries(statesMap).map(([state, count]) => ({ state, count }))
                 },

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -536,11 +536,10 @@ module.exports = {
 
         const restartTargetInstance = targetInstance?.state === 'running'
 
-        app.db.controllers.Project.setInflightState(targetInstance, 'importing')
-        app.db.controllers.Project.setInDeploy(targetInstance)
-
         // Complete heavy work async
         return (async function () {
+            await app.db.controllers.Project.setInflightState(targetInstance, 'importing')
+            app.db.controllers.Project.setInDeploy(targetInstance)
             try {
                 const setAsTargetForDevices = deployToDevices ?? false
                 const targetSnapshot = await copySnapshot(app, sourceSnapshot, targetInstance, {
@@ -559,9 +558,9 @@ module.exports = {
                 await app.auditLog.Project.project.imported(user.id, null, targetInstance, sourceInstance, sourceDevice) // technically this isn't a project event
                 await app.auditLog.Project.project.snapshot.imported(user.id, null, targetInstance, sourceInstance, sourceDevice, targetSnapshot)
 
-                app.db.controllers.Project.clearInflightState(targetInstance)
+                await app.db.controllers.Project.clearInflightState(targetInstance)
             } catch (err) {
-                app.db.controllers.Project.clearInflightState(targetInstance)
+                await app.db.controllers.Project.clearInflightState(targetInstance)
 
                 await app.auditLog.Project.project.imported(user.id, null, targetInstance, sourceInstance, sourceDevice) // technically this isn't a project event
                 await app.auditLog.Project.project.snapshot.imported(user.id, err, targetInstance, sourceInstance, sourceDevice, null)

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -539,7 +539,7 @@ module.exports = {
         // Complete heavy work async
         return (async function () {
             await app.db.controllers.Project.setInflightState(targetInstance, 'importing')
-            app.db.controllers.Project.setInDeploy(targetInstance)
+            await app.db.controllers.Project.setInDeploy(targetInstance)
             try {
                 const setAsTargetForDevices = deployToDevices ?? false
                 const targetSnapshot = await copySnapshot(app, sourceSnapshot, targetInstance, {

--- a/forge/ee/lib/billing/trialTask.js
+++ b/forge/ee/lib/billing/trialTask.js
@@ -123,12 +123,12 @@ module.exports.init = function (app) {
                 // There is some DRY code here with projectActions.js suspend logic.
                 // TODO: consider move to controllers.Project
                 try {
-                    app.db.controllers.Project.setInflightState(project, 'suspending')
+                    await app.db.controllers.Project.setInflightState(project, 'suspending')
                     await app.containers.stop(project)
-                    app.db.controllers.Project.clearInflightState(project)
+                    await app.db.controllers.Project.clearInflightState(project)
                     await app.auditLog.Project.project.suspended(null, null, project)
                 } catch (err) {
-                    app.db.controllers.Project.clearInflightState(project)
+                    await app.db.controllers.Project.clearInflightState(project)
                     const resp = { code: 'unexpected_error', error: err.toString() }
                     await app.auditLog.Project.project.suspended(null, resp, project)
                 }

--- a/forge/ee/routes/customHostnames/index.js
+++ b/forge/ee/routes/customHostnames/index.js
@@ -77,7 +77,7 @@ module.exports = async function (app) {
         if (request.body.hostname) {
             try {
                 await request.project.setCustomHostname(request.body.hostname)
-                app.db.controllers.Project.setInflightState(request.project, 'starting')
+                await app.db.controllers.Project.setInflightState(request.project, 'starting')
                 restartInstance(request.project, request.session.User)
                 reply.send(await request.project.getCustomHostname() || {})
             } catch (err) {
@@ -92,7 +92,7 @@ module.exports = async function (app) {
         preHandler: app.needsPermission('project:edit')
     }, async (request, reply) => {
         await request.project.clearCustomHostname()
-        app.db.controllers.Project.setInflightState(request.project, 'starting')
+        await app.db.controllers.Project.setInflightState(request.project, 'starting')
         await restartInstance(request.project, request.session.User)
         reply.status(204).send({})
     })
@@ -108,7 +108,7 @@ module.exports = async function (app) {
             const startResult = await app.containers.start(project)
             startResult.started.then(async () => {
                 await app.auditLog.Project.project.started(user, null, project)
-                app.db.controllers.Project.clearInflightState(project)
+                await app.db.controllers.Project.clearInflightState(project)
                 return true
             }).catch(err => {
                 app.log.info(`Failed to restart project ${project.id}`)

--- a/forge/ee/routes/ha/index.js
+++ b/forge/ee/routes/ha/index.js
@@ -83,7 +83,7 @@ module.exports = async function (app) {
             // This code is copy/paste with slight changes from projects.js
             // We also have projectActions.js that does suspend logic.
             // TODO: refactor into a Model function to suspend a project
-            app.db.controllers.Project.setInflightState(project, 'starting') // TODO: better inflight state needed
+            await app.db.controllers.Project.setInflightState(project, 'starting') // TODO: better inflight state needed
             reply.send(await project.getHASettings() || {})
 
             const targetState = project.state
@@ -99,10 +99,10 @@ module.exports = async function (app) {
             const startResult = await app.containers.start(project)
             startResult.started.then(async () => {
                 await app.auditLog.Project.project.started(user, null, project)
-                app.db.controllers.Project.clearInflightState(project)
+                await app.db.controllers.Project.clearInflightState(project)
                 return true
-            }).catch(_ => {
-                app.db.controllers.Project.clearInflightState(project)
+            }).catch(async _ => {
+                await app.db.controllers.Project.clearInflightState(project)
             })
         } else {
             // A suspended project doesn't need to do anything more

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -5,6 +5,7 @@ const { ProfilingIntegration } = require('@sentry/profiling-node')
 const fastify = require('fastify')
 
 const auditLog = require('./auditLog')
+const caches = require('./caches')
 const comms = require('./comms')
 const config = require('./config') // eslint-disable-line n/no-unpublished-require
 const containers = require('./containers')
@@ -238,6 +239,8 @@ module.exports = async (options = {}) => {
             await server.register(require('@fastify/rate-limit'), server.config.rate_limits)
         }
 
+        // Setup Caches
+        await server.register(caches)
         // DB : the database connection/models/views/controllers
         await server.register(db)
         // Settings

--- a/forge/housekeeper/tasks/licenseCheck.js
+++ b/forge/housekeeper/tasks/licenseCheck.js
@@ -49,9 +49,9 @@ module.exports = {
             const promises = projectList.map((project) => {
                 return (async () => {
                     try {
-                        app.db.controllers.Project.setInflightState(project, 'suspending')
+                        await app.db.controllers.Project.setInflightState(project, 'suspending')
                         await app.containers.stop(project)
-                        app.db.controllers.Project.clearInflightState(project)
+                        await app.db.controllers.Project.clearInflightState(project)
                         await app.auditLog.Project.project.suspended(null, null, project)
                     } catch (err) {
                         app.log.info(`Failed to suspend ${project.id} when licensed expired. ${err.toString()}`)

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -358,7 +358,7 @@ module.exports = async function (app) {
             }
 
             await app.db.controllers.Project.setInflightState(request.project, 'importing')
-            app.db.controllers.Project.setInDeploy(request.project)
+            await app.db.controllers.Project.setInDeploy(request.project)
 
             await app.auditLog.Project.project.copied(request.session.User.id, null, sourceProject, request.project)
             await app.auditLog.Project.project.imported(request.session.User.id, null, request.project, sourceProject)

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -357,7 +357,7 @@ module.exports = async function (app) {
                 reply.code(403).send('Source Project and Target not in same team')
             }
 
-            app.db.controllers.Project.setInflightState(request.project, 'importing')
+            await app.db.controllers.Project.setInflightState(request.project, 'importing')
             app.db.controllers.Project.setInDeploy(request.project)
 
             await app.auditLog.Project.project.copied(request.session.User.id, null, sourceProject, request.project)
@@ -512,7 +512,7 @@ module.exports = async function (app) {
             let resumeProject, targetState
             if (changesToProjectDefinition) {
                 // Early return and complete the rest async
-                app.db.controllers.Project.setInflightState(request.project, 'starting') // TODO: better inflight state needed
+                await app.db.controllers.Project.setInflightState(request.project, 'starting') // TODO: better inflight state needed
                 reply.code(200).send({})
                 repliedEarly = true
 
@@ -651,14 +651,14 @@ module.exports = async function (app) {
                 const startResult = await app.containers.start(request.project)
                 startResult.started.then(async () => {
                     await app.auditLog.Project.project.started(request.session.User, null, request.project)
-                    app.db.controllers.Project.clearInflightState(request.project)
+                    await app.db.controllers.Project.clearInflightState(request.project)
                     return true
                 }).catch(err => {
                     app.log.info(`Failed to restart project ${request.project.id}`)
                     throw err
                 })
             } else {
-                app.db.controllers.Project.clearInflightState(request.project)
+                await app.db.controllers.Project.clearInflightState(request.project)
             }
         }
 
@@ -1417,7 +1417,7 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
-        app.db.controllers.Project.updateLatestProjectState(request.params.instanceId, request.body.state)
+        await app.db.controllers.Project.updateLatestProjectState(request.params.instanceId, request.body.state)
 
         reply.code(202).send()
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
                 "@levminer/speakeasy": "^1.4.2",
                 "@node-red/util": "^4.0.2",
                 "@node-saml/passport-saml": "^5.0.0",
+                "@redis/client": "^5.8.3",
                 "@sentry/node": "^7.73.0",
                 "@sentry/profiling-node": "^1.2.1",
                 "@sentry/vue": "^7.91.0",
@@ -5925,6 +5926,18 @@
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
             "license": "BSD-3-Clause"
         },
+        "node_modules/@redis/client": {
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.3.tgz",
+            "integrity": "sha512-MZVUE+l7LmMIYlIjubPosruJ9ltSLGFmJqsXApTqPLyHLjsJUSAbAJb/A3N34fEqean4ddiDkdWzNu4ZKPvRUg==",
+            "license": "MIT",
+            "dependencies": {
+                "cluster-key-slot": "1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.40.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.1.tgz",
@@ -10414,6 +10427,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cluster-key-slot": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/color": {
@@ -29755,6 +29777,14 @@
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
         },
+        "@redis/client": {
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.3.tgz",
+            "integrity": "sha512-MZVUE+l7LmMIYlIjubPosruJ9ltSLGFmJqsXApTqPLyHLjsJUSAbAJb/A3N34fEqean4ddiDkdWzNu4ZKPvRUg==",
+            "requires": {
+                "cluster-key-slot": "1.1.2"
+            }
+        },
         "@rollup/rollup-android-arm-eabi": {
             "version": "4.40.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.1.tgz",
@@ -33005,6 +33035,11 @@
             "requires": {
                 "mimic-response": "^1.0.0"
             }
+        },
+        "cluster-key-slot": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
         },
         "color": {
             "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "@levminer/speakeasy": "^1.4.2",
         "@node-red/util": "^4.0.2",
         "@node-saml/passport-saml": "^5.0.0",
+        "@redis/client": "^5.8.3",
         "@sentry/node": "^7.73.0",
         "@sentry/profiling-node": "^1.2.1",
         "@sentry/vue": "^7.91.0",


### PR DESCRIPTION
part of #3642 
## Description

<!-- Describe your changes in detail -->
This adds a new caches component to the `app` object. It can be backed by in memory objects or a remote Redis/Valkey instance to allow sharing between multiple instances of the Forge App.

- `app.caches.initCache()` used to set backend up
- `app.caches.getCache(name)` used to create/retrieve a cache instance with a given name

- `cache.get(key)` gets a value for a key
- `cache.set(key, value)` sets a value for key
- `cache.del(key)` removes a key
- `cache.keys()` array of all keys
- `cache.all()` object with all key value pairs in the cache instance


Needs tests

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#3642

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

