### PR TITLE
Update wording on Enterprise upgrade page to mention extended trial

### DIFF
--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -49,7 +49,7 @@
                     </template>
                     <template v-else-if="billingEnabled">
                         <div class="mb-8 text-sm text-gray-500 space-y-2 text-center">
-                            <p v-if="isContactRequired">To learn more about our {{ input.teamType?.name }} plan, click below to contact our sales team.</p>
+                            <p v-if="isContactRequired">To learn more about our {{ input.teamType?.name }} plan, including the option to purchase an extended trial, click below to contact our sales team.</p>
                             <p v-if="trialMode && !trialHasEnded">Setting up billing will bring your free trial to an end</p>
                             <p v-if="!isContactRequired && team.suspended">Setting up billing will unsuspend your team</p>
                             <p v-if="isUpgradingFromMonthlyToYearly">Any additional Hosted or Remote Instances will also switch to yearly billing.</p>

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -72,7 +72,7 @@
                 </div>
                 <section v-else class="max-w-md">
                     <div class="mb-8 text-sm text-gray-500 space-y-2">
-                        <p>To learn more about our {{ input.teamType?.name }} plan, click below to contact our sales team.</p>
+                        <p>To learn more about our {{ input.teamType?.name }} plan, including the option to purchase an extended trial, click below to contact our sales team.</p>
                     </div>
                     <ff-button class="w-full" @click="sendContact()">
                         Talk to Sales


### PR DESCRIPTION
Closes https://github.com/FlowFuse/customer/issues/476

Updates the wording on the contact sales interaction to include mention of an extended trial being an option.

Before:
<img width="483" height="187" alt="image" src="https://github.com/user-attachments/assets/155c09d2-5273-47fa-ae9a-c56c25a08bc3" />


After:
<img width="437" height="80" alt="image" src="https://github.com/user-attachments/assets/494b1f08-95f5-4e05-8c63-4623d75838f1" />
