### PR TITLE
Add High Availability status display and edit link in `Instance Overview` page

### DIFF
--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -160,7 +160,7 @@
 </template>
 
 <script>
-import { ExternalLinkIcon, LinkIcon, TemplateIcon, TrendingUpIcon, erverIcon } from '@heroicons/vue/outline'
+import { ExternalLinkIcon, LinkIcon, ServerIcon, TemplateIcon, TrendingUpIcon } from '@heroicons/vue/outline'
 import { mapState } from 'vuex'
 
 import InstanceApi from '../../api/instances.js'


### PR DESCRIPTION
## Description

- adds a new entry on the instance overview page for high availability
- if the feature is disabled the status pill text is 'NotAvailable' without a link to the instance settings
- if the feature is enabled the status pill is either 'Disabled' or 'Enabled' and a link to the instance settings

<img width="1122" height="691" alt="image" src="https://github.com/user-attachments/assets/d7803cbd-8fdb-4208-856d-6a944cc286d0" />


## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6043

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

