### PR TITLE
Ensure Instance object has Team when updating Stacks

### DIFF
--- a/forge/db/models/ProjectSettings.js
+++ b/forge/db/models/ProjectSettings.js
@@ -80,9 +80,10 @@ module.exports = {
                         },
                         include: {
                             model: M.Project,
-                            include: {
-                                model: M.ProjectStack
-                            }
+                            include: [
+                                { model: M.ProjectStack },
+                                { model: M.Team }
+                            ]
                         }
                     })
                 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
When polling the list of Instances to upgrade the stack on, ensure that the Team object is populated to allow for checking of suspended teams.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

