### PR TITLE
Force Device Editor to reload if it fails first time

### DIFF
--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -252,10 +252,10 @@ module.exports = async function (app) {
             } else if (tunnelManager.getTunnelStatus(request.device)?.enabled) {
                 // Enabled, but not connected
                 reply.code(502)
-                .header('content-type', 'text/html')
-                .send('<html><head><meta http-equiv="refresh", content="3"></head>' +
-                    '<body><p>The connection to the editor is currently unavailable, will try again in 3 seconds</p></body>' +
-                    '</html>') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
+                    .header('content-type', 'text/html')
+                    .send('<html><head><meta http-equiv="refresh", content="3"></head>' +
+                        '<body><p>The connection to the editor is currently unavailable, will try again in 3 seconds</p></body>' +
+                        '</html>') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
                 return
             }
             // tunnel does not exist

--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -253,7 +253,7 @@ module.exports = async function (app) {
                 // Enabled, but not connected
                 reply.code(502)
                     .header('content-type', 'text/html')
-                    .send('<html><head><meta http-equiv="refresh", content="3"></head>' +
+                    .send('<html><head><meta http-equiv="refresh" content="3"></head>' +
                         '<body><p>The connection to the editor is currently unavailable, will try again in 3 seconds</p></body>' +
                         '</html>') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
                 return

--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -253,7 +253,9 @@ module.exports = async function (app) {
                 // Enabled, but not connected
                 reply.code(502)
                 .header('content-type', 'text/html')
-                .send('<html><head><meta http-equiv="refresh", content="3"></head><body><p>The connection to the editor is currently unavailable</p></body></html>') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
+                .send('<html><head><meta http-equiv="refresh", content="3"></head>' +
+                    '<body><p>The connection to the editor is currently unavailable, will try again in 3 seconds</p></body>' +
+                    '</html>') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
                 return
             }
             // tunnel does not exist

--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -251,7 +251,9 @@ module.exports = async function (app) {
                 return
             } else if (tunnelManager.getTunnelStatus(request.device)?.enabled) {
                 // Enabled, but not connected
-                reply.code(502).send('<html><head><meta http-equiv="refresh", content="3"></head><body><p>The connection to the editor is currently unavailable</p></body></html>') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
+                reply.code(502)
+                .header('content-type', 'text/html')
+                .send('<html><head><meta http-equiv="refresh", content="3"></head><body><p>The connection to the editor is currently unavailable</p></body></html>') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
                 return
             }
             // tunnel does not exist

--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -251,7 +251,7 @@ module.exports = async function (app) {
                 return
             } else if (tunnelManager.getTunnelStatus(request.device)?.enabled) {
                 // Enabled, but not connected
-                reply.code(502).send('The connection to the editor is currently unavailable') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
+                reply.code(502).send('<html><head><meta http-equiv="refresh", content="3"></head><body><p>The connection to the editor is currently unavailable</p></body></html>') // Bad Gateway (tunnel exists but it has lost connection or is in an intermediate state)
                 return
             }
             // tunnel does not exist


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Force refresh if editor load fails first time, rather than return a raw string with the 502 return a html file with hte meta tag to force a refresh after 3 seconds

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/issues/6797

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

