### PR TITLE
fix: resolve eslint indentation and attribute-order warnings

### DIFF
--- a/frontend/src/components/dialogs/SnapshotDiffChangePanel.vue
+++ b/frontend/src/components/dialogs/SnapshotDiffChangePanel.vue
@@ -68,29 +68,29 @@
             <div v-show="!collapsed" class="font-mono">
                 <div class="diff-scroll-container" :class="{ 'diff-wrap': wrapped }">
                     <div class="diff-content">
-                    <template v-for="(line, i) in lines" :key="i">
-                        <!-- Collapsed unchanged section -->
-                        <div
-                            v-if="line.type === 'collapsed'"
-                            class="flex leading-5 text-blue-600 bg-blue-50 cursor-pointer hover:bg-blue-100 select-none border-y border-blue-100"
-                            @click="expandSection(i)"
-                        >
-                            <span class="line-num border-r border-blue-200 text-blue-400" />
-                            <span class="line-num border-r border-blue-200 text-blue-400" />
-                            <span class="px-3 flex-1 text-center">&#8597; {{ line.count }} unchanged line{{ line.count === 1 ? '' : 's' }}</span>
-                        </div>
-                        <!-- Diff line -->
-                        <div
-                            v-else
-                            :class="lineClass(line)"
-                            :data-change="line.type !== 'unchanged' || undefined"
-                            class="flex leading-5"
-                        >
-                            <span class="line-num border-r select-none shrink-0" :class="lineNumClass(line)">{{ line.oldNum || '' }}</span>
-                            <span class="line-num border-r select-none shrink-0" :class="lineNumClass(line)">{{ line.newNum || '' }}</span>
-                            <span class="px-2" :class="wrapped ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'">{{ linePrefix(line) }}{{ line.text }}</span>
-                        </div>
-                    </template>
+                        <template v-for="(line, i) in lines" :key="i">
+                            <!-- Collapsed unchanged section -->
+                            <div
+                                v-if="line.type === 'collapsed'"
+                                class="flex leading-5 text-blue-600 bg-blue-50 cursor-pointer hover:bg-blue-100 select-none border-y border-blue-100"
+                                @click="expandSection(i)"
+                            >
+                                <span class="line-num border-r border-blue-200 text-blue-400" />
+                                <span class="line-num border-r border-blue-200 text-blue-400" />
+                                <span class="px-3 flex-1 text-center">&#8597; {{ line.count }} unchanged line{{ line.count === 1 ? '' : 's' }}</span>
+                            </div>
+                            <!-- Diff line -->
+                            <div
+                                v-else
+                                :class="lineClass(line)"
+                                :data-change="line.type !== 'unchanged' || undefined"
+                                class="flex leading-5"
+                            >
+                                <span class="line-num border-r select-none shrink-0" :class="lineNumClass(line)">{{ line.oldNum || '' }}</span>
+                                <span class="line-num border-r select-none shrink-0" :class="lineNumClass(line)">{{ line.newNum || '' }}</span>
+                                <span class="px-2" :class="wrapped ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'">{{ linePrefix(line) }}{{ line.text }}</span>
+                            </div>
+                        </template>
                     </div>
                 </div>
             </div>

--- a/frontend/src/ui-components/components/kebab-menu/KebabItem.vue
+++ b/frontend/src/ui-components/components/kebab-menu/KebabItem.vue
@@ -5,7 +5,7 @@
             :class="{[className]: kind.length, active, disabled: disabled}"
             :data-el="'kebab-item-' + slugify(label)"
         >
-            <component v-if="icon" :is="icon" class="ff-icon" />
+            <component :is="icon" v-if="icon" class="ff-icon" />
             <label>{{ label }}</label>
         </li>
     </MenuItem>


### PR DESCRIPTION
## Summary

- Fixes 23 `vue/html-indent` warnings in `SnapshotDiffChangePanel.vue`
- Fixes 1 `vue/attributes-order` warning in `KebabItem.vue`

Closes #7229

## Test plan

- [x] Run `npm run lint` — should report no warnings