### PR TITLE
Add option to disable provisioning new users via google login

### DIFF
--- a/forge/ee/routes/sso/social/google.js
+++ b/forge/ee/routes/sso/social/google.js
@@ -61,7 +61,7 @@ module.exports = fp(async function (app, opts) {
                 reply.send({
                     url: '/'
                 })
-            } else {
+            } else if (app.settings.get('platform:sso:google:auto-create') === true) {
                 // Create a new user for this email address
                 const userProperties = {
                     name: googleUserInfo.name || googleUserInfo.email.split('@')[0],
@@ -98,6 +98,10 @@ module.exports = fp(async function (app, opts) {
                         error: `Failed to create user via Google SSO: ${err}`
                     })
                 }
+                reply.send({
+                    url: '/'
+                })
+            } else {
                 reply.send({
                     url: '/'
                 })

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -103,6 +103,7 @@ module.exports = async function (app) {
             if (app.config.features.enabled('sso') && app.settings.get('platform:sso:google') && app.settings.get('platform:sso:google:clientId')) {
                 response['platform:sso:google'] = true
                 response['platform:sso:google:clientId'] = app.settings.get('platform:sso:google:clientId')
+                response['platform:sso:google:auto-create'] = app.settings.get('platform:sso:google:auto-create')
             }
             if (app.config.features.enabled('sso')) {
                 response['platform:sso:direct'] = app.settings.get('platform:sso:direct')

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -69,6 +69,8 @@ module.exports = {
 
     'platform:sso:google': false, // Is Google SSO enabled?
     'platform:sso:google:clientId': null, // Client ID for Google SSO
+    'platform:sso:google:auto-create': false, // Auto-provision users on Google SSO
+
     'platform:sso:direct': false, // Direct SSO Login
 
     // FlowFuse npm registry

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -187,6 +187,9 @@
                     The Client ID for the Google SSO application
                 </template>
             </FormRow>
+            <FormRow v-if="input['platform:sso:google']" v-model="input['platform:sso:google:auto-create']" containerClass="max-w-sm ml-9" type="checkbox" data-el="google-sso-auto-create">
+                Create new users automatically
+            </FormRow>
         </template>
 
         <template v-if="ssoEnabled">
@@ -237,6 +240,7 @@ const validSettings = [
     'branding:account:signUpLeftBanner',
     'platform:stats:token',
     'platform:sso:google',
+    'platform:sso:google:auto-create',
     'platform:sso:google:clientId',
     'platform:sso:direct'
 ]


### PR DESCRIPTION
Part of #6484 

Currently, the google social login flow will always automatically create a new user if they are logging in for the first time.

If we disable self-service sign-up of the app, we also need to prevent the social login from provisioning new users.

This adds a new admin option for the social login as to whether new users should be created when attempting to login for the first time.