### PR TITLE
Hide HubSpot floating bubble when Expert drawer is open and restore it on close

### DIFF
--- a/frontend/src/store/modules/ux/drawers/index.js
+++ b/frontend/src/store/modules/ux/drawers/index.js
@@ -129,13 +129,15 @@ const actions = {
         if (state.rightDrawer.state && component.name === state.rightDrawer.component.name) return
 
         const openDrawer = () => {
-            try {
-                // Hide HubSpot floating bubble while Expert drawer is open
-                if (typeof window.HubSpotConversations?.remove === 'function') {
-                    window.HubSpotConversations.widget.remove()
+            // Hide HubSpot bubble when the Expert drawer component is being opened
+            if (component?.name === 'ExpertDrawer') {
+                try {
+                    if (typeof window.HubSpotConversations.widget.remove === 'function') {
+                        window.HubSpotConversations.widget.remove()
+                    }
+                } catch (_err) {
+                    // ignore - non-critical
                 }
-            } catch (_err) {
-                // ignore - non-critical
             }
             commit('openRightDrawer', {
                 component,
@@ -163,12 +165,16 @@ const actions = {
     closeRightDrawer ({ commit, state, rootState }) {
         // Set closing flag to prevent reopens during transition
         state.rightDrawer.closing = true
-        try {
-            if (typeof window.HubSpotConversations?.load === 'function') {
-                window.HubSpotConversations.widget.load()
+
+        // Restore HubSpot bubble when the Expert drawer component is being closed
+        if (state.rightDrawer.component?.name === 'ExpertDrawer') {
+            try {
+                if (typeof window.HubSpotConversations.widget.load === 'function') {
+                    window.HubSpotConversations.widget.load()
+                }
+            } catch (_err) {
+                // ignore - non-critical
             }
-        } catch (_err) {
-            // ignore - non-critical
         }
 
         // Immediately hide drawer by removing .open class


### PR DESCRIPTION
## Description

Hide HubSpot floating bubble when Expert drawer is open and restore it on close

## Related Issue(s)

closes #3984

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

