### PR TITLE
Fix flakey admin.spec test 

### DIFF
--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -59,7 +59,6 @@ describe('FlowFuse platform admin users', () => {
         cy.intercept('GET', '/api/*/projects/*').as('getInstance')
         cy.intercept('GET', '/api/*/applications/*').as('getApplication')
         cy.intercept('GET', '/api/*/applications/*/instances').as('getApplicationInstances')
-        cy.intercept('GET', '/api/*/teams/*/applications*').as('getTeamApplications')
 
         cy.visit('/admin/overview')
 
@@ -69,10 +68,17 @@ describe('FlowFuse platform admin users', () => {
         // Not a member of BTeam
         cy.get('[data-el="teams-table"]').contains('BTeam').click()
 
-        cy.get('[data-nav="team-applications"]').click()
-        cy.wait('@getTeamApplications')
-
+        cy.url().should('match', /\/team\/[^/]+/)
         cy.get('[data-el="banner-team-as-admin"]').should('exist')
+
+        // Unique alias to avoid colliding with cy.home()'s getTeamApplications
+        cy.intercept('GET', '/api/*/teams/*/applications*').as('getBTeamApplications')
+
+        cy.get('[data-nav="team-applications"]').should('be.visible').click()
+        cy.url().should('include', '/applications')
+        cy.wait('@getBTeamApplications')
+
+        cy.get('[data-el="applications-list"]').should('be.visible')
 
         cy.get('[data-action="view-application"]').contains('application-2').click()
 


### PR DESCRIPTION
## Description

Fix flaky admin test by using a unique intercept alias (avoiding collision with cy.home()) and waiting for navigation + list render before asserting on rows.

## Related Issue(s)

N/A 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

