### PR TITLE
Improve trial no billing setup banner language

### DIFF
--- a/frontend/src/components/banners/TeamTrial.vue
+++ b/frontend/src/components/banners/TeamTrial.vue
@@ -19,7 +19,7 @@
                     You trial instances will be added to your billing subscription at the end of your trial.
                 </span>
                 <span v-else>
-                    Click here to upgrade your team and keep your instances running.
+                    Click here to setup billing
                 </span>
             </span>
             <span v-else>

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -22,7 +22,10 @@
                     </template>
                     <template #tools>
                         <div class="flex flex-row gap-x-4">
-                            <ff-button v-if="!isUnmanaged" data-action="change-team-type" :to="{name: 'TeamChangeType'}">Upgrade Team</ff-button>
+                            <ff-button v-if="!isUnmanaged" data-action="change-team-type" :to="{name: 'TeamChangeType'}">
+                                <span v-if="trialMode || trialHasEnded">Click here to setup billing</span>
+                                <span v-else>Upgrade Team</span>
+                            </ff-button>
                             <ff-button v-if="subscription" @click="customerPortal()">
                                 <template #icon-right><ExternalLinkIcon /></template>
                                 Stripe Customer Portal
@@ -97,7 +100,7 @@
                     </template>
                 </template>
                 <template #actions>
-                    <ff-button v-if="hasPermission('team:edit')" data-action="change-team-type" :to="{name: 'TeamChangeType'}">Setup Billing</ff-button>
+                    <ff-button v-if="hasPermission('team:edit')" data-action="change-team-type" :to="{name: 'TeamChangeType'}">Start Billing</ff-button>
                 </template>
             </EmptyState>
         </ff-page>


### PR DESCRIPTION
## Description

Improve trial cta & banner messages

Expired trial:
<img width="1670" height="835" alt="image" src="https://github.com/user-attachments/assets/b8ad6e69-7ffb-4477-a3d8-739231d0c3eb" />

Active Trial:
<img width="1696" height="849" alt="image" src="https://github.com/user-attachments/assets/13e014a3-1006-4c8f-9c04-a4f4e18ef8d4" />


## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5932

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

