### PR TITLE
Add conditional check for `agentMode` before calling insights agent method

### DIFF
--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -138,7 +138,9 @@ export const useProductExpertStore = defineStore('product-expert', {
                 return router.push({ name: expertRouteName, params: contextStore.route.params })
             }
 
-            useProductExpertInsightsAgentStore().getCapabilities()
+            if (this.agentMode === INSIGHTS_AGENT) {
+                useProductExpertInsightsAgentStore().getCapabilities()
+            }
             // Lazy import to avoid circular dep: product-expert.js → ExpertDrawer.vue → product-expert.js
             return import('../components/drawers/expert/ExpertDrawer.vue')
                 .then(({ default: ExpertDrawer }) => useUxDrawersStore().openRightDrawer({


### PR DESCRIPTION
## Description

this pr gates the features call when opening the expert drawer if the user is not in insights mode.

this PR barely adds a safety check for the logout loop and does not fix the underlying problem which will need more attention

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7221

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

