### PR TITLE
Ensure auto updating stacks jump to latest version

### DIFF
--- a/forge/db/models/ProjectStack.js
+++ b/forge/db/models/ProjectStack.js
@@ -108,6 +108,13 @@ module.exports = {
             instance: {
                 projectCount: async function () {
                     return await M.Project.count({ where: { ProjectStackId: this.id } })
+                },
+                findLatestStack: async function () {
+                    if (this.replacedBy) {
+                        return (await M.ProjectStack.byId(this.replacedBy)).findLatestStack()
+                    } else {
+                        return this
+                    }
                 }
             }
         }

--- a/forge/ee/lib/autoUpdateStacks/tasks/upgrade-stack.js
+++ b/forge/ee/lib/autoUpdateStacks/tasks/upgrade-stack.js
@@ -25,7 +25,7 @@ module.exports = {
                         if (project.Project.ProjectStack.replacedBy) {
                             // need to add audit logging
                             try {
-                                const newStack = await app.db.models.ProjectStack.byId(project.Project.ProjectStack.replacedBy)
+                                const newStack = await project.Project.ProjectStack.findLatestStack()
                                 app.log.info(`Updating project ${project.Project.id} to stack: '${newStack.hashid}'`)
 
                                 const suspendOptions = {
@@ -46,6 +46,7 @@ module.exports = {
                                 // Space out restarts a little to not overwhelm k8s api
                                 await delay(2000)
                             } catch (err) {
+                                console.log(err)
                                 app.log.info(`Problem updating project ${project.Project.id} - ${err.toString()}`)
                             }
                         } else if (project.value.restart) {

--- a/forge/ee/lib/autoUpdateStacks/tasks/upgrade-stack.js
+++ b/forge/ee/lib/autoUpdateStacks/tasks/upgrade-stack.js
@@ -46,7 +46,6 @@ module.exports = {
                                 // Space out restarts a little to not overwhelm k8s api
                                 await delay(2000)
                             } catch (err) {
-                                console.log(err)
                                 app.log.info(`Problem updating project ${project.Project.id} - ${err.toString()}`)
                             }
                         } else if (project.value.restart) {


### PR DESCRIPTION
fixes #6873

## Description

<!-- Describe your changes in detail -->

This checks to find end of the chain of replacement stacks when auto stack upgrade happens to skip steps between. This prevents unneeded restarts on subsquent maintenance windows.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#6873

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

