### PR TITLE
Fix: Add type: 'object' to schema roots with required to silence AJV strictTypes warning on startup

### DIFF
--- a/forge/ee/routes/flowBlueprints/index.js
+++ b/forge/ee/routes/flowBlueprints/index.js
@@ -126,6 +126,7 @@ module.exports = async function (app) {
             summary: 'Create a flow blueprint - admin-only',
             tags: ['Flow Blueprints'],
             body: {
+                type: 'object',
                 allOf: [{ $ref: 'FlowBlueprintInput' }],
                 required: ['name']
             },

--- a/forge/ee/routes/teamBroker/index.js
+++ b/forge/ee/routes/teamBroker/index.js
@@ -406,6 +406,7 @@ module.exports = async function (app) {
                 oneOf: [
                     // Case 1: ownerType and ownerId are obtained from the token
                     {
+                        type: 'object',
                         required: ['password'],
                         properties: {
                             password: { type: 'string' }
@@ -414,6 +415,7 @@ module.exports = async function (app) {
                     },
                     // Case 2: Body has ownerType and ownerId
                     {
+                        type: 'object',
                         required: ['ownerType', 'ownerId'],
                         properties: {
                             ownerType: { type: 'string', enum: ['device', 'instance'] },


### PR DESCRIPTION


## Description

Three route-body schemas declared required without `type: 'object'` at the root, triggering an AJV strictTypes warning on every forge startup. Adding `type: 'object'` silences it without changing validation behavior.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

