### PR TITLE
Conditionally render permission overrides based on RBAC application feature flag

### DIFF
--- a/frontend/src/pages/team/Members/components/ApplicationPermissionOverride.vue
+++ b/frontend/src/pages/team/Members/components/ApplicationPermissionOverride.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div v-if="featuresCheck.isRBACApplicationFeatureEnabled">
         <span v-if="alteredPermissions === 0" class="opacity-50">No Overrides</span>
         <span v-else>{{ alteredPermissions }} x {{ pluralize('Override', 1) }}</span>
     </div>
@@ -7,6 +7,7 @@
 
 <script>
 import { defineComponent } from 'vue'
+import { mapGetters } from 'vuex'
 
 import { pluralize } from '../../../../composables/String.js'
 
@@ -24,6 +25,7 @@ export default defineComponent({
     },
     setup () { return { pluralize } },
     computed: {
+        ...mapGetters('account', ['featuresCheck']),
         alteredPermissions () {
             let counter = 0
             Object.keys((this.permissions?.applications || {})).forEach(key => {


### PR DESCRIPTION
## Description

hides the overrides entry in the team members list for teams that don't have applications RBAC enabled.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6118

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

