### PR TITLE
Update RBAC documentation for Enterprise licensing

### DIFF
--- a/docs/user/role-based-access-control.md
+++ b/docs/user/role-based-access-control.md
@@ -134,6 +134,8 @@ To change a team member's role:
 
 Application-Level RBAC enables you to control permissions at the individual application level within a team. This allows different team members to have different permission levels for different applications without creating multiple teams.
 
+This is an Enterprise lisenced feature for Self Hosted Users and requires an Entprise Team on FlowFuse Cloud.
+
 ### Overview
 
 Team-level roles define default permissions across all resources.  


### PR DESCRIPTION

## Description

<!-- Describe your changes in detail -->
Clarified that Application-Level RBAC is an Enterprise licensed feature for Self Hosted Users and requires an Enterprise Team on FlowFuse Cloud.

re:

https://app-eu1.hubspot.com/help-desk/26586079/view/233410279/ticket/410097312980/thread/18413951208#email

## Related Issue(s)

<!-- What issue does this PR relate to? -->

