### PR TITLE
Fix button width calculation and update route names in VersionHistory page

### DIFF
--- a/frontend/src/components/elements/ToggleButtonGroup.vue
+++ b/frontend/src/components/elements/ToggleButtonGroup.vue
@@ -76,7 +76,7 @@ export default {
             if (this.selectedIndex < 0) return { opacity: 0 }
             return {
                 transform: `translateX(${this.selectedIndex * 100}%)`,
-                width: `${100 / this.buttons.length}%`
+                width: `calc(${100 / this.buttons.length}% - 0.5px)`
             }
         }
     },

--- a/frontend/src/pages/instance/VersionHistory/index.vue
+++ b/frontend/src/pages/instance/VersionHistory/index.vue
@@ -121,8 +121,8 @@ export default {
         pageToggle () {
             if (this.$route.name.includes('editor')) {
                 return [
-                    { title: 'Snapshots', to: { path: './snapshots', params: this.$route.params } },
-                    { title: 'Timeline', to: { path: './timeline', params: this.$route.params } }
+                    { title: 'Snapshots', to: { name: 'instance-editor-snapshots', params: this.$route.params } },
+                    { title: 'Timeline', to: { name: 'instance-editor-version-history-timeline', params: this.$route.params } }
                 ]
             }
 


### PR DESCRIPTION
## Problem
![CleanShot 2026-01-09 at 15 26 18](https://github.com/user-attachments/assets/063d7ffe-99ce-460c-9d32-affe2aff0352)



## Description

Fixes the `ToggleButtonGroup` width to make room for the indicator right border:
Before:
<img width="228" height="80" alt="image" src="https://github.com/user-attachments/assets/e3ff3960-30de-4536-ada1-2b7236ca64ab" />
After:
<img width="230" height="65" alt="image" src="https://github.com/user-attachments/assets/6c134e90-e1cd-43d6-b690-558141cf224f" />

The `ToggleButtonGroup` was not identifying the correct `selectedIndex` because it was receiving a relative path as a prop from the `VersionHistory` page when running in immersive mode. We relied on the `router-link` component to handle the active class until recently and it didn't pose a problem.

Switching to named paths in the `VersionHistory` when setting the `pageToggle` props on the  `ToggleButtonGroup` fixes the problem.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

