### PR TITLE
style(ui): add padding to TableSchema and CreateTable components for consistency

### DIFF
--- a/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/CreateTable.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/CreateTable.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="create-table">
+    <div id="create-table" class="p-4">
         <div class="content-wrapper">
             <div class="section table-name">
                 <h3>Define name</h3>

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/TableSchema.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/TableSchema.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="table-schema">
+    <div id="table-schema" class="p-4">
         <div class="content-wrapper">
             <h3>Columns</h3>
             <div class="header grid grid-cols-10 gap-1 mb-1">


### PR DESCRIPTION
## Description

adding back create table and edit schema drawer paddings

<img width="577" height="584" alt="image" src="https://github.com/user-attachments/assets/3a4e0852-afea-4f40-acf4-9b3772138380" />

<img width="582" height="663" alt="image" src="https://github.com/user-attachments/assets/2574b94b-f3c0-4ffe-9abb-ea3093abfa8d" />


## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6391

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

