### PR TITLE
Ensure TeamType passed to instanceCount

### DIFF
--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -531,7 +531,7 @@ module.exports = {
                         if (currentDeviceCount === null) {
                             currentDeviceCount = await this.deviceCount(transaction)
                         }
-                        const currentInstanceCount = await this.instanceCount(transaction)
+                        const currentInstanceCount = await this.instanceCount(undefined, transaction)
                         const currentRuntimeCount = currentDeviceCount + currentInstanceCount
                         if (currentRuntimeCount >= runtimeLimit) {
                             const err = new Error()
@@ -606,7 +606,7 @@ module.exports = {
                     const runtimeLimit = await this.getRuntimeLimit()
                     if (runtimeLimit > -1) {
                         const currentDeviceCount = await this.deviceCount(transaction)
-                        const currentInstanceCount = await this.instanceCount(transaction)
+                        const currentInstanceCount = await this.instanceCount(undefined, transaction)
                         const currentRuntimeCount = currentDeviceCount + currentInstanceCount
                         if (currentRuntimeCount >= runtimeLimit) {
                             const err = new Error()


### PR DESCRIPTION
fixes #6350

## Description

<!-- Describe your changes in detail -->

When adding the transaction support to the instance create/count 2 calls to instanceCount() were missed and only the transaction was passed, without the projectType argument first.

This appears to silently fail and return 0 on Sqlite and earlier verison of Postgres (not seeing this on prod/staging with PG14) but is failing on PG17 (why we have only seen this at this user).

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#6350 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

