### PR TITLE
[7385] Expert Tools row not available on device  

### DIFF
--- a/frontend/src/components/expert/components/context-selection/index.vue
+++ b/frontend/src/components/expert/components/context-selection/index.vue
@@ -4,7 +4,7 @@
         <div class="chips-container" @wheel="horizontalScrolling">
             <context-chip v-for="(context, index) in selectedContextFiltered" :key="index" :contextItem="context" />
             <debug-chip v-if="hasDebugLogsSelected && !isInsightsAgent" />
-            <selection-chip v-if="hasUserSelection && !isInsightsAgent" />
+            <selection-chip v-if="hasUserSelection && !isInsightsAgent && !isDevice" />
         </div>
     </div>
 </template>
@@ -18,6 +18,7 @@ import SelectionChip from '../chips/SelectionChip.vue'
 
 import ContextSelectorButton from './ContextSelectorButton.vue'
 
+import { useContextStore } from '@/stores/context.js'
 import { useProductAssistantStore } from '@/stores/product-assistant.js'
 import { useProductExpertStore } from '@/stores/product-expert.js'
 
@@ -32,6 +33,7 @@ export default {
     computed: {
         ...mapState(useProductAssistantStore, ['getSelectedContext', 'hasDebugLogsSelected', 'hasUserSelection']),
         ...mapState(useProductExpertStore, ['isInsightsAgent']),
+        ...mapState(useContextStore, { isDevice: store => store.editorEntityType === 'device' }),
         selectedContext () {
             // for insights mode, return empty array
             if (this.isInsightsAgent) {

--- a/frontend/src/components/expert/components/context-selection/index.vue
+++ b/frontend/src/components/expert/components/context-selection/index.vue
@@ -18,7 +18,6 @@ import SelectionChip from '../chips/SelectionChip.vue'
 
 import ContextSelectorButton from './ContextSelectorButton.vue'
 
-import { useContextStore } from '@/stores/context.js'
 import { useProductAssistantStore } from '@/stores/product-assistant.js'
 import { useProductExpertStore } from '@/stores/product-expert.js'
 
@@ -33,7 +32,6 @@ export default {
     computed: {
         ...mapState(useProductAssistantStore, ['getSelectedContext', 'hasDebugLogsSelected', 'hasUserSelection']),
         ...mapState(useProductExpertStore, ['isInsightsAgent']),
-        ...mapState(useContextStore, { isDevice: store => store.editorEntityType === 'device' }),
         selectedContext () {
             // for insights mode, return empty array
             if (this.isInsightsAgent) {

--- a/frontend/src/components/expert/components/context-selection/index.vue
+++ b/frontend/src/components/expert/components/context-selection/index.vue
@@ -4,7 +4,7 @@
         <div class="chips-container" @wheel="horizontalScrolling">
             <context-chip v-for="(context, index) in selectedContextFiltered" :key="index" :contextItem="context" />
             <debug-chip v-if="hasDebugLogsSelected && !isInsightsAgent" />
-            <selection-chip v-if="hasUserSelection && !isInsightsAgent && !isDevice" />
+            <selection-chip v-if="hasUserSelection && !isInsightsAgent" />
         </div>
     </div>
 </template>

--- a/frontend/src/pages/device/Editor/index.vue
+++ b/frontend/src/pages/device/Editor/index.vue
@@ -267,6 +267,7 @@ export default {
         }
     },
     mounted () {
+        this.setIsImmersive(true)
         this.loadDevice()
     },
     beforeUnmount () {

--- a/frontend/src/stores/context.js
+++ b/frontend/src/stores/context.js
@@ -71,8 +71,8 @@ export const useContextStore = defineStore('context', {
                 ? state.route.params?.id
                 : null
             const scope =
-                state.route.fullPath.includes('/instance/') &&
-                state.route.fullPath.includes('editor')
+                (state.route.fullPath.startsWith('/instance/') || state.route.fullPath.startsWith('/device/')) &&
+                state.route.fullPath.includes('/editor')
                     ? 'immersive'
                     : 'ff-app'
 


### PR DESCRIPTION


## Description

The Expert tools row didn't render on remote instance editors. The device editor never called `setIsImmersive(true)` so the context selector was gated out, fixed by restoring that call in `mounted()`.

<s>Also hid the `node-selection` chip on devices: `selectedNodes` is only sent when `scope === 'immersive'`, which is instance-only in `context.js`, so on devices the chip showed a node count that was never actually sent. </s>

> [!IMPORTANT]
> Expert is broken in my dev env(I probably have an outdated flow for it), so no end-to-end check, but confirmed palette/debugLog payloads are sent on devices. 

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7385

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

