### PR TITLE
fix: add ellipsis and tooltip for truncated expert package names and resource titles

### DIFF
--- a/frontend/src/components/expert/components/messages/components/resource-cards/PackageResourceCard.vue
+++ b/frontend/src/components/expert/components/messages/components/resource-cards/PackageResourceCard.vue
@@ -13,7 +13,7 @@
         >
         <div class="package-info">
             <div class="package-text">
-                <div class="package-name">
+                <div class="package-name" :title="packageName">
                     <streamable-content v-model="streamablePackageName" :should-stream="shouldStream" />
                 </div>
                 <div class="package-url">
@@ -211,6 +211,12 @@ export default {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    :deep(.streamable-content) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 }
 
 .package-url {

--- a/frontend/src/components/expert/components/messages/components/resource-cards/PackageResourceCard.vue
+++ b/frontend/src/components/expert/components/messages/components/resource-cards/PackageResourceCard.vue
@@ -226,5 +226,11 @@ export default {
     text-overflow: ellipsis;
     white-space: nowrap;
     margin: 0;
+
+    :deep(.streamable-content) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 }
 </style>

--- a/frontend/src/components/expert/components/messages/components/resource-cards/StandardResourceCard.vue
+++ b/frontend/src/components/expert/components/messages/components/resource-cards/StandardResourceCard.vue
@@ -13,7 +13,7 @@
             @error="handleImageError"
         >
         <div class="resource-info">
-            <div class="resource-title">
+            <div class="resource-title" :title="resourceTitle.streamable">
                 <streamable-content v-model="resourceTitle" :should-stream="shouldStream" />
             </div>
             <div v-if="!shouldStream || resourceTitle.streamed" class="resource-url">
@@ -134,6 +134,12 @@ export default {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    :deep(.streamable-content) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 }
 
 .resource-url {
@@ -143,5 +149,11 @@ export default {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    :deep(.streamable-content) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 }
 </style>


### PR DESCRIPTION
## Summary

**Package names** (`PackageResourceCard.vue`):
- `.package-name` had `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;` but the inner `.streamable-content` div had no overflow constraints, so truncation never triggered. Fixed by adding `:deep(.streamable-content)` with the same rules.
- Added `:title="packageName"` so hovering shows the full name when truncated.

**Resource titles** (`StandardResourceCard.vue`):
- Same issue on `.resource-title` and `.resource-url`. Fixed with the same `:deep(.streamable-content)` approach.
- Added `:title="resourceTitle.streamable"` on `.resource-title`.

<img width="590" height="836" alt="image" src="https://github.com/user-attachments/assets/b2f6eb6d-c52e-4df4-96a5-32da513e35bb" />


## Test plan

- [ ] Open FF Expert and trigger a response with suggested Node packages and Related Resources
- [ ] Narrow the expert panel until names/titles would overflow — verify ellipsis appears on both
- [ ] Hover a truncated package name and resource title — verify tooltips show the full text
- [ ] Wide panel: verify nothing is truncated and text displays normally

Closes #7212
Closes #7214