### PR TITLE
Allow wss:// connections to MQTT broker in CSP connect-src

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -300,10 +300,11 @@ module.exports = async (options = {}) => {
 
             if (runtimeConfig.broker?.public_url) {
                 const mqttBrokerHost = new URL(runtimeConfig.broker?.public_url).host
+                const mqttBrokerSources = [`wss://${mqttBrokerHost}`, `https://${mqttBrokerHost}`]
                 if (contentSecurityPolicy.directives['connect-src'] && Array.isArray(contentSecurityPolicy.directives['connect-src'])) {
-                    contentSecurityPolicy.directives['connect-src'].push(mqttBrokerHost)
+                    contentSecurityPolicy.directives['connect-src'].push(...mqttBrokerSources)
                 } else {
-                    contentSecurityPolicy.directives['connect-src'] = [mqttBrokerHost]
+                    contentSecurityPolicy.directives['connect-src'] = mqttBrokerSources
                 }
             }
 

--- a/test/unit/forge/configuration/http_security_spec.js
+++ b/test/unit/forge/configuration/http_security_spec.js
@@ -282,7 +282,7 @@ describe('Check HTTP Security Headers set', () => {
             const headers = response.headers
             headers.should.have.property('content-security-policy')
             const csp = response.headers['content-security-policy']
-            csp.split(';').should.containEql('connect-src \'self\' mqtt.example.com')
+            csp.split(';').should.containEql('connect-src \'self\' wss://mqtt.example.com https://mqtt.example.com')
         })
     })
 


### PR DESCRIPTION
## Description

- Browsers were blocking `wss://mqtt.flowfuse.cloud` connections because the broker host was added to `connect-src` without a scheme. Per the CSP spec, a bare host inherits the protected page's scheme (https), so WebSocket upgrades to `wss://` were rejected.
- Explicitly allow both `wss://` and `https://` schemes for the broker host so the MQTT-over-WebSockets client can connect.


## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7206

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

