### PR TITLE
Safeguard `dialog.close` call with optional chaining to prevent potential runtime errors

### DIFF
--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -516,7 +516,7 @@ export default {
                                 this.openingTunnel = false
                             })
                         } catch (err) {
-                            this.$refs.dialog.close()
+                            this.$refs.dialog?.close()
                             this.openingTunnel = false
 
                             const enhancedError = new Error(`Failed to enable device editor tunnel: ${err.message}`)


### PR DESCRIPTION
## Description

<img width="1371" height="447" alt="image" src="https://github.com/user-attachments/assets/90572b35-d706-47b5-9c83-f936058b0e1a" />

Was able to replicate the above on prod following the changes in the previous pr.

Safeguarding the catch route in order to pass the custom error through.

## Related Issue(s)

follow up on https://github.com/FlowFuse/flowfuse/pull/6798
part of https://github.com/FlowFuse/flowfuse/issues/6797

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

