### PR TITLE
Adjust tab option margins for consistent spacing in ff-components

### DIFF
--- a/frontend/src/ui-components/stylesheets/ff-components.scss
+++ b/frontend/src/ui-components/stylesheets/ff-components.scss
@@ -1191,9 +1191,11 @@ $countdown_size: 20px;
     flex-direction: row;
     .ff-tab-option {
       margin-right: $ff-unit-md;
+      margin-bottom: $ff-unit-xs;
       &.router-link-active,
       &.ff-tab-option--active {
         border-bottom: $ff-unit-xs solid $ff-blue-700;
+        margin-bottom: 0;
       }
     }
   }


### PR DESCRIPTION
## Description

- Adds margin-bottom to inactive horizontal tab options that matches the active tab's border-bottom width, then removes the margin when the tab becomes active keeping the total height of the tab bar constant
- Scoped to .ff-tabs--horizontal only so vertical tabs are unaffected

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7300

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

