### PR TITLE
ci: Add tests-summary job to the `Tests` workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -199,9 +199,45 @@ jobs:
             test/e2e/frontend/cypress/screenshots
             test/e2e/frontend/cypress/videos
 
+  ### We use this job to gather results from all test jobs and determine the final status of the tests execution.
+  ### Jobs executed with the matrix strategy have dynamic names and cannot be referenced in the status checks of the pull request.
+  tests-summary:
+    name: Tests summary
+    if: ${{ always() }}
+    needs:
+      - check-changes
+      - backend-tests
+      - postgres-tests
+      - ui-unit-tests
+      - ui-os-tests
+      - ui-ee-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate test job results
+        run: |
+          results=(
+            '${{ needs.backend-tests.result }}'
+            '${{ needs.postgres-tests.result }}'
+            '${{ needs.ui-unit-tests.result }}'
+            '${{ needs.ui-os-tests.result }}'
+            '${{ needs.ui-ee-tests.result }}'
+          )
+
+          echo 'Test job results:'
+          printf '%s\n' "${results[@]}"
+
+          for result in "${results[@]}"; do
+            if [ "$result" = 'failure' ] || [ "$result" = 'cancelled' ]; then
+              echo 'One or more test jobs failed or were cancelled'
+              exit 1
+            fi
+          done
+
+          echo 'All test jobs succeeded or were skipped'
+
   notify-slack:
     name: Notify on failure
-    needs: [backend-tests, postgres-tests, ui-os-tests, ui-ee-tests]
+    needs: tests-summary
     if: failure()
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Description

This pull requests extends the `Tests` workflow by adding a `Tests summary` job.
The main purpose of this job is to gather results from all tests jobs and determine the final status of tests execution. This job should be used in a Pull Request status check configuration. 

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/6660

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

