### PR TITLE
Ensure Certified Nodes always first in the list

### DIFF
--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -371,9 +371,14 @@ module.exports = async function (app) {
                     response.palette = response.palette || {}
                     response.palette.catalogues = response.palette.catalogues || ['https://catalogue.nodered.org/catalogue.json']
                 }
-                function updateSettingsForCatalogue (scope, catalogueString) {
+                function updateSettingsForCatalogue (scope, catalogueString, first = false) {
                     const catalogue = new URL(catalogueString)
-                    response.palette.catalogues.push(catalogue.toString())
+                    if (first) {
+                        // insert at start of list
+                        response.palette.catalogues.splice(0, 0, catalogue.toString())
+                    } else {
+                        response.palette.catalogues.push(catalogue.toString())
+                    }
                     const npmrcEntry = `${scope}:registry=${npmRegURL.toString()}\n` +
                           `//${npmRegURL.host}:_auth="${token}"\n`
                     if (response.palette.npmrc) {
@@ -383,7 +388,7 @@ module.exports = async function (app) {
                     }
                 }
                 if (certifiedNodesEnabledForTeam && certNodesCatalogue) {
-                    updateSettingsForCatalogue('@flowfuse-certified-nodes', certNodesCatalogue)
+                    updateSettingsForCatalogue('@flowfuse-certified-nodes', certNodesCatalogue, true)
                 }
                 if (ffNodesEnabledForTeam && ffNodesCatalogue) {
                     updateSettingsForCatalogue('@flowfuse-nodes', ffNodesCatalogue)

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -946,9 +946,14 @@ module.exports = async function (app) {
                     settings.settings.palette = settings.settings.palette || {}
                     settings.settings.palette.catalogue = settings.settings.palette.catalogue || []
                 }
-                function updateSettingsForCatalogue (scope, catalogueString) {
+                function updateSettingsForCatalogue (scope, catalogueString, first = false) {
                     const catalogue = new URL(catalogueString)
-                    settings.settings.palette.catalogue.push(catalogue.toString())
+                    if (first) {
+                        // insert at start of list
+                        settings.settings.palette.catalogue.splice(0, 0, catalogue.toString())
+                    } else {
+                        settings.settings.palette.catalogue.push(catalogue.toString())
+                    }
                     const npmrcEntry = `${scope}:registry=${npmRegURL.toString()}\n` +
                           `//${npmRegURL.host}:_auth="${token}"\n`
                     if (settings.settings.palette.npmrc) {
@@ -958,7 +963,7 @@ module.exports = async function (app) {
                     }
                 }
                 if (certifiedNodesEnabledForTeam && certNodesCatalogue) {
-                    updateSettingsForCatalogue('@flowfuse-certified-nodes', certNodesCatalogue)
+                    updateSettingsForCatalogue('@flowfuse-certified-nodes', certNodesCatalogue, true)
                 }
                 if (ffNodesEnabledForTeam && ffNodesCatalogue) {
                     updateSettingsForCatalogue('@flowfuse-nodes', ffNodesCatalogue)


### PR DESCRIPTION
fixes FlowFuse/product#38

## Description

<!-- Describe your changes in detail -->

Ensure that Certified Nodes catalogue inserted at the start of the array.

<img width="1448" height="634" alt="image" src="https://github.com/user-attachments/assets/26e9c939-7013-4137-9932-95b3d463e56d" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/product#38

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

