### PR TITLE
fix: convert expert packages from grid to list layout

### DIFF
--- a/frontend/src/components/expert/components/messages/components/resource-cards/PackageResourceCard.vue
+++ b/frontend/src/components/expert/components/messages/components/resource-cards/PackageResourceCard.vue
@@ -12,15 +12,17 @@
             @error="handleImageError"
         >
         <div class="package-info">
-            <div class="package-name">
-                <streamable-content v-model="streamablePackageName" :should-stream="shouldStream" />
-            </div>
-            <div class="package-url">
-                <streamable-content
-                    v-if="!shouldStream || streamablePackageName.streamed"
-                    v-model="streamablePackageUrl"
-                    :should-stream="shouldStream"
-                />
+            <div class="package-text">
+                <div class="package-name">
+                    <streamable-content v-model="streamablePackageName" :should-stream="shouldStream" />
+                </div>
+                <div class="package-url">
+                    <streamable-content
+                        v-if="!shouldStream || streamablePackageName.streamed"
+                        v-model="streamablePackageUrl"
+                        :should-stream="shouldStream"
+                    />
+                </div>
             </div>
             <div class="package-actions">
                 <template v-if="canManagePalette && !isCorePackage">
@@ -155,7 +157,6 @@ export default {
 
 <style scoped lang="scss">
 .package-card {
-    position: relative;
     display: flex;
     align-items: flex-start;
     gap: 0.5rem;
@@ -186,17 +187,23 @@ export default {
     flex: 1;
     min-width: 0;
     display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
+    align-items: center;
+    gap: 0.5rem;
 }
+
+.package-text {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
 .package-actions {
-    position: absolute;
-    top: 8px;
-    right: 8px;
+    flex-shrink: 0;
 }
 
 .package-name {
-    padding-right: 3rem;
     font-size: 0.875rem;
     font-weight: 500;
     font-family: monospace;

--- a/frontend/src/components/expert/components/messages/components/resources/PackagesList.vue
+++ b/frontend/src/components/expert/components/messages/components/resources/PackagesList.vue
@@ -3,7 +3,7 @@
         <h4 class="section-title">
             <streamable-content v-model="packagesTitle" :should-stream="shouldStream" />
         </h4>
-        <div v-if="!shouldStream || packagesTitle.streamed" class="packages-grid">
+        <div v-if="!shouldStream || packagesTitle.streamed" class="packages-list">
             <PackageResourceCard
                 v-for="(node, index) in visibleItems" :key="index"
                 :nodePackage="node"
@@ -74,9 +74,9 @@ export default {
 }
 
 .guide-packages {
-    .packages-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    .packages-list {
+        display: flex;
+        flex-direction: column;
         gap: 0.5rem;
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the 2-column CSS grid in `PackagesList.vue` with a single-column flex list so packages stack vertically
- Removes the absolutely positioned Install/Manage button in `PackageResourceCard.vue` that was overlaying package names and URLs, making text unreadable
- Wraps package name + URL in a new `.package-text` flex column that grows to fill available space, with the button placed inline at the row's right edge

Closes #7195

### Before
<img width="1054" height="724" alt="image" src="https://github.com/user-attachments/assets/13fa1dfb-ad5d-488b-9fd3-5964cb341033" />

### After
<img width="509" height="243" alt="Screenshot 2026-05-06 at 16 18 08" src="https://github.com/user-attachments/assets/5563561a-64fd-4ddb-919a-43e3ccc4be66" />

## Test plan

- [ ] Open FF Expert and trigger a response with suggested Node packages
- [ ] Verify package names and URLs are fully readable
- [ ] Verify Install/Manage button appears on the right side of each row without overlapping text
- [ ] Verify clicking Install/Manage still works correctly

Closes #7195