### PR TITLE
Fix 404 for packages in FlowFuse expert due to wrong url pattern

### DIFF
--- a/frontend/src/components/expert/resources/PackageResourceCard.vue
+++ b/frontend/src/components/expert/resources/PackageResourceCard.vue
@@ -34,7 +34,7 @@ export default {
         },
         getPackageUrl (pkg) {
             const packageName = this.getPackageName(pkg)
-            return `https://flows.nodered.org/package/${packageName}`
+            return `https://flows.nodered.org/node/${packageName}`
         },
         addUTMTracking (url) {
             try {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

<img width="1658" height="216" alt="CleanShot 2025-11-25 at 14 15 17@2x" src="https://github.com/user-attachments/assets/fb5e8e1e-ba81-4e18-b270-378ad9c39ca3" />

## Related Issue(s)

<!-- What issue does this PR relate to? -->

Follow up from https://github.com/FlowFuse/flowfuse/pull/6310

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

