### PR TITLE
ci: Use OIDC when authenticating to AWS in the `Create pre-staging environment` workflow

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -424,7 +424,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'FlowFuse/helm'
-          ref: 'feat-project-probes'
+          ref: 'main'
           path: 'helm-repo'
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

This pull request updates the `Create pre-staging environment` workflow to use OIDC with a proper IAM roles to authenticate and authorise to AWS. 

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/6077

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

