### PR TITLE
ci: Bump slack-github-action to `v2.2.1` in `Install Test`

### DIFF
--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -42,11 +42,13 @@ jobs:
     steps:
     - name: Post to a Slack channel
       id: slack
-      uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
+      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
       with:
-        channel-id: 'C067BD0377F'
+        method: chat.postMessage
+        token: ${{ secrets.SLACK_GHBOT_TOKEN }}
         payload: |
           {
+            "channel": "C067BD0377F",
             "blocks": [
               {
                 "type": "header",
@@ -75,5 +77,3 @@ jobs:
               }
             ]
           }
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_GHBOT_TOKEN }}


### PR DESCRIPTION
## Description

Bumps slackapi/slack-github-action from `1.27.1` to `2.1.1` in the `Install Test` workflow

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/pull/6453

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

