### PR TITLE
Expose restricted applications for owners listing when team memberships

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -238,7 +238,8 @@ module.exports = async function (app) {
                 properties: {
                     associationsLimit: { type: 'number' },
                     includeInstances: { type: 'boolean' },
-                    includeApplicationDevices: { type: 'boolean' }
+                    includeApplicationDevices: { type: 'boolean' },
+                    excludeOwnerFiltering: { type: 'boolean' }
                 }
             },
             params: {
@@ -278,8 +279,11 @@ module.exports = async function (app) {
             includeApplicationSummary
         })
 
+        const shouldExcludeOwnerFiltering = Object.prototype.hasOwnProperty.call(request.query, 'excludeOwnerFiltering') &&
+            app.hasPermission(request.teamMembership, 'project:create') // checking for the owner role not if the user can create a project
+
         // Apply Application level RBAC
-        if (!request.session?.User?.admin && request.teamMembership && request.teamMembership.permissions?.applications) {
+        if (!request.session?.User?.admin && request.teamMembership && request.teamMembership.permissions?.applications && !shouldExcludeOwnerFiltering) {
             applications = applications.filter(application => {
                 return app.hasPermission(request.teamMembership, 'project:read', { application })
             })

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -78,13 +78,15 @@ const deleteTeam = async (teamId) => {
  * @param includeApplicationSummary
  * @param includeInstances
  * @param includeApplicationDevices
+ * @param excludeOwnerFiltering
  * @returns An array of application objects containing an array of instances
  */
 const getTeamApplications = async (teamId, {
     associationsLimit,
     includeApplicationSummary = false,
     includeInstances = undefined,
-    includeApplicationDevices = undefined
+    includeApplicationDevices = undefined,
+    excludeOwnerFiltering = undefined
 } = {}) => {
     const options = { params: {} }
     if (associationsLimit) {
@@ -99,6 +101,10 @@ const getTeamApplications = async (teamId, {
     if (includeApplicationDevices !== undefined) {
         options.params.includeApplicationDevices = includeApplicationDevices
     }
+    if (excludeOwnerFiltering !== undefined) {
+        options.params.excludeOwnerFiltering = excludeOwnerFiltering
+    }
+
     const result = await client.get(`/api/v1/teams/${teamId}/applications`, options)
     return result.data
 }

--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -216,7 +216,7 @@ export default {
                 })
         },
         fetchApplications () {
-            return teamApi.getTeamApplications(this.team.id)
+            return teamApi.getTeamApplications(this.team.id, { excludeOwnerFiltering: true })
                 .then(response => {
                     this.applications = response.applications
                 })

--- a/frontend/src/pages/team/Members/components/ApplicationPermissionsRow.vue
+++ b/frontend/src/pages/team/Members/components/ApplicationPermissionsRow.vue
@@ -10,13 +10,14 @@
                 >
                     <span class="item" />
                     <span class="item name" data-el="application-name">
-                        <ff-team-link :to="{name: 'application-settings-user-access', params: {id: application.id}}" class="ff-link">
+                        <ff-team-link v-if="!application.disabled" :to="{name: 'application-settings-user-access', params: {id: application.id}}" class="ff-link">
                             {{ application.name }}
                         </ff-team-link>
+                        <span v-else>{{ application.name }}</span>
                     </span>
                     <RoleCompare :baseRole="data.role" :overrideRole="application.role" class="w-40" />
                     <span class="item action w-40 pl-5" data-action="update-role">
-                        <PencilAltIcon class="ff-icon ff-icon-sm ff-link" @click.prevent="onUpdateRole(application)" />
+                        <PencilAltIcon v-if="!application.disabled" class="ff-icon ff-icon-sm ff-link" @click.prevent="onUpdateRole(application)" />
                     </span>
                 </li>
             </ul>
@@ -30,6 +31,7 @@ import { defineComponent } from 'vue'
 
 import RoleCompare from '../../../../components/permissions/RoleCompare.vue'
 import FfTeamLink from '../../../../components/router-links/TeamLink.vue'
+import usePermissions from '../../../../composables/Permissions.js'
 
 import { slugify } from '../../../../composables/String.js'
 
@@ -53,7 +55,8 @@ export default defineComponent({
     },
     emits: ['application-role-updated'],
     setup () {
-        return { ArrowDownIcon, ArrowUpIcon, BanIcon, slugify }
+        const { hasPermission } = usePermissions()
+        return { ArrowDownIcon, ArrowUpIcon, BanIcon, slugify, hasPermission }
     },
     computed: {
         rows () {
@@ -64,7 +67,8 @@ export default defineComponent({
                 return {
                     id: application.id,
                     name: application.name,
-                    role: customRole ?? teamRole
+                    role: customRole ?? teamRole,
+                    disabled: !this.hasPermission('project:read', { application })
                 }
             })
         }


### PR DESCRIPTION
## Description

Adds a new parameter to the team applications list that will ignore rbac filtering when listing applications for owner roles so that they still have a visual queue/reference that restricted applications exist.

Removed the possibility to change roles from the UI, although the backend will accept requests to modify access permissions from owner roles.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6478

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

