### PR TITLE
Update "Nullable" label to "Allow null" in TableSchema and CreateTable drawers

### DIFF
--- a/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/CreateTable.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/CreateTable.vue
@@ -21,7 +21,7 @@
                     <span class="col-span-3 title">Type</span>
                     <span class="col-span-4 title">Default</span>
                     <!-- <span class="col-span-2 title">Options</span>-->
-                    <span class="col-span-1 title">Nullable</span>
+                    <span class="col-span-1 title">Allow null</span>
                     <!-- <span class="col-span-1 title -ml-2">Unsigned</span>-->
                 </div>
                 <ul class="columns">

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/TableSchema.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/TableSchema.vue
@@ -5,7 +5,7 @@
             <div class="header grid grid-cols-10 gap-1 mb-1">
                 <span class="col-span-2 title">Name</span>
                 <span class="col-span-2 title">Type</span>
-                <span class="col-span-2 title">Nullable</span>
+                <span class="col-span-2 title">Allow null</span>
                 <span class="col-span-2 title">Default</span>
                 <span class="col-span-2 title">Generated</span>
             </div>


### PR DESCRIPTION
## Description

Update "Nullable" label to "Allow null" in TableSchema and CreateTable drawers

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6395

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

