### PR TITLE
ci: Do not create pre-staging environment for a release branch

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -36,6 +36,8 @@ on:
       - synchronize
       - reopened
       - closed
+    branches-ignore:
+      - 'release-**'
     paths-ignore:
       - 'docs/**'
 


### PR DESCRIPTION
## Description

This pull request adjusts the `Create pre-staging environment` workflow by adding a `release-**` regex to the list of ignored branches. As a result, a pre-staging environment should not be created for a release-related pull request. 

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/6434

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

