### PR TITLE
fix: await DOM flush before rendering snapshot comparison

### DIFF
--- a/frontend/src/components/dialogs/AssetCompareDialog.vue
+++ b/frontend/src/components/dialogs/AssetCompareDialog.vue
@@ -292,6 +292,10 @@ export default {
             } finally {
                 this.loading = false
             }
+            // v-show="!loading" uses display:none — wait for Vue to flush
+            // the DOM update so the container is visible before rendering
+            // (SVG getBBox() returns zeros inside display:none ancestors)
+            await this.$nextTick()
             if (!compareSnapshot?.flows?.flows) {
                 Alerts.emit('Flows not found in the selected snapshot', 'warning')
                 return

--- a/frontend/src/components/dialogs/AssetCompareDialog.vue
+++ b/frontend/src/components/dialogs/AssetCompareDialog.vue
@@ -292,9 +292,8 @@ export default {
             } finally {
                 this.loading = false
             }
-            // v-show="!loading" uses display:none — wait for Vue to flush
-            // the DOM update so the container is visible before rendering
-            // (SVG getBBox() returns zeros inside display:none ancestors)
+            // Wait for the container to become visible (v-show removes display:none)
+            // before rendering — SVG getBBox() returns zeros in hidden containers
             await this.$nextTick()
             if (!compareSnapshot?.flows?.flows) {
                 Alerts.emit('Flows not found in the selected snapshot', 'warning')


### PR DESCRIPTION
## Summary
- Snapshot comparison rendering was broken: ports appeared at the top-left corner of nodes and wires were misaligned
- Root cause: `v-show="!loading"` hides the container with `display: none`. After setting `loading = false`, Vue hasn't flushed the DOM update yet, so `flowRenderer.compare()` runs while the SVG is still inside a `display: none` ancestor — `getBBox()` returns zeros for all elements
- Fix: `await this.$nextTick()` after `loading = false` to ensure the DOM is updated before rendering

## Test plan
- [x] Open a snapshot comparison dialog with two snapshots that have differing nodes
- [x] Verify nodes render with correct port positions (input on left, output on right)
- [x] Verify wires connect between ports, not from node top-left corners