### PR TITLE
Wrap device names in router-link for navigation to DeviceOverview page

### DIFF
--- a/frontend/src/pages/application/DeviceGroup/devices.vue
+++ b/frontend/src/pages/application/DeviceGroup/devices.vue
@@ -48,7 +48,9 @@
                             <ff-data-table-cell>
                                 <ff-checkbox v-model="device.selected" />
                             </ff-data-table-cell>
-                            <ff-data-table-cell>{{ device.name }}</ff-data-table-cell>
+                            <ff-data-table-cell>
+                                <router-link :to="{name: 'DeviceOverview', params: {id: device.id}}">{{ device.name }}</router-link>
+                            </ff-data-table-cell>
                             <ff-data-table-cell>{{ device.type }}</ff-data-table-cell>
                         </ff-data-table-row>
                     </template>
@@ -77,7 +79,9 @@
                             <ff-data-table-cell v-if="editMode">
                                 <ff-checkbox v-model="device.selected" class="inline" />
                             </ff-data-table-cell>
-                            <ff-data-table-cell class="w-1/3">{{ device.name }}</ff-data-table-cell>
+                            <ff-data-table-cell class="w-1/3">
+                                <router-link :to="{name: 'DeviceOverview', params: {id: device.id}}">{{ device.name }}</router-link>
+                            </ff-data-table-cell>
                             <ff-data-table-cell class="w-1/3">{{ device.name }}</ff-data-table-cell>
                             <ff-data-table-cell v-if="!editMode" class="w-1/3">
                                 <ActiveSnapshotCell :activeSnapshot="getDeviceActiveSnapshot(device)" :targetSnapshot="targetSnapshot" />


### PR DESCRIPTION
## Description

adds router links on device names in the device group member page for ease of navigation

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6117

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

