### PR TITLE
Add "next" to snapshot NR version revert

### DIFF
--- a/frontend/src/pages/device/Settings/General.vue
+++ b/frontend/src/pages/device/Settings/General.vue
@@ -109,7 +109,7 @@
             <FormRow containerClass="max-w-md" wrapperClass="max-w-md">
                 Node-RED Version
                 <template #description>
-                    Use this field to use the Node-RED version specified in the Remote Instance's active snapshot. Defaults to 'latest' if the snapshot does not specify a version.
+                    Use this field to override the Node-RED version specified in the Remote Instance's active snapshot. Defaults to 'latest' if the snapshot does not specify a version.
                 </template>
                 <template #input>
                     <div class="flex flex-wrap">


### PR DESCRIPTION
fixes #5597

## Description

<!-- Describe your changes in detail -->
Rather than try and unpick how to get the device agent to work out what the old snapshot node-red version is, just leave it as it is until the next Snapshot is pushed.


## Related Issue(s)

<!-- What issue does this PR relate to? -->
#5597

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

