### PR TITLE
ci: Run single-replica emqx cluster on pre-staging environments

### DIFF
--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -43,6 +43,9 @@ forge:
           database: postgres
           ssl: false
 
+broker:
+  replicas: 1
+
 postgresql:
   persistence:
     enabled: false


### PR DESCRIPTION
## Description

This pull request ensures that each pre-staging environment gets a single-replica emqx cluster.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

