### PR TITLE
fix(housekeeper): add optional chaining for broker availability check

### DIFF
--- a/forge/housekeeper/index.js
+++ b/forge/housekeeper/index.js
@@ -24,7 +24,7 @@ module.exports = fp(async function (app, _opts) {
     const leaderVotes = {}
     // vote every 15 seconds
     const voteInterval = setInterval(() => {
-        app.comms.platform.housekeeper.vote(localLeaderVote)
+        app.comms?.platform?.housekeeper?.vote(localLeaderVote)
     }, 15000)
 
     // Ensure we stop any scheduled tasks when the app is shutting down


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

The housekeeper leadership voting feature introduced in PR #6239 assumes the MQTT broker is always configured. This causes a crash when running FlowFuse without broker configuration (which is valid for local dev).

Add optional chaining to safely handle cases where app.comms.platform is undefined, consistent with how other parts of the codebase handle missing broker configuration (e.g., forge/settings/index.js).

## Related Issue(s)

<!-- What issue does this PR relate to? -->

No issue as of yet. But the change was necessary due to #6239

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

