### PR TITLE
Strip transfer-encoding from proxied editor response

### DIFF
--- a/forge/ee/lib/deviceEditor/DeviceTunnelManager.js
+++ b/forge/ee/lib/deviceEditor/DeviceTunnelManager.js
@@ -196,6 +196,9 @@ class DeviceTunnelManager {
                     reply.send()
                     this.app.log.warn(`Device ${device.hashid} tunnel error: unexpected response: ${msg.toString()}`)
                 } else {
+                    if (response.headers && response.headers['transfer-encoding'] === 'chunked') {
+                        delete response.headers['transfer-encoding']
+                    }
                     reply.headers(response.headers ? response.headers : {})
                     reply.code(response.status)
                     if (response.body) {


### PR DESCRIPTION
fixes #6203

## Description

<!-- Describe your changes in detail -->
Remove the `Transfer-Encoding` header if it is `chunked` because the proxy consolidates the chunks before sending

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#6203

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

