### PR TITLE
Replace `message-bubble` content with `streamable-content` component in `HumanMessage`

### DIFF
--- a/frontend/src/components/expert/components/messages/HumanMessage.vue
+++ b/frontend/src/components/expert/components/messages/HumanMessage.vue
@@ -1,15 +1,17 @@
 <template>
     <message-bubble type="human">
-        {{ content }}
+        <streamable-content :string="content" :rich-content="true" :should-stream="false" />
     </message-bubble>
 </template>
 
 <script>
 import MessageBubble from './components/MessageBubble.vue'
 
+import StreamableContent from '@/components/expert/components/messages/components/resources/StreamableContent.vue'
+
 export default {
     name: 'HumanMessage',
-    components: { MessageBubble },
+    components: { StreamableContent, MessageBubble },
     props: {
         content: {
             required: true,


### PR DESCRIPTION
## Description

This change allows the rendering of user messages as markdown to ease reading of own long messages which may have been copy pasted.

xss injection tested, it does not render or execute the code and the agent provides a nice reply.

## Related Issue(s)

n/a

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

