### PR TITLE
ci: Add Node-RED 5 stack to a pre-staging environment

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -188,6 +188,7 @@ create_stack "Default" "Default (4.1.x)" 30 256 "flowfuse/node-red:$(get_latest_
 create_stack "NR-40x" "4.0.x" 30 256 "flowfuse/node-red:$(get_latest_image_tag "4.0.x")"
 create_stack "NR-30x" "3.0.x" 30 256 "flowfuse/node-red:latest"
 create_stack "NR-31x" "3.1.x" 30 256 "flowfuse/node-red:$(get_latest_image_tag "3.1.x")"
+create_stack "NR-50x" "5.0.x" 30 256 "flowfuse/node-red:$(get_latest_image_tag "5.0.x")"
 
 
 ### Link Default to project type


### PR DESCRIPTION
## Description

This pull request updates the `initial-setup.sh` script, responsible for the initial setup of each pre-staging environment, to ensure that a Node-RED 5 stack is created.

## Related Issue(s)

Blocked by: https://github.com/FlowFuse/helm/issues/934
Closes https://github.com/FlowFuse/flowfuse/issues/7388

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

