### PR TITLE
ci: Cover development dependecies in the SAST scan

### DIFF
--- a/.github/trivy.yaml
+++ b/.github/trivy.yaml
@@ -22,7 +22,7 @@ pkg:
   types:
     - os
     - library
-
+  include-dev-deps: true
 
 format: "sarif"
 ignorefile: ".github/.trivyignore.yaml"


### PR DESCRIPTION
## Description

This pull request adds SAST coverage for development dependencies by setting `include-dev-deps` parameter to `true` in the Trivy configuration file.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

