### PR TITLE
Enable trial team creation for admin-created users

### DIFF
--- a/forge/lib/userTeam.js
+++ b/forge/lib/userTeam.js
@@ -5,7 +5,7 @@ const crypto = require('crypto')
  *   - creates user team (if `user:team:auto-create` is enabled
  *   - accepts any invitations matching the email
  */
-async function completeUserSignup (app, user) {
+async function completeUserSignup (app, user, { createTeamOverride = false } = {}) {
     // Process invites first to see if user is in any teams
     const pendingInvitations = await app.db.models.Invitation.forExternalEmail(user.email)
     for (let i = 0; i < pendingInvitations.length; i++) {
@@ -22,7 +22,7 @@ async function completeUserSignup (app, user) {
     }
 
     let personalTeam
-    if (app.settings.get('user:team:auto-create')) {
+    if (createTeamOverride || app.settings.get('user:team:auto-create')) {
         const teamLimit = app.license.get('teams')
         const teamCount = await app.db.models.Team.count()
         if (teamCount >= teamLimit) {


### PR DESCRIPTION
Closes #6484 

The admin UI to create a new user includes a checkbox to 'create personal team'.

This creates a team for the user however:
 - it assumes there's a teamtype called 'starter' and uses that
 - it doesn't create applicaiton/instance
 - it doesn't apply trial settings


This PR updates the backend for this path to use the standard `completeUserSignup` function that handles all of the above. I *think* this is now used consistently across all ways a user can get registered on the platform.

