### PR TITLE
ci: Disable shared cache on pre-staging environments

### DIFF
--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -2,12 +2,15 @@ forge:
   domain: flowfuse.dev
   https: true
   localPostgresql: true
+  localValkey: false
   projectIngressClassName: traefik
   broker:
     enabled: true
     teamBroker:
       uiOnly: true
   cloudProvider: aws
+  cache:
+    type: memory
   email:
     ses:
       region: eu-west-1


### PR DESCRIPTION
## Description

This pull request disables valkey cache in a favour of in-memory solution. Pre-staging environments do not need to provide HA configuration by default.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

