### PR TITLE
Remove WebSocket communication handling and associated methods from the immersive device editor

### DIFF
--- a/frontend/src/pages/device/Editor/index.vue
+++ b/frontend/src/pages/device/Editor/index.vue
@@ -201,10 +201,8 @@ export default {
         device (device) {
             if (device && this.isEditorAvailable) {
                 this.setContextDevice(device)
-                this.pollDeviceComms()
                 this.runInitialTease()
             } else {
-                this.closeComms()
                 this.$router.push({ name: 'device-overview' })
                     .then(() => Alerts.emit('Unable to connect to the Remote Instance', 'warning'))
                     .catch(e => e)
@@ -232,9 +230,6 @@ export default {
             })
             .catch(err => err)
     },
-    beforeUnmount () {
-        this.closeComms()
-    },
     methods: {
         ...mapActions('context', { setContextDevice: 'setDevice' }),
         loadDevice: async function () {
@@ -251,30 +246,6 @@ export default {
 
             // todo we first need to get the device and set the team afterwards
             await this.$store.dispatch('account/setTeam', this.device.team.slug)
-        },
-        pollDeviceComms () {
-            if (!this.isEditorAvailable || this.ws) return
-
-            const uri = `/api/v1/devices/${this.device.id}/editor/proxy/comms`
-
-            this.ws = new WebSocket(uri)
-
-            this.ws.addEventListener('error', this.handleCommsDisconnect)
-            this.ws.addEventListener('close', this.handleCommsDisconnect)
-        },
-        handleCommsDisconnect (event) {
-            console.warn(event)
-            this.$router.push({ name: 'device-overview' })
-                .then(() => Alerts.emit('Disconnected from remote instance.', 'warning'))
-                .catch(e => e)
-        },
-        closeComms () {
-            if (this.ws) {
-                this.ws.removeEventListener('error', this.handleCommsDisconnect)
-                this.ws.removeEventListener('close', this.handleCommsDisconnect)
-                this.ws.close()
-                this.ws = null
-            }
         }
     }
 }


### PR DESCRIPTION
## Description

Remove WS tunnel healthcheck to prevent idle connection timeouts. Resolves an issue where users were redirected to the instance overview page after 60s in immersive editor mode.

Without the active healthcheck, tunnel connection drops are now silent. Users will be notified of a lost connection only upon attempting a Node-RED deployment

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/6599

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

