### PR TITLE
Guard against undefined template owner

### DIFF
--- a/frontend/src/pages/admin/Templates/index.vue
+++ b/frontend/src/pages/admin/Templates/index.vue
@@ -94,10 +94,11 @@ export default {
             this.nextCursor = result.meta.next_cursor
             result.templates.forEach(v => {
                 // map owner to top tier to show in table
-                v.owner_avatar = v.owner.avatar
-                v.owner_id = v.owner.id
-                v.owner_username = v.owner.username
-
+                if (v.owner) {
+                    v.owner_avatar = v.owner.avatar
+                    v.owner_id = v.owner.id
+                    v.owner_username = v.owner.username
+                }
                 this.templates.push(v)
             })
             this.loading = false


### PR DESCRIPTION
Fixes #7027

## Description

It is possible for a Template object to not have an owner. The front-end didn't handle that, resulting in a broken view.

I haven't got to the bottom of how/why the template didn't have an owner, but this addresses the UI side of things.
