### PR TITLE
Added a missing keycloack SSO setup required step

### DIFF
--- a/docs/admin/sso/saml.md
+++ b/docs/admin/sso/saml.md
@@ -359,6 +359,7 @@ In Keycloak and the Realm setup with FlowFuse as a client:
  - "Add mapper" and pick "By configuration"
  - Select "Group list" from the options
  - Give it a name and set "Group attribute name" to `ff-roles` (this must match the value configured in FlowFuse, default 'ff-roles')
+ - Enable 'Single Group Attribute'
  - Ensure that "Full group path" is unchecked
  - Save and return to the "Clients" list and select your FlowFuse Client created earlier
  - Under "Client scopes", use the "Add client scope" button to add the new scope


### PR DESCRIPTION
## Description

For this to work, the user needs to set 'Single Group Attribute' to On. This wasn't included in the instructions.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

