### PR TITLE
Ensure correct mime type used for cached device editor

### DIFF
--- a/forge/ee/lib/deviceEditor/DeviceTunnelManager.js
+++ b/forge/ee/lib/deviceEditor/DeviceTunnelManager.js
@@ -35,12 +35,12 @@
 const fs = require('node:fs')
 const path = require('node:path')
 const localCacheFiles = [
-    { path: '/vendor/monaco/dist/editor.js', type: 'application/json; charset=UTF-8' }, // ~4.1MB
-    { path: '/vendor/monaco/dist/ts.worker.js', type: 'application/json; charset=UTF-8' }, // ~4.7MB
-    { path: '/vendor/monaco/dist/css.worker.js', type: 'application/json; charset=UTF-8' }, // ~1.1MB
-    { path: '/vendor/vendor.js', type: 'application/json; charset=UTF-8' }, // ~1.1MB
-    { path: '/vendor/mermaid/mermaid.min.js', type: 'application/json; charset=UTF-8' }, // ~2.5MB
-    { path: '/red/red.min.js', type: 'application/json; charset=UTF-8' },
+    { path: '/vendor/monaco/dist/editor.js', type: 'application/javascript; charset=UTF-8' }, // ~4.1MB
+    { path: '/vendor/monaco/dist/ts.worker.js', type: 'application/javascript; charset=UTF-8' }, // ~4.7MB
+    { path: '/vendor/monaco/dist/css.worker.js', type: 'application/javascript; charset=UTF-8' }, // ~1.1MB
+    { path: '/vendor/vendor.js', type: 'application/javascript; charset=UTF-8' }, // ~1.1MB
+    { path: '/vendor/mermaid/mermaid.min.js', type: 'application/javascript; charset=UTF-8' }, // ~2.5MB
+    { path: '/red/red.min.js', type: 'application/javascript; charset=UTF-8' },
     { path: '/red/style.min.css', type: 'text/css; charset=UTF-8' }
 ]
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Device editor cache was returning `application/json` not `application/javascript` for .js files.

Modern browers refuse to load .js content with incorrect mime type.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

