### PR TITLE
Intercept kebab menu item click to close the menu

### DIFF
--- a/frontend/src/ui-components/components/KebabMenu.vue
+++ b/frontend/src/ui-components/components/KebabMenu.vue
@@ -12,6 +12,7 @@
                     top: position.top + 'px',
                     left: position.left + 'px'
                 }"
+                @click="onClickIntercept"
             >
                 <slot></slot>
             </ul>
@@ -27,6 +28,7 @@ export default {
     components: {
         DotsVerticalIcon
     },
+    emits: ['click'],
     data () {
         return {
             open: false,
@@ -97,6 +99,10 @@ export default {
             })
 
             this.observer.observe(this.$refs.trigger)
+        },
+        onClickIntercept (e) {
+            this.closeOptions()
+            this.$emit('click', e)
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes an issue where clicking actionable items inside the kebab menu did not close the menu. Inside datatables, menu items are injected multiple component levels deep and many list items have .stop listeners, preventing the detection of mouse interaction. 

This update intercepts internal clicks, closes the menu, and re-emits the click event to the parent, avoiding broader structural changes while restoring the expected behavior.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5798

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

