### PR TITLE
ci: Build pre-staging environments on node 24 container

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 
 RUN apk add --no-cache --virtual build-base g++ make py3-pip sqlite-dev python3
 
@@ -16,7 +16,7 @@ RUN npm install --no-audit --no-fund pg-hstore@^2.3.4 && \
     npm run build
 
 
-FROM node:20-alpine
+FROM node:24-alpine
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
## Description

This pull request bumps the `node` container image tag for pre-staging environments to `24-alpine`.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/6951

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

