### PR TITLE
Align Expert FF Expert chat and MCP endpoints

### DIFF
--- a/forge/ee/routes/expert/index.js
+++ b/forge/ee/routes/expert/index.js
@@ -118,7 +118,6 @@ module.exports = async function (app) {
         const selectedCapabilities = context.selectedCapabilities
         if (selectedCapabilities && Array.isArray(selectedCapabilities) && selectedCapabilities.length > 0) {
             const applicationCache = {}
-            const instanceCache = {}
             const mcpServersList = []
 
             // Premise:
@@ -126,8 +125,9 @@ module.exports = async function (app) {
             // in order of computational cost, we need to:
             // 1. filter out any MCP servers the user does not have access to at all (application level)
             // 2. filter out any MCP server features (prompts/resources/tools) the user does not have access to (feature level)
-            // 3. for the remaining MCP servers, load (and cache) the instance and get/create access token as needed
-            //    based on the instance's node security settings
+            // 3. re-resolve the remaining MCP servers against the team's trusted MCP registry, verify
+            //    instance/application ownership, and get/create access tokens as needed based on the
+            //    instance's node security settings
 
             // first pass - get associated applications for the MCP servers selected by user
             for (const server of selectedCapabilities || []) {
@@ -146,42 +146,82 @@ module.exports = async function (app) {
             // second pass - filter features per MCP server based on user access to features (e.g. a tool with the destructive hint requires extra permission than a read-only tool)
             const accessibleServers = filterAccessibleMCPServerFeatures(app, mcpServersList, request.team, request.teamMembership)
 
-            // final pass - now that we have list of accessible servers, apply access tokens as needed
-            for (const server of accessibleServers) {
-                const instanceId = server.instance
-                const instanceType = server.instanceType
-                const application = applicationCache[server.application]
-                if (!application || !instanceId || !instanceType) { continue }
+            // Build the team's trusted MCP registry. This is the source of truth for which MCP servers
+            // exist and their transport details (instance, endpoint, protocol). The client-supplied
+            // transport fields (e.g. mcpServerUrl, instanceUrl, mcpEndpoint) are NEVER trusted - they
+            // are re-resolved from here so a user cannot point a minted access token at an arbitrary
+            // URL, nor attach a token for an instance they have not been authorised against.
+            // (mirrors the /mcp/features route)
+            const registrations = await app.db.models.MCPRegistration.byTeam(request.team.id, { includeInstance: true }) || []
+            const trustedRegistrations = new Map()
+            for (const reg of registrations) {
+                if (reg.targetType !== 'instance' || !reg.Project) {
+                    continue
+                } // devices are not yet supported for MCP servers
+                trustedRegistrations.set(`${reg.Project.id}::${reg.name}`, reg)
+            }
 
-                // short cut - if the token cache has an entry, use it (avoid loading the instance model)
-                server.mcpAccessToken = await app.expert.mcp.getCachedToken(instanceId)
-                if (server.mcpAccessToken) {
+            // final pass - re-resolve each accessible server against the trusted registry, verify
+            // instance/application ownership, then apply access tokens as needed
+            for (const server of accessibleServers) {
+                const application = applicationCache[server.application]
+                if (!application || !server.instance) {
+                    server._invalid = true // flag the server as invalid to be filtered out later
                     continue
                 }
 
-                // load instance from local cache or db (an instance can appear multiple times if multiple MCP servers are registered)
-                if (!Object.hasOwnProperty.call(instanceCache, instanceId)) {
-                    switch (instanceType) {
-                    case 'instance':
-                        instanceCache[instanceId] = await app.db.models.Project.byId(instanceId)
-                        break
-                    case 'device':
-                        instanceCache[instanceId] = await app.db.models.Device.byId(instanceId)
-                        break
-                    default:
-                        continue
-                    }
+                // re-resolve against the trusted registry - drops any selection that is not a
+                // registered MCP server for this team
+                const registration = trustedRegistrations.get(`${server.instance}::${server.mcpServerName}`)
+                const instance = registration?.Project
+                if (!instance) {
+                    server._invalid = true
+                    continue
                 }
 
-                const instance = instanceCache[instanceId]
-                if (instance) {
-                    // sanity check - ensure instance is linked to application
-                    if (instance.ApplicationId !== application.id) {
-                        server._invalid = true // flag the server as invalid to be filtered out later
-                        continue
-                    }
-                    server.mcpAccessToken = await app.expert.mcp.getOrCreateToken(instance, instanceType, instanceId, request.teamHttpSecurityFeature)
+                // SECURITY: the registered instance must belong to the claimed application (the user was
+                // only permission-checked against the claimed application in the second pass). This
+                // ownership check MUST happen BEFORE reading or minting any access token, because the
+                // token cache is keyed by instanceId alone.
+                if (instance.ApplicationId !== application.id) {
+                    server._invalid = true
+                    continue
                 }
+
+                const instanceType = registration.targetType // trusted instance type ('instance')
+
+                // Tamper detection (audit signal only - we overwrite with trusted values regardless).
+                // A well-behaved client echoes back the transport details we issued via /mcp/features,
+                // so any disagreement indicates either a stale client or tampering. We log it rather
+                // than reject, to avoid failing legitimate requests in a race condition. mcpServerUrl is
+                // not compared - FlowFuse never issues it as an authoritative field (the agent builds
+                // it client-side), so it is simply dropped below.
+                const tamperedFields = []
+                if (server.instanceUrl !== undefined && server.instanceUrl !== instance.url) { tamperedFields.push('instanceUrl') }
+                if (server.mcpEndpoint !== undefined && server.mcpEndpoint !== registration.endpointRoute) { tamperedFields.push('mcpEndpoint') }
+                if (server.mcpProtocol !== undefined && server.mcpProtocol !== registration.protocol) { tamperedFields.push('mcpProtocol') }
+                if (tamperedFields.length > 0) {
+                    app.log.warn(`Expert chat: correcting client-supplied MCP transport fields [${tamperedFields.join(', ')}] that did not match the trusted registry (user=${request.user.hashid}, team=${request.team.hashid}, instance=${instance.id})`)
+                }
+
+                // Overwrite all transport/identity fields with trusted values - never trust the client's
+                // copy. The agent rebuilds mcpServerUrl from instanceUrl + mcpEndpoint, as it does for
+                // the /mcp/features response.
+                server.team = request.team.hashid
+                server.application = application.hashid
+                server.instanceType = instanceType
+                server.instanceName = instance.name
+                server.instanceUrl = instance.url
+                server.mcpServerName = registration.name
+                server.mcpEndpoint = registration.endpointRoute
+                server.mcpProtocol = registration.protocol
+                server.title = registration.title
+                server.version = registration.version
+                server.description = registration.description
+                delete server.mcpServerUrl
+
+                // ownership verified - safe to read/create the cached access token for this instance
+                server.mcpAccessToken = await app.expert.mcp.getOrCreateToken(instance, instanceType, instance.id, request.teamHttpSecurityFeature)
             }
             const filteredAccessibleServers = accessibleServers.filter(s => !s._invalid)
             context.selectedCapabilities = filteredAccessibleServers?.length > 0 ? filteredAccessibleServers : undefined

--- a/test/unit/forge/ee/routes/expert/index_spec.js
+++ b/test/unit/forge/ee/routes/expert/index_spec.js
@@ -52,6 +52,20 @@ describe('Expert API', function () {
         await app.defaultTeamType.save()
     }
 
+    // Create a real MCP registration row for an instance so that the /chat route's trusted-registry
+    // re-resolution finds it. TeamId is derived from the instance (no need to stub byTeam).
+    async function createMcpRegistration (app, instance, { name, endpointRoute = '/mcp', protocol = 'http', nodeId } = {}) {
+        return app.db.models.MCPRegistration.create({
+            name,
+            protocol,
+            targetType: 'instance',
+            targetId: '' + instance.id,
+            nodeId: nodeId || `mcp:node:${name}`,
+            endpointRoute,
+            TeamId: instance.TeamId
+        })
+    }
+
     afterEach(async function () {
         sinon.restore()
     })
@@ -97,6 +111,8 @@ describe('Expert API', function () {
         afterEach(async function () {
             // clear the expert MCP access token cache
             await app.expert.mcp.clearTokenCache()
+            // remove any MCP registrations created during tests
+            await app.db.models.MCPRegistration.destroy({ where: {} })
             // delete all extra users, applications, instances created during tests
             await app.db.models.Project.destroy({ where: { name: ['alice2-instance', 'bob2-instance', 'chris2-instance'] } })
             await app.db.models.Application.destroy({ where: { name: ['application-alice', 'application-bob', 'application-chris'] } })
@@ -108,6 +124,12 @@ describe('Expert API', function () {
         })
 
         describe('Chat Endpoint', function () {
+            beforeEach(async function () {
+                // register an MCP server for the default instance so the /chat trusted-registry
+                // re-resolution recognises selectedCapabilities that reference it (mcpServerName 'mcp-server-1')
+                await createMcpRegistration(app, instance, { name: 'mcp-server-1', endpointRoute: '/mcp1' })
+            })
+
             it('should return 401 for missing session', async function () {
                 const response = await app.inject({
                     method: 'POST',
@@ -266,6 +288,12 @@ describe('Expert API', function () {
                     app.projectType,
                     { start: true }
                 )
+
+                // register a (trusted) MCP server for each instance so the /chat route's registry
+                // re-resolution recognises the selectedCapabilities referencing them
+                await createMcpRegistration(app, instanceAlice2, { name: 'alice2' })
+                await createMcpRegistration(app, instanceBob2, { name: 'bob2' })
+                await createMcpRegistration(app, instanceChris2, { name: 'chris2' })
 
                 const buildMcpServerFeaturesResponse = (name, applicationHashid, instance, instanceType) => ({
                     team: team.hashid,
@@ -654,6 +682,153 @@ describe('Expert API', function () {
                     scheme: 'Bearer',
                     scope: ['ff-expert:mcp', 'instance']
                 })
+            })
+
+            it('should NOT attach a cached token when the claimed application does not own the selected instance', async function () {
+                // A cached MCP token must not be attached unless the selected instance genuinely belongs to the claimed application
+                const token = bobToken // bob is a team owner (so passes the claimed-application permission check)
+                await setFeatureForTeam(app, 'teamHttpSecurity', true)
+
+                // Create a "victim" application + instance in the SAME team but a DIFFERENT application
+                // than the one the attacker will claim access to.
+                const victimApplication = await app.factory.createApplication({ name: 'application-chris' }, team)
+                const victimInstance = await app.factory.createInstance(
+                    { name: 'chris2-instance' },
+                    victimApplication,
+                    app.stack,
+                    app.template,
+                    app.projectType,
+                    { start: false }
+                )
+
+                // Register the victim instance's MCP server (under the attacker-chosen name) so the
+                // capability survives the trusted-registry re-resolution and the test specifically
+                // exercises the instance/application OWNERSHIP check rather than the registry-miss path.
+                await createMcpRegistration(app, victimInstance, { name: 'attacker-controlled' })
+
+                // The victim instance uses FlowFuse http auth, so a real Bearer token would be minted/cached
+                sinon.stub(app.db.models.ProjectSettings, 'findOne').callsFake(async (options) => {
+                    if (options.where.ProjectId === victimInstance.id && options.where.key === 'settings') {
+                        return { value: { httpNodeAuth: { type: 'flowforge-user' } } }
+                    }
+                    return this.wrappedMethod.apply(this, arguments)
+                })
+
+                // Pre-populate the token cache for the victim instance (simulates a legitimate prior use)
+                const victimToken = await app.expert.mcp.getOrCreateToken(victimInstance, 'instance', victimInstance.id, true)
+                should.exist(victimToken)
+                should.exist(await app.expert.mcp.getCachedToken(victimInstance.id)) // confirm it is cached
+
+                // capture what gets forwarded to the expert backend
+                let capturedPostData = null
+                sinon.stub(axios, 'post').callsFake((url, data) => {
+                    capturedPostData = data
+                    return Promise.resolve({ data: { transactionId: 'abc', context: {} } })
+                })
+
+                // Attacker claims the application they DO have access to (`application`), but references
+                // the victim instance (which belongs to `victimApplication`).
+                const response = await app.inject({
+                    method: 'POST',
+                    url: '/api/v1/expert/chat',
+                    cookies: { sid: token },
+                    headers: { 'x-chat-transaction-id': 'abc' },
+                    payload: {
+                        context: {
+                            teamId: team.hashid,
+                            query: 'use the selected MCP resource',
+                            selectedCapabilities: [
+                                {
+                                    team: team.hashid,
+                                    application: application.hashid, // claimed application (attacker has access)
+                                    instance: victimInstance.id, // victim instance (belongs to a different application)
+                                    instanceType: 'instance',
+                                    instanceName: 'target-instance',
+                                    mcpServerName: 'attacker-controlled',
+                                    mcpServerUrl: 'https://attacker.example/mcp',
+                                    mcpProtocol: 'http',
+                                    prompts: [],
+                                    resources: [{ name: 'leak', uri: 'resource://leak' }],
+                                    resourceTemplates: [],
+                                    tools: []
+                                }
+                            ]
+                        }
+                    }
+                })
+                response.statusCode.should.equal(200)
+
+                // The mismatched capability must be dropped entirely - no cached token leaked downstream
+                capturedPostData.should.be.an.Object()
+                should(capturedPostData.context.selectedCapabilities).be.undefined()
+
+                await app.db.models.Project.destroy({ where: { id: victimInstance.id } })
+                await app.db.models.Application.destroy({ where: { id: victimApplication.id } })
+            })
+
+            it('should overwrite client-supplied transport fields with trusted registry values', async function () {
+                const token = bobToken // team owner
+
+                const warnSpy = sinon.spy(app.log, 'warn')
+                let capturedPostData = null
+                sinon.stub(axios, 'post').callsFake((url, data) => {
+                    capturedPostData = data
+                    return Promise.resolve({ data: { transactionId: 'abc', context: {} } })
+                })
+
+                const response = await app.inject({
+                    method: 'POST',
+                    url: '/api/v1/expert/chat',
+                    cookies: { sid: token },
+                    headers: { 'x-chat-transaction-id': 'abc' },
+                    payload: {
+                        context: {
+                            teamId: team.hashid,
+                            query: 'use the selected MCP resource',
+                            selectedCapabilities: [
+                                {
+                                    team: team.hashid,
+                                    application: application.hashid,
+                                    instance: instance.id,
+                                    instanceType: 'instance',
+                                    instanceName: 'spoofed-name',
+                                    mcpServerName: 'mcp-server-1', // matches the registration created in beforeEach
+                                    mcpServerUrl: 'https://attacker.example/mcp', // client provided - must be dropped
+                                    instanceUrl: 'https://attacker.example', // client provided - must be overwritten
+                                    mcpEndpoint: '/evil', // client provided - must be overwritten
+                                    mcpProtocol: 'sse', // client provided - must be overwritten
+                                    prompts: [],
+                                    resources: [{ name: 'res', uri: 'resource://res' }],
+                                    resourceTemplates: [],
+                                    tools: []
+                                }
+                            ]
+                        }
+                    }
+                })
+                response.statusCode.should.equal(200)
+
+                capturedPostData.should.be.an.Object()
+                const forwarded = capturedPostData.context.selectedCapabilities
+                forwarded.should.be.an.Array().and.have.length(1)
+                // the client-supplied URL must never be forwarded; the agent rebuilds it from trusted parts
+                forwarded[0].should.not.have.property('mcpServerUrl')
+                // transport/identity fields re-resolved from the trusted registry + instance
+                forwarded[0].should.have.property('instanceUrl', instance.url)
+                forwarded[0].should.have.property('mcpEndpoint', '/mcp1')
+                forwarded[0].should.have.property('mcpProtocol', 'http')
+                forwarded[0].should.have.property('mcpServerName', 'mcp-server-1')
+                forwarded[0].should.have.property('instanceName', instance.name)
+                forwarded[0].should.have.property('team', team.hashid)
+                forwarded[0].should.have.property('application', application.hashid)
+
+                // the mismatch between client-supplied and trusted transport fields should be logged (audit signal)
+                warnSpy.called.should.be.true()
+                const warnMessage = warnSpy.getCalls().map(c => c.args[0]).find(m => typeof m === 'string' && m.includes('transport fields'))
+                should.exist(warnMessage)
+                warnMessage.should.match(/instanceUrl/)
+                warnMessage.should.match(/mcpEndpoint/)
+                warnMessage.should.match(/mcpProtocol/)
             })
 
             it('should clear cached MCP server access token when project setting httpNodeAuth is changed', async function () {


### PR DESCRIPTION
## Description

Align the Expert `/chat` endpoint the same way `/mcp/features` already does to a consistent single server-side source of truth.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

