### PR TITLE
Rate limit AutoStackUpdate task

### DIFF
--- a/forge/ee/lib/autoUpdateStacks/tasks/upgrade-stack.js
+++ b/forge/ee/lib/autoUpdateStacks/tasks/upgrade-stack.js
@@ -58,7 +58,7 @@ module.exports = {
                                 await app.auditLog.Project.project.restarted(null, null, project.Project)
                                 await app.db.controllers.Project.clearInflightState(project.Project)
                                 // space out the Node-RED restarts a little.
-                                await delay(1000)
+                                await delay(2000)
                             } catch (err) {
                                 app.log.info(`Problem restarting project ${project.Project.id} - ${err.toString()}`)
                             }


### PR DESCRIPTION
fixes #6872

## Description

<!-- Describe your changes in detail -->
This adds a 1 second delay between suspend and restart and another 1 second after each instance in the list.

It also no longer tries to upgrade suspended instances.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#6872 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

