### PR TITLE
[7400] Overflow menu is clipped by Expert  

### DIFF
--- a/frontend/src/ui-components/components/tabs/Tabs.vue
+++ b/frontend/src/ui-components/components/tabs/Tabs.vue
@@ -54,7 +54,7 @@
                 <ChevronRightIcon class="ff-icon ff-icon-second" />
             </MenuButton>
             <Teleport to="body">
-                <MenuItems class="z-50 fixed origin-top-left max-h-96 overflow-y-auto bg-white divide-y divide-gray-100 rounded-sm shadow-lg ring-1 ring-black/10 focus:outline-hidden" :style="rightMenuStyle">
+                <MenuItems class="fixed origin-top-left max-h-96 overflow-y-auto bg-white divide-y divide-gray-100 rounded-sm shadow-lg ring-1 ring-black/10 focus:outline-hidden" :style="rightMenuStyle">
                     <MenuItem
                         v-for="tab in hiddenRightTabs"
                         :key="'right-' + tab.label"
@@ -146,7 +146,7 @@ export default {
             })
         },
         rightMenuStyle () {
-            return this.rightMenuPosition
+            return { ...this.rightMenuPosition, zIndex: 200 }
         }
     },
     watch: {


### PR DESCRIPTION


## Description

Raises the tab-overflow dropdown's z-index (50 → 200) so it floats above the Expert drawer instead of being clipped. No repositioning logic, ff-tabs is generic and shouldn't know about the drawer, and the menu already clamps to the viewport. 

Follow-up #7405 opened to centralize our scattered z-index values.

## Related Issue(s)

Resolves #7400 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

