### PR TITLE
ci: Run UI OS and EE tests in parallel

### DIFF
--- a/test/e2e/frontend/cypress/tests/admin/templates.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin/templates.spec.js
@@ -61,6 +61,6 @@ describe('FlowFuse - Templates', () => {
         cy.get('.ff-dialog-box').should('be.visible')
 
         // check that the "Delete" button is disabled
-        cy.get('.ff-dialog-box button.ff-btn.ff-btn--danger').contains('Delete').should('be.disabled')
+        cy.get('.ff-dialog-box button.ff-btn.ff-btn--danger').contains('Delete').parent().should('be.disabled')
     })
 })


### PR DESCRIPTION
## Description

This pull request splits the OS and EE UI tests and executes them in parallel instead of one after another.

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/6179

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

