### PR TITLE
Ensure only Device Palette settings sent when changed

### DIFF
--- a/frontend/src/pages/device/Settings/Palette.vue
+++ b/frontend/src/pages/device/Settings/Palette.vue
@@ -143,6 +143,7 @@ export default {
         },
         save: async function () {
             const settings = await deviceApi.getSettings(this.device.id)
+            delete settings.security
             settings.palette = {
                 catalogues: this.urls,
                 npmrc: this.npmrc ? this.npmrc : undefined


### PR DESCRIPTION
fixes #7166

## Description

<!-- Describe your changes in detail -->
When saving the palette changes the component was requesting the whole settings object and only updating the npmrc file and the catalogues, but this also included the sanitised security settings which includes `pass: true` to show if a password is set, but not it's value (or hashed value). This needed to be removed before it is returned.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#7166 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

