### PR TITLE
Ensure community catalogue available to remote instances

### DIFF
--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -365,11 +365,10 @@ module.exports = async function (app) {
                 const ffNodesCatalogue = app.config['ff-npm-registry']?.catalogue?.ffNodes || 'https://ff-certified-nodes.flowfuse.cloud/ff-catalogue.json'
 
                 // Handle FF Exclusive Nodes
-
                 if (certNodesCatalogue || ffNodesCatalogue) {
                     // At least one is configured - so initialise the settings
                     response.palette = response.palette || {}
-                    response.palette.catalogues = response.palette.catalogues || []
+                    response.palette.catalogues = response.palette.catalogues || ['https://catalogue.nodered.org/catalogue.json']
                 }
                 function updateSettingsForCatalogue (scope, catalogueString) {
                     const catalogue = new URL(catalogueString)
@@ -389,7 +388,7 @@ module.exports = async function (app) {
                     updateSettingsForCatalogue('@flowfuse-nodes', ffNodesCatalogue)
                 }
             } catch (err) {
-                app.log.error('Failed to configure platform npm registry for device', err)
+                app.log.error(`Failed to configure platform npm registry for device ${err.toString()}`)
             }
         }
 


### PR DESCRIPTION
fixes #6200

## Description

<!-- Describe your changes in detail -->

This injects the community catalogue url into the device live settings if the settings are empty when the either the FlowFuse only nodes catalogue or the FlowFuse Certified nodes catalogue is added to the settings and there is no `palette.catalogues` entry in the DeviceSettings table.

This works because a totally fresh device has no extra settings, so first the TeamNPM test is done, if there are no entries then the default catalogue is added along with the team catalogue.

If TeamNPM is false then the FF-certified and FF-exclusive test is done, if this is done and the `response.palette.catalogue` is still empty then the default catalogue should be added as well as either/both of the FF-certified and FF-exclusive are added.

If the user uses the UI to add custom catalogues or remove the default catalogue, then there will be an entry in the DeviceSetting table which will pre-populate the object before the 2 tests mentioned above so the TeamNP, FF-certified or FF-exclusive will be added to that array as needed.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#6200

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

