### PR TITLE
ci: point docs link checker at website/nuxt/dist

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: 'website'
       - uses: untitaker/hyperlink@fb5bb9c5011a3d143a54b4b30aedc30ec5bc0f89 # 0.2.0
         with:
-          args: website/nuxt/.output/public/ --check-anchors --sources website/src
+          args: website/nuxt/dist/ --check-anchors --sources website/src
   publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The `Test Documentation with website` job fails on every docs PR with:

```
Error: IO error for operation on website/nuxt/.output/public/: No such file or directory (os error 2)
```

FlowFuse/website#5122 (merged 2026-06-03) switched the website Nuxt build from `generate` to `build`, moving its output from `nuxt/.output/public/` to `nuxt/dist/`. That PR updated the website's own link-check workflow but not this repo's `docs.yml`, which still pointed at the old path.

This updates the hyperlink check to `website/nuxt/dist/`, matching the website's current build output and its own `test.yml`.