### PR TITLE
Fix dev/prod CSS loader inconsistencies causing cascade ordering mismatches

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -26,8 +26,8 @@ module.exports = function (env, argv) {
         output: {
             path: getPath('frontend/dist/app'),
             publicPath: '/app/',
-            assetModuleFilename: './assets/[hash][ext][query]',
-            filename: '[name].[contenthash].js',
+            assetModuleFilename: devMode ? './assets/[name][ext]' : './assets/[hash][ext][query]',
+            filename: devMode ? '[name].js' : '[name].[contenthash].js',
             clean: true
         },
         module: {
@@ -58,10 +58,7 @@ module.exports = function (env, argv) {
                     test: /\.css$/i,
                     include: getPath('frontend/src'),
                     use: [
-                        {
-                            loader: devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
-                            options: {}
-                        },
+                        MiniCssExtractPlugin.loader,
                         {
                             loader: 'css-loader',
                             options: { importLoaders: 1 }
@@ -75,23 +72,22 @@ module.exports = function (env, argv) {
                             }
                         }
                     ]
-                }, {
+                },
+                {
                     test: /\.css$/i,
                     exclude: getPath('frontend/src'),
                     use: [
-                        {
-                            loader: 'style-loader',
-                            options: {}
-                        },
+                        MiniCssExtractPlugin.loader,
                         {
                             loader: 'css-loader',
                             options: { importLoaders: 1 }
                         }
                     ]
-                }, {
+                },
+                {
                     test: /\.scss$/,
                     use: [
-                        devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
+                        MiniCssExtractPlugin.loader,
                         {
                             loader: 'css-loader',
                             options: { import: true, url: true }
@@ -102,7 +98,6 @@ module.exports = function (env, argv) {
                                 additionalData: '@use "@/ui-components/stylesheets/ff-colors.scss" as *;@use "@/ui-components/stylesheets/ff-utility.scss" as *;'
                             }
                         }
-
                     ]
                 },
                 {
@@ -135,9 +130,7 @@ module.exports = function (env, argv) {
                 filename: getPath('frontend/dist-setup/setup.html'),
                 chunks: ['setup']
             }),
-            new MiniCssExtractPlugin({
-                filename: '[name].[contenthash].css'
-            }),
+            new MiniCssExtractPlugin({ filename: devMode ? '[name].css' : '[name].[contenthash].css' }),
             new CopyPlugin({
                 patterns: [
                     { from: getPath('frontend/public'), to: '..' }
@@ -177,7 +170,8 @@ module.exports = function (env, argv) {
             historyApiFallback: true
         },
         watchOptions: {
-            poll: 1000
+            poll: 1000,
+            ignored: [getPath('frontend/dist/**'), '**/node_modules/**']
         },
         resolve: {
             extensions: ['.ts', '.js', '.vue', '.json'],

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -66,6 +66,7 @@ module.exports = function (env, argv) {
                         {
                             loader: 'postcss-loader',
                             options: {
+                                sourceMap: false,
                                 postcssOptions: {
                                     config: path.resolve(__dirname, 'postcss.config.js')
                                 }
@@ -77,15 +78,16 @@ module.exports = function (env, argv) {
                     test: /\.css$/i,
                     exclude: getPath('frontend/src'),
                     use: [
-                        MiniCssExtractPlugin.loader,
+                        devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
                         {
                             loader: 'css-loader',
-                            options: { importLoaders: 1 }
+                            options: { importLoaders: 1, sourceMap: false }
                         }
                     ]
                 },
                 {
                     test: /\.scss$/,
+                    exclude: /node_modules/,
                     use: [
                         MiniCssExtractPlugin.loader,
                         {
@@ -97,6 +99,20 @@ module.exports = function (env, argv) {
                             options: {
                                 additionalData: '@use "@/ui-components/stylesheets/ff-colors.scss" as *;@use "@/ui-components/stylesheets/ff-utility.scss" as *;'
                             }
+                        }
+                    ]
+                },
+                {
+                    test: /\.scss$/,
+                    include: /node_modules/,
+                    use: [
+                        devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
+                        {
+                            loader: 'css-loader',
+                            options: { import: true, url: true }
+                        },
+                        {
+                            loader: 'sass-loader'
                         }
                     ]
                 },


### PR DESCRIPTION
## Description

  - Replaced all `style-loader` usage with `MiniCssExtractPlugin.loader` across all CSS/SCSS rules, ensuring identical CSS cascade and `@layer` ordering between development and production builds
  - Added dev-mode–friendly output filenames (`[name].js`, `[name].css`, `[name][ext]`) so developers can still identify assets by name without content hashes
  - Added `watchOptions.ignored` for `frontend/dist/**` and `node_modules/**` to prevent recompile cycles from `writeToDisk: true`

### Note
Vendor CSS/SCSS (node_modules) keeps style-loader in dev because of a source map problem with MiniCssExtractPlugin. When all CSS goes through MiniCssExtractPlugin, it generates a single combined CSS source map covering every module that contributed to the output. Packages like @vuepic/vue-datepicker ship  dist/main.css with a /*# sourceMappingURL=main.css.map */ reference — and that .map file points back to .scss source files that aren't even included in the published package. Those phantom paths end up in the combined source map as webpack:// URLs that browser DevTools can't resolve, producing errors on every page load and whenever a developer inspects styles.                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
Using style-loader for vendor CSS in dev keeps it out of the extracted CSS file entirely — the styles are injected as <style> tags via JS, so they never pollute the MiniCssExtractPlugin source map.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7303

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

