### PR TITLE
Switch to immediate watcher to retrieve logs and update schedule

### DIFF
--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -234,34 +234,33 @@ export default {
         }
     },
     watch: {
-        'instance.id': function (old, news) {
-            this.loadLogs()
-            this.getUpdateSchedule(this.instance.id)
+        instance: {
+            handler: function (instance) {
+                if (instance) {
+                    this.loadLogs()
+                    this.getUpdateSchedule(instance.id)
+                }
+            },
+            immediate: true
         }
-    },
-    mounted () {
-        this.loadLogs()
-        this.getUpdateSchedule(this.instance.id)
     },
     methods: {
         openUrl () {
             this.openInANewTab(this.instance.url, `_${this.instance.id}`)
         },
         loadLogs () {
-            if (this.instance && this.instance.id) {
-                this.loading = true
-                this.loadItems(this.instance.id)
-                    .then((data) => {
-                        this.auditLog = data.log
-                    })
-                    .catch((error) => {
-                        console.error('Error loading logs:', error)
-                        this.auditLog = []
-                    })
-                    .finally(() => {
-                        this.loading = false
-                    })
-            }
+            this.loading = true
+            this.loadItems(this.instance.id)
+                .then((data) => {
+                    this.auditLog = data.log
+                })
+                .catch((error) => {
+                    console.error('Error loading logs:', error)
+                    this.auditLog = []
+                })
+                .finally(() => {
+                    this.loading = false
+                })
         },
         loadItems: async function (instanceId, cursor) {
             return await InstanceApi.getInstanceAuditLog(instanceId, null, cursor, 4)


### PR DESCRIPTION
## Description

Use an immediate watcher to retrieve logs and update the schedule, preventing repetitive calls. Additionally, this implements a check to block API calls when no instance is available, resolving an issue where calls were being made to `/api/v1/projects/undefined/autoUpdateStacks`

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6426

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

