### PR TITLE
Convert device logs and performance to use MqttService

### DIFF
--- a/frontend/src/pages/device/components/DeviceLog.vue
+++ b/frontend/src/pages/device/components/DeviceLog.vue
@@ -60,8 +60,15 @@ export default {
             return `ff/v1/${this.device.team.id}/d/${this.device.id}/logs`
         }
     },
-    mounted () {
-        this.connectMQTT()
+    watch: {
+        device: {
+            immediate: true,
+            handler (device) {
+                if (device && device.id) {
+                    this.connectMQTT()
+                }
+            }
+        }
     },
     unmounted () {
         this.disconnectMQTT()
@@ -72,7 +79,7 @@ export default {
         },
         async connectMQTT () {
             const mqttService = this.getMqttService()
-            window.qwe = mqttService
+
             await mqttService.createClient(this.mqttConnectionKey, {
                 getCredentials: () => deviceApi.getDeviceLogCreds(this.device.id),
                 onConnect: async (_connack, client) => {

--- a/frontend/src/pages/device/components/DeviceLog.vue
+++ b/frontend/src/pages/device/components/DeviceLog.vue
@@ -27,7 +27,9 @@
 <script>
 import deviceApi from '../../../api/devices.js'
 
-let mqtt
+import getServicesOrchestrator from '@/services/service.orchestrator'
+
+const HEARTBEAT_INTERVAL = 10000
 
 export default {
     name: 'DeviceLogView',
@@ -43,103 +45,96 @@ export default {
         return {
             loading: true,
             logEntries: [],
-            prevCursor: null,
-            nextCursor: null,
-            keepAliveInterval: null,
-            connection: null,
-            client: null
+            keepAliveInterval: null
         }
     },
     computed: {
         deviceOnline () {
             const offline = ['stopped', 'offline', 'error']
             return !offline.includes(this.device.status)
+        },
+        mqttConnectionKey () {
+            return `device-logs-${this.device.id}`
+        },
+        logTopic () {
+            return `ff/v1/${this.device.team.id}/d/${this.device.id}/logs`
         }
     },
-    async mounted () {
-    // need to subscribe to log stream
-        const { default: mqttImp } = await import('mqtt')
-        mqtt = mqttImp
+    mounted () {
         this.connectMQTT()
     },
     unmounted () {
-        // need to unsubscribe here
-        // const topic = `ff/v1/${this.device.team.id}/d/${this.device.id}/logs`
-        // this.client.publish(`${topic}/heartbeat`, 'leaving')
-        setTimeout(() => this.disconnectMQTT())
-        clearInterval(this.keepAliveInterval)
+        this.disconnectMQTT()
     },
     methods: {
-        connectMQTT: async function () {
-            const creds = await deviceApi.getDeviceLogCreds(this.device.id)
-            this.client = mqtt.connect(creds.url, {
-                username: creds.username,
-                password: creds.password,
-                reconnectPeriod: 0
-            })
+        getMqttService () {
+            return getServicesOrchestrator().$serviceInstances.mqtt
+        },
+        async connectMQTT () {
+            const mqttService = this.getMqttService()
+            window.qwe = mqttService
+            await mqttService.createClient(this.mqttConnectionKey, {
+                getCredentials: () => deviceApi.getDeviceLogCreds(this.device.id),
+                onConnect: async (_connack, client) => {
+                    await mqttService.subscribe(this.mqttConnectionKey, this.logTopic)
+                    this.loading = false
 
-            this.client.on('connect', () => {
-                const topic = `ff/v1/${this.device.team.id}/d/${this.device.id}/logs`
-                this.client.subscribe(topic)
-                this.loading = false
-                this.client.publish(`${topic}/heartbeat`, 'alive')
-                this.keepAliveInterval = setInterval(() => {
-                    this.client.publish(`${topic}/heartbeat`, 'alive')
-                }, 10000)
-                this.$emit('connected')
-            })
-
-            this.client.on('close', () => {
-                // if no broker to connect to, we see this event
-                this.loading = false
-                this.$emit('disconnected')
-            })
-
-            this.client.on('offline', () => {
-                this.client = null
-                this.connectMQTT()
-                this.$emit('disconnected')
-            })
-
-            this.client.on('error', () => {
-                // where to report error?
-                this.$emit('disconnected')
-            })
-
-            this.client.on('message', (topic, message) => {
-                const m = JSON.parse(message)
-                if (!Array.isArray(m)) {
-                    if (!isNaN(m.ts)) {
-                        m.ts = `${m.ts}`
-                    }
-                    const d = new Date(parseInt(m.ts.substring(0, m.ts.length - 4)))
-                    m.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
-                    if (typeof m.msg !== 'string') {
-                        m.msg = JSON.stringify(m.msg)
-                    }
-                    this.logEntries.push(m)
-                } else {
-                    m.forEach((row) => {
-                        if (!isNaN(row.ts)) {
-                            row.ts = `${row.ts}`
-                        }
-                        const d = new Date(
-                            parseInt(row.ts.substring(0, row.ts.length - 4))
-                        )
-                        row.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
-                        if (typeof row.msg !== 'string') {
-                            row.msg = JSON.stringify(row.msg)
-                        }
-                        this.logEntries.push(row)
+                    await mqttService.publishMessage(this.mqttConnectionKey, {
+                        topic: `${this.logTopic}/heartbeat`,
+                        payload: 'alive',
+                        qos: 0,
+                        serialize: 'raw'
                     })
+
+                    clearInterval(this.keepAliveInterval)
+                    this.keepAliveInterval = setInterval(() => {
+                        mqttService.publishMessage(this.mqttConnectionKey, {
+                            topic: `${this.logTopic}/heartbeat`,
+                            payload: 'alive',
+                            qos: 0,
+                            serialize: 'raw'
+                        }).catch(() => {})
+                    }, HEARTBEAT_INTERVAL)
+
+                    this.$emit('connected')
+                },
+                onClose: () => {
+                    this.loading = false
+                    this.$emit('disconnected')
+                },
+                onOffline: () => {
+                    this.$emit('disconnected')
+                },
+                onError: () => {
+                    this.$emit('disconnected')
+                },
+                onMessage: (topic, message) => {
+                    const m = JSON.parse(message)
+                    if (!Array.isArray(m)) {
+                        this.processLogEntry(m)
+                    } else {
+                        m.forEach((row) => this.processLogEntry(row))
+                    }
                 }
             })
         },
-        disconnectMQTT: async function () {
-            if (this.client?.connected) {
-                this.client.end()
+        processLogEntry (entry) {
+            if (!isNaN(entry.ts)) {
+                entry.ts = `${entry.ts}`
             }
-            this.client = null
+            const d = new Date(parseInt(entry.ts.substring(0, entry.ts.length - 4)))
+            entry.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
+            if (typeof entry.msg !== 'string') {
+                entry.msg = JSON.stringify(entry.msg)
+            }
+            this.logEntries.push(entry)
+        },
+        async disconnectMQTT () {
+            clearInterval(this.keepAliveInterval)
+            const mqttService = this.getMqttService()
+            if (mqttService.hasClient(this.mqttConnectionKey)) {
+                await mqttService.destroyClient(this.mqttConnectionKey)
+            }
         }
     }
 }

--- a/frontend/src/pages/device/components/DevicePerformance.vue
+++ b/frontend/src/pages/device/components/DevicePerformance.vue
@@ -74,10 +74,11 @@ import MemoryChart from '../../../components/charts/performance/MemoryChart.vue'
 import InformationWell from '../../../components/wells/InformationWell.vue'
 import usePermissions from '../../../composables/Permissions.js'
 
+import getServicesOrchestrator from '@/services/service.orchestrator'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useContextStore } from '@/stores/context.js'
 
-let mqtt
+const HEARTBEAT_INTERVAL = 10000
 
 export default {
     name: 'DevicePerformanceView',
@@ -110,9 +111,7 @@ export default {
         return {
             loading: true,
             resources: [],
-            keepAliveInterval: null,
-            connection: null,
-            client: null
+            keepAliveInterval: null
         }
     },
     computed: {
@@ -129,58 +128,67 @@ export default {
             return this.featuresCheck.isInstanceResourcesFeatureEnabledForPlatform &&
                 this.featuresCheck.isInstanceResourcesFeatureEnabledForTeam &&
                 this.agentSatisfiesVersion && this.deviceOnline
+        },
+        mqttConnectionKey () {
+            return `device-resources-${this.device.id}`
+        },
+        resourcesTopic () {
+            return `ff/v1/${this.device.team.id}/d/${this.device.id}/resources`
         }
     },
-    async mounted () {
-        // need to subscribe to resources stream
-        const { default: mqttImp } = await import('mqtt')
-        mqtt = mqttImp
+    mounted () {
         if (this.featureAvailable) {
             this.connectMQTT()
         }
     },
     unmounted () {
-        // need to unsubscribe here
-        setTimeout(() => this.disconnectMQTT())
-        clearInterval(this.keepAliveInterval)
+        this.disconnectMQTT()
     },
     methods: {
-        connectMQTT: async function () {
-            const creds = await deviceApi.getDeviceResourcesCreds(this.device.id)
-            this.client = mqtt.connect(creds.url, {
-                username: creds.username,
-                password: creds.password,
-                reconnectPeriod: 0
-            })
-
-            this.client.on('connect', () => {
-                const topic = `ff/v1/${this.device.team.id}/d/${this.device.id}/resources`
-                this.client.subscribe(topic)
-                this.loading = false
-                this.client.publish(`${topic}/heartbeat`, 'alive')
-                this.keepAliveInterval = setInterval(() => {
-                    this.client.publish(`${topic}/heartbeat`, 'alive')
-                }, 10000)
-            })
-
-            this.client.on('message', (topic, message) => {
-                const resourceData = JSON.parse(message.toString())
-                if (Array.isArray(resourceData)) {
-                    this.resources = resourceData
-                } else {
-                    this.resources.push(resourceData)
-                }
-            })
-
-            this.keepAliveInterval = setInterval(() => {
-                if (this.client && this.client.connected) {
-                    this.client.publish(`ff/v1/${this.device.team.id}/d/${this.device.id}/resources/heartbeat`, 'alive')
-                }
-            }, 30000)
+        getMqttService () {
+            return getServicesOrchestrator().$serviceInstances.mqtt
         },
-        disconnectMQTT: function () {
-            if (this.client) {
-                this.client.end()
+        async connectMQTT () {
+            const mqttService = this.getMqttService()
+
+            await mqttService.createClient(this.mqttConnectionKey, {
+                getCredentials: () => deviceApi.getDeviceResourcesCreds(this.device.id),
+                onConnect: async () => {
+                    await mqttService.subscribe(this.mqttConnectionKey, this.resourcesTopic)
+                    this.loading = false
+
+                    await mqttService.publishMessage(this.mqttConnectionKey, {
+                        topic: `${this.resourcesTopic}/heartbeat`,
+                        payload: 'alive',
+                        qos: 0,
+                        serialize: 'raw'
+                    })
+
+                    clearInterval(this.keepAliveInterval)
+                    this.keepAliveInterval = setInterval(() => {
+                        mqttService.publishMessage(this.mqttConnectionKey, {
+                            topic: `${this.resourcesTopic}/heartbeat`,
+                            payload: 'alive',
+                            qos: 0,
+                            serialize: 'raw'
+                        }).catch(() => {})
+                    }, HEARTBEAT_INTERVAL)
+                },
+                onMessage: (topic, message) => {
+                    const resourceData = JSON.parse(message.toString())
+                    if (Array.isArray(resourceData)) {
+                        this.resources = resourceData
+                    } else {
+                        this.resources.push(resourceData)
+                    }
+                }
+            })
+        },
+        async disconnectMQTT () {
+            clearInterval(this.keepAliveInterval)
+            const mqttService = this.getMqttService()
+            if (mqttService.hasClient(this.mqttConnectionKey)) {
+                await mqttService.destroyClient(this.mqttConnectionKey)
             }
         }
     }

--- a/frontend/src/pages/device/components/DevicePerformance.vue
+++ b/frontend/src/pages/device/components/DevicePerformance.vue
@@ -136,9 +136,14 @@ export default {
             return `ff/v1/${this.device.team.id}/d/${this.device.id}/resources`
         }
     },
-    mounted () {
-        if (this.featureAvailable) {
-            this.connectMQTT()
+    watch: {
+        device: {
+            immediate: true,
+            handler (device) {
+                if (this.featureAvailable && device && device.id) {
+                    this.connectMQTT()
+                }
+            }
         }
     },
     unmounted () {


### PR DESCRIPTION
## Description

- Refactored DeviceLog.vue and DevicePerformance.vue to use the centralized MqttService via the service orchestrator instead of managing raw MQTT connections directly
- Removes direct dependency on the mqtt npm module from device components, gaining automatic reconnection with exponential backoff, subscription replay, and credential refresh
  on reconnect

## how to test

- Navigate to a device's Logs tab — verify live logs stream in and the connection status indicator works
- Navigate to a device's Performance tab — verify CPU and Memory charts populate with data
- Simulate a broker disconnect (e.g. toggle network) — verify reconnection happens automatically and data resumes
- Navigate away from the logs/performance pages — verify no console errors from stale MQTT clients

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/6963

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

