### PR TITLE
[7052] Silence rrweb Posthog errors in Sentry 

### DIFF
--- a/frontend/src/services/error-tracking.js
+++ b/frontend/src/services/error-tracking.js
@@ -49,6 +49,11 @@ export const setupSentry = (app, router) => {
         replaysSessionSampleRate: window.sentryConfig.production ? 0.01 : 0.1,
         replaysOnErrorSampleRate: 0.1,
 
+        // PostHog rrweb noise on cross-origin iframe teardown — see #7052
+        ignoreErrors: [
+            /bufferBelongsToIframe/
+        ],
+
         // Skip localhost reporting
         beforeSend: (event) => {
             if (['localhost', '127.0.0.1'].includes(window.location.hostname)) {


### PR DESCRIPTION
## Description

See details [here](https://github.com/FlowFuse/flowfuse/issues/7052#issue-4227233833). 

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7052

## Checklist


 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

