### PR TITLE
Fix ignored paths in webpack watch options

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -187,7 +187,7 @@ module.exports = function (env, argv) {
         },
         watchOptions: {
             poll: 1000,
-            ignored: [getPath('frontend/dist/**'), '**/node_modules/**']
+            ignored: ['**/frontend/dist/**', '**/node_modules/**']
         },
         resolve: {
             extensions: ['.ts', '.js', '.vue', '.json'],


### PR DESCRIPTION
## Description

This pull request makes a minor adjustment to the `watchOptions.ignored` configuration in the `webpack.config.js` file to fix the terminal error witnessed on windows dev time CLI (see the related issue OP in #7383 for details)

* Changed the ignored file pattern from `getPath('frontend/dist/**')` to a glob string `'**/frontend/dist/**'` in the `watchOptions.ignored` array to improve reliability and consistency.

> [!NOTE]
> Untested on *nix

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

