### PR TITLE
Add UI for device apiMaxLength - styling, typo and validation fixes 

### DIFF
--- a/frontend/src/pages/device/Settings/Editor.vue
+++ b/frontend/src/pages/device/Settings/Editor.vue
@@ -1,6 +1,6 @@
 <template>
-    <form class="space-y-4" data-el="instance-editor" @submit.prevent>
-        <FormHeading class="pt-8">Limits</FormHeading>
+    <form class="space-y-6" data-el="instance-editor" @submit.prevent>
+        <FormHeading>Limits</FormHeading>
         <div v-if="limitAvailable">
             <div v-if="limitsLauncherEnabled">
                 <div class="flex flex-col sm:flex-row">
@@ -17,7 +17,7 @@
             </div>
             <div v-else class="flex flex-col sm:flex-row">
                 <div class="space-y-4 w-full max-w-md sm:mr-8">
-                    Please upgrade your Device Agent to v3.8.4 be able to set apiMaxLength or debugMaxLength
+                    Please upgrade your Device Agent to v3.8.4 to be able to set apiMaxLength or debugMaxLength
                 </div>
             </div>
         </div>
@@ -73,7 +73,8 @@ export default {
                 },
                 errors: {
                     apiMaxLength: ''
-                }
+                },
+                hasErrors: false
             },
             original: {
                 apiMaxLength: '',
@@ -146,14 +147,14 @@ export default {
             if (this.editable.settings.apiMaxLength.length > 0) {
                 if (pattern.test(this.editable.settings.apiMaxLength)) {
                     this.editable.errors.apiMaxLength = ''
-                    return true
                 } else {
                     this.editable.errors.apiMaxLength = 'Invalid Value'
-                    return false
                 }
+            } else {
+                this.editable.errors.apiMaxLength = ''
             }
-            this.editable.errors.apiMaxLength = ''
-            return true
+            this.editable.hasErrors = !!this.editable.errors.apiMaxLength
+            return !this.editable.hasErrors
         }
     }
 }


### PR DESCRIPTION
# Device Editor Settings — Cleanup Notes

**File:** `frontend/src/pages/device/Settings/Editor.vue`


### Before 

<img width="938" height="466" alt="Screenshot 2026-03-04 at 11 32 30 AM" src="https://github.com/user-attachments/assets/cbc29710-df0e-4405-aa5b-1e2c72b3dce6" />

### After 

<img width="1064" height="441" alt="Screenshot 2026-03-04 at 11 55 45 AM" src="https://github.com/user-attachments/assets/300cb035-dbcb-45ed-9a41-6906a1a75417" />

## Changes Made

### 1. Removed extra top padding from `FormHeading`

The heading had `class="pt-8"` which added 32px of padding above "Limits". Since it is the first element on the page there was nothing above it to separate from, so the padding just created an awkward gap at the top of the content area. Removed the class entirely to match how other device settings pages style their headings.

### 2. Fixed spacing consistency (`space-y-4` → `space-y-6`)

The form used `space-y-4` for vertical spacing between sections. Other device settings pages (Palette, Security) use `space-y-6`. Updated to match.

### 3. Fixed typo in agent upgrade message

The message read:
> "Please upgrade your Device Agent to v3.8.4 **be** able to set..."

Missing word — corrected to:
> "Please upgrade your Device Agent to v3.8.4 **to be** able to set..."

### 4. Fixed `hasErrors` bug in `validate()`

The Save button is disabled via `:disabled="!unsavedChanges || editable.hasErrors"`, but `hasErrors` was never declared on the `editable` data object and was never set inside `validate()`. The original `validate()` used early `return true/false` statements, which meant `hasErrors` was always `undefined` (falsy) — so the button would stay enabled even when the field contained an invalid value.

**Fix:**
- Added `hasErrors: false` to the `editable` data object
- Removed early returns from `validate()` so all branches set `editable.errors.apiMaxLength` first
- Added `this.editable.hasErrors = !!this.editable.errors.apiMaxLength` at the end of `validate()` so the button correctly reflects validation state

