### PR TITLE
Handle duplicate expert messages

### DIFF
--- a/forge/ee/lib/expert/emxq-bridge/templates.js
+++ b/forge/ee/lib/expert/emxq-bridge/templates.js
@@ -90,7 +90,7 @@ const ruleIn = {
                 retain: false,
                 payload: '${payload}', // eslint-disable-line no-template-curly-in-string
                 topic: '${topic}', // eslint-disable-line no-template-curly-in-string
-                qos: 1,
+                qos: 2,
                 direct_dispatch: false,
                 mqtt_properties: {
                     'Correlation-Data': '${correlation_data}', // eslint-disable-line no-template-curly-in-string

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -30,7 +30,8 @@ export const useProductExpertStore = defineStore('product-expert', {
         agentMode: SUPPORT_AGENT, // support-agent or insights-agent
         loadingVariant: SUPPORT_AGENT,
         shouldWakeUpAssistant: false,
-        inFlightUpdates: []
+        inFlightUpdates: [],
+        _seenTransactionIds: new Map()
     }),
     getters: {
         _agentStore () {
@@ -596,14 +597,27 @@ export const useProductExpertStore = defineStore('product-expert', {
             const sessionId = packet.properties?.userProperties?.sessionId // chat session
             const chatTransactionId = packet.properties?.userProperties?.transactionId // passed through for integrity
 
+            // Drop duplicates (QoS 1 retries, bridge re-fires, redundant resubscribes).
+            // Must run synchronously before any await so a second delivery can't race past the check.
+            if (transactionId) {
+                if (this._seenTransactionIds.has(transactionId)) {
+                    console.warn(`Duplicate MQTT message received and ignored (transactionId: ${transactionId})`)
+                    return // already processed this message
+                }
+                this._seenTransactionIds.set(transactionId, true)
+                if (this._seenTransactionIds.size > 200) {
+                    this._seenTransactionIds.delete(this._seenTransactionIds.keys().next().value)
+                }
+            }
+
             switch (true) {
-            case parsedTopic.isReply:
+            case parsedTopic.isReply: // final chat response
                 // remove inFlight request because it is now resolved
                 this._inFlightRequests.delete(transactionId)
                 // handle the response
                 await this.handleMessageResponse(JSON.parse(message.toString()))
                 break
-            case parsedTopic.isInflightRequest:
+            case parsedTopic.isInflightRequest: // in-flight request from the agent (e.g., action invocation, status update)
                 await this.handleInFlightRequest({
                     topic,
                     message,

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -601,7 +601,6 @@ export const useProductExpertStore = defineStore('product-expert', {
             // Must run synchronously before any await so a second delivery can't race past the check.
             if (transactionId) {
                 if (this._seenTransactionIds.has(transactionId)) {
-                    console.warn(`Duplicate MQTT message received and ignored (transactionId: ${transactionId})`)
                     return // already processed this message
                 }
                 this._seenTransactionIds.set(transactionId, true)


### PR DESCRIPTION
## Description

This pull request introduces improvements to message handling reliability and deduplication in the product expert chat system. The main changes include increasing the MQTT Quality of Service (QoS) level for message delivery and implementing logic to detect and ignore duplicate messages based on transaction IDs.

**Reliability and Deduplication Improvements:**

* Increased the MQTT `qos` level from 1 to 2 in the `ruleIn` template, ensuring exactly-once message delivery for chat payloads.
* Added a `_seenTransactionIds` map to the product expert store in `frontend/src/stores/product-expert.js` to track processed transaction IDs and prevent duplicate message processing.
* Implemented logic to drop duplicate MQTT messages by checking the transaction ID before processing.

These changes collectively help ensure that chat messages are processed exactly once, improving the reliability of the chat experience for users.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

