### PR TITLE
Hide Expert contextual selectors in non-immersive mode

### DIFF
--- a/frontend/src/components/expert/ExpertChatInput.vue
+++ b/frontend/src/components/expert/ExpertChatInput.vue
@@ -34,12 +34,14 @@
 
             <div class="actions">
                 <div class="left">
-                    <context-selector v-if="!isOperatorAgent" />
-                    <div class="context-items-container" @wheel="horizontalScrolling">
-                        <include-context-item v-for="(context, index) in selectedContextFiltered" :key="index" :contextItem="context" />
-                        <include-debug-context-button v-if="hasDebugLogsSelected && !isOperatorAgent" />
-                        <include-selection-button v-if="hasUserSelection && !isOperatorAgent" />
-                    </div>
+                    <template v-if="isImmersive">
+                        <context-selector v-if="!isOperatorAgent" />
+                        <div class="context-items-container" @wheel="horizontalScrolling">
+                            <include-context-item v-for="(context, index) in selectedContextFiltered" :key="index" :contextItem="context" />
+                            <include-debug-context-button v-if="hasDebugLogsSelected && !isOperatorAgent" />
+                            <include-selection-button v-if="hasUserSelection && !isOperatorAgent" />
+                        </div>
+                    </template>
                 </div>
 
                 <div class="right">
@@ -134,7 +136,13 @@ export default {
         }
     },
     computed: {
-        ...mapGetters('product/assistant', ['getSelectedContext', 'hasDebugLogsSelected', 'hasUserSelection']),
+        ...mapGetters('product/assistant', [
+            'getSelectedContext',
+            'hasDebugLogsSelected',
+            'hasUserSelection',
+            'immersiveInstance',
+            'immersiveDevice'
+        ]),
         isInputDisabled () {
             if (this.isSessionExpired) return true
             if (this.isGenerating) return true
@@ -161,6 +169,9 @@ export default {
         },
         selectedContextFiltered () {
             return this.selectedContext.filter(c => c.showAsChip !== false)
+        },
+        isImmersive () {
+            return this.immersiveDevice || this.immersiveInstance
         }
     },
     mounted () {


### PR DESCRIPTION
## Description

Hides contextual selectors when the expert is in non-immersive mode

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6819

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

