### PR TITLE
ci: Use Node-RED 4.1 as a baseline for a custom NR stack on pre-staging environment

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -195,7 +195,7 @@ jobs:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   build-node-red:
-    name: Build Node-RED 4.0.x container images
+    name: Build Node-RED 4.1.x container images
     needs: 
       - validate-user
       - publish_nr_launcher
@@ -207,7 +207,7 @@ jobs:
     with:
       image_name: 'node-red'
       dockerfile_path: Dockerfile
-      image_tag_prefix: '4.0.x-'
+      image_tag_prefix: '4.1.x-'
       build_context: './ci/node-red'
       build_arguments: |
         BUILD_TAG=${{ needs.publish_nr_launcher.outputs.release_name }}
@@ -217,7 +217,7 @@ jobs:
       temporary_registry_token: ${{ secrets.GITHUB_TOKEN }}
 
   upload-node-red:
-    name: Publish Node-RED 4.0.x container images
+    name: Publish Node-RED 4.1.x container images
     needs:
       - validate-user 
       - build-node-red
@@ -239,7 +239,7 @@ jobs:
     steps:
       - name: Set variables
         run: | 
-          echo "tagged_image=${{ env.IMAGE_NAME }}:4.0.x-pr-${{ env.PR_NUMBER }}" >> $GITHUB_ENV
+          echo "tagged_image=${{ env.IMAGE_NAME }}:4.1.x-pr-${{ env.PR_NUMBER }}" >> $GITHUB_ENV
           echo "timestamp=$(date +%s)" >> $GITHUB_ENV
 
       - name: Setup Docker buildx
@@ -495,7 +495,7 @@ jobs:
     steps:
       - name: Create/update stack
         run: |
-          customStackId=$(curl -ks -XGET -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" https://$PR_NUMBER.$FLOWFUSE_DOMAIN/api/v1/stacks/ | jq -r '.stacks[] | select(.name == "NR-40-Custom") | .id')
+          customStackId=$(curl -ks -XGET -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" https://$PR_NUMBER.$FLOWFUSE_DOMAIN/api/v1/stacks/ | jq -r '.stacks[] | select(.name == "NR-41-Custom") | .id')
           if [ -n "$customStackId" ]; then
             echo "Stack already exists, updating..."
             curl -ks -X PUT \
@@ -511,7 +511,7 @@ jobs:
               --fail-with-body \
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer ${{ secrets.INIT_CONFIG_ACCESS_TOKEN }}" \
-              -d '{"name":"'"NR-40-Custom"'","label":"'"4.0.x-custom"'", "projectType":"'"$projectTypeId"'","properties":{ "cpu":'"30"',"memory":'"256"',"container":"'"${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-node-red.outputs.nr_custom_image_tag }}"'"}}' \
+              -d '{"name":"'"NR-41-Custom"'","label":"'"4.1.x-custom"'", "projectType":"'"$projectTypeId"'","properties":{ "cpu":'"30"',"memory":'"256"',"container":"'"${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ needs.upload-node-red.outputs.nr_custom_image_tag }}"'"}}' \
               https://$PR_NUMBER.$FLOWFUSE_DOMAIN/api/v1/stacks/
           fi
   

--- a/ci/node-red/Dockerfile
+++ b/ci/node-red/Dockerfile
@@ -1,4 +1,4 @@
-FROM nodered/node-red:4.0.2-20
+FROM nodered/node-red:4.1.5-22
 
 ARG REGISTRY
 ARG REGISTRY_TOKEN


### PR DESCRIPTION
## Description

This pull request:
* bumps the node-red tag to `4.1.5.-22` in the Dockerfile used to create custom Node-RED container image
* updates custom NR stack name created by the workflow

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/6712

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

