### PR TITLE
Add selected nodes support and enhance assistant messaging logic

### DIFF
--- a/frontend/src/store/modules/product/assistant/index.js
+++ b/frontend/src/store/modules/product/assistant/index.js
@@ -8,7 +8,8 @@ const initialState = () => ({
         target: 'nr-assistant',
         scope: 'flowfuse-expert',
         source: 'flowfuse-expert'
-    }
+    },
+    selectedNodes: []
 })
 
 const meta = {
@@ -33,6 +34,9 @@ const mutations = {
     SET_PALETTE (state, palette) {
         state.palette = palette ?? []
     },
+    SET_SELECTED_NODES (state, selection) {
+        state.selectedNodes = selection
+    },
     RESET (state) {
         const newState = initialState()
         Object.keys(newState).forEach(key => {
@@ -47,12 +51,12 @@ const actions = {
             console.warn('Received message from unknown origin. Ignoring.')
             return
         }
-
         switch (true) {
         case payload.data.type === 'assistant-ready':
             commit('SET_VERSION', payload.data.version)
             commit('SET_PALETTE', payload.data.palette)
             dispatch('requestSupportedActions')
+            dispatch('requestSelectedNodes')
             return await dispatch('requestPalette')
         case payload.data.type === 'get-assistant-version':
             return dispatch('setVersion', payload.data.version)
@@ -60,6 +64,8 @@ const actions = {
             return dispatch('setSupportedActions', payload.data.supportedActions)
         case payload.data.type === 'set-palette':
             return dispatch('setPalette', payload.data.palette)
+        case payload.data.type === 'set-selection':
+            return dispatch('setSelectedNodes', payload.data.selection)
         default:
             // do nothing
         }
@@ -73,6 +79,9 @@ const actions = {
     requestPalette: async ({ dispatch }) => {
         return dispatch('sendMessage', { type: 'get-palette' })
     },
+    requestSelectedNodes: async ({ dispatch }) => {
+        return dispatch('sendMessage', { type: 'get-selection' })
+    },
     setVersion: ({ commit }, version) => {
         commit('SET_VERSION', version)
     },
@@ -81,6 +90,9 @@ const actions = {
     },
     setPalette: ({ commit }, palette) => {
         commit('SET_PALETTE', palette)
+    },
+    setSelectedNodes: async ({ commit }, selection) => {
+        commit('SET_SELECTED_NODES', selection)
     },
     reset: ({ commit }) => {
         commit('RESET')


### PR DESCRIPTION
## Description

Adds support to handle assistant node-selection messages.

adds support to request selected nodes on init, and set selected nodes when the assistant emits them.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6562

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

