### PR TITLE
Ensure getProjectsToUpgrade Matches all Project Settings

### DIFF
--- a/forge/db/models/ProjectSettings.js
+++ b/forge/db/models/ProjectSettings.js
@@ -77,9 +77,18 @@ module.exports = {
                     return await this.findAll({
                         where: {
                             key: `${KEY_STACK_UPGRADE_HOUR}_${day}`,
-                            value: {
-                                [Op.like]: `${JSON.stringify({ hour }).slice(0, -1)},%`
-                            }
+                            [Op.or]: [
+                                {
+                                    value: {
+                                        [Op.eq]: `${JSON.stringify({ hour })}`
+                                    }
+                                },
+                                {
+                                    value: {
+                                        [Op.like]: `${JSON.stringify({ hour }).slice(0, -1)},%`
+                                    }
+                                }
+                            ]
                         },
                         include: {
                             model: M.Project,


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
When looking at why only a few projects where updated, noticed that the query only matches settings that also include a restart flag.

This now tests for just bare hour markers.

