### PR TITLE
Fix Team name in trial emails

### DIFF
--- a/forge/ee/lib/billing/emailTemplates/TrialTeamEnded.js
+++ b/forge/ee/lib/billing/emailTemplates/TrialTeamEnded.js
@@ -9,7 +9,7 @@ module.exports = {
     text:
 `Hello {{{username}}},
 
-Your FlowFuse trial has now ended on '{{teamName}}'.
+Your FlowFuse trial has now ended on '{{teamName.text}}'.
 
 We hope you are enjoying your time with us and look forward to seeing what else you
 create.
@@ -21,7 +21,7 @@ Your friendly FlowFuse Team
     html:
 `<p>Hello {{{username}}},</p>
 
-<p>Your FlowFuse trial has now ended on '{{teamName}}'.</p>
+<p>Your FlowFuse trial has now ended on '{{teamName.html}}'.</p>
 <p>We hope you are enjoying your time with us and look forward to seeing what else you
 create.</p>
 <p>Cheers!</p>

--- a/forge/ee/lib/billing/emailTemplates/TrialTeamReminder.js
+++ b/forge/ee/lib/billing/emailTemplates/TrialTeamReminder.js
@@ -10,7 +10,7 @@ module.exports = {
     text:
 `Hello {{{username}}},
 
-Just to let you know, your free trial on team '{{{teamname}}}' ends in {{{endingInDuration}}}.
+Just to let you know, your free trial on team '{{{teamName.text}}}' ends in {{{endingInDuration}}}.
 
 {{#if billingSetup}}
 We can see you have already setup billing on the team - that's great. When
@@ -36,7 +36,7 @@ Your friendly FlowFuse Team
     html:
 `<p>Hello {{{username}}},</p>
 
-<p>Just to let you know, your free trial on team '{{{teamname}}}' ends in {{{endingInDuration}}}.</p>
+<p>Just to let you know, your free trial on team '{{{teamName.html}}}' ends in {{{endingInDuration}}}.</p>
 
 {{#if billingSetup}}
 <p>We can see you have already setup billing on the team - that's great. When

--- a/forge/ee/lib/billing/trialTask.js
+++ b/forge/ee/lib/billing/trialTask.js
@@ -106,7 +106,7 @@ module.exports.init = function (app) {
                     template,
                     {
                         username: user.name,
-                        teamname: team.name,
+                        teamName: team.name,
                         ...inserts
                     }
                 )


### PR DESCRIPTION
fixes #6289

## Description

<!-- Describe your changes in detail -->
Testing locally I can recreate this, but I can't explain it. The value passed is string so should not end up as `[bbject Object]` and if I change the name of the context variable passed to the template renderer from `teamName` to `teamname` it works correctly.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#6289

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

