### PR TITLE
Fix expert messages reactivity when switching between agent modes

### DIFF
--- a/frontend/src/components/expert/components/ExpertMessages.vue
+++ b/frontend/src/components/expert/components/ExpertMessages.vue
@@ -1,7 +1,7 @@
 <template>
     <div ref="messagesWrapper" class="messages-wrapper">
         <ul class="flex flex-col gap-3">
-            <li v-for="(message, index) in messages" :key="index" class="flex flex-col gap-3">
+            <li v-for="message in messages" :key="message._uuid" class="flex flex-col gap-3">
                 <component :is="messageTypes[message._type]" v-if="messageTypes[message._type]" v-bind="{...message}" />
             </li>
             <li v-if="isWaitingForResponse">


### PR DESCRIPTION
## Description

The message component was using array indices as key props. When switching between different agent modes, the underlying data changed but the indices remained the same (0,1,2...). This caused the framework to incorrectly reuse DOM elements, leading to rendering artifacts and stale state.

I updated the message rendering logic to use each message's unique uuid as the key. This ensures that the UI correctly disposes of old message components and mounts new ones when the agent context changes.

## Related Issue(s)

introduced by https://github.com/FlowFuse/flowfuse/pull/6839

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

