### PR TITLE
Fix SAMLProvider lookup by correctly accessing `user.email`

### DIFF
--- a/forge/ee/routes/sso/auth.js
+++ b/forge/ee/routes/sso/auth.js
@@ -195,7 +195,7 @@ module.exports = fp(async function (app, opts) {
         preValidation: fastifyPassport.authenticate('saml', { session: false })
     }, async (request, reply, err, user, info, status) => {
         if (request.user) {
-            const { options } = await app.db.models.SAMLProvider.forEmail(request.user)
+            const { options } = await app.db.models.SAMLProvider.forEmail(request.user.email)
             const result = await completeSSOSignIn(app, request.user, options.sessionExpiry, options.sessionIdle)
             if (result.cookie) {
                 // Valid session


### PR DESCRIPTION
## Description

Fixes prod auth callback error that prevents sso auth.

pass in the user email to the samlProvider instead of the whole user model

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

