### PR TITLE
Remove community support link from README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -233,7 +233,6 @@ Once you're more comfortable with FlowFuse, you may want to explore some of our 
 ## Support
 
 - [Troubleshooting](/docs/debugging/)
-- [Community Support](https://community.flowfuse.com/)
 - [FlowFuse Cloud Support](/docs/premium-support/)
 
 ## Contributing to FlowFuse


### PR DESCRIPTION
## Description

This removed the link to community.flowfuse.com, which is retired and in read-only mode.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

