### PR TITLE
Fix Expert errors when device are present in MCPRegistrations

### DIFF
--- a/forge/ee/routes/mcp/index.js
+++ b/forge/ee/routes/mcp/index.js
@@ -110,9 +110,20 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         try {
+            let typeId = request.params.typeId
+            if (request.params.type === 'device') {
+                const device = app.db.models.Device.byId(request.params.typeId)
+
+                if (!device) {
+                    throw new Error(`Device ${request.params.typeId} not found`)
+                }
+
+                typeId = device.id
+            }
+
             await app.db.models.MCPRegistration.upsert({
                 targetType: request.params.type,
-                targetId: request.params.typeId,
+                targetId: typeId,
                 nodeId: request.params.nodeId,
                 title: request.body.title,
                 version: request.body.version,

--- a/forge/routes/api/expert.js
+++ b/forge/routes/api/expert.js
@@ -347,9 +347,11 @@ module.exports = async function (app) {
 
                 // Now we have confirmed access is allowed, check instance is actually running before offering
                 // MCP features (querying a non-running instance would cause timeouts)
-                const liveState = await instance.liveState({ omitStorageFlows: true })
-                if (liveState?.meta?.state !== 'running') {
-                    continue
+                if (instance.liveState) {
+                    const liveState = await instance.liveState({ omitStorageFlows: true })
+                    if (liveState?.meta?.state !== 'running') {
+                        continue
+                    }
                 }
 
                 // Check instance settings for node security. If FlowFuse auth is enabled, generate a short-lived (5 mins)


### PR DESCRIPTION
## Description

- Handle device id inconsistency when upserting MCPRegistations table.
- don't query live state for devices when retrieving features

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6583

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

