### PR TITLE
fix(ui): add padding to `SnapshotDetailsDrawer` component

### DIFF
--- a/frontend/src/components/drawers/snapshots/SnapshotDetailsDrawer.vue
+++ b/frontend/src/components/drawers/snapshots/SnapshotDetailsDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="snapshot-details-drawer" data-el="snapshot-details-drawer">
+    <div id="snapshot-details-drawer" data-el="snapshot-details-drawer" class="p-4">
         <div class="container">
             <section v-if="hasPermission('snapshot:full', applicationContext)" class="flow-viewer flex flex-1 flex-col overflow-auto">
                 <div class="header flex flex-row justify-between">
@@ -355,7 +355,6 @@ export default defineComponent({
 <style scoped lang="scss">
 #snapshot-details-drawer {
     flex: 1;
-    padding: 10px;
 
     &, .container {
         display: flex;


### PR DESCRIPTION
## Description

fixes SnapshotDetailsDrawer padding

Before:
<img width="479" height="1493" alt="image" src="https://github.com/user-attachments/assets/494318ca-f917-458d-bcc1-6e503a761d18" />

After:
<img width="477" height="1494" alt="image" src="https://github.com/user-attachments/assets/f516ea95-e7e1-470f-a176-16a7d20598df" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

