### PR TITLE
Add rate limiting to team suspension instance shutdown

### DIFF
--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -8,6 +8,8 @@ const { DataTypes, literal, Op } = require('sequelize')
 const { Roles } = require('../../lib/roles')
 const { slugify, generateTeamAvatar, buildPaginationSearchClause } = require('../utils')
 
+const delay = (time) => new Promise(resolve => setTimeout(resolve, time))
+
 module.exports = {
     name: 'Team',
     schema: {
@@ -759,13 +761,14 @@ module.exports = {
                         }
                     })
                     // Shut down all running instances
-                    instanceList.forEach(async (instance) => {
+                    for (const instance of instanceList) {
                         try {
                             await app.containers.stop(instance)
                         } catch (err) {
                             // do we need to log a failure?
                         }
-                    })
+                        await delay(1000)
+                    }
                 },
 
                 /**


### PR DESCRIPTION
fixes #6913

## Description

<!-- Describe your changes in detail -->

Adds 1 second between instance suspension

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#6913

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

