### PR TITLE
fix: snapshots list dropdown not flexible on resize

### DIFF
--- a/frontend/src/mixins/TeleportedMenuMixin.js
+++ b/frontend/src/mixins/TeleportedMenuMixin.js
@@ -67,19 +67,8 @@ export default {
             // Use viewport-relative coordinates (no window.scrollX/Y)
             let triggerTop = triggerRect.bottom + this.optionsOffsetTop
             let triggerLeft = triggerRect.left
-            let width = triggerRect.width
+            const width = triggerRect.width
             const transform = ''
-
-            const menuEl = this.$refs['menu-items']?.$el
-            if (menuEl) {
-                const firstChild = menuEl.firstElementChild
-                if (firstChild) {
-                    const firstChildWidth = firstChild.getBoundingClientRect().width
-                    if (firstChildWidth > width) {
-                        width = firstChildWidth
-                    }
-                }
-            }
 
             // Set initial position immediately
             this.position = {
@@ -95,8 +84,9 @@ export default {
                     return
                 }
 
+                const menuEl = this.$refs['menu-items'].$el
                 const menuRect = menuEl.getBoundingClientRect()
-                const menuWidth = width // Use the calculated width
+                const menuWidth = menuRect.width
                 const menuHeight = menuRect.height
 
                 // Re-calculate based on actual dimensions

--- a/frontend/src/ui-components/components/form/ListBox.vue
+++ b/frontend/src/ui-components/components/form/ListBox.vue
@@ -48,7 +48,7 @@
                         ref="menu-items"
                         data-el="listbox-options"
                         :data-select="`${selector}-options`"
-                        class="fixed w-full overflow-y-auto overflow-x-hidden bg-white py-1 ff-options"
+                        class="fixed overflow-y-auto overflow-x-hidden bg-white py-1 ff-options"
                         :style="{
                             top: position.top + 'px',
                             left: position.left + 'px',


### PR DESCRIPTION
Closes #7397

## Summary
- Removed firstChild width expansion in `TeleportedMenuMixin` that created a feedback loop preventing the dropdown from shrinking on window resize
- Use actual rendered menu width (instead of trigger width) for overflow repositioning, so kebab menus and other small-trigger menus still correct their position correctly
- Removed stale `w-full` class from `ListBox` options container (overridden by inline style and incorrect on `position: fixed` elements)

## Test plan
Tested on:
- [x] Snapshots list in the asset compare dialog — dropdown resizes correctly with the window
- [x] Kebab menu on the hosted instances table — context menu appears at the correct position and does not break existing functionality