### PR TITLE
Pinning Remote Instances default NR to 4.1.x

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -403,7 +403,8 @@ module.exports = {
                     let nodeRedVersion = '3.0.2' // default to older Node-RED
                     if (SemVer.satisfies(SemVer.coerce(this.agentVersion), '>=1.11.2')) {
                         // 1.11.2 includes fix for ESM loading of GOT, so lets use 'latest' as before
-                        nodeRedVersion = 'latest'
+                        // pinning to NR 4.1.x while we fix the device agent
+                        nodeRedVersion = '~4.1.11'
                     }
                     return nodeRedVersion
                 },

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -790,7 +790,7 @@ describe('Device API', async function () {
                 result.should.have.property('id')
                 result.should.have.property('name', 'Starter Snapshot')
                 result.should.have.property('modules').and.be.an.Object()
-                result.modules.should.have.property('node-red', 'latest')
+                result.modules.should.have.property('node-red', '~4.1.11')
             })
             it('snapshot uploaded without node-red dependency is always delivered to a device with the node-red:version', async function () {
                 const agentVersion = '1.11.2' // min agent version required for NR 3.1 (as this agent handles ESM issue)
@@ -846,7 +846,7 @@ describe('Device API', async function () {
                 result.should.have.property('id')
                 result.should.have.property('name', 'uploaded snapshot')
                 result.should.have.property('modules').and.be.an.Object()
-                result.modules.should.have.property('node-red', 'latest')
+                result.modules.should.have.property('node-red', '~4.1.11')
             })
             it('device updated to use target snapshot of an instance returns correct env vars', async function () {
                 // It is possible to "view all application snapshots" and pick one to assign to a device


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
This is to prevent failing to start on NodeJS < 22.9

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

