### PR TITLE
fix(expert): add `initialState` to store module export

### DIFF
--- a/frontend/src/store/modules/product/expert/index.js
+++ b/frontend/src/store/modules/product/expert/index.js
@@ -617,6 +617,7 @@ const actions = {
 export default {
     namespaced: true,
     meta,
+    initialState: initialState(),
     state,
     getters,
     mutations,


### PR DESCRIPTION
## Description

adds the initial state on the expert exported module params to enable clearing state when users log out

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6297

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

