### PR TITLE
docs: add descriptions to standard environment variables

### DIFF
--- a/docs/user/envvar.md
+++ b/docs/user/envvar.md
@@ -49,17 +49,17 @@ The image below shows an instance with the following environment variables:
 Standard environment variables are set for all Node-RED instances running
 within the platform:
 
-- `FF_INSTANCE_ID`
-- `FF_INSTANCE_NAME`
-- `FF_INSTANCE_URL`
+- `FF_INSTANCE_ID` - The unique identifier of the instance
+- `FF_INSTANCE_NAME` - The name of the instance as set in FlowFuse
+- `FF_INSTANCE_URL` - The full URL of the instance (e.g. `https://my-instance.flowfuse.cloud`)
 
 In addition, the following variables are set when running on a device:
 
-- `FF_DEVICE_ID`
-- `FF_DEVICE_NAME`
-- `FF_DEVICE_TYPE`
-- `FF_SNAPSHOT_ID`
-- `FF_SNAPSHOT_NAME`
+- `FF_DEVICE_ID` - The unique identifier of the device
+- `FF_DEVICE_NAME` - The name of the device as set in FlowFuse
+- `FF_DEVICE_TYPE` - The device type label assigned in FlowFuse
+- `FF_SNAPSHOT_ID` - The unique identifier of the snapshot currently deployed to the device
+- `FF_SNAPSHOT_NAME` - The name of the snapshot currently deployed to the device
 
 When deploying the same set of flows out to multiple devices, these variables can
 be used by the flows to identify the specific device being run on.


### PR DESCRIPTION
## Description

Added inline descriptions to all standard environment variables to clarify what each variable contains.

## Related Issue(s)

https://github.com/FlowFuse/website/issues/4694

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

