### PR TITLE
Add section on private CA to k8s install instructions

### DIFF
--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -218,6 +218,19 @@ ingress:
 
 Apply changes with [platform startup command](#start-flowfuse-platform).
 
+#### Using Internal/Private Certificate Authorities
+
+If you are issuing your own HTTPS certificates (rather than using a Public Certificate Authority) you will need to tell the Hosted Node-RED Instances to trust this CA. To do this you need to pass base64 encoded CA certificate chain to the helm chart in the `customization.yml`. Details are in the Helm chart [README.md](https://github.com/FlowFuse/helm/blob/main/helm/flowfuse/README.md#private-certificate-authority).
+
+```yaml
+forge:
+  privateCA:
+    certs: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk...
+```
+
+Assuming the certificate chain is held in `chain.pem` the value would be created by running `base64 -w 0 certs.pem`
+
+
 ### I use Kubernetes Network Policies, how can I configure them?
 
 If your cluster uses Network Policies to restrict traffic between namespaces, you'll need to create appropriate policies.


### PR DESCRIPTION
fixes #7237

## Description

<!-- Describe your changes in detail -->
Add k8s instruction to use private CA

## Related Issue(s)

<!-- What issue does this PR relate to? -->
 #7237


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

