### PR TITLE
docs: add hosted vs remote instance comparison table

### DIFF
--- a/docs/user/concepts.md
+++ b/docs/user/concepts.md
@@ -67,9 +67,9 @@ Within your Application, you can have one or more instances of Node-RED. FlowFus
 | Feature | Hosted Instance | Remote Instance (Device) |
 |--------|-----------------|--------------------------|
 | Where it runs | On FlowFuse-managed infrastructure (cloud or self-hosted) | On user-provided hardware (Edge, VM, Pi, PLC) |
-| Provisioning | Automatic via the FlowFuse UI. | Manual installation of the FlowFuse Device Agent. |
-| Lifecycle | Fully managed by FlowFuse. | Managed by FlowFuse via the Device Agent. |
-| Common Use | Core logic, APIs, dashboards, development, testing. | Local data processing, IO, edge control. |
+| Provisioning | Automatic via the FlowFuse UI | Manual installation of the FlowFuse Device Agent |
+| Lifecycle | Fully managed by FlowFuse | Managed by FlowFuse via the Device Agent |
+| Common Use | Core logic, APIs, dashboards, development, testing | Local data processing, IO, edge control |
 
 ### Hosted Instance
 


### PR DESCRIPTION
Adds a concise comparison table to the Instance section of the Concepts docs to clearly distinguish Hosted and Remote Instances.

This helps users quickly understand where each type runs, how it is provisioned, and common use cases before diving into the detailed sections below.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

