### PR TITLE
[7165 + 7164 + 7163 + 7162] Wire device-updated / assign-device events into the immersive remote-instance editor

### DIFF
--- a/frontend/src/pages/device/Editor/index.vue
+++ b/frontend/src/pages/device/Editor/index.vue
@@ -21,6 +21,8 @@
             <router-view
                 :device="device"
                 :instance="device?.instance"
+                @device-updated="refreshDevice"
+                @assign-device="openAssignmentDialog"
             />
         </EditorDrawer>
 
@@ -35,6 +37,25 @@
                 @toggle="toggleEditorImmersiveDrawer"
             />
         </div>
+
+        <AssignDeviceDialog
+            v-if="notAssigned"
+            ref="assignment-dialog"
+            data-el="assignment-dialog"
+            @assign-option-selected="assignOptionSelected"
+        />
+        <DeviceAssignInstanceDialog
+            v-if="notAssigned"
+            ref="deviceAssignInstanceDialog"
+            data-el="assignment-dialog-instance"
+            @assign-device="assignDeviceToInstance"
+        />
+        <DeviceAssignApplicationDialog
+            v-if="notAssigned"
+            ref="deviceAssignApplicationDialog"
+            data-el="assignment-dialog-application"
+            @assign-device="assignDeviceToApplication"
+        />
     </div>
 </template>
 
@@ -42,6 +63,7 @@
 import { CogIcon } from '@heroicons/vue/solid/index.js'
 import { mapActions, mapState } from 'pinia'
 
+import deviceApi from '../../../api/devices.js'
 import DropdownMenu from '../../../components/DropdownMenu.vue'
 import ExpertTabIcon from '../../../components/icons/ff-minimal-grey.js'
 import DrawerTrigger from '../../../components/immersive-editor/DrawerTrigger.vue'
@@ -51,6 +73,11 @@ import { useDeviceHelper } from '../../../composables/DeviceHelper.js'
 import usePermissions from '../../../composables/Permissions.js'
 import Alerts from '../../../services/alerts.js'
 
+import DeviceAssignApplicationDialog from '../../team/Devices/dialogs/DeviceAssignApplicationDialog.vue'
+import DeviceAssignInstanceDialog from '../../team/Devices/dialogs/DeviceAssignInstanceDialog.vue'
+
+import AssignDeviceDialog from '../components/AssignDeviceDialog.vue'
+
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
@@ -59,7 +86,10 @@ import { useUxDrawersStore } from '@/stores/ux-drawers.js'
 export default {
     name: 'DeviceEditor',
     components: {
+        AssignDeviceDialog,
         CogIcon,
+        DeviceAssignApplicationDialog,
+        DeviceAssignInstanceDialog,
         DropdownMenu,
         DrawerTrigger,
         EditorDrawer,
@@ -180,6 +210,12 @@ export default {
             }
             return {}
         },
+        notAssigned () {
+            const device = this.device
+            const hasApplication = device?.ownerType === 'application' && device.application
+            const hasInstance = device?.ownerType === 'instance' && device.instance
+            return !hasApplication && !hasInstance
+        },
         actionsDropdownOptions () {
             if (!this.device) return []
 
@@ -262,6 +298,27 @@ export default {
         },
         showConfirmDeleteDialog () {
             this.showDeleteDeviceDialog()
+        },
+        async refreshDevice () {
+            await this.fetchDevice()
+        },
+        openAssignmentDialog () {
+            this.$refs['assignment-dialog'].show()
+        },
+        assignOptionSelected (option) {
+            if (option === 'instance') {
+                this.$refs.deviceAssignInstanceDialog.show(this.device)
+            } else if (option === 'application') {
+                this.$refs.deviceAssignApplicationDialog.show(this.device)
+            }
+        },
+        async assignDeviceToInstance (device, instanceId) {
+            this.device = await deviceApi.updateDevice(device.id, { instance: instanceId })
+            Alerts.emit('Device successfully assigned to instance.', 'confirmation')
+        },
+        async assignDeviceToApplication (device, applicationId) {
+            this.device = await deviceApi.updateDevice(device.id, { application: applicationId, instance: null })
+            Alerts.emit('Device successfully assigned to application.', 'confirmation')
         },
         handlePolling () {
             const pollingRoutes = [


### PR DESCRIPTION
## Description

This wraps the following changes into one PR: 

1. #7163
2. #7162
3. #7164
4. #7165

<details><summary> ✅ All tests passed! </summary>

- [x] **7162 immersive Assign (unassigned device):** unassigned remote instance → immersive editor → Settings → click **Assign**. Dialog opens; pick Instance or Application and confirm. Device updates without manual reload; Assign UI flips to assigned state.
- [x] **7162 Unassign → Assign cycle:** assigned remote instance → immersive Settings → **Unassign**. Assign button re-enables and is responsive immediately (no stale state, no manual reload).
- [x] **7163 group Remove + Reassign:** application-owned remote instance currently in a device group → immersive Settings → General → in the **Group** section, click **Remove from the group**. Section flips to "no group" state immediately. Then click **Reassign** (or **Assign to a group**) and pick a group — section updates without manual reload.
  - **Known limitation:** group removal clears the active snapshot → `editor.connected` briefly false → pre-existing watcher in `Editor/index.vue:213-227` bounces to `device-overview`. Out of scope for this bug fix. 
- [x] **7164 env-var save:** immersive Settings → Environment → add or modify a var → **Save Settings**. Button disables after success (no longer stays "dirty").
- [x] **7165 max-payload save:** immersive Settings → Editor → change max HTTP payload size → **Save Settings**. Button disables after success.
- [x] **Non-immersive (no-regression):** repeat #7162-#7165 flows from non-immersive Settings — behavior unchanged from `main`.

</details>

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7163
Resolves https://github.com/FlowFuse/flowfuse/issues/7162
Resolves https://github.com/FlowFuse/flowfuse/issues/7164
Resolves https://github.com/FlowFuse/flowfuse/issues/7165

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

