### PR TITLE
[7157] Follow Up: Cannot regenerate remote instance credentials from overview/settings page

### DIFF
--- a/frontend/src/pages/device/Settings/Danger.vue
+++ b/frontend/src/pages/device/Settings/Danger.vue
@@ -1,5 +1,18 @@
 <template>
     <ff-loading v-if="loading.deleting" message="Deleting Device..." />
+    <template v-if="!loading.deleting && device?.lastSeenAt">
+        <FormHeading class="text-red-700">Regenerate Configuration</FormHeading>
+        <div class="flex flex-col lg:flex-row max-w-2xl space-y-4 mb-8" data-el="device-regenerate-config">
+            <div class="flex-grow">
+                <div class="max-w-sm pt-2">
+                    Regenerate the agent configuration for this Remote Instance.
+                </div>
+            </div>
+            <div class="min-w-fit flex-shrink-0">
+                <ff-button kind="danger" @click="showRegenerateDialog()">Regenerate Configuration</ff-button>
+            </div>
+        </div>
+    </template>
     <FormHeading v-if="!loading.deleting" class="text-red-700">Delete Remote Instance</FormHeading>
     <div v-if="!loading.deleting" class="flex flex-col lg:flex-row max-w-2xl space-y-4" data-el="device-danger">
         <div class="flex-grow">
@@ -12,6 +25,7 @@
             <ConfirmDeviceDeleteDialog @delete-device="deleteDevice()" ref="confirmDeviceDeleteDialog" />
         </div>
     </div>
+    <DeviceCredentialsDialog ref="deviceCredentialsDialog" />
 </template>
 <script>
 import { mapState } from 'pinia'
@@ -19,6 +33,7 @@ import { mapState } from 'pinia'
 import deviceApi from '../../../api/devices.js'
 import FormHeading from '../../../components/FormHeading.vue'
 import usePermissions from '../../../composables/Permissions.js'
+import DeviceCredentialsDialog from '../../team/Devices/dialogs/DeviceCredentialsDialog.vue'
 
 import ConfirmDeviceDeleteDialog from './dialogs/ConfirmDeviceDeleteDialog.vue'
 
@@ -31,6 +46,7 @@ export default {
     inheritAttrs: false,
     components: {
         ConfirmDeviceDeleteDialog,
+        DeviceCredentialsDialog,
         FormHeading
     },
     computed: {
@@ -59,6 +75,9 @@ export default {
         },
         showConfirmDeleteDialog () {
             this.$refs.confirmDeviceDeleteDialog.show(this.device)
+        },
+        showRegenerateDialog () {
+            this.$refs.deviceCredentialsDialog.show(this.device)
         },
         deleteDevice () {
             this.loading.deleting = true


### PR DESCRIPTION
## Description

Adds a **Regenerate Configuration** action to a Remote Instance's Settings → Danger tab so users can regenerate credentials without leaving the device. Reuses the existing `DeviceCredentialsDialog`, gated on `device:edit` (Owner), and hidden when the device has never connected (the header's Finish Setup button already covers that). Appears on both the standalone settings page and the immersive editor's settings drawer.

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7157

## Checklist


 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

