### PR TITLE
Update group entry display for non-assignable devices and permissions

### DIFF
--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -79,7 +79,7 @@
                                     <span v-if="canBeAssignedToGroups">None</span>
                                     <span
                                         v-else title="Only application owned instances can be assigned to groups."
-                                        class="cursor-help"
+                                        class="cursor-help text-gray-500 italic"
                                     >
                                         Not Applicable
                                     </span>


### PR DESCRIPTION
## Description

Update group entry on the device overview pages by hiding the edit button for non-assignable devices and adding a tooltip to make it clear why devices are not assignable.

devices assigned to an application and group:
<img width="1116" height="724" alt="image" src="https://github.com/user-attachments/assets/0ddeebfb-637b-4f1e-9cd2-40dca268883c" />

devices assigned to an application but not to a group:
<img width="1064" height="794" alt="image" src="https://github.com/user-attachments/assets/be744c84-1756-4ca6-b1da-36553781b67b" />

devices assigned to an instance:
<img width="969" height="800" alt="image" src="https://github.com/user-attachments/assets/0f36e922-b32a-4e37-a2d3-87906a1bfea9" />

unassigned devices:
<img width="1203" height="769" alt="image" src="https://github.com/user-attachments/assets/b3335237-f14a-4c6f-98ad-d4e2834fa8d4" />



## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6369

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

