### PR TITLE
Refactor tour cancel logic and add final step handling for hosted instance tours

### DIFF
--- a/frontend/src/tours/tour-welcome.js
+++ b/frontend/src/tours/tour-welcome.js
@@ -70,6 +70,7 @@ export default [
         modalOverlayOpeningRadius: 6
     },
     { // last step for teams that already have an instance created when signing up
+        id: 'final-step-with-hosted-instance',
         title: 'You’re All Set',
         text: `
             <p>There is lots more on offer with FlowFuse, but let's dive into your newly created Hosted Instance and get building some flows. Click the <b>Open Editor</b> button now to dive in and start building.</p>
@@ -109,6 +110,7 @@ export default [
         modalOverlayOpeningRadius: 6
     },
     {
+        id: 'final-step-without-hosted-instance',
         title: 'You’re All Set',
         text: `
             <p>There’s much more you can do with FlowFuse, but first, let’s get you started by creating your Hosted Instance. Click the <b>Create Instance</b> button to set one up and begin building your flows.</p>


### PR DESCRIPTION
## Description

starting a new product tour when closing the initial one before completion brought clunky ui artefacts and perturbed the order in which follow-up actions reacted.

I overwrote the tour cancel method and replaced it with the initial onClose hook.
The cancel method now redirects to the 2n'd to last step or last step in the welcome tour. The 2nd to last tour step highlights the newly created instance if it exists, and if it doesn't exist it will redirect to the last step with the 'you're all set` message.

PH events should remain the same, alongside subsequent actions that occurred after the tour completed.

https://github.com/user-attachments/assets/65690ac7-3fad-4e4e-a3cb-7ed29779b111

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/5580

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

