### PR TITLE
Add `value` property to team selection options in Settings page

### DIFF
--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -108,6 +108,7 @@ export default {
                 }
                 return {
                     id: team.id,
+                    value: team.id,
                     label: team.name,
                     slug: team.slug,
                     role: RoleNames[team.role],


### PR DESCRIPTION
## Description

The listbox component requres that option have a value key in order to function. The teams options were missing that key.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6523

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.
   - no need
 

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

