### PR TITLE
docs: update Cloud free trial length from 14 to 30 days

### DIFF
--- a/docs/cloud/introduction.md
+++ b/docs/cloud/introduction.md
@@ -20,16 +20,16 @@ meta:
 FlowFuse Cloud is a hosted service allowing users to sign-up and start creating Node-RED instances without having to install and manage their own instance of FlowFuse.
 The [Concepts](/docs/user/concepts.md) remain the same, but we run the platform for you.
 
-## 14-day Free Trial
+## 30-day Free Trial
 
-When users sign-up to FlowFuse Cloud they get a 14-day free trial of the platform.
+When users sign-up to FlowFuse Cloud they get a 30-day free trial of the platform.
 This is a great way to start using FlowFuse and discover a lot of the value it provides.
 
 Users can end their trial by heading to the Billing page of their team and 
 setting up their payment information. This includes the option to pick which
 plan you want to upgrade the team to.
 
-Otherwise, at the end of the 14-day trial period, any instances created in the team
+Otherwise, at the end of the 30-day trial period, any instances created in the team
 will be suspended. This means they will no longer be running and the
 editor will not be accessible. Users will need to add their Billing details at which
 point they will be able to restart their suspended Node-RED instances.


### PR DESCRIPTION
fixes: https://github.com/FlowFuse/product/issues/345

## Description

Updates the FlowFuse Cloud free-trial documentation in `docs/cloud/introduction.md` from 14 days to 30 days, reflecting the extension of the trial period. Three references updated: the section heading, the sign-up sentence, and the trial-expiry sentence.

This is the canonical source for the trial-length copy that the website pulls in at build time.