### PR TITLE
Replace npm install with npm ci in Dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -11,7 +11,7 @@ COPY frontend/ /build/frontend/
 COPY forge/ /build/forge/
 RUN npm install --no-audit --no-fund pg-hstore@^2.3.4 && \
     npm install --no-audit --no-fund @flowfuse/driver-kubernetes@$KUBERNETES_DRIVER_TAG && \
-    npm install --no-audit --no-fund && \    
+    npm ci --no-audit --no-fund && \    
     npm run build
 
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -6,6 +6,7 @@ ARG KUBERNETES_DRIVER_TAG=nightly
 
 WORKDIR /build
 COPY package.json /build
+COPY package-lock.json /build
 COPY config/ /build/config/
 COPY frontend/ /build/frontend/
 COPY forge/ /build/forge/


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Force `npm ci` for ci pipeline container builds

Using `npm install` is pulling versions not in the package-lock.josn file

