### PR TITLE
Allow valid npm package names to be deployed via pipelines

### DIFF
--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -1,3 +1,5 @@
+const validate = require('validate-npm-package-name')
+
 const { BUILT_IN_MODULES } = require('../../lib/builtInModules')
 const { templateFields, defaultTemplateValues, defaultTemplatePolicy } = require('../../lib/templates')
 const { hash, mapEnvArrayToObject } = require('../utils')
@@ -100,9 +102,9 @@ module.exports = {
             const validateModuleName = (name) => {
                 if (name.startsWith('@flowfuse-')) {
                     // Team Library private NPM packages
-                    return /^@flowfuse-[a-zA-Z0-9-._~]*\/[a-z0-9-~][a-z0-9-._~]*$/.test(name)
+                    return validate(name).validForOldPackages
                 } else {
-                    return !BUILT_IN_MODULES.includes(name) && /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name)
+                    return !BUILT_IN_MODULES.includes(name) && validate(name).validForOldPackages
                 }
             }
             const validateModuleVersion = (version) => /^\*$|x|(?:[\^~]?(0|[1-9]\d*)\.(x$|0|[1-9]\d*)(?:\.(x$|0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?)$/.test(version)

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,11 +1,11 @@
-import axios from 'axios'
+import { create as createClient } from 'axios'
 
 import Alerts from '../services/alerts.js'
 
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useUxLoadingStore } from '@/stores/ux-loading.js'
 
-const client = axios.create({
+const client = createClient({
     headers: {
         'Content-Type': 'application/json'
     },

--- a/frontend/src/pages/admin/Template/sections/PaletteModules.vue
+++ b/frontend/src/pages/admin/Template/sections/PaletteModules.vue
@@ -149,6 +149,7 @@
 <script>
 
 import { CheckIcon, LockClosedIcon, PencilIcon, PlusSmIcon, TrashIcon, XIcon } from '@heroicons/vue/outline'
+import validate from 'validate-npm-package-name'
 
 import { BUILT_IN_MODULES } from '../../../../../../forge/lib/builtInModules.js'
 
@@ -275,9 +276,9 @@ export default {
     methods: {
         validateModuleName (name) {
             if (name.startsWith('@flowfuse-')) {
-                return /^@flowfuse-[a-zA-Z0-9-._~]*\/[a-z0-9-~][a-z0-9-._~]*$/.test(name)
+                return validate(name).validForOldPackages
             } else {
-                return /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name) && !BUILT_IN_MODULES.includes(name)
+                return validate(name).validForOldPackages && !BUILT_IN_MODULES.includes(name)
             }
         },
         validateModuleVersion (version) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
                 "stripe": "^8.222.0",
                 "tar-stream": "^3.1.7",
                 "uuid": "^14.0.0",
+                "validate-npm-package-name": "^7.0.2",
                 "vue": "^3.4.5",
                 "vue-echarts": "^7.0.3",
                 "vue-router": "^4.2.5",
@@ -26813,6 +26814,15 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
+        "node_modules/validate-npm-package-name": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/validator": {
             "version": "13.15.23",
             "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
@@ -46485,6 +46495,11 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "validate-npm-package-name": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="
         },
         "validator": {
             "version": "13.15.23",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
         "stripe": "^8.222.0",
         "tar-stream": "^3.1.7",
         "uuid": "^14.0.0",
+        "validate-npm-package-name": "^7.0.2",
         "vue": "^3.4.5",
         "vue-echarts": "^7.0.3",
         "vue-router": "^4.2.5",


### PR DESCRIPTION
Fixes #7293

## Description

<!-- Describe your changes in detail -->
Moves to use npm's validate-npm-package-name package rather than custom regex.

Have to use `validForOldPackages` value in returned object

Also fixed a lint warning about axios package.

## Related Issue(s)
 #7293

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

