### PR TITLE
ci: Add `nr-subflow-export` package to the pre-staging environments

### DIFF
--- a/.github/workflows/branch-deploy.yaml
+++ b/.github/workflows/branch-deploy.yaml
@@ -34,6 +34,10 @@ on:
         description: 'flowfuse/nr-mqtt-nodes branch name'
         required: true
         default: 'main'
+      nr_subflow_export_branch:
+        description: 'flowfuse/nr-subflow-export branch name'
+        required: true
+        default: 'main'
   pull_request:
     types: 
       - opened
@@ -171,6 +175,23 @@ jobs:
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
+  publish_nr_subflow_export:
+    name: Build and publish nr-subflow-export package
+    needs: validate-user
+    if: |
+      needs.validate-user.outputs.is_org_member == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.nr_subflow_export_branch != 'main'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.49.0'
+    with:
+      package_name: nr-subflow-export
+      publish_package: true
+      repository_name: 'FlowFuse/nr-subflow-export'
+      branch_name: ${{ inputs.nr_subflow_export_branch }}
+      release_name: "pre-staging-${{ inputs.nr_subflow_export_branch }}"
+    secrets:
+      npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
   publish_nr_mqtt_nodes:
     name: Build and publish nr-mqtt-nodes package
     needs: validate-user
@@ -197,10 +218,17 @@ jobs:
       - publish_nr_assistant
       - publish_nr_tables_nodes
       - publish_nr_mqtt_nodes
+      - publish_nr_subflow_export
     if: |
       needs.validate-user.outputs.is_org_member == 'true' &&
       github.event_name == 'workflow_dispatch' &&
-      (always() && inputs.nr_launcher_branch != 'main') || needs.publish_nr_project_nodes.result == 'success' || needs.publish_nr_file_nodes.result == 'success' || needs.publish_nr_assistant.result == 'success' || needs.publish_nr_tables_nodes.result == 'success' || needs.publish_nr_mqtt_nodes.result == 'success'
+      (always() && inputs.nr_launcher_branch != 'main') || 
+      needs.publish_nr_project_nodes.result == 'success' || 
+      needs.publish_nr_file_nodes.result == 'success' || 
+      needs.publish_nr_assistant.result == 'success' || 
+      needs.publish_nr_tables_nodes.result == 'success' || 
+      needs.publish_nr_mqtt_nodes.result == 'success' || 
+      needs.publish_nr_subflow_export.result == 'success'
     uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.49.0'
     with:
       package_name: flowfuse-nr-launcher
@@ -214,6 +242,7 @@ jobs:
         @flowfuse/nr-assistant=${{ inputs.nr_assistant_branch != 'main' && needs.publish_nr_assistant.outputs.release_name || 'nightly' }}
         @flowfuse/nr-tables-nodes=${{ inputs.nr_tables_nodes_branch != 'main' && needs.publish_nr_tables_nodes.outputs.release_name || 'nightly' }}
         @flowfuse/nr-mqtt-nodes=${{ inputs.nr_mqtt_nodes_branch != 'main' && needs.publish_nr_mqtt_nodes.outputs.release_name || 'nightly' }}
+        @flowfuse/nr-subflow-export=${{ inputs.nr_subflow_export_branch != 'main' && needs.publish_nr_subflow_export.outputs.release_name || 'nightly' }}
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
 


### PR DESCRIPTION
## Description

This pull request adds the option to build the `nr-subflow-export`package from the feature branch and bundle it as a part of a custom Node-RED stack on a pre-staging environment.

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/6710

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

