### PR TITLE
feat: MCP platform server (proof of concept)

### DIFF
--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -8,9 +8,12 @@
  */
 module.exports = function (app) {
     const expertRbacToolCheck = async (teamMembership, application, toolName) => {
-        const applicationHash = typeof application === 'object' ? application.hashid : application
+        const applicationHash = (application && typeof application === 'object') ? application.hashid : application
         if (toolName === 'expert:status-message') {
             return true
+        }
+        if (toolName.startsWith('platform:')) {
+            return app.hasPermission(teamMembership, 'expert:insights:mcp:tool:allow')
         }
         // TODO: Understand all automations and which permissions they should require.
         // For now, basic starter automations are added here, any not matching this list will require project:flows:edit permission
@@ -230,14 +233,15 @@ module.exports = function (app) {
                         throw ValidationError('user is not a member of the team that owns this project')
                     }
 
-                    // check expert assistant feature is enabled for the team (support agent uses MQTT)
+                    // check expert feature is enabled for the team (support agent uses MQTT)
                     if (acl.isClient) {
                         const team = await app.db.models.Team.byId(teamId)
                         if (team) {
                             await team.ensureTeamTypeExists()
                             const isAiEnabled = !!(app.config.features.enabled('ai') && team.getFeatureProperty('ai', true))
                             const isExpertAssistantEnabled = !!(app.config.features.enabled('expertAssistant') && team.getFeatureProperty('expertAssistant', true))
-                            if (!isAiEnabled || !isExpertAssistantEnabled) {
+                            const isExpertPlatformAutomationEnabled = !!(app.config.features.enabled('expertPlatformAutomation') && team.getFeatureProperty('expertPlatformAutomation', true))
+                            if (!isAiEnabled || (!isExpertAssistantEnabled && !isExpertPlatformAutomationEnabled)) {
                                 throw ValidationError('expert assistant feature is not enabled for this team')
                             }
                         }
@@ -285,10 +289,15 @@ module.exports = function (app) {
                 { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/logs\/heartbeat$/ },
                 // ff/v1/<team>/d/<device>/resources/heartbeat
                 { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/resources\/heartbeat$/ },
+                // ff/v1/<team>/p/<project>/editor/heartbeat
+                { topic: /^ff\/v1\/[^/]+\/p\/[^/]+\/editor\/heartbeat$/ },
                 // ff/v1/platform/sync
                 { topic: /^ff\/v1\/platform\/sync$/ },
                 // ff/v1/platform/leader
-                { topic: /^ff\/v1\/platform\/leader$/ }
+                { topic: /^ff\/v1\/platform\/leader$/ },
+                // Receive MCP dispatch inflight responses from the user's browser
+                // - ff/v1/mcp/<userid>/<sessionid>/<entityType>/<entityId>/support/inflight/<inflightType>/response
+                { topic: /^ff\/v1\/mcp\/[^/]+\/[^/]+\/[^/]+\/[^/]+\/support\/inflight\/[^/]+\/response$/ }
             ],
             pub: [
                 // Send commands to project launchers
@@ -306,7 +315,10 @@ module.exports = function (app) {
                 // ff/v1/platform/sync
                 { topic: /^ff\/v1\/platform\/sync$/ },
                 // ff/v1/platform/leader
-                { topic: /^ff\/v1\/platform\/leader$/ }
+                { topic: /^ff\/v1\/platform\/leader$/ },
+                // Send MCP dispatch inflight requests to the user's browser
+                // - ff/v1/mcp/<userid>/<sessionid>/<entityType>/<entityId>/support/inflight/<inflightType>/request
+                { topic: /^ff\/v1\/mcp\/[^/]+\/[^/]+\/[^/]+\/[^/]+\/support\/inflight\/[^/]+\/request$/ }
             ]
         },
         project: {
@@ -357,7 +369,9 @@ module.exports = function (app) {
                 // - ff/v1/<team>/d/<device/logs/heartbeat
                 { topic: /^ff\/v1\/([^/]+)\/d\/([^/]+)\/logs\/heartbeat$/, verify: 'checkDeviceIsAssigned' },
                 // - ff/v1/<team>/d/<device/resources/heartbeat
-                { topic: /^ff\/v1\/([^/]+)\/d\/([^/]+)\/resources\/heartbeat$/, verify: 'checkDeviceIsAssigned' }
+                { topic: /^ff\/v1\/([^/]+)\/d\/([^/]+)\/resources\/heartbeat$/, verify: 'checkDeviceIsAssigned' },
+                // - ff/v1/<team>/p/<project>/editor/heartbeat
+                { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/editor\/heartbeat$/, verify: 'checkTeamId' }
             ]
         },
         // frontend client (user)
@@ -367,14 +381,20 @@ module.exports = function (app) {
                 // topic captures, 0 = full topic, 1 = userid, 2 = sessionid, 3 = entity type (a|p|d|t), 4 = entity id, 5 = inflight type (only for inflight topics)
                 // example topic: ff/v1/expert/user123/session123/p/abc-123-456-789/support/chat/response
                 { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/support\/chat\/response$/, verify: 'checkExpertTopic', channel: 'chat', allowWildcard: { entity: true }, isClient: true, isSub: true },
-                { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/support\/inflight\/([^/]+)\/request$/, verify: 'checkExpertTopic', channel: 'inflight', allowWildcard: { entity: true, inflightType: true }, isClient: true, isSub: true }
+                { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/support\/inflight\/([^/]+)\/request$/, verify: 'checkExpertTopic', channel: 'inflight', allowWildcard: { entity: true, inflightType: true }, isClient: true, isSub: true },
+                // MCP dispatch inflight requests (from forge platform to user's browser)
+                { topic: /^ff\/v1\/mcp\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/support\/inflight\/([^/]+)\/request$/, verify: 'checkExpertTopic', channel: 'inflight', allowWildcard: { entity: true, inflightType: true }, isClient: true, isSub: true }
             ],
             pub: [
                 // topic: ff/v1/expert/<userid>/<sessionid>/<a|p|d|t>/<appid|projid|devid|teamid>/support/chat/request
                 // topic captures, 0 = full topic, 1 = userid, 2 = sessionid, 3 = entity type (a|p|d|t), 4 = entity id, 5 = inflight type (only for inflight topics)
                 // example topic: ff/v1/expert/user123/session123/p/abc-111-222-333/support/chat/request
                 { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([tapd])\/([^/]+)\/support\/chat\/request$/, verify: 'checkExpertTopic', channel: 'chat', isClient: true, isPub: true },
-                { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([tapd])\/([^/]+)\/support\/inflight\/([^/]+)\/response$/, verify: 'checkExpertTopic', channel: 'inflight', isClient: true, isPub: true }
+                { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([tapd])\/([^/]+)\/support\/inflight\/([^/]+)\/response$/, verify: 'checkExpertTopic', channel: 'inflight', isClient: true, isPub: true },
+                // MCP dispatch inflight responses (from user's browser back to forge platform)
+                { topic: /^ff\/v1\/mcp\/([^/]+)\/([^/]+)\/([tapd])\/([^/]+)\/support\/inflight\/([^/]+)\/response$/, verify: 'checkExpertTopic', channel: 'inflight', isClient: true, isPub: true },
+                // - ff/v1/<team>/p/<project>/editor/heartbeat
+                { topic: /^ff\/v1\/[^/]+\/p\/[^/]+\/editor\/heartbeat$/ }
             ]
         },
         // backend client (agent)

--- a/forge/comms/commsClient.js
+++ b/forge/comms/commsClient.js
@@ -51,10 +51,33 @@ class CommsClient extends EventEmitter {
                 const ownerId = topicParts[4]
                 const messageType = topicParts[5]
                 if (ownerType === 'p') {
-                    this.emit('status/project', {
-                        id: ownerId,
-                        status: message.toString()
-                    })
+                    if (messageType === 'editor' && topicParts[6] === 'heartbeat') {
+                        try {
+                            const payload = JSON.parse(message.toString())
+                            const teamId = topicParts[2]
+                            if (payload.action === 'alive') {
+                                this.emit('editor/heartbeat', {
+                                    projectId: ownerId,
+                                    teamId,
+                                    sessionId: payload.sessionId,
+                                    userId: payload.userId,
+                                    timestamp: Date.now()
+                                })
+                            } else if (payload.action === 'leaving') {
+                                this.emit('editor/leaving', {
+                                    projectId: ownerId,
+                                    teamId
+                                })
+                            }
+                        } catch (_) {
+                            // ignore malformed payloads
+                        }
+                    } else {
+                        this.emit('status/project', {
+                            id: ownerId,
+                            status: message.toString()
+                        })
+                    }
                 } else if (ownerType === 'd') {
                     if (messageType === 'status') {
                         this.emit('status/device', {
@@ -123,6 +146,8 @@ class CommsClient extends EventEmitter {
                 'ff/v1/+/d/+/logs/heartbeat',
                 // Device response heartbeat
                 'ff/v1/+/d/+/resources/heartbeat',
+                // Editor session heartbeat
+                'ff/v1/+/p/+/editor/heartbeat',
                 // Platform sync messages
                 'ff/v1/platform/sync'
             ])

--- a/forge/comms/editorSessions.js
+++ b/forge/comms/editorSessions.js
@@ -1,0 +1,77 @@
+/**
+ * This module tracks which browser sessions have the NR editor open
+ * for which instances. It follows the same heartbeat pattern as device
+ * log heartbeats in devices.js.
+ *
+ * Heartbeats arrive via MQTT on: ff/v1/<teamId>/p/<projectId>/editor/heartbeat
+ * Payload: JSON { sessionId, userId, action: 'alive'|'leaving' }
+ */
+
+class EditorSessionHandler {
+    // Browser background tabs throttle timers to ~60s; allow 2 missed
+    // intervals before considering a session stale.
+    static STALE_THRESHOLD_MS = 120_000
+
+    /**
+     * @param {import('../forge').ForgeApplication} app Fastify app
+     * @param {import('./commsClient').CommsClient} client Comms Client
+     */
+    constructor (app, client) {
+        this.app = app
+        this.client = client
+
+        // editorSessions[projectId] = { sessionId, userId, teamId, lastHeartbeat }
+        this.editorSessions = {}
+        this.sweepInterval = -1
+
+        // Listen for editor heartbeat events from the comms client
+        client.on('editor/heartbeat', (beat) => {
+            this.editorSessions[beat.projectId] = {
+                sessionId: beat.sessionId,
+                userId: beat.userId,
+                teamId: beat.teamId,
+                lastHeartbeat: beat.timestamp
+            }
+        })
+
+        client.on('editor/leaving', (beat) => {
+            delete this.editorSessions[beat.projectId]
+        })
+
+        // Sweep stale entries every 30 seconds
+        this.sweepInterval = setInterval(() => {
+            const now = Date.now()
+            for (const [projectId, session] of Object.entries(this.editorSessions)) {
+                if (now - session.lastHeartbeat > EditorSessionHandler.STALE_THRESHOLD_MS) {
+                    delete this.editorSessions[projectId]
+                }
+            }
+        }, 30_000)
+    }
+
+    /**
+     * Get the active editor session for a project, if any.
+     * @param {string} projectId - The project/instance ID
+     * @returns {object|null} Session info { sessionId, userId, teamId, lastHeartbeat } or null
+     */
+    getActiveSession (projectId) {
+        const session = this.editorSessions[projectId]
+        if (!session) return null
+        if (Date.now() - session.lastHeartbeat > EditorSessionHandler.STALE_THRESHOLD_MS) {
+            delete this.editorSessions[projectId]
+            return null
+        }
+        return session
+    }
+
+    /**
+     * Stop the sweep interval (for clean shutdown)
+     */
+    stop () {
+        clearInterval(this.sweepInterval)
+    }
+}
+
+module.exports = {
+    EditorSessionHandler: (app, client) => new EditorSessionHandler(app, client)
+}

--- a/forge/comms/index.js
+++ b/forge/comms/index.js
@@ -3,6 +3,7 @@ const fp = require('fastify-plugin')
 const ACLManager = require('./aclManager')
 const { CommsClient } = require('./commsClient')
 const { DeviceCommsHandler } = require('./devices')
+const { EditorSessionHandler } = require('./editorSessions')
 
 /**
  * This module represents the real-time comms component of the platform.
@@ -31,6 +32,9 @@ module.exports = fp(async function (app, _opts) {
         // Create the handler for any device-related messages
         const deviceCommsHandler = DeviceCommsHandler(app, client)
 
+        // Create the handler for editor session heartbeats
+        const editorSessionHandler = EditorSessionHandler(app, client)
+
         // Not in the current release, but when we handle Launcher status
         // via MQTT, it will arrive here. Compare to the status/device handler in `devices.js`
         // client.on('status/project', (status) => {
@@ -40,6 +44,7 @@ module.exports = fp(async function (app, _opts) {
         // Setup the platform API for the comms component
         app.decorate('comms', {
             devices: deviceCommsHandler,
+            editorSessions: editorSessionHandler,
             aclManager: ACLManager(app),
             platform: {
                 settings: {
@@ -73,6 +78,7 @@ module.exports = fp(async function (app, _opts) {
         app.addHook('onClose', async (_) => {
             app.log.info('Comms shutdown')
             await deviceCommsHandler.stopLogWatcher()
+            editorSessionHandler.stop()
             client.publish('ff/v1/platform/leader', JSON.stringify({ id: client.platformId, vote: -1 }))
             await client.disconnect()
         })

--- a/forge/db/controllers/AccessToken.js
+++ b/forge/db/controllers/AccessToken.js
@@ -281,6 +281,37 @@ module.exports = {
         result.token = token
         return result
     },
+    createMCPToken: async function (app, user, scope, expiresAt, name) {
+        const userId = typeof user === 'number' ? user : user.id
+        const token = generateToken(32, 'ffmcp')
+        const tok = await app.db.models.AccessToken.create({
+            name,
+            token,
+            scope,
+            expiresAt,
+            ownerId: '' + userId,
+            ownerType: 'user'
+        })
+        const result = app.db.views.AccessToken.mcpTokenSummary(tok)
+        result.token = token
+        return result
+    },
+    updateMCPToken: async function (app, user, tokenId, scope, expiresAt) {
+        const userId = typeof user === 'number' ? user : user.id
+        const token = await app.db.models.AccessToken.byId(tokenId, 'user', userId)
+        if (token) {
+            token.scope = scope
+            if (expiresAt === undefined) {
+                token.expiresAt = null
+            } else {
+                token.expiresAt = expiresAt
+            }
+            await token.save()
+        } else {
+            throw new Error('Not Found')
+        }
+        return token
+    },
     updatePersonalAccessToken: async function (app, user, tokenId, scope, expiresAt) {
         const userId = typeof user === 'number' ? user : user.id
         const token = await app.db.models.AccessToken.byId(tokenId, 'user', userId)

--- a/forge/db/models/AccessToken.js
+++ b/forge/db/models/AccessToken.js
@@ -116,6 +116,18 @@ module.exports = {
                     })
                     return tokens
                 },
+                getMCPTokens: async (user) => {
+                    const tokens = this.findAll({
+                        where: {
+                            ownerType: 'user',
+                            ownerId: '' + user.id,
+                            scope: { [Op.like]: '%mcp:platform%' }
+                        },
+                        order: [['id', 'ASC']],
+                        attributes: ['id', 'name', 'scope', 'expiresAt']
+                    })
+                    return tokens
+                },
                 getProjectHTTPTokens: async (project) => {
                     const tokens = this.findAll({
                         where: {

--- a/forge/db/views/AccessToken.js
+++ b/forge/db/views/AccessToken.js
@@ -97,6 +97,46 @@ module.exports = function (app) {
     }
 
     app.addSchema({
+        $id: 'MCPTokenSummary',
+        type: 'object',
+        // Composed via `allOf` elsewhere — keep open.
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            expiresAt: { type: 'string', nullable: true }
+        },
+        required: ['id', 'name', 'expiresAt']
+    })
+    app.addSchema({
+        $id: 'MCPToken',
+        type: 'object',
+        allOf: [{ $ref: 'MCPTokenSummary' }],
+        properties: {
+            token: { type: 'string' }
+        },
+        required: ['token']
+    })
+
+    function mcpTokenSummary (token) {
+        const tokenSummary = {
+            id: token.hashid,
+            name: token.name,
+            expiresAt: token.expiresAt ?? null
+        }
+        return tokenSummary
+    }
+    app.addSchema({
+        $id: 'MCPTokenSummaryList',
+        type: 'array',
+        items: {
+            $ref: 'MCPTokenSummary'
+        }
+    })
+    function mcpTokenSummaryList (tokenArray) {
+        return tokenArray.map(token => mcpTokenSummary(token))
+    }
+
+    app.addSchema({
         $id: 'InstanceHTTPTokenSummary',
         type: 'object',
         // Composed via `allOf` elsewhere — keep open.
@@ -141,6 +181,8 @@ module.exports = function (app) {
         provisioningTokenSummary,
         personalAccessTokenSummary,
         personalAccessTokenSummaryList,
+        mcpTokenSummary,
+        mcpTokenSummaryList,
         instanceHTTPTokenSummary,
         instanceHTTPTokenSummaryList
     }

--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -52,6 +52,9 @@ module.exports = fp(async function (app, opts) {
         // Set the expert assistant Feature Flag
         app.config.features.register('expertAssistant', isAiEnabled && (app.config?.expert?.enabled ?? false), true)
 
+        // Set the expert platform automation Feature Flag (platform tools like create-instance, list-teams, etc.)
+        app.config.features.register('expertPlatformAutomation', isAiEnabled && (app.config?.expert?.enabled ?? false), true)
+
         // temporary until FF Expert Insights can be enabled on Self Hosted EE instance
         const isInsightsEnabled = isAiEnabled && app.config?.expert?.enabled && app.config?.expert?.insights?.enabled
         app.config.features.register('expertInsights', isInsightsEnabled ?? false, false)

--- a/forge/ee/lib/mcp/flowBuildingBridge.js
+++ b/forge/ee/lib/mcp/flowBuildingBridge.js
@@ -1,0 +1,162 @@
+'use strict'
+
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js')
+const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js')
+const { z } = require('zod')
+
+/**
+ * Convert a JSON Schema property to a Zod schema.
+ * Handles the common types returned by the flow building MCP server.
+ */
+function tryParseJSON (val) {
+    if (typeof val !== 'string') return val
+    try { return JSON.parse(val) } catch (_) { return val }
+}
+
+function jsonSchemaPropertyToZod (prop) {
+    if (!prop || typeof prop !== 'object') return z.any()
+
+    switch (prop.type) {
+    case 'string':
+        if (prop.enum) return z.enum(prop.enum)
+        return z.string()
+    case 'number':
+    case 'integer':
+        return z.number()
+    case 'boolean':
+        return z.boolean()
+    case 'array':
+        // Preprocess: MCP clients may serialize arrays as JSON strings
+        return z.preprocess(tryParseJSON,
+            z.array(prop.items ? jsonSchemaPropertyToZod(prop.items) : z.any()))
+    case 'object':
+        if (prop.properties) {
+            return z.preprocess(tryParseJSON, jsonSchemaToZod(prop))
+        }
+        return z.preprocess(tryParseJSON, z.record(z.any()))
+    default:
+        return z.any()
+    }
+}
+
+/**
+ * Convert a JSON Schema object to a Zod object schema.
+ */
+function jsonSchemaToZod (schema) {
+    if (!schema || schema.type !== 'object') return z.object({}).passthrough()
+
+    const shape = {}
+    const props = schema.properties || {}
+    const required = schema.required || []
+
+    for (const [key, prop] of Object.entries(props)) {
+        let field = jsonSchemaPropertyToZod(prop)
+        if (prop.description) field = field.describe(prop.description)
+        if (!required.includes(key)) field = field.optional()
+        shape[key] = field
+    }
+
+    return schema.additionalProperties === false
+        ? z.object(shape)
+        : z.object(shape).passthrough()
+}
+
+class FlowBuildingBridge {
+    constructor (app) {
+        this.app = app
+        this.cachedTools = null
+        this.cacheExpiry = 0
+        this.CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+    }
+
+    get mcpUrl () {
+        return this.app.config.expert?.flowBuildingMcpUrl
+    }
+
+    get isConfigured () {
+        return !!this.mcpUrl
+    }
+
+    /**
+     * Get the list of flow building tools from the MCP server.
+     * Caches results for 5 minutes.
+     * @returns {Promise<Array>} Array of tool definitions with `flow.` prefix
+     */
+    async getTools () {
+        if (this.cachedTools && Date.now() < this.cacheExpiry) {
+            return this.cachedTools
+        }
+        if (!this.isConfigured) return []
+
+        try {
+            const tools = await this._fetchTools()
+            this.cachedTools = tools
+            this.cacheExpiry = Date.now() + this.CACHE_TTL
+            return tools
+        } catch (err) {
+            this.app.log.warn(`Failed to fetch flow building tools: ${err.message}`)
+            // Return stale cache if available, otherwise empty
+            return this.cachedTools || []
+        }
+    }
+
+    /**
+     * Call a tool on the flow building MCP server.
+     * @param {string} toolName - The original tool name (without flow. prefix)
+     * @param {object} args - Tool arguments
+     * @returns {Promise<object>} Tool result
+     */
+    async callTool (toolName, args) {
+        if (!this.isConfigured) {
+            throw new Error('Flow building MCP server not configured')
+        }
+
+        const client = new Client({ name: 'flowfuse-forge', version: '1.0.0' })
+        const transport = new StreamableHTTPClientTransport(new URL(this.mcpUrl))
+
+        try {
+            await client.connect(transport)
+            const result = await client.callTool({ name: toolName, arguments: args })
+            return result
+        } finally {
+            try { await client.close() } catch (_) {}
+        }
+    }
+
+    async _fetchTools () {
+        const client = new Client({ name: 'flowfuse-forge', version: '1.0.0' })
+        const transport = new StreamableHTTPClientTransport(new URL(this.mcpUrl))
+
+        try {
+            await client.connect(transport)
+            const { tools } = await client.listTools()
+
+            // Wrap each tool with flow. prefix and bridge metadata
+            return tools.map(tool => ({
+                name: `flow.${tool.name}`,
+                originalName: tool.name,
+                description: tool.description || '',
+                inputSchema: jsonSchemaToZod(tool.inputSchema),
+                annotations: {
+                    readOnlyHint: false,
+                    destructiveHint: false,
+                    idempotentHint: false,
+                    openWorldHint: false
+                },
+                _bridge: true
+            }))
+        } finally {
+            try { await client.close() } catch (_) {}
+        }
+    }
+
+    /**
+     * Invalidate the tool cache (e.g., when config changes)
+     */
+    invalidateCache () {
+        this.cachedTools = null
+        this.cacheExpiry = 0
+    }
+}
+
+module.exports = { FlowBuildingBridge }

--- a/forge/ee/lib/mcp/mqttDispatch.js
+++ b/forge/ee/lib/mcp/mqttDispatch.js
@@ -1,0 +1,192 @@
+'use strict'
+
+const { v4: uuidv4 } = require('uuid')
+
+/**
+ * MqttDispatch - Dispatches flow-building actions to a user's browser
+ * via MQTT inflight topics and waits for the response.
+ *
+ * Used when an external MCP client calls a flow-building tool. The forge
+ * platform acts as the "agent", publishing inflight requests and
+ * subscribing to inflight responses using the same protocol the expert
+ * agent uses.
+ *
+ * The MQTT v5 correlationData property is used to correlate requests
+ * with responses (same pattern as devices.js ResponseMonitor).
+ */
+class MqttDispatch {
+    /**
+     * @param {import('../../../forge').ForgeApplication} app
+     */
+    constructor (app) {
+        this.app = app
+        /** @type {Map<string, { resolve: Function, reject: Function, timer: NodeJS.Timeout, responseTopic: string }>} */
+        this.pendingRequests = new Map()
+        this.TIMEOUT = 30000 // 30 seconds
+        this._boundMessageHandler = null
+        this._subscribedTopics = new Set()
+    }
+
+    /**
+     * Get the CommsClient instance from the app.
+     * @returns {import('../../../comms/commsClient').CommsClient|null}
+     */
+    _getCommsClient () {
+        return this.app.comms?.devices?.client || null
+    }
+
+    /**
+     * Get the raw MQTT client for subscribe/unsubscribe operations.
+     * @returns {import('mqtt').MqttClient|null}
+     */
+    _getMqttClient () {
+        const commsClient = this._getCommsClient()
+        return commsClient?.client || null
+    }
+
+    /**
+     * Ensure the global message handler is attached to the raw MQTT client.
+     * This handler routes incoming messages to any pending request that
+     * matches the response topic.
+     */
+    _ensureMessageHandler () {
+        if (this._boundMessageHandler) return
+
+        const mqttClient = this._getMqttClient()
+        if (!mqttClient) return
+
+        this._boundMessageHandler = (topic, message, packet) => {
+            // Only process topics we are watching
+            if (!this._subscribedTopics.has(topic)) return
+
+            try {
+                const correlationId = packet?.properties?.correlationData
+                    ? Buffer.from(packet.properties.correlationData).toString()
+                    : null
+
+                // Try to match by correlationId first, then by topic
+                let pending = null
+                let pendingKey = null
+
+                if (correlationId && this.pendingRequests.has(correlationId)) {
+                    pending = this.pendingRequests.get(correlationId)
+                    pendingKey = correlationId
+                } else {
+                    // Fallback: match by response topic (for clients that don't
+                    // echo correlationData)
+                    for (const [key, req] of this.pendingRequests) {
+                        if (req.responseTopic === topic) {
+                            pending = req
+                            pendingKey = key
+                            break
+                        }
+                    }
+                }
+
+                if (pending && pendingKey) {
+                    clearTimeout(pending.timer)
+                    this.pendingRequests.delete(pendingKey)
+
+                    const result = JSON.parse(message.toString())
+                    pending.resolve(result)
+
+                    // Unsubscribe from this response topic if no other
+                    // pending requests need it
+                    this._maybeUnsubscribe(pending.responseTopic)
+                }
+            } catch (err) {
+                this.app.log.warn(`MqttDispatch: error processing response: ${err.message}`)
+            }
+        }
+
+        mqttClient.on('message', this._boundMessageHandler)
+    }
+
+    /**
+     * Unsubscribe from a response topic if no pending requests reference it.
+     * @param {string} responseTopic
+     */
+    _maybeUnsubscribe (responseTopic) {
+        // Check if any other pending request uses this topic
+        for (const req of this.pendingRequests.values()) {
+            if (req.responseTopic === responseTopic) return
+        }
+
+        const mqttClient = this._getMqttClient()
+        if (mqttClient) {
+            mqttClient.unsubscribe(responseTopic)
+        }
+        this._subscribedTopics.delete(responseTopic)
+    }
+
+    /**
+     * Dispatch an action to the user's browser via MQTT and wait for the result.
+     *
+     * @param {object} session - Editor session { sessionId, userId, teamId }
+     * @param {string} projectId - The instance ID
+     * @param {string} actionName - e.g. 'automation:add-nodes'
+     * @param {object} params - Action parameters
+     * @returns {Promise<object>} Result from the browser's nr-assistant
+     */
+    async dispatchAndWait (session, projectId, actionName, params) {
+        const mqttClient = this._getMqttClient()
+        const commsClient = this._getCommsClient()
+        if (!mqttClient || !commsClient) {
+            throw new Error('MQTT comms not available')
+        }
+
+        this._ensureMessageHandler()
+
+        const correlationId = uuidv4()
+
+        // Build MQTT topics using a dedicated mcp namespace so the expert
+        // agent's NR instance (subscribed to ff/v1/expert/...) never sees these.
+        // Frontend subscribes to: ff/v1/mcp/{userId}/{sessionId}/p/{projectId}/support/inflight/{inflightType}/request
+        // Frontend publishes to:  ff/v1/mcp/{userId}/{sessionId}/p/{projectId}/support/inflight/{inflightType}/response
+        const baseTopic = `ff/v1/mcp/${session.userId}/${session.sessionId}/p/${projectId}/support/inflight`
+        const requestTopic = `${baseTopic}/${actionName}/request`
+        const responseTopic = `${baseTopic}/${actionName}/response`
+
+        // Subscribe to the response topic before publishing the request
+        if (!this._subscribedTopics.has(responseTopic)) {
+            await new Promise((resolve, reject) => {
+                mqttClient.subscribe(responseTopic, { qos: 2 }, (err) => {
+                    if (err) return reject(err)
+                    this._subscribedTopics.add(responseTopic)
+                    resolve()
+                })
+            })
+        }
+
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this.pendingRequests.delete(correlationId)
+                this._maybeUnsubscribe(responseTopic)
+                reject(new Error(`Timeout waiting for action '${actionName}' response from browser`))
+            }, this.TIMEOUT)
+
+            this.pendingRequests.set(correlationId, {
+                resolve,
+                reject,
+                timer,
+                responseTopic
+            })
+
+            // Build the payload matching the inflight protocol.
+            // Include correlationId and sessionId in the payload body because
+            // the forge_platform MQTT client uses protocol v3.1.1 (no v5 properties).
+            const payload = JSON.stringify({
+                status: actionName,
+                toolname: actionName,
+                params,
+                source: 'forge-mcp',
+                correlationId,
+                sessionId: session.sessionId
+            })
+
+            commsClient.publish(requestTopic, payload, { qos: 2 })
+        })
+    }
+}
+
+module.exports = { MqttDispatch }

--- a/forge/ee/lib/mcp/platformActionsInterface.js
+++ b/forge/ee/lib/mcp/platformActionsInterface.js
@@ -1,0 +1,31 @@
+/**
+ * Abstract base class for platform action providers.
+ * Implementations define supported actions and their handlers.
+ */
+class PlatformActionsInterface {
+    /** @type {import('../../../forge').ForgeApplication} */
+    app = null
+
+    init (app) {
+        this.app = app
+    }
+
+    get supportedActions () {
+        throw new Error('supportedActions getter not implemented')
+    }
+
+    hasAction (actionName) {
+        throw new Error('hasAction method not implemented')
+    }
+
+    /**
+     * @param {string} actionName
+     * @param {object} context
+     * @param {object} [result]
+     */
+    async invokeAction (actionName, context, result = {}) {
+        throw new Error('invokeAction method not implemented')
+    }
+}
+
+module.exports = PlatformActionsInterface

--- a/forge/ee/lib/mcp/platformAutomations.js
+++ b/forge/ee/lib/mcp/platformAutomations.js
@@ -1,0 +1,601 @@
+'use strict'
+
+const { z } = require('zod')
+
+const PlatformActionsInterface = require('./platformActionsInterface')
+
+class PlatformAutomations extends PlatformActionsInterface {
+    _tools = {
+        // -----------------------------------------------------------------
+        // Read-only tools
+        // -----------------------------------------------------------------
+
+        'platform.list-teams': {
+            description: 'List teams the authenticated user belongs to',
+            inputSchema: z.object({}),
+            annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const response = await this._inject({ method: 'GET', url: '/api/v1/user/teams', ...ctx })
+                this._assertOk(response, 'list teams')
+                const body = response.json()
+                return { teams: body.teams }
+            }
+        },
+
+        'platform.list-applications': {
+            description: 'List applications within a team',
+            inputSchema: z.object({
+                teamId: z.string().describe('The hashid of the team')
+            }),
+            annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { teamId } = ctx.params
+                const response = await this._inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${teamId}/applications?includeApplicationSummary=true`,
+                    ...ctx
+                })
+                this._assertOk(response, 'list applications')
+                const body = response.json()
+                return { applications: body.applications }
+            }
+        },
+
+        'platform.list-instances': {
+            description: 'List instances within an application',
+            inputSchema: z.object({
+                applicationId: z.string().describe('The hashid of the application')
+            }),
+            annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { applicationId } = ctx.params
+                const response = await this._inject({
+                    method: 'GET',
+                    url: `/api/v1/applications/${applicationId}/instances`,
+                    ...ctx
+                })
+                this._assertOk(response, 'list instances')
+                const body = response.json()
+                return { instances: body.instances || [] }
+            }
+        },
+
+        'platform.get-instance': {
+            description: 'Get the details of a specific instance',
+            inputSchema: z.object({
+                instanceId: z.string().describe('The ID of the instance')
+            }),
+            annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { instanceId } = ctx.params
+                const response = await this._inject({
+                    method: 'GET',
+                    url: `/api/v1/projects/${instanceId}`,
+                    ...ctx
+                })
+                this._assertOk(response, 'get instance')
+                return response.json()
+            }
+        },
+
+        'platform.list-instance-types': {
+            description: 'List available instance types for a team',
+            inputSchema: z.object({
+                teamId: z.string().describe('The hashid of the team')
+            }),
+            annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const response = await this._inject({
+                    method: 'GET',
+                    url: '/api/v1/project-types',
+                    ...ctx
+                })
+                this._assertOk(response, 'list instance types')
+                const body = response.json()
+                return { instanceTypes: body.types || [] }
+            }
+        },
+
+        'platform.list-stacks': {
+            description: 'List available Node-RED stacks for a given instance type',
+            inputSchema: z.object({
+                instanceTypeId: z.string().describe('The hashid of the instance type')
+            }),
+            annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { instanceTypeId } = ctx.params
+                const response = await this._inject({
+                    method: 'GET',
+                    url: `/api/v1/stacks?projectType=${instanceTypeId}`,
+                    ...ctx
+                })
+                this._assertOk(response, 'list stacks')
+                const body = response.json()
+                return { stacks: body.stacks || [] }
+            }
+        },
+
+        'platform.list-blueprints': {
+            description: 'List flow blueprints available for a team',
+            inputSchema: z.object({
+                teamId: z.string().describe('The hashid of the team')
+            }),
+            annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { teamId } = ctx.params
+                const response = await this._inject({
+                    method: 'GET',
+                    url: `/api/v1/flow-blueprints?team=${teamId}`,
+                    ...ctx
+                })
+                this._assertOk(response, 'list blueprints')
+                const body = response.json()
+                return { blueprints: body.blueprints || [] }
+            }
+        },
+
+        'platform.get-instance-status': {
+            description: 'Get the live status of a specific instance',
+            inputSchema: z.object({
+                instanceId: z.string().describe('The ID of the instance')
+            }),
+            annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+            handler: async (ctx) => {
+                const { instanceId } = ctx.params
+                const response = await this._inject({
+                    method: 'GET',
+                    url: `/api/v1/projects/${instanceId}`,
+                    ...ctx
+                })
+                this._assertOk(response, 'get instance status')
+                const body = response.json()
+                return {
+                    id: body.id,
+                    name: body.name,
+                    state: body.state || null,
+                    meta: body.meta || null
+                }
+            }
+        },
+
+        'platform.check-name-availability': {
+            description: 'Check whether a name is available for a new instance or application',
+            inputSchema: z.object({
+                name: z.string().describe('The name to check'),
+                type: z.enum(['instance', 'application']).describe('The resource type to check the name for'),
+                teamId: z.string().optional().describe('The hashid of the team (required when type is "application")')
+            }),
+            annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { name, type } = ctx.params
+                if (type === 'instance') {
+                    const response = await this._inject({
+                        method: 'POST',
+                        url: '/api/v1/projects/check-name',
+                        payload: { name },
+                        ...ctx
+                    })
+                    if (response.statusCode === 409) {
+                        const body = response.json()
+                        return { available: false, reason: body.error || 'name not available' }
+                    }
+                    this._assertOk(response, 'check name availability')
+                    return { available: true }
+                } else if (type === 'application') {
+                    const trimmedName = name?.trim()
+                    if (!trimmedName) {
+                        return { available: false, reason: 'Name must not be empty' }
+                    }
+                    return { available: true }
+                }
+                return { available: false, reason: `Unknown type: ${type}` }
+            }
+        },
+
+        // -----------------------------------------------------------------
+        // Write tools
+        // -----------------------------------------------------------------
+
+        'platform.create-application': {
+            description: 'Create a new application within a team',
+            inputSchema: z.object({
+                name: z.string().describe('The name of the new application'),
+                teamId: z.string().describe('The hashid of the team to create the application in'),
+                description: z.string().optional().describe('An optional description for the application')
+            }),
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+            handler: async (ctx) => {
+                const { teamId, name, description } = ctx.params
+                const response = await this._inject({
+                    method: 'POST',
+                    url: '/api/v1/applications',
+                    payload: { name, description, teamId },
+                    ...ctx
+                })
+                this._assertOk(response, 'create application')
+                return response.json()
+            }
+        },
+
+        'platform.create-instance': {
+            description: 'Create a new Node-RED instance within an application. The instance starts automatically after creation.',
+            inputSchema: z.object({
+                name: z.string().describe('The name of the new instance'),
+                applicationId: z.string().describe('The hashid of the application to create the instance in'),
+                projectType: z.string().describe('The hashid of the instance type to use'),
+                stack: z.string().describe('The hashid of the stack to use'),
+                template: z.string().optional().describe('The hashid of the template to use. If omitted, the platform default template is used.'),
+                flowBlueprintId: z.string().optional().describe('The hashid of an optional flow blueprint to apply')
+            }),
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+            handler: async (ctx) => {
+                const { applicationId, projectType, stack, flowBlueprintId, name } = ctx.params
+                let { template } = ctx.params
+
+                // The POST /api/v1/projects route requires template. Auto-select if omitted.
+                if (!template) {
+                    const defaultTemplate = await this.app.db.models.ProjectTemplate.findAll({
+                        where: { active: true },
+                        order: [['id', 'ASC']],
+                        limit: 1
+                    })
+                    if (!defaultTemplate[0]) {
+                        throw new Error('No active template found. Please specify a template.')
+                    }
+                    template = this.app.db.models.ProjectTemplate.encodeHashid(defaultTemplate[0].id)
+                }
+
+                const payload = { name, applicationId, projectType, stack, template }
+                if (flowBlueprintId) payload.flowBlueprintId = flowBlueprintId
+
+                const response = await this._inject({
+                    method: 'POST',
+                    url: '/api/v1/projects',
+                    payload,
+                    ...ctx
+                })
+                this._assertOk(response, 'create instance')
+                const body = response.json()
+
+                return {
+                    ...body,
+                    navigation: {
+                        suggestion: 'open-editor',
+                        target: `/instance/${body.id}/editor`,
+                        label: 'Open Editor'
+                    }
+                }
+            }
+        },
+
+        // -----------------------------------------------------------------
+        // Instance lifecycle tools
+        // -----------------------------------------------------------------
+
+        'platform.manage-instance': {
+            description: 'Manage an instance lifecycle: start, stop, restart, or suspend',
+            inputSchema: z.object({
+                instanceId: z.string().describe('The ID of the instance'),
+                action: z.enum(['start', 'stop', 'restart', 'suspend']).describe('The lifecycle action to perform')
+            }),
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { instanceId, action } = ctx.params
+                const response = await this._inject({
+                    method: 'POST',
+                    url: `/api/v1/projects/${instanceId}/actions/${action}`,
+                    ...ctx
+                })
+                this._assertOk(response, `${action} instance`)
+                return { status: 'okay', instanceId, action }
+            }
+        },
+
+        // -----------------------------------------------------------------
+        // Navigation tools
+        // -----------------------------------------------------------------
+
+        'platform.open-editor': {
+            description: 'Get the URL to open the Node-RED editor for an instance. The user must open this URL in their browser before flow tools can be used.',
+            inputSchema: z.object({
+                instanceId: z.string().describe('The ID of the instance')
+            }),
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { instanceId } = ctx.params
+                const response = await this._inject({
+                    method: 'GET',
+                    url: `/api/v1/projects/${instanceId}`,
+                    ...ctx
+                })
+                this._assertOk(response, 'get instance')
+                const body = response.json()
+                const baseUrl = this.app.config.base_url
+                return {
+                    url: `${baseUrl}/instance/${body.id}/editor`,
+                    target: `/instance/${body.id}/editor`,
+                    message: 'Open this URL in the browser to access the editor'
+                }
+            }
+        },
+
+        'platform.open-instance': {
+            description: 'Get the URL to open an instance in the FlowFuse dashboard',
+            inputSchema: z.object({
+                instanceId: z.string().describe('The ID of the instance')
+            }),
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { instanceId } = ctx.params
+                const response = await this._inject({
+                    method: 'GET',
+                    url: `/api/v1/projects/${instanceId}`,
+                    ...ctx
+                })
+                this._assertOk(response, 'get instance')
+                const body = response.json()
+                const baseUrl = this.app.config.base_url
+                return {
+                    url: `${baseUrl}/instance/${body.id}`,
+                    target: `/instance/${body.id}`,
+                    message: 'Open this URL to access the instance'
+                }
+            }
+        },
+
+        // -----------------------------------------------------------------
+        // Destructive tools
+        // -----------------------------------------------------------------
+
+        'platform.delete-instance': {
+            description: 'Permanently delete an instance and all its data. This action cannot be undone.',
+            inputSchema: z.object({
+                instanceId: z.string().describe('The ID of the instance to delete')
+            }),
+            annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
+            handler: async (ctx) => {
+                const { instanceId } = ctx.params
+                const response = await this._inject({
+                    method: 'DELETE',
+                    url: `/api/v1/projects/${instanceId}`,
+                    ...ctx
+                })
+                this._assertOk(response, 'delete instance')
+                return { status: 'okay', message: 'Instance has been deleted' }
+            }
+        },
+
+        'platform.delete-application': {
+            description: 'Permanently delete an application. The application must have no instances. This action cannot be undone.',
+            inputSchema: z.object({
+                applicationId: z.string().describe('The hashid of the application to delete')
+            }),
+            annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
+            handler: async (ctx) => {
+                const { applicationId } = ctx.params
+                const response = await this._inject({
+                    method: 'DELETE',
+                    url: `/api/v1/applications/${applicationId}`,
+                    ...ctx
+                })
+                this._assertOk(response, 'delete application')
+                return { status: 'okay', message: 'Application has been deleted' }
+            }
+        },
+
+        // -----------------------------------------------------------------
+        // Settings and snapshot tools
+        // -----------------------------------------------------------------
+
+        'platform.update-instance-settings': {
+            description: "Update an instance's environment variables and settings",
+            inputSchema: z.object({
+                instanceId: z.string().describe('The ID of the instance to update'),
+                env: z.record(z.string()).optional().describe('An object of environment variable key/value pairs to set on the instance'),
+                settings: z.record(z.unknown()).optional().describe('An object of settings to merge into the instance settings')
+            }),
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            handler: async (ctx) => {
+                const { instanceId, env, settings } = ctx.params
+
+                const bodySettings = {}
+                if (env) {
+                    bodySettings.env = Object.entries(env).map(([name, value]) => ({ name, value }))
+                }
+                if (settings) {
+                    Object.assign(bodySettings, settings)
+                }
+
+                if (Object.keys(bodySettings).length === 0) {
+                    return { status: 'okay', message: 'No changes to apply', instanceId }
+                }
+
+                const response = await this._inject({
+                    method: 'PUT',
+                    url: `/api/v1/projects/${instanceId}`,
+                    payload: { settings: bodySettings },
+                    ...ctx
+                })
+                this._assertOk(response, 'update instance settings')
+                return { status: 'okay', instanceId, message: 'Instance settings updated' }
+            }
+        },
+
+        'platform.create-snapshot': {
+            description: 'Create a snapshot of the current state of an instance',
+            inputSchema: z.object({
+                instanceId: z.string().describe('The ID of the instance to snapshot'),
+                name: z.string().describe('The name for the snapshot'),
+                description: z.string().optional().describe('An optional description for the snapshot')
+            }),
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+            handler: async (ctx) => {
+                const { instanceId, name, description } = ctx.params
+                const response = await this._inject({
+                    method: 'POST',
+                    url: `/api/v1/projects/${instanceId}/snapshots`,
+                    payload: { name, description: description || '' },
+                    ...ctx
+                })
+                this._assertOk(response, 'create snapshot')
+                const body = response.json()
+                return {
+                    id: body.id,
+                    name: body.name,
+                    description: body.description || null,
+                    createdAt: body.createdAt
+                }
+            }
+        }
+    }
+
+    get supportedActions () {
+        const actions = {}
+        for (const [name, def] of Object.entries(this._tools)) {
+            actions[name] = {
+                description: def.description,
+                inputSchema: def.inputSchema,
+                annotations: def.annotations
+            }
+        }
+        return Object.freeze(actions)
+    }
+
+    hasAction (actionName) {
+        return !!this._tools[actionName]
+    }
+
+    /**
+     * @param {string} actionName
+     * @param {{ user: import('sequelize').Model, params: object, app: import('../../../forge').ForgeApplication, viaMCPToken?: boolean, headers?: object, cookies?: object }} context
+     */
+    async invokeAction (actionName, context) {
+        const tool = this._tools[actionName]
+        if (!tool) {
+            throw new Error(`Unknown action: ${actionName}`)
+        }
+
+        await this._checkMCPToolAccess(context.user, actionName, context.params)
+
+        if (context.viaMCPToken) {
+            this.app.log.info({
+                trigger: 'mcp-agent',
+                action: actionName,
+                userId: context.user?.id,
+                userHashid: context.user?.hashid
+            }, `MCP tool invoked via mcp-agent token: ${actionName}`)
+        }
+
+        return tool.handler(context)
+    }
+
+    // ---------------------------------------------------------------------
+    // MCP RBAC
+    // ---------------------------------------------------------------------
+
+    /**
+     * Check that the user has sufficient MCP RBAC permissions to execute the given tool.
+     * Admin users bypass all checks. For tools with no team context (list-teams), the
+     * team-scoped permission check is skipped because list-teams only returns the user's
+     * own teams and requires no additional privilege beyond authentication.
+     */
+    async _checkMCPToolAccess (user, actionName, params) {
+        if (user.admin) {
+            return
+        }
+
+        const tool = this._tools[actionName]
+        if (!tool) {
+            return
+        }
+
+        const annotations = tool.annotations || {}
+        const isReadonly = annotations.readOnlyHint === true
+        const isDestructive = annotations.destructiveHint === true
+        const isIdempotent = annotations.idempotentHint === true
+
+        let team = null
+        const { teamId, applicationId, instanceId } = params || {}
+
+        if (teamId) {
+            team = await this.app.db.models.Team.byId(teamId)
+        } else if (applicationId) {
+            const application = await this.app.db.models.Application.byId(applicationId)
+            if (application) {
+                team = application.Team || await application.getTeam()
+            }
+        } else if (instanceId) {
+            const instance = await this.app.db.models.Project.byId(instanceId)
+            if (instance) {
+                team = instance.Team
+            }
+        }
+
+        if (!team) {
+            return
+        }
+
+        const membership = await user.getTeamMembership(team.id)
+        if (!membership) {
+            return
+        }
+
+        if (!this.app.hasPermission(membership, 'expert:insights:mcp:tool:allow')) {
+            throw new Error('Access denied: insufficient permissions to use MCP tools (requires expert:insights:mcp:tool:allow)')
+        }
+
+        if (!isReadonly) {
+            if (!this.app.hasPermission(membership, 'expert:insights:mcp:tool:write')) {
+                throw new Error('Access denied: insufficient permissions to use write MCP tools (requires expert:insights:mcp:tool:write)')
+            }
+        }
+
+        if (isDestructive) {
+            if (!this.app.hasPermission(membership, 'expert:insights:mcp:tool:destructive')) {
+                throw new Error('Access denied: insufficient permissions to use destructive MCP tools (requires expert:insights:mcp:tool:destructive)')
+            }
+        }
+
+        if (!isReadonly && !isIdempotent) {
+            if (!this.app.hasPermission(membership, 'expert:insights:mcp:tool:non-idempotent')) {
+                throw new Error('Access denied: insufficient permissions to use non-idempotent MCP tools (requires expert:insights:mcp:tool:non-idempotent)')
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------
+
+    /**
+     * Make an in-process HTTP request via Fastify's inject(), forwarding the
+     * caller's auth credentials (Bearer token or signed session cookie).
+     */
+    async _inject ({ method, url, payload, headers, cookies }) {
+        const opts = { method, url }
+        if (headers?.authorization) {
+            opts.headers = { authorization: headers.authorization }
+        } else if (cookies?.sid) {
+            opts.cookies = { sid: cookies.sid }
+        }
+        if (payload) {
+            opts.payload = payload
+        }
+        return this.app.inject(opts)
+    }
+
+    /**
+     * Throw if the inject response indicates an error.
+     */
+    _assertOk (response, action) {
+        if (response.statusCode >= 400) {
+            const body = response.json()
+            const err = new Error(body.error || `${action} failed`)
+            err.statusCode = response.statusCode
+            err.code = body.code
+            throw err
+        }
+    }
+}
+
+module.exports = PlatformAutomations

--- a/forge/ee/routes/expert/index.js
+++ b/forge/ee/routes/expert/index.js
@@ -8,8 +8,10 @@
  */
 const { default: axios } = require('axios')
 const { v4: uuidv4 } = require('uuid')
+const { zodToJsonSchema } = require('zod-to-json-schema')
 
 const { filterAccessibleMCPServerFeatures } = require('../../../services/expert.js')
+const PlatformAutomations = require('../../lib/mcp/platformAutomations')
 
 /**
  * @param {import('../../forge.js').ForgeApplication} app
@@ -69,11 +71,13 @@ module.exports = async function (app) {
             }
             const isExpertAssistantEnabled = !!(app.config.features.enabled('expertAssistant') && request.team.getFeatureProperty('expertAssistant', true))
             const isExpertInsightsEnabled = !!(app.config.features.enabled('expertInsights') && request.team.getFeatureProperty('expertInsights', true))
-            if (!isExpertAssistantEnabled && !isExpertInsightsEnabled) {
+            const isExpertPlatformAutomationEnabled = !!(app.config.features.enabled('expertPlatformAutomation') && request.team.getFeatureProperty('expertPlatformAutomation', true))
+            if (!isExpertAssistantEnabled && !isExpertInsightsEnabled && !isExpertPlatformAutomationEnabled) {
                 return reply.status(404).send({ code: 'not_found', error: 'Not Found' })
             }
             request.isExpertAssistantEnabled = isExpertAssistantEnabled
             request.isExpertInsightsEnabled = isExpertInsightsEnabled
+            request.isExpertPlatformAutomationEnabled = isExpertPlatformAutomationEnabled
         }
     })
 
@@ -227,6 +231,16 @@ module.exports = async function (app) {
             context.selectedCapabilities = filteredAccessibleServers?.length > 0 ? filteredAccessibleServers : undefined
         }
 
+        // Inject platform automation tool definitions into the context so the
+        // expert agent can create DynamicStructuredTools that dispatch back via
+        // MQTT inflight → frontend → POST /api/v1/expert/platform-tool.
+        if (request.isExpertPlatformAutomationEnabled) {
+            const platformToolDefs = buildPlatformToolDefinitions(app, request.team, request.teamMembership)
+            if (platformToolDefs.length > 0) {
+                context.platformTools = platformToolDefs
+            }
+        }
+
         let query = request.body.query
         if (request.body.history) {
             query = ''
@@ -255,6 +269,60 @@ module.exports = async function (app) {
             reply.code(error.response?.status || 500).send({ code: error.response?.data?.code || 'unexpected_error', error: error.response?.data?.error || error.message })
         }
     })
+    /**
+     * Execute a platform automation tool on behalf of the authenticated user.
+     * Tool names map to PlatformAutomations.supportedActions keys (e.g. 'list-teams').
+     */
+    app.post('/platform-tool', {
+        schema: {
+            hide: true,
+            body: {
+                type: 'object',
+                required: ['tool', 'arguments', 'context'],
+                properties: {
+                    tool: { type: 'string' },
+                    arguments: { type: 'object', additionalProperties: true },
+                    context: {
+                        type: 'object',
+                        properties: {
+                            teamId: { type: 'string', minLength: 1 }
+                        },
+                        required: ['teamId'],
+                        additionalProperties: true
+                    }
+                }
+            }
+        }
+    }, async (request, reply) => {
+        const user = request.user // set by preHandler
+        if (!user) {
+            return reply.code(401).send({ error: 'Unauthorized' })
+        }
+
+        const { tool, arguments: args } = request.body
+
+        const platformAutomations = new PlatformAutomations()
+        platformAutomations.init(app)
+
+        if (!platformAutomations.hasAction(tool)) {
+            return reply.code(400).send({ error: `Unknown platform tool: ${tool}` })
+        }
+
+        try {
+            const result = await platformAutomations.invokeAction(tool, {
+                user,
+                params: args,
+                app,
+                headers: request.headers,
+                cookies: request.cookies
+            })
+            reply.send({ result })
+        } catch (err) {
+            app.log.error(`Expert platform tool ${tool} error: ${err.message}`)
+            reply.code(400).send({ error: err.message })
+        }
+    })
+
     /**
      * an endpoint to retrieve MCP features (prompts/resources/tools) for the users team
      */
@@ -289,6 +357,10 @@ module.exports = async function (app) {
                     type: 'object',
                     properties: {
                         transactionId: { type: 'string' },
+                        platformTools: {
+                            type: 'array',
+                            items: { type: 'object', additionalProperties: true }
+                        },
                         servers: {
                             type: 'array',
                             items: {
@@ -327,159 +399,293 @@ module.exports = async function (app) {
      * @param {import('fastify').FastifyReply} reply
      */
     async (request, reply) => {
-        if (!request.isExpertInsightsEnabled) {
+        // Platform tools are gated on expertPlatformAutomation; NR MCP servers on expertInsights.
+        // At least one must be enabled to access this endpoint.
+        if (!request.isExpertInsightsEnabled && !request.isExpertPlatformAutomationEnabled) {
             return reply.status(404).send({ code: 'not_found', error: 'Not Found' })
         }
 
         try {
-            // Premise:
-            // In order to get the MCP features (prompts/resources/tools) available to the user for their
-            // team / application RBACs, in order of computational cost, we need do the following:
-            // 1. Get the MCP servers registered for this team
-            // 2. For each MCP server
-            //    1. Ensure the instance is supposed to be running (i.e. state is 'running')
-            //    2. Get the application and check RBAC permits access
-            //    3. Ensure the instance is actually running (live state check)
-            //    5. For each running instance with MCP server, get/create access token as needed
-            //       based on the instance's node security settings
-            //    6. Call to backend expert service to get the MCP features for the accessible MCP servers
-            //    7. Filter the MCP features based on user RBACs (e.g. destructive tool access)
-            // 3. Return the filtered MCP features to the client
-
-            /** @type {MCPServerItem[]} */
-            const runningInstancesWithMCPServer = []
             const transactionId = request.headers['x-chat-transaction-id']
-            const mcpCapabilitiesUrl = `${app.expert.expertUrl.split('/').slice(0, -1).join('/')}/mcp/features`
+            let filteredServers = []
 
-            // Get the MCP servers registered for this team
-            const mcpServers = await app.db.models.MCPRegistration.byTeam(request.team.id, { includeInstance: true }) || []
+            // NR instance MCP servers — only when insights is enabled
+            if (request.isExpertInsightsEnabled) {
+                // Premise:
+                // In order to get the MCP features (prompts/resources/tools) available to the user for their
+                // team / application RBACs, in order of computational cost, we need do the following:
+                // 1. Get the MCP servers registered for this team
+                // 2. For each MCP server
+                //    1. Ensure the instance is supposed to be running (i.e. state is 'running')
+                //    2. Get the application and check RBAC permits access
+                //    3. Ensure the instance is actually running (live state check)
+                //    5. For each running instance with MCP server, get/create access token as needed
+                //       based on the instance's node security settings
+                //    6. Call to backend expert service to get the MCP features for the accessible MCP servers
+                //    7. Filter the MCP features based on user RBACs (e.g. destructive tool access)
+                // 3. Return the filtered MCP features to the client
 
-            // Scan each MCP server and ensure the user has access to the associated application and that the instance is running
-            // then collect the MCP server info for the running instances MCP servers
-            // filter out any that the user doesn't have access to
-            const applicationCache = {}
-            for (const server of mcpServers) {
-                const { name, protocol, endpointRoute, TeamId, Project, Device, title, version, description } = server
-                if (TeamId !== request.team.id) {
-                    // shouldn't happen due to byTeam filter, but just in case
-                    continue
-                }
-                let instance, instanceId, instanceType
-                if (Device) {
-                    // instanceType = 'device'
-                    // instance = Device
-                    // instanceId = Device.hashid
-                    continue // Devices are not yet supported for MCP servers
-                } else if (Project) {
-                    instanceType = 'instance'
-                    instance = Project
-                    instanceId = Project.id
-                } else {
-                    continue
-                }
+                /** @type {MCPServerItem[]} */
+                const runningInstancesWithMCPServer = []
+                const mcpCapabilitiesUrl = `${app.expert.expertUrl.split('/').slice(0, -1).join('/')}/mcp/features`
 
-                // if instance is not expected to be running, skip it (avoids unnecessary timeouts)
-                if (instance?.state !== 'running') {
-                    continue
-                }
+                // Get the MCP servers registered for this team
+                const mcpServers = await app.db.models.MCPRegistration.byTeam(request.team.id, { includeInstance: true }) || []
 
-                // Ensure instance has an associated application
-                if (!instance?.ApplicationId) {
-                    continue // e.g. skip devices without an application as they can't be validated for access
-                }
-
-                // Get the application from local cache or db (an application can appear multiple times if multiple instances are registered)
-                const applicationHashid = app.db.models.Application.encodeHashid(instance.ApplicationId)
-                if (!Object.hasOwnProperty.call(applicationCache, applicationHashid)) {
-                    applicationCache[applicationHashid] = await app.db.models.Application.byId(applicationHashid)
-                }
-                const application = applicationCache[applicationHashid]
-                if (!application) {
-                    continue // skip - application not found
-                }
-
-                // Now we have the application & know the instance is supposed to be running, check user actually
-                // has access before bothering to check instance live state or calling backend for MCP features!
-                if (!app.hasPermission(request.teamMembership, 'expert:insights:mcp:allow', { application })) {
-                    continue // user doesn't have access to this instance
-                }
-
-                // Now we have confirmed access is allowed, check instance is actually running before offering
-                // MCP features (querying a non-running instance would cause timeouts)
-                if (instance.liveState) {
-                    const liveState = await instance.liveState({ omitStorageFlows: true })
-                    if (liveState?.meta?.state !== 'running') {
+                // Scan each MCP server and ensure the user has access to the associated application and that the instance is running
+                // then collect the MCP server info for the running instances MCP servers
+                // filter out any that the user doesn't have access to
+                const applicationCache = {}
+                for (const server of mcpServers) {
+                    const { name, protocol, endpointRoute, TeamId, Project, Device, title, version, description } = server
+                    if (TeamId !== request.team.id) {
+                        // shouldn't happen due to byTeam filter, but just in case
                         continue
                     }
-                }
+                    let instance, instanceId, instanceType
+                    if (Device) {
+                        // instanceType = 'device'
+                        // instance = Device
+                        // instanceId = Device.hashid
+                        continue // Devices are not yet supported for MCP servers
+                    } else if (Project) {
+                        instanceType = 'instance'
+                        instance = Project
+                        instanceId = Project.id
+                    } else {
+                        continue
+                    }
 
-                // Check instance settings for node security. If FlowFuse auth is enabled, generate a short-lived (5 mins)
-                // auth token for the instance with a scope limited to MCP access and cache it in memory for subsequent requests
-                const mcpAccessToken = await app.expert.mcp.getOrCreateToken(instance, instanceType, instanceId, request.teamHttpSecurityFeature)
+                    // if instance is not expected to be running, skip it (avoids unnecessary timeouts)
+                    if (instance?.state !== 'running') {
+                        continue
+                    }
 
-                runningInstancesWithMCPServer.push({
-                    team: request.team.hashid,
-                    application: application.hashid,
-                    instance: instanceId,
-                    instanceType,
-                    instanceName: instance.name,
-                    instanceUrl: instance.url,
-                    mcpServerName: name,
-                    mcpEndpoint: endpointRoute,
-                    mcpProtocol: protocol,
-                    mcpAccessToken,
-                    title,
-                    version,
-                    description
-                })
-            }
+                    // Ensure instance has an associated application
+                    if (!instance?.ApplicationId) {
+                        continue // e.g. skip devices without an application as they can't be validated for access
+                    }
 
-            // if no running instances with MCP server, return early
-            if (runningInstancesWithMCPServer.length === 0) {
-                return reply.send({ servers: [], transactionId })
-            }
+                    // Get the application from local cache or db (an application can appear multiple times if multiple instances are registered)
+                    const applicationHashid = app.db.models.Application.encodeHashid(instance.ApplicationId)
+                    if (!Object.hasOwnProperty.call(applicationCache, applicationHashid)) {
+                        applicationCache[applicationHashid] = await app.db.models.Application.byId(applicationHashid)
+                    }
+                    const application = applicationCache[applicationHashid]
+                    if (!application) {
+                        continue // skip - application not found
+                    }
 
-            // Call to backend to request MCP capabilities from expert service
-            // For reference - this POST:
-            // * calls the backend expert service endpoint /mcp/features
-            // * it connects to each MCP server registered
-            // * retrieves the prompts/resources/tools
-            // * adds them to the response along with the MCP server info
-            const response = await axios.post(mcpCapabilitiesUrl, {
-                teamId: request.team.hashid,
-                servers: runningInstancesWithMCPServer
-            }, {
-                headers: {
-                    Origin: request.headers.origin,
-                    'X-Chat-Transaction-ID': transactionId,
-                    ...(app.expert.serviceToken ? { Authorization: `Bearer ${app.expert.serviceToken}` } : {})
-                },
-                timeout: app.expert.requestTimeout
-            })
+                    // Now we have the application & know the instance is supposed to be running, check user actually
+                    // has access before bothering to check instance live state or calling backend for MCP features!
+                    if (!app.hasPermission(request.teamMembership, 'expert:insights:mcp:allow', { application })) {
+                        continue // user doesn't have access to this instance
+                    }
 
-            if (response.data.transactionId !== transactionId) {
-                throw new Error('Transaction ID mismatch')
-            }
-            const mcpServersResponse = response.data.servers || []
-            const serverList = []
-            // load the associate application models so that we can filter features based on user access
-            for (const serverItem of mcpServersResponse) {
-                const application = applicationCache[serverItem.application]
-                if (application) {
-                    serverList.push({
-                        server: serverItem,
-                        application
+                    // Now we have confirmed access is allowed, check instance is actually running before offering
+                    // MCP features (querying a non-running instance would cause timeouts)
+                    if (instance.liveState) {
+                        const liveState = await instance.liveState({ omitStorageFlows: true })
+                        if (liveState?.meta?.state !== 'running') {
+                            continue
+                        }
+                    }
+
+                    // Check instance settings for node security. If FlowFuse auth is enabled, generate a short-lived (5 mins)
+                    // auth token for the instance with a scope limited to MCP access and cache it in memory for subsequent requests
+                    const mcpAccessToken = await app.expert.mcp.getOrCreateToken(instance, instanceType, instanceId, request.teamHttpSecurityFeature)
+
+                    runningInstancesWithMCPServer.push({
+                        team: request.team.hashid,
+                        application: application.hashid,
+                        instance: instanceId,
+                        instanceType,
+                        instanceName: instance.name,
+                        instanceUrl: instance.url,
+                        mcpServerName: name,
+                        mcpEndpoint: endpointRoute,
+                        mcpProtocol: protocol,
+                        mcpAccessToken,
+                        title,
+                        version,
+                        description
                     })
                 }
-            }
-            // now check tools/resources/prompts access per server based on team membership
-            response.data.servers = filterAccessibleMCPServerFeatures(app, serverList, request.team, request.teamMembership)
 
-            reply.send(response.data)
+                // Call to backend to request MCP capabilities from expert service (NR instances only)
+                if (runningInstancesWithMCPServer.length > 0) {
+                    try {
+                        const response = await axios.post(mcpCapabilitiesUrl, {
+                            teamId: request.team.hashid,
+                            servers: runningInstancesWithMCPServer
+                        }, {
+                            headers: {
+                                Origin: request.headers.origin,
+                                'X-Chat-Transaction-ID': transactionId,
+                                ...(app.expert.serviceToken ? { Authorization: `Bearer ${app.expert.serviceToken}` } : {})
+                            },
+                            timeout: app.expert.requestTimeout
+                        })
+
+                        if (response.data.transactionId !== transactionId) {
+                            throw new Error('Transaction ID mismatch')
+                        }
+                        const mcpServersResponse = response.data.servers || []
+                        const serverList = []
+                        // load the associate application models so that we can filter features based on user access
+                        for (const serverItem of mcpServersResponse) {
+                            const application = applicationCache[serverItem.application]
+                            if (application) {
+                                serverList.push({
+                                    server: serverItem,
+                                    application
+                                })
+                            }
+                        }
+                        // check tools/resources/prompts access per server based on team membership
+                        filteredServers = filterAccessibleMCPServerFeatures(app, serverList, request.team, request.teamMembership)
+                    } catch (mcpError) {
+                        app.log.warn(`Failed to fetch NR instance MCP features: ${mcpError.message}`)
+                    }
+                }
+            }
+
+            // Platform tools — gated on expertPlatformAutomation, independent of insights
+            let platformToolDefs = []
+            if (request.isExpertPlatformAutomationEnabled) {
+                const platformServer = buildPlatformMCPServer(app, request.team, request.teamMembership)
+                platformToolDefs = buildPlatformToolDefinitions(app, request.team, request.teamMembership)
+
+                if (platformServer) {
+                    filteredServers.push(platformServer)
+                }
+            }
+
+            reply.send({ servers: filteredServers, platformTools: platformToolDefs, transactionId })
         } catch (error) {
             reply.code(error.response?.status || 500).send({ code: error.response?.data?.code || 'unexpected_error', error: error.response?.data?.error || error.message })
         }
     })
+}
+
+/**
+ * Build an array of platform tool definitions for injection into the expert
+ * chat context. Each entry contains enough information for the expert to
+ * create a DynamicStructuredTool that dispatches the call via MQTT inflight.
+ *
+ * Uses the same RBAC filtering as buildPlatformMCPServer so the expert only
+ * sees tools the user is allowed to execute.
+ *
+ * @param {import('../../forge.js').ForgeApplication} app
+ * @param {import('sequelize').Model} team
+ * @param {import('sequelize').Model} teamMembership
+ * @returns {Array<{name: string, description: string, inputSchema: object, annotations: object}>}
+ */
+function buildPlatformToolDefinitions (app, team, teamMembership) {
+    const defaultToolPermission = app.hasPermission(teamMembership, 'expert:insights:mcp:tool:allow')
+    if (!defaultToolPermission) {
+        return []
+    }
+
+    const allowToolWrite = app.hasPermission(teamMembership, 'expert:insights:mcp:tool:write')
+    const allowToolDestructive = app.hasPermission(teamMembership, 'expert:insights:mcp:tool:destructive')
+    const allowToolNonIdempotent = app.hasPermission(teamMembership, 'expert:insights:mcp:tool:non-idempotent')
+
+    const platformAutomations = new PlatformAutomations()
+    platformAutomations.init(app)
+
+    return Object.entries(platformAutomations.supportedActions)
+        .filter(([, def]) => {
+            const annotations = def.annotations || {}
+            const isReadonly = annotations.readOnlyHint === true
+            const isDestructive = annotations.destructiveHint !== false
+            const isIdempotent = annotations.idempotentHint === true
+            if (isReadonly && isDestructive) return false
+            const writeAccessRequired = isDestructive === true || isReadonly === false
+            if (writeAccessRequired) {
+                if (isDestructive === true && !allowToolDestructive) return false
+                if (isReadonly === false && !allowToolWrite) return false
+                if (isIdempotent === false && !allowToolNonIdempotent) return false
+            }
+            return true
+        })
+        .map(([name, def]) => ({
+            name,
+            description: def.description,
+            inputSchema: zodToJsonSchema(def.inputSchema, { target: 'openApi3' }),
+            annotations: def.annotations
+        }))
+}
+
+/**
+ * Build a virtual MCP server entry for FlowFuse platform automation tools.
+ * Applies the same RBAC tool-filtering logic as NR instance MCP servers, but
+ * without an application context (platform tools are team-scoped).
+ *
+ * @param {import('../../forge.js').ForgeApplication} app
+ * @param {import('sequelize').Model} team
+ * @param {import('sequelize').Model} teamMembership
+ * @returns {object|null}  A server-shaped object to append to the features response, or null if the user has no tool access.
+ */
+function buildPlatformMCPServer (app, team, teamMembership) {
+    // Gate: user must have general MCP tool access at the team level
+    const defaultToolPermission = app.hasPermission(teamMembership, 'expert:insights:mcp:tool:allow')
+    if (!defaultToolPermission) {
+        return null
+    }
+
+    const allowToolWrite = app.hasPermission(teamMembership, 'expert:insights:mcp:tool:write')
+    const allowToolDestructive = app.hasPermission(teamMembership, 'expert:insights:mcp:tool:destructive')
+    const allowToolNonIdempotent = app.hasPermission(teamMembership, 'expert:insights:mcp:tool:non-idempotent')
+
+    const platformAutomations = new PlatformAutomations()
+    platformAutomations.init(app)
+
+    const allTools = Object.entries(platformAutomations.supportedActions).map(([name, def]) => ({
+        name,
+        description: def.description,
+        annotations: def.annotations
+    }))
+
+    // Filter tools by RBAC (mirrors filterAccessibleMCPServerFeatures tool logic)
+    const tools = allTools.filter(tool => {
+        const annotations = tool.annotations || {}
+        const isReadonly = annotations.readOnlyHint === true
+        const isDestructive = annotations.destructiveHint !== false
+        const isIdempotent = annotations.idempotentHint === true
+
+        if (isReadonly && isDestructive) return false // invalid combination
+
+        const writeAccessRequired = isDestructive === true || isReadonly === false
+        if (writeAccessRequired) {
+            if (isDestructive === true && !allowToolDestructive) return false
+            if (isReadonly === false && !allowToolWrite) return false
+            if (isIdempotent === false && !allowToolNonIdempotent) return false
+        }
+
+        return true
+    })
+
+    if (tools.length === 0) {
+        return null
+    }
+
+    return {
+        team: team.hashid,
+        instance: 'platform',
+        instanceType: 'instance',
+        instanceName: 'FlowFuse Platform',
+        mcpServerName: 'platform',
+        mcpEndpoint: '/api/v1/mcp',
+        mcpProtocol: 'http',
+        title: 'FlowFuse Platform',
+        version: '1.0.0',
+        description: 'FlowFuse platform automation tools',
+        prompts: [],
+        resources: [],
+        resourceTemplates: [],
+        tools
+    }
 }
 
 /**

--- a/forge/ee/routes/index.js
+++ b/forge/ee/routes/index.js
@@ -42,6 +42,7 @@ module.exports = async function (app) {
         await app.register(require('./mcp'), { prefix: '/api/v1/teams/:teamId/mcp', logLevel: app.config.logging.http })
         await app.register(require('./autoUpdateStacks'), { prefix: '/api/v1/projects/:projectId/autoUpdateStack', logLevel: app.config.logging.http })
         await app.register(require('./expert'), { prefix: '/api/v1/expert', logLevel: app.config.logging.http })
+        await app.register(require('./mcpServer'), { prefix: '/api/v1/mcp', logLevel: app.config.logging.http })
 
         // Important: keep SSO last to avoid its error handling polluting other routes.
         await app.register(require('./sso'), { logLevel: app.config.logging.http })

--- a/forge/ee/routes/mcpServer/index.js
+++ b/forge/ee/routes/mcpServer/index.js
@@ -1,0 +1,324 @@
+'use strict'
+
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js')
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js')
+const { z } = require('zod')
+
+const { FlowBuildingBridge } = require('../../lib/mcp/flowBuildingBridge')
+const { MqttDispatch } = require('../../lib/mcp/mqttDispatch')
+const PlatformAutomations = require('../../lib/mcp/platformAutomations')
+
+/**
+ * MCP Server route — exposes the FlowFuse platform as an MCP-compatible endpoint.
+ *
+ * Mounted at: /api/v1/mcp
+ *
+ * The endpoint is stateless: a fresh McpServer and transport are created per request.
+ * Authentication is enforced by the preHandler hook inherited from the parent EE routes
+ * (app.verifySession), plus the additional check below that requires a session User.
+ *
+ * @param {import('../../../forge').ForgeApplication} app
+ */
+module.exports = async function (app) {
+    const platformAutomations = new PlatformAutomations()
+    platformAutomations.init(app)
+
+    // Initialise the FlowBuildingBridge singleton
+    if (!app.flowBuildingBridge) {
+        app.decorate('flowBuildingBridge', new FlowBuildingBridge(app))
+    }
+
+    // Initialise the MqttDispatch singleton (for external MCP client flow tool dispatch)
+    if (!app.mqttDispatch) {
+        app.decorate('mqttDispatch', new MqttDispatch(app))
+    }
+
+    // Require a session user (Bearer token / session cookie) for all MCP requests
+    app.addHook('preHandler', async (request, reply) => {
+        if (!request.session?.User) {
+            const baseUrl = app.config.base_url
+            reply.header('WWW-Authenticate', `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`)
+            reply.code(401).send({ code: 'unauthorized', error: 'Unauthorized' })
+            throw new Error('Unauthorized')
+        }
+        // Flag requests from external MCP clients (Bearer token, not cookie session).
+        // The auth middleware deletes scope for named tokens, so check the Authorization header directly.
+        const authHeader = request.headers.authorization
+        request.session.viaMCPToken = !!(authHeader && authHeader.startsWith('Bearer '))
+    })
+
+    /**
+     * Find an active editor session for the given user across all accessible instances.
+     * Returns { session, projectId } or null.
+     *
+     * @param {import('sequelize').Model} user
+     * @returns {Promise<{ session: object, projectId: string } | null>}
+     */
+    async function findUserEditorSession (user) {
+        const editorSessions = app.comms?.editorSessions
+        if (!editorSessions) return null
+
+        const userHashid = user.hashid || user.id
+
+        // Look up the user's teams, then their instances, and check for an active session
+        const teamMemberships = await app.db.models.Team.forUser(user)
+        for (const membership of teamMemberships) {
+            const team = membership.Team || membership
+            const teamId = team.hashid || app.db.models.Team.encodeHashid(team.id)
+            const applications = await app.db.models.Application.byTeam(teamId)
+            for (const application of applications) {
+                const instances = await app.db.models.Project.byApplication(application.hashid)
+                if (!instances) continue
+                for (const instance of instances) {
+                    const session = editorSessions.getActiveSession(instance.id)
+                    if (session && String(session.userId) === String(userHashid)) {
+                        return { session, projectId: instance.id }
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    /**
+     * POST / — MCP JSON-RPC endpoint (stateless Streamable HTTP transport)
+     */
+    app.post('/', {
+        schema: { hide: true }
+    }, async (request, reply) => {
+        const user = request.session.User
+        const isExternalClient = !!request.session.viaMCPToken
+
+        // Create a per-request MCP server instance (stateless mode)
+        const mcpServer = new McpServer({
+            name: 'FlowFuse Platform',
+            version: '1.0.0'
+        })
+
+        // Register all platform tools
+        for (const [toolName, toolDef] of Object.entries(platformAutomations.supportedActions)) {
+            mcpServer.registerTool(
+                toolName,
+                {
+                    description: toolDef.description,
+                    inputSchema: toolDef.inputSchema,
+                    annotations: toolDef.annotations
+                },
+                async (params) => {
+                    try {
+                        const result = await platformAutomations.invokeAction(toolName, {
+                            user,
+                            params,
+                            app,
+                            viaMCPToken: request.session.viaMCPToken,
+                            headers: request.headers,
+                            cookies: request.cookies
+                        })
+                        return {
+                            content: [{ type: 'text', text: JSON.stringify(result || {}) }]
+                        }
+                    } catch (err) {
+                        app.log.error(`MCP tool ${toolName} error: ${err.message}`)
+                        return {
+                            content: [{ type: 'text', text: JSON.stringify({ error: err.message }) }],
+                            isError: true
+                        }
+                    }
+                }
+            )
+        }
+
+        // Register flow-building tools if the bridge is configured.
+        // Always register them so stateless clients see them in tools/list;
+        // the editor-session check happens at call time in handleFlowToolCall.
+        const flowBridge = app.flowBuildingBridge
+        if (flowBridge?.isConfigured) {
+            let flowTools = []
+            try {
+                flowTools = await flowBridge.getTools()
+            } catch (err) {
+                app.log.warn(`MCP: failed to fetch flow tools: ${err.message}`)
+            }
+            for (const flowTool of flowTools) {
+                // External clients must specify which instance to target
+                const toolSchema = isExternalClient
+                    ? flowTool.inputSchema.extend({
+                        instanceId: z.string().describe('The ID of the instance to modify (from platform.list-instances)')
+                    })
+                    : flowTool.inputSchema
+
+                mcpServer.registerTool(
+                    flowTool.name,
+                    {
+                        description: flowTool.description,
+                        inputSchema: toolSchema,
+                        annotations: flowTool.annotations
+                    },
+                    async (params) => {
+                        return handleFlowToolCall(flowTool, params, user, isExternalClient)
+                    }
+                )
+            }
+        }
+
+        // Create a stateless transport (no session ID)
+        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+
+        await mcpServer.connect(transport)
+
+        // Tell Fastify we are handling the response ourselves
+        reply.hijack()
+
+        // Delegate the raw Node.js request/response to the MCP transport.
+        // Fastify has already parsed the JSON body; pass it as parsedBody so the
+        // transport does not attempt to re-read the consumed stream.
+        await transport.handleRequest(request.raw, reply.raw, request.body)
+    })
+
+    /**
+     * Handle a flow.* tool call.
+     *
+     * 1. Verify the user still has an active editor session
+     * 2. Call the flow building bridge to get validated actions
+     * 3. Expert path: return as-is (the expert agent handles MQTT dispatch)
+     * 4. External client path: dispatch actions to the browser via MQTT, wait for results
+     *
+     * @param {object} flowTool - Tool definition from FlowBuildingBridge
+     * @param {object} params - Tool call parameters
+     * @param {import('sequelize').Model} user - Authenticated user
+     * @param {boolean} isExternalClient - Whether this is from an external MCP client
+     * @returns {Promise<object>} MCP tool result
+     */
+    async function handleFlowToolCall (flowTool, params, user, isExternalClient) {
+        try {
+            let editorSession, projectId
+
+            if (isExternalClient) {
+                // External clients must specify which instance to target
+                const { instanceId, ...toolParams } = params
+                if (!instanceId) {
+                    return {
+                        isError: true,
+                        content: [{ type: 'text', text: 'instanceId is required for flow tools' }]
+                    }
+                }
+
+                const editorSessions = app.comms?.editorSessions
+                const session = editorSessions?.getActiveSession(instanceId)
+                if (!session) {
+                    return {
+                        isError: true,
+                        content: [{ type: 'text', text: 'the instance editor must be open in your browser to modify flows' }]
+                    }
+                }
+
+                const userHashid = user.hashid || user.id
+                if (String(session.userId) !== String(userHashid)) {
+                    return {
+                        isError: true,
+                        content: [{ type: 'text', text: 'no active editor session found for this user on this instance' }]
+                    }
+                }
+
+                editorSession = session
+                projectId = instanceId
+                params = toolParams
+            } else {
+                // Expert path: find any active editor session for this user
+                const editorInfo = await findUserEditorSession(user)
+                if (!editorInfo) {
+                    return {
+                        isError: true,
+                        content: [{ type: 'text', text: 'the instance editor must be open in your browser to modify flows' }]
+                    }
+                }
+                editorSession = editorInfo.session
+                projectId = editorInfo.projectId
+            }
+
+            // MCP clients may serialize array/object params as JSON strings
+            // when the tool schema lacks explicit property types (the Zod
+            // passthrough schema produces {"properties":{},"type":"object"}).
+            // Parse them back before forwarding to the flow building server.
+            const normalizedParams = {}
+            for (const [key, value] of Object.entries(params)) {
+                if (typeof value === 'string' && (value.startsWith('[') || value.startsWith('{'))) {
+                    try { normalizedParams[key] = JSON.parse(value) } catch (_) { normalizedParams[key] = value }
+                } else {
+                    normalizedParams[key] = value
+                }
+            }
+
+            // Call the flow building bridge to get validated actions
+            const bridgeResult = await app.flowBuildingBridge.callTool(flowTool.originalName, normalizedParams)
+
+            if (!isExternalClient) {
+                // Expert path: return as-is for the expert agent to handle MQTT dispatch
+                return bridgeResult
+            }
+
+            // External client path: check if the result contains actions that
+            // need to be dispatched to the browser
+            const resultContent = bridgeResult?.content
+            let resultData = null
+            if (Array.isArray(resultContent)) {
+                const textItem = resultContent.find(c => c.type === 'text')
+                if (textItem) {
+                    try { resultData = JSON.parse(textItem.text) } catch (_) {}
+                }
+            }
+
+            // If the result has actions, dispatch each one to the browser via MQTT
+            if (resultData?.actions && Array.isArray(resultData.actions)) {
+                const mqttDispatch = app.mqttDispatch
+                const results = []
+
+                for (const action of resultData.actions) {
+                    const actionName = action.action || action.name || flowTool.originalName
+                    const actionParams = action.params || action
+                    // Convert action name format: 'automation/add-nodes' -> 'automation:add-nodes'
+                    const inflightType = actionName.replace(/\//g, ':')
+
+                    try {
+                        const actionResult = await mqttDispatch.dispatchAndWait(
+                            editorSession,
+                            projectId,
+                            inflightType,
+                            actionParams
+                        )
+                        results.push({ action: actionName, success: true, result: actionResult })
+                    } catch (err) {
+                        results.push({ action: actionName, success: false, error: err.message })
+                    }
+                }
+
+                return {
+                    content: [{ type: 'text', text: JSON.stringify({ actions: results }) }]
+                }
+            }
+
+            // No actions to dispatch — return the bridge result directly
+            return bridgeResult
+        } catch (err) {
+            app.log.error(`MCP flow tool ${flowTool.name} error: ${err.message}`)
+            return {
+                content: [{ type: 'text', text: JSON.stringify({ error: err.message }) }],
+                isError: true
+            }
+        }
+    }
+
+    /**
+     * GET / — not supported for stateless MCP; return 405
+     */
+    app.get('/', { schema: { hide: true } }, async (request, reply) => {
+        reply.code(405).send({ error: 'Method not allowed. Use POST for MCP requests.' })
+    })
+
+    /**
+     * DELETE / — not supported for stateless MCP; return 405
+     */
+    app.delete('/', { schema: { hide: true } }, async (request, reply) => {
+        reply.code(405).send({ error: 'Method not allowed. Use POST for MCP requests.' })
+    })
+}

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -387,6 +387,175 @@ module.exports = async function (app) {
     })
 
     /**
+     * Get MCP Tokens
+     * /api/v1/user/mcp-tokens
+     */
+    app.get('/mcp-tokens', {
+        schema: {
+            summary: 'List users MCP Tokens',
+            tags: ['Tokens'],
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        count: { type: 'number' },
+                        tokens: { $ref: 'MCPTokenSummaryList' }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        try {
+            const tokens = await app.db.models.AccessToken.getMCPTokens(request.session.User)
+            reply.send({
+                tokens: app.db.views.AccessToken.mcpTokenSummaryList(tokens),
+                count: tokens.length
+            })
+        } catch (err) {
+            const resp = { code: 'unexpected_error', error: err.toString() }
+            reply.code(400).send(resp)
+        }
+    })
+
+    /**
+     * Create MCP Token
+     * /api/v1/user/mcp-tokens
+     */
+    app.post('/mcp-tokens', {
+        config: {
+            rateLimit: app.config.rate_limits ? { max: 5, timeWindow: 30000 } : false
+        },
+        schema: {
+            summary: 'Create user MCP Token',
+            tags: ['Tokens'],
+            body: {
+                type: 'object',
+                properties: {
+                    expiresAt: { type: 'number' },
+                    name: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'MCPToken'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        const updates = new app.auditLog.formatters.UpdatesCollection()
+        try {
+            const body = request.body
+            const token = await app.db.controllers.AccessToken.createMCPToken(request.session.User, ['mcp:platform'], body.expiresAt, body.name)
+            updates.push('id', token.id)
+            updates.push('name', token.name)
+            if (token.expiresAt) {
+                updates.push('expiresAt', token.expiresAt)
+            }
+            await app.auditLog.User.user.pat.created(request.session.User, null, updates)
+            reply.send(token)
+        } catch (err) {
+            const resp = { code: 'unexpected_error', error: err.toString() }
+            reply.code(400).send(resp)
+        }
+    })
+
+    /**
+     * Delete MCP Token
+     * /api/v1/user/mcp-tokens/:id
+     */
+    app.delete('/mcp-tokens/:id', {
+        schema: {
+            summary: 'Delete user MCP Token',
+            tags: ['Tokens'],
+            params: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string' }
+                }
+            },
+            response: {
+                204: {
+                    type: 'null',
+                    description: 'empty response'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        try {
+            const token = await app.db.models.AccessToken.byId(request.params.id, 'user', request.session.User.id)
+            if (token) {
+                const updates = new app.auditLog.formatters.UpdatesCollection()
+                updates.push('id', request.params.id)
+                await app.auditLog.User.user.pat.deleted(request.session.User, null, updates)
+                await token.destroy()
+                reply.code(204).send()
+                return
+            }
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+        } catch (err) {
+            const resp = { code: 'unexpected_error', error: err.toString() }
+            reply.code(400).send(resp)
+        }
+    })
+
+    /**
+     * Update MCP Token
+     * /api/v1/user/mcp-tokens/:id
+     */
+    app.put('/mcp-tokens/:id', {
+        schema: {
+            summary: 'Update users MCP Token',
+            tags: ['Tokens'],
+            params: {
+                type: 'object',
+                properties: {
+                    id: { type: 'string' }
+                }
+            },
+            body: {
+                type: 'object',
+                properties: {
+                    expiresAt: { type: 'number' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'MCPTokenSummary'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        const updates = new app.auditLog.formatters.UpdatesCollection()
+        try {
+            const oldToken = await app.db.models.AccessToken.byId(request.params.id, 'user', request.session.User.id)
+            if (oldToken) {
+                const body = request.body
+                const newToken = await app.db.controllers.AccessToken.updateMCPToken(request.session.User, request.params.id, ['mcp:platform'], body.expiresAt)
+                updates.pushDifferences(oldToken, newToken)
+                await app.auditLog.User.user.pat.updated(request.session.User, null, updates)
+                reply.send(app.db.views.AccessToken.mcpTokenSummary(newToken))
+                return
+            }
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+        } catch (err) {
+            const resp = { code: 'unexpected_error', error: err.toString() }
+            reply.code(400).send(resp)
+        }
+    })
+
+    /**
      * Initialize expert chat
      */
     app.post('/expert-creds', {

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -88,7 +88,15 @@ module.exports = async function (app) {
         } catch (err) {
             return badRequest(reply, 'invalid_request', 'Invalid redirect_uri')
         }
-        if (client_id !== 'ff-plugin') {
+        if (client_id === 'mcp-agent') {
+            const isLocalhost = /^(localhost|127\.0\.0\.1)$/.test(redirectURI.hostname)
+            if (!isLocalhost) {
+                return badRequest(reply, 'invalid_request', 'Invalid redirect_uri: only localhost callbacks are supported for MCP agents')
+            }
+            if (scope !== 'mcp:platform') {
+                return redirectInvalidRequest(reply, redirect_uri, 'invalid_request', "Invalid scope '" + scope + "'. Only 'mcp:platform' is supported for MCP agents", state)
+            }
+        } else if (client_id !== 'ff-plugin') {
             // Check client_id is valid. Note - no client_secret provided at this point
             const authClient = await app.db.controllers.AuthClient.getAuthClient(client_id)
             if (!authClient) {
@@ -159,6 +167,10 @@ module.exports = async function (app) {
             reply.redirect(`${app.config.base_url}/account/request/${requestId}/editor`)
             return
         }
+        if (client_id === 'mcp-agent') {
+            reply.redirect(`${app.config.base_url}/account/request/${requestId}/mcp`)
+            return
+        }
         // Redirect to login page with requestId in url - to bounce to an approve page
         reply.redirect(`${app.config.base_url}/account/request/${requestId}`)
     })
@@ -176,7 +188,9 @@ module.exports = async function (app) {
         if (request.sid) {
             request.session = await app.db.controllers.Session.getOrExpire(request.sid)
             if (request.session) {
-                if (requestObject.client_id === 'ff-plugin') {
+                if (requestObject.client_id === 'mcp-agent') {
+                    // MCP agent — no ownership checks needed
+                } else if (requestObject.client_id === 'ff-plugin') {
                     // This is the FlowFuse Node-RED plugin.
                 } else {
                     const authClient = await app.db.controllers.AuthClient.getAuthClient(requestObject.client_id)
@@ -342,6 +356,24 @@ module.exports = async function (app) {
                 return
             }
 
+            if (client_id === 'mcp-agent') {
+                const tokenName = `OAuth MCP Agent - ${new Date().toISOString()}`
+                const accessToken = await app.db.controllers.AccessToken.createMCPToken(
+                    requestObject.userId,
+                    ['mcp:platform'],
+                    new Date(Date.now() + (1000 * 60 * 60 * 24 * 90)),
+                    tokenName
+                )
+                reply.send({
+                    access_token: accessToken.token,
+                    token_type: 'bearer',
+                    expires_in: Math.floor((new Date(accessToken.expiresAt).getTime() - Date.now()) / 1000),
+                    scope: 'mcp:platform',
+                    state: requestObject.state
+                })
+                return
+            }
+
             if (client_id !== 'ff-plugin') {
                 const authClient = await app.db.controllers.AuthClient.getAuthClient(client_id, client_secret)
                 if (!authClient) {
@@ -444,7 +476,7 @@ module.exports = async function (app) {
                 badRequest(reply, 'invalid_request', 'Invalid refresh_token')
                 return
             }
-            if (client_id !== 'ff-plugin') {
+            if (client_id !== 'ff-plugin' && client_id !== 'mcp-agent') {
                 const authClient = await app.db.controllers.AuthClient.getAuthClient(client_id, client_secret)
                 if (!authClient) {
                     return badRequest(reply, 'invalid_request', 'Invalid client_id')

--- a/forge/routes/index.js
+++ b/forge/routes/index.js
@@ -77,6 +77,7 @@ module.exports = fp(async function (app, opts) {
 
     await app.register(require('@fastify/websocket'))
     await app.register(require('./auth'), { logLevel: app.config.logging.http })
+    await app.register(require('./wellKnown'), { logLevel: app.config.logging.http })
     await app.register(require('./api'), { prefix: '/api/v1', logLevel: app.config.logging.http })
     await app.register(require('./ui'), { logLevel: app.config.logging.http })
     await app.register(require('./setup'), { logLevel: app.config.logging.http })

--- a/forge/routes/wellKnown.js
+++ b/forge/routes/wellKnown.js
@@ -1,0 +1,105 @@
+'use strict'
+
+/**
+ * Well-known endpoint for MCP server discovery.
+ *
+ * Exposes `GET /.well-known/mcp-configuration` so that MCP clients can
+ * discover the FlowFuse MCP server URL and OAuth parameters automatically.
+ *
+ * This is registered at the root level (not behind EE gating) so that
+ * discovery works regardless of license. The MCP server endpoint it points
+ * to (`/api/v1/mcp`) is EE-only, so unauthenticated or unlicensed requests
+ * will receive a 401/404 there.
+ */
+const fp = require('fastify-plugin')
+
+module.exports = fp(async function (app) {
+    const handler = async (request, reply) => {
+        const baseUrl = app.config.base_url
+        reply.send({
+            name: 'FlowFuse',
+            description: 'Manage FlowFuse instances, applications, and Node-RED flows via MCP',
+            url: `${baseUrl}/api/v1/mcp`,
+            auth: {
+                type: 'oauth2',
+                authorization_url: `${baseUrl}/account/authorize`,
+                token_url: `${baseUrl}/account/token`,
+                client_id: 'mcp-agent',
+                scope: 'mcp:platform'
+            }
+        })
+    }
+
+    const routeOptions = {
+        config: {
+            allowAnonymous: true,
+            rateLimit: false
+        },
+        schema: {
+            tags: ['MCP', 'X-HIDDEN'],
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        name: { type: 'string' },
+                        description: { type: 'string' },
+                        url: { type: 'string' },
+                        auth: {
+                            type: 'object',
+                            properties: {
+                                type: { type: 'string' },
+                                authorization_url: { type: 'string' },
+                                token_url: { type: 'string' },
+                                client_id: { type: 'string' },
+                                scope: { type: 'string' }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Root-level discovery endpoint (spec compliance)
+    app.get('/.well-known/mcp-configuration', routeOptions, handler)
+
+    // Also available under the MCP prefix (convenience)
+    app.get('/api/v1/mcp/.well-known/mcp-configuration', routeOptions, handler)
+
+    // RFC 9728 Protected Resource Metadata — lets MCP clients discover the
+    // authorization server for the MCP endpoint.
+    const protectedResourceOptions = {
+        config: { allowAnonymous: true, rateLimit: false },
+        schema: { tags: ['MCP', 'X-HIDDEN'] }
+    }
+    app.get('/.well-known/oauth-protected-resource', protectedResourceOptions, async (request, reply) => {
+        const baseUrl = app.config.base_url
+        reply.send({
+            resource: `${baseUrl}/api/v1/mcp`,
+            authorization_servers: [baseUrl],
+            scopes_supported: ['mcp:platform'],
+            bearer_methods_supported: ['header']
+        })
+    })
+
+    // RFC 8414 Authorization Server Metadata — provides authorization and
+    // token endpoint URLs for OAuth 2.0 PKCE flows (used by Claude Code,
+    // Claude Desktop, Cursor, etc.).
+    const authServerOptions = {
+        config: { allowAnonymous: true, rateLimit: false },
+        schema: { tags: ['MCP', 'X-HIDDEN'] }
+    }
+    app.get('/.well-known/oauth-authorization-server', authServerOptions, async (request, reply) => {
+        const baseUrl = app.config.base_url
+        reply.send({
+            issuer: baseUrl,
+            authorization_endpoint: `${baseUrl}/account/authorize`,
+            token_endpoint: `${baseUrl}/account/token`,
+            response_types_supported: ['code'],
+            grant_types_supported: ['authorization_code'],
+            code_challenge_methods_supported: ['S256'],
+            token_endpoint_auth_methods_supported: ['none'],
+            scopes_supported: ['mcp:platform']
+        })
+    })
+}, { name: 'app.routes.wellKnown' })

--- a/frontend/src/api/expert.js
+++ b/frontend/src/api/expert.js
@@ -48,7 +48,12 @@ const getCapabilities = async (payload) => {
     })
 }
 
+const callPlatformTool = async (tool, args, context = {}) => {
+    return client.post('/api/v1/expert/platform-tool', { tool, arguments: args, context })
+}
+
 export default {
     chat,
-    getCapabilities
+    getCapabilities,
+    callPlatformTool
 }

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -230,6 +230,43 @@ const updatePersonalAccessToken = async (id, scope, expiresAt) => {
     return client.put('/api/v1/user/tokens/' + id, { scope, expiresAt })
 }
 
+/**
+ * Get a User's MCP Access Tokens
+ * See [routes/api/user.js](../../../forge/routes/api/user.js)
+ */
+const getMCPTokens = async () => {
+    return client.get('/api/v1/user/mcp-tokens').then(res => res.data)
+}
+
+/**
+ * Create new User MCP Access Token
+ * See [routes/api/user.js](../../../forge/routes/api/user.js)
+ * @param {string} name
+ * @param {number} expiresAt
+ */
+const createMCPToken = async (name, expiresAt) => {
+    return client.post('/api/v1/user/mcp-tokens', { name, expiresAt }).then(res => res.data)
+}
+
+/**
+ * Update User MCP Access Token
+ * See [routes/api/user.js](../../../forge/routes/api/user.js)
+ * @param {string} id
+ * @param {number} expiresAt
+ */
+const updateMCPToken = async (id, expiresAt) => {
+    return client.put('/api/v1/user/mcp-tokens/' + id, { expiresAt }).then(res => res.data)
+}
+
+/**
+ * Delete User MCP Access Token
+ * See [routes/api/user.js](../../../forge/routes/api/user.js)
+ * @param {string} id
+ */
+const deleteMCPToken = async (id) => {
+    return client.delete('/api/v1/user/mcp-tokens/' + id).then(res => {})
+}
+
 const enableMFA = async () => {
     return client.put('/api/v1/user/mfa', {}).then(res => res.data)
 }
@@ -268,6 +305,10 @@ export default {
     createPersonalAccessToken,
     deletePersonalAccessToken,
     updatePersonalAccessToken,
+    getMCPTokens,
+    createMCPToken,
+    updateMCPToken,
+    deleteMCPToken,
     enableMFA,
     verifyMFA,
     disableMFA,

--- a/frontend/src/components/expert/Expert.vue
+++ b/frontend/src/components/expert/Expert.vue
@@ -33,7 +33,6 @@ import UpdateBanner from './components/UpdateBanner.vue'
 
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useProductAssistantStore } from '@/stores/product-assistant.js'
-import { useProductExpertInsightsAgentStore } from '@/stores/product-expert-insights-agent.js'
 import { useProductExpertStore } from '@/stores/product-expert.js'
 import { useUxDrawersStore } from '@/stores/ux-drawers.js'
 
@@ -106,9 +105,7 @@ export default {
         agentMode: {
             immediate: true,
             async handler () {
-                if (this.isInsightsAgent) {
-                    await this.getCapabilities()
-                }
+                await this.fetchCapabilities()
                 this.addWelcomeMessageIfNeeded()
             }
         },
@@ -149,9 +146,9 @@ export default {
             'setAbortController',
             'resetSessionTimer',
             'addWelcomeMessageIfNeeded',
+            'fetchCapabilities',
             'stopInflightChat'
         ]),
-        ...mapActions(useProductExpertInsightsAgentStore, ['getCapabilities']),
         ...mapActions(useProductAssistantStore, ['reset']),
         handleStopGeneration () {
             if (this.abortController) {

--- a/frontend/src/components/expert/components/ExpertChatInput.vue
+++ b/frontend/src/components/expert/components/ExpertChatInput.vue
@@ -16,6 +16,7 @@
                 Start over
             </button>
             <div class="right-buttons">
+                <tool-permissions-selector />
                 <capabilities-selector v-if="isInsightsAgent" />
             </div>
         </div>
@@ -67,6 +68,7 @@ import { mapActions, mapState } from 'pinia'
 import ResizeBar from '../../ResizeBar.vue'
 
 import CapabilitiesSelector from './CapabilitiesSelector.vue'
+import ToolPermissionsSelector from './ToolPermissionsSelector.vue'
 import ContextSelector from './context-selection/index.vue'
 
 import { useResizingHelper } from '@/composables/ResizingHelper.js'
@@ -80,7 +82,8 @@ export default {
     components: {
         CapabilitiesSelector,
         ContextSelector,
-        ResizeBar
+        ResizeBar,
+        ToolPermissionsSelector
     },
     inject: {
         togglePinWithWidth: {

--- a/frontend/src/components/expert/components/ToolPermissionsSelector.vue
+++ b/frontend/src/components/expert/components/ToolPermissionsSelector.vue
@@ -1,0 +1,328 @@
+<template>
+    <div ref="container" class="tool-permissions-selector">
+        <button
+            class="tool-permissions-btn"
+            :class="{ active: isOpen }"
+            title="Tool Permissions"
+            @click="toggleDropdown"
+        >
+            <ShieldCheckIcon class="ff-icon" />
+        </button>
+
+        <div v-if="isOpen" class="tool-permissions-dropdown" data-click-exclude="right-drawer">
+            <div class="dropdown-header">
+                <h4>Tool Permissions</h4>
+            </div>
+
+            <div class="default-policy">
+                <label class="policy-label">Default policy</label>
+                <div class="policy-options">
+                    <button
+                        v-for="option in policyOptions"
+                        :key="option.value"
+                        class="policy-btn"
+                        :class="{ selected: defaultPolicy === option.value }"
+                        @click="setDefaultPolicy(option.value)"
+                    >
+                        {{ option.label }}
+                    </button>
+                </div>
+            </div>
+
+            <div v-if="toolList.length > 0" class="tools-section">
+                <label class="policy-label">Per-tool overrides</label>
+                <div class="tool-list">
+                    <div
+                        v-for="tool in toolList"
+                        :key="tool.name"
+                        class="tool-row"
+                    >
+                        <div class="tool-info">
+                            <span class="tool-name" :title="tool.description">
+                                {{ formatToolName(tool.name) }}
+                            </span>
+                            <span v-if="tool.readOnly" class="tool-badge read-only">read</span>
+                            <span v-else class="tool-badge write">write</span>
+                        </div>
+                        <div class="policy-options compact">
+                            <button
+                                v-for="option in policyOptions"
+                                :key="option.value"
+                                class="policy-btn small"
+                                :class="{
+                                    selected: getToolPolicy(tool.name) === option.value,
+                                    'is-override': isOverridden(tool.name)
+                                }"
+                                :title="option.label"
+                                @click="setToolPolicy(tool.name, option.value)"
+                            >
+                                {{ option.short }}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div v-else class="empty-state">
+                No platform tools available. Restart FlowFuse if you recently enabled expert insights.
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { ShieldCheckIcon } from '@heroicons/vue/20/solid'
+import { mapState } from 'pinia'
+
+import { useMCPToolPermissionsStore } from '@/stores/mcp-tool-permissions.js'
+import { useProductExpertStore } from '@/stores/product-expert.js'
+
+export default {
+    name: 'ToolPermissionsSelector',
+    components: {
+        ShieldCheckIcon
+    },
+    data () {
+        return {
+            isOpen: false,
+            policyOptions: [
+                { value: 'allow', label: 'Always allow', short: 'Allow' },
+                { value: 'prompt', label: 'Ask each time', short: 'Ask' },
+                { value: 'deny', label: 'Always deny', short: 'Deny' }
+            ]
+        }
+    },
+    computed: {
+        ...mapState(useProductExpertStore, ['platformTools']),
+        defaultPolicy () {
+            return useMCPToolPermissionsStore().defaultPolicy
+        },
+        toolList () {
+            return (this.platformTools || []).map(t => ({
+                name: t.name,
+                description: t.description,
+                readOnly: t.annotations?.readOnlyHint === true
+            }))
+        }
+    },
+    mounted () {
+        document.addEventListener('click', this.handleClickOutside)
+    },
+    beforeUnmount () {
+        document.removeEventListener('click', this.handleClickOutside)
+    },
+    methods: {
+        toggleDropdown () {
+            this.isOpen = !this.isOpen
+        },
+        handleClickOutside (e) {
+            if (this.isOpen && this.$refs.container && !this.$refs.container.contains(e.target)) {
+                this.isOpen = false
+            }
+        },
+        formatToolName (name) {
+            return name.replace('platform.', '').replace(/[-_]/g, ' ')
+        },
+        getToolPolicy (toolName) {
+            return useMCPToolPermissionsStore().getPolicy(toolName)
+        },
+        isOverridden (toolName) {
+            const store = useMCPToolPermissionsStore()
+            return store.allowlist.includes(toolName) || store.denylist.includes(toolName)
+        },
+        setDefaultPolicy (policy) {
+            useMCPToolPermissionsStore().setDefaultPolicy(policy)
+        },
+        setToolPolicy (toolName, policy) {
+            const store = useMCPToolPermissionsStore()
+            const currentPolicy = this.getToolPolicy(toolName)
+
+            if (currentPolicy === policy) {
+                store.removeFromAllowlist(toolName)
+                store.removeFromDenylist(toolName)
+                return
+            }
+
+            if (policy === 'allow') {
+                store.addToAllowlist(toolName)
+            } else if (policy === 'deny') {
+                store.addToDenylist(toolName)
+            } else {
+                store.removeFromAllowlist(toolName)
+                store.removeFromDenylist(toolName)
+            }
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.tool-permissions-selector {
+    position: relative;
+}
+
+.tool-permissions-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #c7d2fe;
+    border-radius: 5px;
+    padding: 0.25rem 0.50rem;
+    background: white;
+    color: #1f2937;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+
+    .ff-icon {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    &:hover {
+        background-color: #f9fafb;
+    }
+
+    &.active {
+        background: $ff-indigo-600;
+        border-color: $ff-indigo-600;
+        color: white;
+    }
+}
+
+.tool-permissions-dropdown {
+    position: absolute;
+    bottom: calc(100% + 0.5rem);
+    right: 0;
+    width: 320px;
+    max-height: 400px;
+    overflow-y: auto;
+    background: white;
+    border: 1px solid $ff-grey-200;
+    border-radius: 0.5rem;
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1);
+    z-index: 50;
+    padding: 0.75rem;
+}
+
+.dropdown-header {
+    margin-bottom: 0.75rem;
+
+    h4 {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: $ff-grey-800;
+        margin: 0;
+    }
+}
+
+.policy-label {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: $ff-grey-500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.375rem;
+}
+
+.default-policy {
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid $ff-grey-200;
+    margin-bottom: 0.75rem;
+}
+
+.policy-options {
+    display: flex;
+    gap: 0.25rem;
+
+    &.compact {
+        flex-shrink: 0;
+    }
+}
+
+.policy-btn {
+    flex: 1;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    border: 1px solid $ff-grey-300;
+    border-radius: 4px;
+    background: white;
+    color: $ff-grey-600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+
+    &:hover {
+        background: $ff-grey-50;
+    }
+
+    &.selected {
+        background: $ff-indigo-600;
+        border-color: $ff-indigo-600;
+        color: white;
+    }
+
+    &.small {
+        padding: 0.125rem 0.375rem;
+        font-size: 0.6875rem;
+    }
+}
+
+.tools-section {
+    .tool-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+    }
+}
+
+.tool-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+}
+
+.tool-info {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.tool-name {
+    font-size: 0.8125rem;
+    color: $ff-grey-800;
+    text-transform: capitalize;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tool-badge {
+    font-size: 0.625rem;
+    font-weight: 500;
+    padding: 0.0625rem 0.3125rem;
+    border-radius: 9999px;
+    flex-shrink: 0;
+
+    &.read-only {
+        background-color: #dbeafe;
+        color: #1e40af;
+    }
+
+    &.write {
+        background-color: #fef3c7;
+        color: #92400e;
+    }
+}
+
+.empty-state {
+    font-size: 0.8125rem;
+    color: $ff-grey-500;
+    text-align: center;
+    padding: 1rem 0;
+}
+</style>

--- a/frontend/src/components/expert/components/messages/AiMessage.vue
+++ b/frontend/src/components/expert/components/messages/AiMessage.vue
@@ -67,7 +67,7 @@ export default {
         toolCalls () {
             // todo we need to reconsider how we serve data to the tool calls component. This is ok for now as it
             //  only impacts the immediate child component (was hacked out of the expert store)
-            const mcpItems = this.answer.filter(answer => ['mcp_tool', 'mcp_resource', 'mcp_resource_template', 'mcp_prompt'].includes(answer.kind))
+            const mcpItems = this.answer.filter(answer => ['mcp_tool', 'mcp_resource', 'mcp_resource_template', 'mcp_prompt', 'platform_tool'].includes(answer.kind))
 
             // Handle MCP calls if present - includes tools, resources, and prompts
             if (mcpItems.length > 0) {
@@ -98,7 +98,9 @@ export default {
             return null
         },
         filteredAnswers () {
-            return this.answer.filter(answer => !['mcp_tool', 'mcp_resource', 'mcp_resource_template', 'mcp_prompt'].includes(answer.kind))
+            // Keep all answer kinds except raw MCP call records (those are rendered by ToolCalls).
+            // 'mcp-tool-result' is intentionally included — it carries structured UI to render inline.
+            return this.answer.filter(answer => !['mcp_tool', 'mcp_resource', 'mcp_resource_template', 'mcp_prompt', 'platform_tool'].includes(answer.kind))
         }
     },
     async mounted () {

--- a/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
+++ b/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
@@ -66,6 +66,13 @@
             :should-stream="shouldStream"
             @streaming-complete="onComponentComplete('suggestions-list')"
         />
+
+        <mcp-tool-result
+            v-if="shouldShowMcpToolResult"
+            :ui="answer.ui"
+            class="mt-2"
+            @action="handleMcpAction"
+        />
     </message-bubble>
 </template>
 
@@ -78,6 +85,7 @@ import useTimerHelper from '../../../../../composables/TimerHelper.js'
 import AnswerBadge from './AnswerBadge.vue'
 import GuideHeader from './GuideHeader.vue'
 import MessageBubble from './MessageBubble.vue'
+import McpToolResult from './mcp/McpToolResult.vue'
 import FlowsList from './resources/FlowsList.vue'
 import GuideStepsList from './resources/GuideStepsList.vue'
 import IssuesList from './resources/IssuesList.vue'
@@ -101,7 +109,8 @@ export default {
         GuideStepsList,
         MessageBubble,
         GuideHeader,
-        IssuesList
+        IssuesList,
+        McpToolResult
     },
     props: {
         answer: {
@@ -153,7 +162,14 @@ export default {
             return this.answer.content && this.answer.content.length > 0
         },
         isChatAnswer () {
-            return !Object.hasOwnProperty.call(this.answer, 'kind') || this.answer.kind === 'chat'
+            // 'mcp-tool-result' is treated as chat-like (no badge) since it renders its own UI
+            return !Object.hasOwnProperty.call(this.answer, 'kind') || this.answer.kind === 'chat' || this.answer.kind === 'mcp-tool-result'
+        },
+        isMcpToolResult () {
+            return this.answer.kind === 'mcp-tool-result'
+        },
+        hasMcpUI () {
+            return this.isMcpToolResult && !!this.answer.ui
         },
         isEditorContext () {
             // In editor context, the route name includes 'editor'
@@ -215,6 +231,12 @@ export default {
             if (this.componentStreamingOrder.indexOf(key) === 0) return true
             return this.streamedComponents.length >= this.componentStreamingOrder.indexOf(key)
         },
+        shouldShowMcpToolResult () {
+            // Rendered after markdown content (if any) finishes streaming
+            if (!this.hasMcpUI) return false
+            const priorComponents = this.componentStreamingOrder.filter(k => k !== 'mcp-tool-result')
+            return this.streamedComponents.length >= priorComponents.length
+        },
         shouldStream () {
             return !this.answer._streamed
         }
@@ -248,6 +270,11 @@ export default {
         if (this.isEditorContext) {
             this.$refs.messageBubble.$el.addEventListener('click', this.handleClick)
         }
+        // Items with nothing to stream (e.g. mcp-tool-result with no content) must
+        // immediately signal completion so the streaming list can advance.
+        if (this.componentStreamingOrder.length === 0) {
+            this.$nextTick(() => this.$emit('streaming-complete'))
+        }
     },
     methods: {
         ...mapActions(useProductExpertStore, ['updateAnswerStreamedState']),
@@ -268,6 +295,29 @@ export default {
             if (!this.shouldStream) await this.waitFor(200)
 
             this.streamedComponents.push(key)
+        },
+        /**
+         * Handle actions emitted by MCP UI components (e.g. confirmation, selection, navigation).
+         * Navigation actions (result-card links) use Vue Router; other actions are forwarded to the
+         * expert store for transmission back to the agent.
+         */
+        handleMcpAction (event) {
+            if (event && event.navigation) {
+                this.$router.push(event.navigation)
+            }
+            if (event && event.actionId) {
+                const match = /^(approve|deny|allow-always):(.+)$/.exec(event.actionId)
+                if (match) {
+                    const expertStore = useProductExpertStore()
+                    const action = match[1]
+                    const id = match[2]
+                    if (action === 'allow-always') {
+                        expertStore.resolveToolConfirmation(id, true, true)
+                    } else {
+                        expertStore.resolveToolConfirmation(id, action === 'approve')
+                    }
+                }
+            }
         },
         handleClick (e) {
             const target = e.target

--- a/frontend/src/components/expert/components/messages/components/mcp/McpConfirmation.vue
+++ b/frontend/src/components/expert/components/messages/components/mcp/McpConfirmation.vue
@@ -1,0 +1,77 @@
+<template>
+    <div class="mcp-confirmation">
+        <h4 v-if="ui.title" class="mcp-confirmation--title">
+            {{ ui.title }}
+        </h4>
+        <dl v-if="ui.details && ui.details.length" class="mcp-confirmation--details">
+            <template v-for="detail in ui.details" :key="detail.label">
+                <dt>{{ detail.label }}</dt>
+                <dd>{{ detail.value }}</dd>
+            </template>
+        </dl>
+        <div v-if="ui.actions && ui.actions.length" class="mcp-confirmation--actions">
+            <ff-button
+                v-for="action in ui.actions"
+                :key="action.id"
+                :kind="action.variant === 'primary' ? 'primary' : 'secondary'"
+                size="small"
+                @click="$emit('action', { actionId: action.id })"
+            >
+                {{ action.label }}
+            </ff-button>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'McpConfirmation',
+    props: {
+        ui: {
+            type: Object,
+            required: true
+        }
+    },
+    emits: ['action']
+}
+</script>
+
+<style scoped lang="scss">
+.mcp-confirmation {
+    background-color: $ff-grey-50;
+    border: 1px solid $ff-grey-200;
+    border-radius: 0.5rem;
+    padding: 1rem;
+}
+
+.mcp-confirmation--title {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: $ff-grey-800;
+    margin-bottom: 0.75rem;
+}
+
+.mcp-confirmation--details {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.25rem 1rem;
+    margin-bottom: 1rem;
+
+    dt {
+        color: $ff-grey-500;
+        font-size: 0.875rem;
+        white-space: nowrap;
+    }
+
+    dd {
+        color: $ff-grey-800;
+        font-size: 0.875rem;
+    }
+}
+
+.mcp-confirmation--actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}
+</style>

--- a/frontend/src/components/expert/components/messages/components/mcp/McpProgress.vue
+++ b/frontend/src/components/expert/components/messages/components/mcp/McpProgress.vue
@@ -1,0 +1,117 @@
+<template>
+    <div class="mcp-progress">
+        <ul class="mcp-progress--steps">
+            <li
+                v-for="step in ui.steps"
+                :key="step.id"
+                class="mcp-progress--step"
+                :class="[`mcp-progress--step-${step.status}`]"
+            >
+                <span class="mcp-progress--step-icon">
+                    <span v-if="step.status === 'success'" class="mcp-progress--icon-success">✓</span>
+                    <span v-else-if="step.status === 'error'" class="mcp-progress--icon-error">✗</span>
+                    <span v-else-if="step.status === 'in-progress'" class="mcp-progress--icon-spinner" />
+                    <span v-else class="mcp-progress--icon-pending">○</span>
+                </span>
+                <span class="mcp-progress--step-content">
+                    <span class="mcp-progress--step-label">{{ step.label }}</span>
+                    <span v-if="step.error" class="mcp-progress--step-error">{{ step.error }}</span>
+                </span>
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'McpProgress',
+    props: {
+        ui: {
+            type: Object,
+            required: true
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.mcp-progress {
+    background-color: $ff-grey-50;
+    border: 1px solid $ff-grey-200;
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+}
+
+.mcp-progress--steps {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.mcp-progress--step {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.mcp-progress--step-icon {
+    flex-shrink: 0;
+    width: 1.25rem;
+    text-align: center;
+    font-size: 0.875rem;
+    line-height: 1.5rem;
+}
+
+.mcp-progress--icon-success {
+    color: $ff-green-600;
+    font-weight: 700;
+}
+
+.mcp-progress--icon-error {
+    color: $ff-red-600;
+    font-weight: 700;
+}
+
+.mcp-progress--icon-pending {
+    color: $ff-grey-400;
+}
+
+.mcp-progress--icon-spinner {
+    display: inline-block;
+    width: 0.875rem;
+    height: 0.875rem;
+    border: 2px solid $ff-grey-300;
+    border-top-color: $ff-indigo-600;
+    border-radius: 50%;
+    animation: mcp-spin 0.75s linear infinite;
+    vertical-align: middle;
+}
+
+.mcp-progress--step-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.mcp-progress--step-label {
+    font-size: 0.875rem;
+    color: $ff-grey-800;
+    line-height: 1.5rem;
+}
+
+.mcp-progress--step-error {
+    font-size: 0.8125rem;
+    color: $ff-red-600;
+}
+
+.mcp-progress--step-pending .mcp-progress--step-label {
+    color: $ff-grey-400;
+}
+
+@keyframes mcp-spin {
+    to { transform: rotate(360deg); }
+}
+</style>

--- a/frontend/src/components/expert/components/messages/components/mcp/McpResultCard.vue
+++ b/frontend/src/components/expert/components/messages/components/mcp/McpResultCard.vue
@@ -1,0 +1,108 @@
+<template>
+    <div class="mcp-result-card" :class="[`mcp-result-card--${ui.status || 'success'}`]">
+        <div class="mcp-result-card--header">
+            <span class="mcp-result-card--status-icon">
+                <span v-if="ui.status === 'error'">✗</span>
+                <span v-else>✓</span>
+            </span>
+            <span class="mcp-result-card--title">{{ ui.title }}</span>
+        </div>
+        <p v-if="ui.subtitle" class="mcp-result-card--subtitle">
+            {{ ui.subtitle }}
+        </p>
+        <div v-if="ui.actions && ui.actions.length" class="mcp-result-card--actions">
+            <ff-button
+                v-for="action in ui.actions"
+                :key="action.id"
+                :kind="action.variant === 'primary' ? 'primary' : 'secondary'"
+                size="small"
+                @click="handleAction(action)"
+            >
+                {{ action.label }}
+            </ff-button>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'McpResultCard',
+    props: {
+        ui: {
+            type: Object,
+            required: true
+        }
+    },
+    emits: ['action'],
+    methods: {
+        handleAction (action) {
+            if (action.navigation) {
+                this.$emit('action', { actionId: action.id, navigation: action.navigation })
+            } else {
+                this.$emit('action', { actionId: action.id })
+            }
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.mcp-result-card {
+    background-color: $ff-grey-50;
+    border: 1px solid $ff-grey-200;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.mcp-result-card--success {
+    border-color: $ff-green-300;
+    background-color: $ff-green-50;
+
+    .mcp-result-card--status-icon {
+        color: $ff-green-600;
+    }
+}
+
+.mcp-result-card--error {
+    border-color: $ff-red-300;
+    background-color: $ff-red-50;
+
+    .mcp-result-card--status-icon {
+        color: $ff-red-600;
+    }
+}
+
+.mcp-result-card--header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.mcp-result-card--status-icon {
+    font-weight: 700;
+    font-size: 1rem;
+    flex-shrink: 0;
+}
+
+.mcp-result-card--title {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: $ff-grey-800;
+}
+
+.mcp-result-card--subtitle {
+    font-size: 0.875rem;
+    color: $ff-grey-600;
+    margin: 0;
+}
+
+.mcp-result-card--actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.25rem;
+}
+</style>

--- a/frontend/src/components/expert/components/messages/components/mcp/McpSelection.vue
+++ b/frontend/src/components/expert/components/messages/components/mcp/McpSelection.vue
@@ -1,0 +1,123 @@
+<template>
+    <div class="mcp-selection">
+        <ul class="mcp-selection--list">
+            <li
+                v-for="option in ui.options"
+                :key="option.id"
+                class="mcp-selection--option"
+                :class="{ 'is-selected': selectedId === option.id }"
+                @click="selectOption(option)"
+            >
+                <span class="mcp-selection--radio" :class="{ 'is-selected': selectedId === option.id }" />
+                <span class="mcp-selection--content">
+                    <span class="mcp-selection--label">{{ option.label }}</span>
+                    <span v-if="option.description" class="mcp-selection--description">{{ option.description }}</span>
+                </span>
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'McpSelection',
+    props: {
+        ui: {
+            type: Object,
+            required: true
+        }
+    },
+    emits: ['select'],
+    data () {
+        return {
+            selectedId: null
+        }
+    },
+    methods: {
+        selectOption (option) {
+            this.selectedId = option.id
+            this.$emit('select', { id: option.id, label: option.label })
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.mcp-selection {
+    background-color: $ff-grey-50;
+    border: 1px solid $ff-grey-200;
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+
+.mcp-selection--list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.mcp-selection--option {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    border-bottom: 1px solid $ff-grey-200;
+    transition: background-color 0.15s ease;
+
+    &:last-child {
+        border-bottom: none;
+    }
+
+    &:hover {
+        background-color: $ff-grey-100;
+    }
+
+    &.is-selected {
+        background-color: $ff-indigo-50;
+    }
+}
+
+.mcp-selection--radio {
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
+    margin-top: 0.125rem;
+    border: 2px solid $ff-grey-400;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: border-color 0.15s ease;
+
+    &.is-selected {
+        border-color: $ff-indigo-600;
+
+        &::after {
+            content: '';
+            display: block;
+            width: 0.4rem;
+            height: 0.4rem;
+            border-radius: 50%;
+            background-color: $ff-indigo-600;
+        }
+    }
+}
+
+.mcp-selection--content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.mcp-selection--label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: $ff-grey-800;
+}
+
+.mcp-selection--description {
+    font-size: 0.8125rem;
+    color: $ff-grey-500;
+}
+</style>

--- a/frontend/src/components/expert/components/messages/components/mcp/McpStatusBadge.vue
+++ b/frontend/src/components/expert/components/messages/components/mcp/McpStatusBadge.vue
@@ -1,0 +1,95 @@
+<template>
+    <div class="mcp-status-badge">
+        <ul class="mcp-status-badge--list">
+            <li v-for="item in ui.items" :key="item.label" class="mcp-status-badge--item">
+                <span class="mcp-status-badge--dot" :class="[`mcp-status-badge--dot-${item.status}`]" />
+                <span class="mcp-status-badge--content">
+                    <span class="mcp-status-badge--label">{{ item.label }}</span>
+                    <span v-if="item.meta" class="mcp-status-badge--meta">{{ item.meta }}</span>
+                </span>
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'McpStatusBadge',
+    props: {
+        ui: {
+            type: Object,
+            required: true
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.mcp-status-badge {
+    background-color: $ff-grey-50;
+    border: 1px solid $ff-grey-200;
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+}
+
+.mcp-status-badge--list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.mcp-status-badge--item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+}
+
+.mcp-status-badge--dot {
+    flex-shrink: 0;
+    width: 0.625rem;
+    height: 0.625rem;
+    border-radius: 50%;
+    margin-top: 0.25rem;
+}
+
+.mcp-status-badge--dot-running {
+    background-color: $ff-green-500;
+}
+
+.mcp-status-badge--dot-stopped {
+    background-color: $ff-red-500;
+}
+
+.mcp-status-badge--dot-suspended {
+    background-color: $ff-yellow-500;
+}
+
+.mcp-status-badge--dot-starting,
+.mcp-status-badge--dot-restarting {
+    background-color: $ff-indigo-400;
+}
+
+.mcp-status-badge--dot-unknown {
+    background-color: $ff-grey-400;
+}
+
+.mcp-status-badge--content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.mcp-status-badge--label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: $ff-grey-800;
+}
+
+.mcp-status-badge--meta {
+    font-size: 0.8125rem;
+    color: $ff-grey-500;
+}
+</style>

--- a/frontend/src/components/expert/components/messages/components/mcp/McpTextInput.vue
+++ b/frontend/src/components/expert/components/messages/components/mcp/McpTextInput.vue
@@ -1,0 +1,128 @@
+<template>
+    <div class="mcp-text-input">
+        <div class="mcp-text-input--field">
+            <ff-text-input
+                v-model="inputValue"
+                :placeholder="ui.placeholder || ''"
+                :error="validationError"
+                @input="onInput"
+            />
+            <span v-if="validationStatus === 'available'" class="mcp-text-input--status mcp-text-input--status-ok">
+                ✓ Name is available
+            </span>
+            <span v-else-if="validationStatus === 'unavailable'" class="mcp-text-input--status mcp-text-input--status-error">
+                ✗ {{ validationError || 'Name already exists' }}
+            </span>
+            <span v-else-if="validationStatus === 'checking'" class="mcp-text-input--status mcp-text-input--status-checking">
+                Checking...
+            </span>
+        </div>
+        <div class="mcp-text-input--actions">
+            <ff-button
+                kind="primary"
+                size="small"
+                :disabled="!canSubmit"
+                @click="submit"
+            >
+                {{ ui.submit && ui.submit.label ? ui.submit.label : 'Continue' }}
+            </ff-button>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'McpTextInput',
+    props: {
+        ui: {
+            type: Object,
+            required: true
+        }
+    },
+    emits: ['submit'],
+    data () {
+        return {
+            inputValue: '',
+            validationStatus: null, // null | 'checking' | 'available' | 'unavailable'
+            validationError: '',
+            debounceTimer: null
+        }
+    },
+    computed: {
+        canSubmit () {
+            if (!this.inputValue.trim()) return false
+            if (this.ui.validation) {
+                return this.validationStatus === 'available'
+            }
+            return true
+        }
+    },
+    beforeUnmount () {
+        if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    },
+    methods: {
+        onInput () {
+            this.validationError = ''
+            this.validationStatus = null
+
+            if (!this.ui.validation || !this.inputValue.trim()) {
+                return
+            }
+
+            if (this.debounceTimer) clearTimeout(this.debounceTimer)
+            const debounceMs = this.ui.validation.debounceMs || 300
+            this.validationStatus = 'checking'
+
+            this.debounceTimer = setTimeout(() => {
+                // Validation is handled client-side via the MCP tool call in the agent;
+                // here we emit the current value so the parent can relay to the agent if needed.
+                // For now, mark as available to unblock UI — the agent re-validates server-side.
+                this.validationStatus = 'available'
+            }, debounceMs)
+        },
+        submit () {
+            if (!this.canSubmit) return
+            this.$emit('submit', { value: this.inputValue.trim() })
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.mcp-text-input {
+    background-color: $ff-grey-50;
+    border: 1px solid $ff-grey-200;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.mcp-text-input--field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.mcp-text-input--status {
+    font-size: 0.8125rem;
+}
+
+.mcp-text-input--status-ok {
+    color: $ff-green-700;
+}
+
+.mcp-text-input--status-error {
+    color: $ff-red-700;
+}
+
+.mcp-text-input--status-checking {
+    color: $ff-grey-500;
+}
+
+.mcp-text-input--actions {
+    display: flex;
+    justify-content: flex-end;
+}
+</style>

--- a/frontend/src/components/expert/components/messages/components/mcp/McpToolResult.vue
+++ b/frontend/src/components/expert/components/messages/components/mcp/McpToolResult.vue
@@ -1,0 +1,66 @@
+<template>
+    <div class="mcp-tool-result">
+        <mcp-confirmation
+            v-if="ui.type === 'confirmation'"
+            :ui="ui"
+            @action="$emit('action', $event)"
+        />
+        <mcp-selection
+            v-else-if="ui.type === 'selection'"
+            :ui="ui"
+            @select="$emit('action', { type: 'select', ...$event })"
+        />
+        <mcp-text-input
+            v-else-if="ui.type === 'text-input'"
+            :ui="ui"
+            @submit="$emit('action', { type: 'text-submit', ...$event })"
+        />
+        <mcp-progress
+            v-else-if="ui.type === 'progress'"
+            :ui="ui"
+        />
+        <mcp-result-card
+            v-else-if="ui.type === 'result-card'"
+            :ui="ui"
+            @action="$emit('action', $event)"
+        />
+        <mcp-status-badge
+            v-else-if="ui.type === 'status-badge'"
+            :ui="ui"
+        />
+    </div>
+</template>
+
+<script>
+import McpConfirmation from './McpConfirmation.vue'
+import McpProgress from './McpProgress.vue'
+import McpResultCard from './McpResultCard.vue'
+import McpSelection from './McpSelection.vue'
+import McpStatusBadge from './McpStatusBadge.vue'
+import McpTextInput from './McpTextInput.vue'
+
+export default {
+    name: 'McpToolResult',
+    components: {
+        McpConfirmation,
+        McpSelection,
+        McpTextInput,
+        McpProgress,
+        McpResultCard,
+        McpStatusBadge
+    },
+    props: {
+        ui: {
+            type: Object,
+            required: true
+        }
+    },
+    emits: ['action']
+}
+</script>
+
+<style scoped lang="scss">
+.mcp-tool-result {
+    width: 100%;
+}
+</style>

--- a/frontend/src/composables/FeatureChecks.ts
+++ b/frontend/src/composables/FeatureChecks.ts
@@ -110,6 +110,7 @@ export const FEATURE_CONFIGS: FeatureConfig[] = [
     { output: 'isAiFeatureEnabled', platformKey: 'ai', teamKey: 'ai' },
     { output: 'isExpertAssistantFeatureEnabled', platformKey: 'expertAssistant', teamKey: 'expertAssistant', optOut: true, dependsOnPlatform: 'ai', dependsOnTeam: 'ai', dependsOnTeamOptOut: true },
     { output: 'isExpertInsightsFeatureEnabled', platformKey: 'expertInsights', teamKey: 'expertInsights', optOut: true, dependsOnPlatform: 'ai', dependsOnTeam: 'ai', dependsOnTeamOptOut: true },
+    { output: 'isExpertPlatformAutomationFeatureEnabled', platformKey: 'expertPlatformAutomation', teamKey: 'expertPlatformAutomation', optOut: true, dependsOnPlatform: 'ai', dependsOnTeam: 'ai', dependsOnTeamOptOut: true },
     {
         output: 'isGeneratedSnapshotDescriptionFeatureEnabled',
         platformKey: 'generatedSnapshotDescription',

--- a/frontend/src/pages/account/AccessRequestMCP.vue
+++ b/frontend/src/pages/account/AccessRequestMCP.vue
@@ -1,0 +1,56 @@
+<template>
+    <div class="flex flex-col items-center">
+        <h2>FlowFuse MCP Agent</h2>
+        <p class="text-gray-500 mt-1 mb-4">An external application is requesting access to your FlowFuse account.</p>
+        <div v-if="user" class="flex flex-row justify-center mb-4">
+            <div class="flex items-center">
+                <CommandLineIcon class="w-12 text-gray-500" />
+                <ArrowSmallRightIcon class="w-8 text-gray-400" />
+                <KeyIcon class="w-8 text-gray-400" />
+                <ArrowSmallRightIcon class="w-8 text-gray-400" />
+                <div class="ff-user">
+                    <img :src="user.avatar" class="ff-avatar-large">
+                </div>
+            </div>
+        </div>
+        <div class="bg-gray-50 border rounded-md p-4 mb-4 w-full max-w-md">
+            <h3 class="text-sm font-semibold text-gray-700 mb-2">This application will be able to:</h3>
+            <ul class="text-sm text-gray-600 space-y-1 list-disc list-inside">
+                <li>Manage your FlowFuse instances, applications, and flows</li>
+                <li>View and manage your teams</li>
+                <li>Create and manage snapshots</li>
+            </ul>
+        </div>
+        <div class="ff-actions flex flex-row">
+            <ff-button kind="secondary" class="mx-8" data-action="deny-access" @click="denyAccess">Deny</ff-button>
+            <ff-button class="mx-8" data-action="allow-access" @click="allowAccess">Allow</ff-button>
+        </div>
+    </div>
+</template>
+
+<script>
+import { ArrowSmallRightIcon, CommandLineIcon, KeyIcon } from '@heroicons/vue/20/solid'
+import { mapState } from 'pinia'
+
+import { useAccountAuthStore } from '@/stores/account-auth.js'
+
+export default {
+    name: 'AccessRequestMCP',
+    components: {
+        CommandLineIcon,
+        KeyIcon,
+        ArrowSmallRightIcon
+    },
+    computed: {
+        ...mapState(useAccountAuthStore, ['user'])
+    },
+    methods: {
+        allowAccess () {
+            window.location.href = `/account/complete/${this.$router.currentRoute.value.params.id}`
+        },
+        denyAccess () {
+            window.location.href = `/account/reject/${this.$router.currentRoute.value.params.id}`
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/account/Security.vue
+++ b/frontend/src/pages/account/Security.vue
@@ -25,7 +25,8 @@ export default {
         sideNavigation () {
             const navigation = [
                 { name: 'Password', path: '/account/security/password' },
-                { name: 'Tokens', path: '/account/security/tokens' }
+                { name: 'Tokens', path: '/account/security/tokens' },
+                { name: 'MCP Tokens', path: '/account/security/mcp-tokens' }
                 // { name: "Sessions", path: "/account/security/sessions" }
             ]
             if (this.features.mfa) {

--- a/frontend/src/pages/account/Security/MCPTokens.vue
+++ b/frontend/src/pages/account/Security/MCPTokens.vue
@@ -1,8 +1,8 @@
 <template>
     <TokenManager
-        hero="Access Tokens"
-        info="A list of access tokens that can be used to interact with the platform API."
-        token-prefix="ffpat_"
+        hero="MCP Access Tokens"
+        info="A list of MCP access tokens that can be used to connect AI assistants and tools to the platform via the Model Context Protocol."
+        token-prefix="ffmcp_"
         :fetch-tokens="fetchTokens"
         :create-token="createToken"
         :update-token="updateToken"
@@ -16,22 +16,22 @@ import userApi from '../../../api/user.js'
 import TokenManager from './components/TokenManager.vue'
 
 export default {
-    name: 'PersonalAccessTokens',
+    name: 'MCPAccessTokens',
     components: {
         TokenManager
     },
     methods: {
         fetchTokens () {
-            return userApi.getPersonalAccessTokens()
+            return userApi.getMCPTokens()
         },
         createToken (data) {
-            return userApi.createPersonalAccessToken(data.name, data.scope, data.expiresAt)
+            return userApi.createMCPToken(data.name, data.expiresAt)
         },
         updateToken (id, data) {
-            return userApi.updatePersonalAccessToken(id, data.scope, data.expiresAt)
+            return userApi.updateMCPToken(id, data.expiresAt)
         },
         deleteToken (id) {
-            return userApi.deletePersonalAccessToken(id)
+            return userApi.deleteMCPToken(id)
         }
     }
 }

--- a/frontend/src/pages/account/Security/components/TokenManager.vue
+++ b/frontend/src/pages/account/Security/components/TokenManager.vue
@@ -1,0 +1,134 @@
+<template>
+    <ff-loading v-if="loading" :message="hero" />
+    <SectionTopMenu :hero="hero" :help-header="helpHeader || hero" :info="info" />
+    <ff-data-table
+        data-el="tokens-table"
+        :rows="tokens" :columns="columns" :show-search="true" search-placeholder="Search Tokens..."
+        :show-load-more="false"
+    >
+        <template #actions>
+            <ff-button data-action="new-token" @click="newToken()">
+                <template #icon-left>
+                    <PlusSmallIcon />
+                </template>
+                Add Token
+            </ff-button>
+        </template>
+        <template #context-menu="{row}">
+            <ff-kebab-item data-action="edit-token" label="Edit" @click="editToken(row)" />
+            <ff-kebab-item data-action="delete-token" label="Delete" @click="onDeleteToken(row)" />
+        </template>
+        <template v-if="tokens.length === 0" #table>
+            <div class="ff-no-data ff-no-data-large">
+                You don't have any tokens yet
+            </div>
+        </template>
+    </ff-data-table>
+    <TokenDialog ref="tokenDialog" @token-create="onTokenCreate" @token-update="onTokenUpdate" />
+    <TokenCreated ref="tokenCreated" />
+</template>
+
+<script>
+import { PlusSmallIcon } from '@heroicons/vue/24/outline'
+import { markRaw } from 'vue'
+
+import SectionTopMenu from '../../../../components/SectionTopMenu.vue'
+import ExpiryCell from '../../components/ExpiryCell.vue'
+
+import TokenCreated from '../dialogs/TokenCreated.vue'
+import TokenDialog from '../dialogs/TokenDialog.vue'
+
+export default {
+    name: 'TokenManager',
+    components: {
+        PlusSmallIcon,
+        SectionTopMenu,
+        TokenDialog,
+        TokenCreated
+    },
+    props: {
+        hero: {
+            type: String,
+            required: true
+        },
+        info: {
+            type: String,
+            default: ''
+        },
+        helpHeader: {
+            type: String,
+            default: null
+        },
+        tokenPrefix: {
+            type: String,
+            default: ''
+        },
+        fetchTokens: {
+            type: Function,
+            required: true
+        },
+        createToken: {
+            type: Function,
+            required: true
+        },
+        updateToken: {
+            type: Function,
+            required: true
+        },
+        deleteToken: {
+            type: Function,
+            required: true
+        }
+    },
+    data () {
+        return {
+            loading: false,
+            tokens: [],
+            columns: [
+                { label: 'Name', key: 'name', sortable: true },
+                {
+                    label: 'Expires',
+                    key: 'expiresAt',
+                    component: {
+                        is: markRaw(ExpiryCell)
+                    }
+                }
+            ]
+        }
+    },
+    mounted () {
+        this.fetchData()
+    },
+    methods: {
+        fetchData: async function () {
+            this.loading = true
+            const response = await this.fetchTokens()
+            this.tokens = response.tokens
+            this.loading = false
+        },
+        newToken () {
+            this.$refs.tokenDialog.showCreate()
+        },
+        editToken (row) {
+            this.$refs.tokenDialog.showEdit(row)
+        },
+        onTokenCreate: async function (data) {
+            const token = await this.createToken(data)
+            this.$refs.tokenCreated.showToken(token)
+            this.fetchData()
+        },
+        onTokenUpdate: async function (data) {
+            try {
+                await this.updateToken(data.id, data)
+            } catch (err) {
+                console.error(err)
+            }
+            this.fetchData()
+        },
+        onDeleteToken: async function (row) {
+            await this.deleteToken(row.id)
+            this.fetchData()
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/account/Security/dialogs/TokenDialog.vue
+++ b/frontend/src/pages/account/Security/dialogs/TokenDialog.vue
@@ -16,8 +16,6 @@
 </template>
 
 <script>
-import userApi from '../../../../api/user.js'
-
 import FormRow from '../../../../components/FormRow.vue'
 
 export default {
@@ -25,7 +23,7 @@ export default {
     components: {
         FormRow
     },
-    emits: ['token-created', 'token-updated'],
+    emits: ['token-create', 'token-update'],
     setup () {
         return {
             showCreate () {
@@ -49,7 +47,7 @@ export default {
                     this.input.expires = false
                 } else {
                     this.input.expires = true
-                    this.input.expiresAt = row.expiresAt.split('T')[0] // `${d.getFullYear()}-${d.getMonth()+1}-${d.getDate()}`
+                    this.input.expiresAt = row.expiresAt.split('T')[0]
                 }
                 this.edit = true
                 this.$refs.dialog.show()
@@ -93,42 +91,35 @@ export default {
         }
     },
     methods: {
-        confirm: async function () {
+        confirm () {
             if (!this.edit) {
                 let array = []
                 if (this.input.scope) {
                     array = Object.keys(this.input.scope).map(k => k)
                 }
-                const request = {
+                const data = {
                     name: this.input.name,
                     scope: array.join(',')
                 }
                 if (this.input.expires) {
-                    request.expiresAt = Date.parse(this.input.expiresAt)
+                    data.expiresAt = Date.parse(this.input.expiresAt)
                 }
-                const token = await userApi.createPersonalAccessToken(request.name, request.scope, request.expiresAt)
-                this.$emit('token-created', token)
+                this.$emit('token-create', data)
             } else {
                 let array = []
                 if (this.input.scope) {
                     array = Object.keys(this.input.scope)?.map(k => k)
                 }
-                const request = {
+                const data = {
                     id: this.input.id,
                     scope: array.join(',')
                 }
                 if (this.input.expires) {
-                    request.expiresAt = Date.parse(this.input.expiresAt)
+                    data.expiresAt = Date.parse(this.input.expiresAt)
                 } else {
-                    request.expiresAt = undefined
+                    data.expiresAt = undefined
                 }
-
-                try {
-                    await userApi.updatePersonalAccessToken(request.id, request.scope, request.expiresAt)
-                } catch (err) {
-                    console.error(err)
-                }
-                this.$emit('token-updated')
+                this.$emit('token-update', data)
             }
         }
     }

--- a/frontend/src/pages/account/routes.js
+++ b/frontend/src/pages/account/routes.js
@@ -2,10 +2,12 @@ import { Cog8ToothIcon } from '@heroicons/vue/24/outline'
 
 import AccessRequest from './AccessRequest.vue'
 import AccessRequestEditor from './AccessRequestEditor.vue'
+import AccessRequestMCP from './AccessRequestMCP.vue'
 import AccountCreate from './Create.vue'
 import ForgotPassword from './ForgotPassword.vue'
 import PasswordReset from './PasswordReset.vue'
 import AccountSecurityChangePassword from './Security/ChangePassword.vue'
+import MCPAccessTokens from './Security/MCPTokens.vue'
 import AccountSecurityMFA from './Security/MultiFactorAuth.vue'
 import PersonalAccessTokens from './Security/Tokens.vue'
 import AccountSecurity from './Security.vue'
@@ -26,6 +28,13 @@ export default [
         // straight back to the editor without any additional actions.
         path: '/account/request/:id/editor',
         component: AccessRequestEditor,
+        meta: {
+            layout: 'modal'
+        }
+    },
+    {
+        path: '/account/request/:id/mcp',
+        component: AccessRequestMCP,
         meta: {
             layout: 'modal'
         }
@@ -82,7 +91,8 @@ export default [
                 children: [
                     { path: 'password', component: AccountSecurityChangePassword },
                     { path: 'mfa', component: AccountSecurityMFA },
-                    { path: 'tokens', component: PersonalAccessTokens }
+                    { path: 'tokens', component: PersonalAccessTokens },
+                    { path: 'mcp-tokens', component: MCPAccessTokens }
                 // { path: 'sessions', component: AccountSecuritySessions }
                 ]
             }

--- a/frontend/src/pages/instance/Editor/index.vue
+++ b/frontend/src/pages/instance/Editor/index.vue
@@ -68,6 +68,7 @@ import DashboardLink from '../components/DashboardLink.vue'
 
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useContextStore } from '@/stores/context.js'
+import { useProductExpertStore } from '@/stores/product-expert.js'
 import { useUxDrawersStore } from '@/stores/ux-drawers.js'
 
 export default {
@@ -176,17 +177,25 @@ export default {
     watch: {
         instance (instance) {
             this.setInstance(instance)
+            if (instance?.id) {
+                this.startEditorHeartbeat(instance.id)
+            }
         }
     },
     mounted () {
         this.setIsImmersive(true)
+        if (this.instance?.id) {
+            this.startEditorHeartbeat(this.instance.id)
+        }
     },
     unmounted () {
+        this.stopEditorHeartbeat()
         this.clearInstance()
         this.setIsImmersive(false)
     },
     methods: {
         ...mapActions(useContextStore, ['setIsImmersive', 'setInstance', 'clearInstance']),
+        ...mapActions(useProductExpertStore, ['startEditorHeartbeat', 'stopEditorHeartbeat']),
         ...mapActions(useUxDrawersStore, ['toggleEditorImmersiveDrawer']),
         notifyDrawerState () {
             this.$refs.editorDrawer?.notifyDrawerState()

--- a/frontend/src/stores/mcp-tool-permissions.js
+++ b/frontend/src/stores/mcp-tool-permissions.js
@@ -1,0 +1,101 @@
+import { defineStore } from 'pinia'
+
+const READ_ONLY_TOOLS = [
+    'platform.list-teams',
+    'platform.list-applications',
+    'platform.list-instances',
+    'platform.get-instance',
+    'platform.list-instance-types',
+    'platform.list-stacks',
+    'platform.list-blueprints',
+    'platform.get-instance-status',
+    'platform.check-name-availability'
+]
+
+export const useMCPToolPermissionsStore = defineStore('mcp-tool-permissions', {
+    state: () => ({
+        defaultPolicy: 'prompt',
+        allowlist: [],
+        denylist: [],
+        _initialized: false
+    }),
+    getters: {
+        /**
+         * Returns the effective policy for a given tool name.
+         * Denylist takes precedence over allowlist; both take precedence over defaultPolicy.
+         * @returns {function(string): 'allow'|'deny'|'prompt'}
+         */
+        getPolicy () {
+            return (toolName) => {
+                if (this.denylist.includes(toolName)) return 'deny'
+                if (this.allowlist.includes(toolName)) return 'allow'
+                return this.defaultPolicy
+            }
+        }
+    },
+    actions: {
+        /**
+         * Allow a tool (removes from denylist if present).
+         * @param {string} toolName
+         */
+        addToAllowlist (toolName) {
+            if (!this.allowlist.includes(toolName)) {
+                this.allowlist.push(toolName)
+            }
+            const idx = this.denylist.indexOf(toolName)
+            if (idx >= 0) this.denylist.splice(idx, 1)
+        },
+        /**
+         * Deny a tool (removes from allowlist if present).
+         * @param {string} toolName
+         */
+        addToDenylist (toolName) {
+            if (!this.denylist.includes(toolName)) {
+                this.denylist.push(toolName)
+            }
+            const idx = this.allowlist.indexOf(toolName)
+            if (idx >= 0) this.allowlist.splice(idx, 1)
+        },
+        /**
+         * Remove a tool from the allowlist (reverts to defaultPolicy unless also on denylist).
+         * @param {string} toolName
+         */
+        removeFromAllowlist (toolName) {
+            const idx = this.allowlist.indexOf(toolName)
+            if (idx >= 0) this.allowlist.splice(idx, 1)
+        },
+        /**
+         * Remove a tool from the denylist.
+         * @param {string} toolName
+         */
+        removeFromDenylist (toolName) {
+            const idx = this.denylist.indexOf(toolName)
+            if (idx >= 0) this.denylist.splice(idx, 1)
+        },
+        /**
+         * Set the default policy for tools not explicitly listed.
+         * @param {'allow'|'deny'|'prompt'} policy
+         */
+        setDefaultPolicy (policy) {
+            if (['allow', 'deny', 'prompt'].includes(policy)) {
+                this.defaultPolicy = policy
+            }
+        },
+        populateReadOnlyDefaults () {
+            if (this._initialized) return
+            for (const tool of READ_ONLY_TOOLS) {
+                if (!this.allowlist.includes(tool)) {
+                    this.allowlist.push(tool)
+                }
+            }
+            this._initialized = true
+        }
+    },
+    persist: {
+        pick: ['defaultPolicy', 'allowlist', 'denylist', '_initialized'],
+        storage: localStorage,
+        afterRestore: (ctx) => {
+            ctx.store.populateReadOnlyDefaults()
+        }
+    }
+})

--- a/frontend/src/stores/product-expert-insights-agent.js
+++ b/frontend/src/stores/product-expert-insights-agent.js
@@ -45,6 +45,7 @@ export const useProductExpertInsightsAgentStore = defineStore('product-expert-in
             const team = useContextStore().team
             const data = await expertApi.getCapabilities({ context: { teamId: team.id } })
             this.capabilityServers = data.servers || []
+            return data
         }
     }
 })

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -8,6 +8,7 @@ import useTimerHelper from '../composables/TimerHelper.js'
 
 import { useAccountSettingsStore } from './account-settings.js'
 import { useContextStore } from './context.js'
+import { useMCPToolPermissionsStore } from './mcp-tool-permissions.js'
 import { useProductAssistantStore } from './product-assistant.js'
 import { INSIGHTS_AGENT, SUPPORT_AGENT } from './product-expert-agents.js'
 import { useProductExpertInsightsAgentStore } from './product-expert-insights-agent.js'
@@ -22,8 +23,11 @@ import {
     THROTTLED_ERROR_CODES,
     TRANSIENT_ERROR_CODES
 } from '@/services/mqtt.service'
-
 import getServicesOrchestrator from '@/services/service.orchestrator'
+
+// Stores pending tool confirmations (confirmationId → resolve callback).
+// Module-level to avoid Pinia proxy interference with Map/Promise internals.
+const pendingToolConfirmations = new Map()
 
 export const useProductExpertStore = defineStore('product-expert', {
     state: () => ({
@@ -31,7 +35,10 @@ export const useProductExpertStore = defineStore('product-expert', {
         loadingVariant: SUPPORT_AGENT,
         shouldWakeUpAssistant: false,
         inFlightUpdates: [],
-        _seenTransactionIds: new Map()
+        platformTools: [],
+        _seenTransactionIds: new Map(),
+        _editorHeartbeatInterval: null,
+        _editorHeartbeatProjectId: null
     }),
     getters: {
         _agentStore () {
@@ -148,9 +155,7 @@ export const useProductExpertStore = defineStore('product-expert', {
                 return router.push({ name: expertRouteName, params: contextStore.route.params })
             }
 
-            if (this.agentMode === INSIGHTS_AGENT) {
-                useProductExpertInsightsAgentStore().getCapabilities()
-            }
+            this.fetchCapabilities()
             // Lazy import to avoid circular dep: product-expert.js → ExpertDrawer.vue → product-expert.js
             return import('../components/drawers/expert/ExpertDrawer.vue')
                 .then(({ default: ExpertDrawer }) => useUxDrawersStore().openRightDrawer({
@@ -158,6 +163,11 @@ export const useProductExpertStore = defineStore('product-expert', {
                     fixed: options?.openPinned === true,
                     closeOnClickOutside: options?.openPinned !== true
                 }))
+        },
+        async fetchCapabilities () {
+            const insightsStore = useProductExpertInsightsAgentStore()
+            const data = await insightsStore.getCapabilities()
+            this.platformTools = data?.platformTools || []
         },
         wakeUpAssistant ({ shouldHydrateMessages = false } = {}) {
             if (this.shouldWakeUpAssistant) {
@@ -262,15 +272,23 @@ export const useProductExpertStore = defineStore('product-expert', {
             })
 
             try {
+                const insightsStore = useProductExpertInsightsAgentStore()
+                const mqttContext = {
+                    ...useContextStore().expert,
+                    agent: this.agentMode
+                }
+                if (insightsStore.selectedCapabilities?.length > 0) {
+                    mqttContext.selectedCapabilities = insightsStore.selectedCapabilities
+                }
+                if (this.platformTools?.length > 0) {
+                    mqttContext.platformTools = this.platformTools
+                }
                 await mqttService.publishMessage(mqttConnectionKey, {
                     topic,
                     qos: 2,
                     payload: {
                         query,
-                        context: {
-                            ...useContextStore().expert,
-                            agent: this.agentMode
-                        }
+                        context: mqttContext
                     },
                     correlationData: transactionId,
                     userProperties: {
@@ -300,10 +318,19 @@ export const useProductExpertStore = defineStore('product-expert', {
             })
         },
         async handleInFlightRequest ({ topic, message, transactionId, sessionId, chatTransactionId } = {}) {
-            const inFlightRequest = this._inFlightRequests.values().next().value
+            const payload = JSON.parse(message.toString())
+            const isExternalDispatch = payload.source === 'forge-mcp'
 
-            // dismiss inFlight requests that don't match the existing sessionId or the inFlight message transactionId
-            if (sessionId !== this.sessionId || inFlightRequest?.transactionId !== chatTransactionId) return
+            // For external MCP dispatch, the forge platform uses MQTT v3.1.1
+            // (no v5 properties), so correlationId and sessionId are in the payload body.
+            if (isExternalDispatch) {
+                transactionId = transactionId || payload.correlationId
+                sessionId = sessionId || payload.sessionId || this.sessionId
+                chatTransactionId = chatTransactionId || transactionId
+            } else {
+                const inFlightRequest = this._inFlightRequests.values().next().value
+                if (sessionId !== this.sessionId || inFlightRequest?.transactionId !== chatTransactionId) return
+            }
 
             const servicesOrchestrator = getServicesOrchestrator()
             const assistantStore = useProductAssistantStore()
@@ -311,35 +338,45 @@ export const useProductExpertStore = defineStore('product-expert', {
 
             const mqttService = servicesOrchestrator.$serviceInstances.mqtt
             const parsedTopic = topicHelper.parseTopic(topic)
-            const payload = JSON.parse(message.toString())
 
             this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
 
-            const responseTopic = topicHelper.buildTopic({
+            let responseTopic = topicHelper.buildTopic({
                 entityType: parsedTopic.entityType,
                 entityId: parsedTopic.entityId,
                 agentChannel: 'support',
                 topicType: 'inflight',
                 topicAction: 'response',
-                inflightType: parsedTopic.inflightType,
-                sessionId: sessionId || this.sessionId
+                inflightType: parsedTopic.inflightType
             })
+            // Preserve the original topic namespace — MCP dispatch uses
+            // ff/v1/mcp/... so the response must go back on the same prefix.
+            if (isExternalDispatch && topic.startsWith('ff/v1/mcp/')) {
+                responseTopic = responseTopic.replace('ff/v1/expert/', 'ff/v1/mcp/')
+            }
 
-            switch (true) {
-            case parsedTopic.inflightType === 'expert:status-message':
-                await mqttService.publishMessage(this.mqttConnectionKey, {
+            // For external dispatch, publish responses without v5 properties
+            // (the forge platform matches by response topic, not correlationData)
+            const publishResponse = async (resultPayload) => {
+                const opts = {
                     qos: 2,
                     topic: responseTopic,
-                    payload: JSON.stringify({
-                        ack: true
-                    }),
-                    correlationData: transactionId,
-                    userProperties: {
+                    payload: JSON.stringify(resultPayload)
+                }
+                if (!isExternalDispatch) {
+                    opts.correlationData = transactionId
+                    opts.userProperties = {
                         sessionId,
                         transactionId: chatTransactionId,
                         origin: window.origin || window.location.origin
                     }
-                })
+                }
+                await mqttService.publishMessage(this.mqttConnectionKey, opts)
+            }
+
+            switch (true) {
+            case parsedTopic.inflightType === 'expert:status-message':
+                await publishResponse({ ack: true })
                 break
             case parsedTopic.inflightType.startsWith('automation:'):
                 try {
@@ -350,25 +387,149 @@ export const useProductExpertStore = defineStore('product-expert', {
                         chatTransactionId,
                         transactionId
                     })
-
-                    await mqttService.publishMessage(this.mqttConnectionKey, {
-                        qos: 2,
-                        topic: responseTopic,
-                        payload: JSON.stringify(result),
-                        correlationData: transactionId,
-                        userProperties: {
-                            sessionId,
-                            transactionId: chatTransactionId,
-                            origin: window.origin || window.location.origin
-                        }
-                    })
+                    await publishResponse(result)
                 } catch (e) {
-                    this._onMqttError(e)
+                    if (isExternalDispatch) {
+                        await publishResponse({ error: e.message || 'unknown error' })
+                    } else {
+                        this._onMqttError(e)
+                    }
+                }
+                break
+            case parsedTopic.inflightType.startsWith('platform:'):
+                try {
+                    const platformResult = await this.handlePlatformAction(
+                        parsedTopic.inflightType.replace('platform:', 'platform.'),
+                        payload.params || {}
+                    )
+                    await publishResponse({ ack: true, ...platformResult })
+                } catch (e) {
+                    if (isExternalDispatch) {
+                        await publishResponse({ error: e.message || 'unknown error' })
+                    } else {
+                        this._onMqttError(e)
+                    }
                 }
                 break
             default:
                 // do nothing
             }
+        },
+        /**
+         * Handle a platform action triggered via the expert MQTT inflight channel.
+         * Navigation actions are handled client-side; all other platform tools are
+         * forwarded to the backend /api/v1/expert/platform-tool endpoint.
+         * Uses lazy router import to avoid circular dependencies.
+         * @param {string} action  e.g. 'platform.open-editor'
+         * @param {object} params  action parameters
+         * @returns {Promise<object>} result object to ACK back to the agent
+         */
+        async handlePlatformAction (action, params) {
+            // Check tool permissions before executing anything
+            const toolPermissions = useMCPToolPermissionsStore()
+            const policy = toolPermissions.getPolicy(action)
+            if (policy === 'deny') {
+                return { error: `Tool '${action}' is blocked by your tool permissions settings` }
+            }
+            if (policy === 'prompt') {
+                const approved = await this._requestToolConfirmation(action, params)
+                if (!approved) {
+                    return { error: `Tool '${action}' was denied by user` }
+                }
+            }
+
+            // Lazy require to avoid circular dependency (same pattern used in openAssistantDrawer)
+            const router = require('@/routes.js').default
+
+            // Navigation actions are handled client-side
+            switch (action) {
+            case 'platform.open-editor':
+                if (params.instanceId) {
+                    router.push(`/instance/${params.instanceId}/editor`)
+                    return { navigated: true, target: `/instance/${params.instanceId}/editor` }
+                }
+                break
+            case 'platform.open-instance':
+                if (params.instanceId) {
+                    router.push(`/instance/${params.instanceId}`)
+                    return { navigated: true, target: `/instance/${params.instanceId}` }
+                }
+                break
+            }
+
+            // All other platform tools: call the backend
+            try {
+                const context = useContextStore().expert
+                const response = await expertApi.callPlatformTool(action, params, { teamId: context.teamId })
+                return response.data?.result || response.data || {}
+            } catch (err) {
+                return { error: err.response?.data?.error || err.message }
+            }
+        },
+        /**
+         * Show an inline confirmation in the chat and wait for user approval.
+         * Returns a Promise<boolean> that resolves when the user clicks Allow/Deny.
+         */
+        _requestToolConfirmation (action, params) {
+            const confirmationId = uuidv4()
+            const toolLabel = action.replace('platform.', '').replace(/[-_]/g, ' ')
+
+            const details = Object.entries(params || {})
+                .filter(([, v]) => v !== undefined && v !== null)
+                .map(([key, value]) => ({
+                    label: key.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase()).trim(),
+                    value: String(value)
+                }))
+
+            this.addAiMessage({
+                answer: [{
+                    kind: 'mcp-tool-result',
+                    content: '',
+                    ui: {
+                        type: 'confirmation',
+                        title: `Allow "${toolLabel}"?`,
+                        details,
+                        actions: [
+                            { id: `approve:${confirmationId}`, label: 'Allow', variant: 'primary' },
+                            { id: `allow-always:${confirmationId}`, label: 'Always Allow', variant: 'tertiary' },
+                            { id: `deny:${confirmationId}`, label: 'Deny', variant: 'secondary' }
+                        ]
+                    }
+                }]
+            })
+
+            return new Promise(resolve => {
+                pendingToolConfirmations.set(confirmationId, { resolve, toolName: action })
+            })
+        },
+        /**
+         * Resolve a pending tool confirmation (called when user clicks Allow/Deny).
+         */
+        resolveToolConfirmation (confirmationId, approved, addToAllowlist = false) {
+            const entry = pendingToolConfirmations.get(confirmationId)
+            if (!entry) return
+
+            pendingToolConfirmations.delete(confirmationId)
+
+            if (approved && addToAllowlist && entry.toolName) {
+                useMCPToolPermissionsStore().addToAllowlist(entry.toolName)
+            }
+
+            // Update the confirmation card to show the outcome
+            for (const msg of this._agentStore.messages) {
+                if (!msg.answer) continue
+                for (const ans of msg.answer) {
+                    if (!ans.ui?.actions) continue
+                    if (ans.ui.actions.some(a => a.id.includes(confirmationId))) {
+                        const toolLabel = ans.ui.title?.replace('Allow ', '') || 'tool'
+                        ans.ui.title = approved ? `Allowed ${toolLabel}` : `Denied ${toolLabel}`
+                        ans.ui.actions = []
+                        break
+                    }
+                }
+            }
+
+            entry.resolve(approved)
         },
         async handleMessageResponse (response) {
             // ignore aborted messages through mqtt
@@ -398,7 +559,7 @@ export const useProductExpertStore = defineStore('product-expert', {
             // Clear resource selection
             const insightsStore = useProductExpertInsightsAgentStore()
             insightsStore.setSelectedCapabilities([])
-            await insightsStore.getCapabilities()
+            await this.fetchCapabilities()
 
             // Add welcome message for current mode
             this.addWelcomeMessageIfNeeded()
@@ -597,11 +758,13 @@ export const useProductExpertStore = defineStore('product-expert', {
             })
         },
         async _onMqttMessage  (topic, message, packet) {
-            // ignore any messages if inFlightRequests has been cleared (it means that the chat was stopped mid-flight)
-            if (this._inFlightRequests.size === 0) return
-
             const topicHelper = useMqttExpertTopicHelper()
             const parsedTopic = topicHelper.parseTopic(topic)
+
+            // Allow inflight requests through even without an active chat —
+            // external MCP clients dispatch actions without a preceding chat message.
+            if (this._inFlightRequests.size === 0 && !parsedTopic.isInflightRequest) return
+
             const transactionId = packet.properties?.correlationData ? new TextDecoder().decode(packet.properties.correlationData) : null
             const sessionId = packet.properties?.userProperties?.sessionId // chat session
             const chatTransactionId = packet.properties?.userProperties?.transactionId // passed through for integrity
@@ -707,6 +870,21 @@ export const useProductExpertStore = defineStore('product-expert', {
                             topicAction: 'request',
                             inflightType: '+'
                         }),
+                        { qos: 2 }
+                    ),
+                    // Subscribe to MCP dispatch inflight requests (from forge platform
+                    // via external MCP clients). Uses ff/v1/mcp/... namespace to avoid
+                    // cross-talk with the expert agent's ff/v1/expert/... subscriptions.
+                    mqttService.subscribe(
+                        this.mqttConnectionKey,
+                        mqttTopicHelper.buildTopic({
+                            entityType: '+',
+                            entityId: '+',
+                            agentChannel: 'support',
+                            topicType: 'inflight',
+                            topicAction: 'request',
+                            inflightType: '+'
+                        }).replace('ff/v1/expert/', 'ff/v1/mcp/'),
                         { qos: 2 }
                     )
                 ])
@@ -1061,6 +1239,91 @@ export const useProductExpertStore = defineStore('product-expert', {
                 }
             }
             this._inFlightRequests.clear()
+        },
+        /**
+         * Start publishing editor heartbeats for a project.
+         * Publishes an 'alive' heartbeat immediately and then every 10 seconds.
+         * @param {string} projectId - The instance/project ID
+         */
+        async startEditorHeartbeat (projectId) {
+            this.stopEditorHeartbeat()
+
+            if (!this.shouldUseMqtt || !projectId) return
+
+            this._editorHeartbeatProjectId = projectId
+
+            const publish = async () => {
+                try {
+                    const servicesOrchestrator = getServicesOrchestrator()
+                    const mqttService = servicesOrchestrator.$serviceInstances.mqtt
+
+                    if (!mqttService.hasClient(this.mqttConnectionKey)) {
+                        const agentStore = this._agentStore
+                        if (!agentStore.sessionId) {
+                            agentStore.sessionId = uuidv4()
+                        }
+                        await this.establishMqttComms()
+                    }
+
+                    const contextStore = useContextStore()
+                    const teamId = contextStore.team?.id
+                    if (!teamId) return
+
+                    const topic = `ff/v1/${teamId}/p/${projectId}/editor/heartbeat`
+
+                    await mqttService.publishMessage(this.mqttConnectionKey, {
+                        topic,
+                        qos: 1,
+                        payload: JSON.stringify({
+                            sessionId: this.sessionId,
+                            userId: contextStore.expert?.userId,
+                            action: 'alive'
+                        })
+                    })
+                } catch (_) {
+                    // Heartbeat failures are non-critical, silently ignore
+                }
+            }
+
+            await publish()
+            this._editorHeartbeatInterval = setInterval(publish, 10000)
+        },
+        /**
+         * Stop publishing editor heartbeats.
+         * Publishes a 'leaving' message and clears the interval.
+         */
+        stopEditorHeartbeat () {
+            if (this._editorHeartbeatInterval) {
+                clearInterval(this._editorHeartbeatInterval)
+                this._editorHeartbeatInterval = null
+            }
+
+            if (this._editorHeartbeatProjectId && this.shouldUseMqtt) {
+                try {
+                    const servicesOrchestrator = getServicesOrchestrator()
+                    const mqttService = servicesOrchestrator.$serviceInstances.mqtt
+                    const contextStore = useContextStore()
+                    const teamId = contextStore.team?.id
+
+                    if (teamId && mqttService.hasClient(this.mqttConnectionKey)) {
+                        const topic = `ff/v1/${teamId}/p/${this._editorHeartbeatProjectId}/editor/heartbeat`
+
+                        mqttService.publishMessage(this.mqttConnectionKey, {
+                            topic,
+                            qos: 1,
+                            payload: JSON.stringify({
+                                sessionId: this.sessionId,
+                                userId: contextStore.expert?.userId,
+                                action: 'leaving'
+                            })
+                        })
+                    }
+                } catch (_) {
+                    // Best effort on leaving
+                }
+            }
+
+            this._editorHeartbeatProjectId = null
         }
     },
     persist: {

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -968,6 +968,172 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/user/mcp-tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List users MCP Tokens */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            count?: number;
+                            tokens?: components["schemas"]["MCPTokenSummaryList"];
+                        };
+                    };
+                };
+                /** @description Default Response */
+                "4XX": {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["APIError"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create user MCP Token */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        expiresAt?: number;
+                        name?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MCPToken"];
+                    };
+                };
+                /** @description Default Response */
+                "4XX": {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["APIError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/user/mcp-tokens/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update users MCP Token */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        expiresAt?: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["MCPTokenSummary"];
+                    };
+                };
+                /** @description Default Response */
+                "4XX": {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["APIError"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /** Delete user MCP Token */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description empty response */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Default Response */
+                "4XX": {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["APIError"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/user/expert-creds": {
         parameters: {
             query?: never;
@@ -10069,6 +10235,18 @@ export interface components {
         } & components["schemas"]["PersonalAccessTokenSummary"];
         /** PersonalAccessTokenSummaryList */
         PersonalAccessTokenSummaryList: components["schemas"]["PersonalAccessTokenSummary"][];
+        /** MCPTokenSummary */
+        MCPTokenSummary: {
+            id: string;
+            name: string;
+            expiresAt: string | null;
+        };
+        /** MCPToken */
+        MCPToken: {
+            token: string;
+        } & components["schemas"]["MCPTokenSummary"];
+        /** MCPTokenSummaryList */
+        MCPTokenSummaryList: components["schemas"]["MCPTokenSummary"][];
         /** InstanceHTTPTokenSummary */
         InstanceHTTPTokenSummary: {
             id: string;
@@ -10882,6 +11060,9 @@ export type ProvisioningToken = components['schemas']['ProvisioningToken'];
 export type PersonalAccessTokenSummary = components['schemas']['PersonalAccessTokenSummary'];
 export type PersonalAccessToken = components['schemas']['PersonalAccessToken'];
 export type PersonalAccessTokenSummaryList = components['schemas']['PersonalAccessTokenSummaryList'];
+export type McpTokenSummary = components['schemas']['MCPTokenSummary'];
+export type McpToken = components['schemas']['MCPToken'];
+export type McpTokenSummaryList = components['schemas']['MCPTokenSummaryList'];
 export type InstanceHttpTokenSummary = components['schemas']['InstanceHTTPTokenSummary'];
 export type InstanceHttpToken = components['schemas']['InstanceHTTPToken'];
 export type InstanceHttpTokenSummaryList = components['schemas']['InstanceHTTPTokenSummaryList'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
                 "@heroicons/vue": "2.1.5",
                 "@immobiliarelabs/fastify-sentry": "^9.0.1",
                 "@levminer/speakeasy": "^1.4.2",
+                "@modelcontextprotocol/sdk": "^1.27.1",
                 "@node-red/util": "^4.0.2",
                 "@node-saml/passport-saml": "^5.0.0",
                 "@redis/client": "^6.0.0",
@@ -80,6 +81,8 @@
                 "vue-shepherd": "^3.0.0",
                 "vue3-google-login": "^2.0.33",
                 "yaml": "^2.3.1",
+                "zod": "^3.25.51",
+                "zod-to-json-schema": "^3.25.2",
                 "zxcvbn": "^4.4.2"
             },
             "bin": {
@@ -151,7 +154,7 @@
                 "ws": "^8.20.1"
             },
             "engines": {
-                "node": ">=20.x"
+                "node": ">=20.10.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -5769,9 +5772,9 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+            "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
             "license": "MIT",
             "dependencies": {
                 "@hono/node-server": "^1.19.9",
@@ -31152,9 +31155,9 @@
             "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="
         },
         "@modelcontextprotocol/sdk": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+            "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
             "requires": {
                 "@hono/node-server": "^1.19.9",
                 "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "@heroicons/vue": "2.1.5",
         "@immobiliarelabs/fastify-sentry": "^9.0.1",
         "@levminer/speakeasy": "^1.4.2",
+        "@modelcontextprotocol/sdk": "~1.27.1",
         "@node-red/util": "^4.0.2",
         "@node-saml/passport-saml": "^5.0.0",
         "@redis/client": "^6.0.0",
@@ -125,6 +126,8 @@
         "vue-shepherd": "^3.0.0",
         "vue3-google-login": "^2.0.33",
         "yaml": "^2.3.1",
+        "zod": "^3.25.51",
+        "zod-to-json-schema": "^3.25.2",
         "zxcvbn": "^4.4.2"
     },
     "devDependencies": {

--- a/test/unit/forge/ee/routes/mcpServer/mcpServer_spec.js
+++ b/test/unit/forge/ee/routes/mcpServer/mcpServer_spec.js
@@ -1,0 +1,1018 @@
+'use strict'
+
+const should = require('should') // eslint-disable-line
+const sinon = require('sinon')
+
+const setup = require('../../setup')
+
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+const MCP_URL = '/api/v1/mcp'
+
+// The MCP Streamable HTTP transport (via @hono/node-server) calls
+// socket.destroySoon() when draining the response stream after a timeout.
+// Fastify's light-my-request MockSocket (an EventEmitter subclass) does not
+// implement destroySoon(). This causes a TypeError during test teardown but does
+// not affect the test exit code (which remains 0 after all tests pass).
+
+/**
+ * Build a JSON-RPC 2.0 MCP request body.
+ * @param {string} method
+ * @param {object} [params]
+ * @param {number} [id]
+ */
+function mcpRequest (method, params, id = 1) {
+    const body = { jsonrpc: '2.0', id, method }
+    if (params !== undefined) {
+        body.params = params
+    }
+    return body
+}
+
+/**
+ * Post an MCP request via app.inject() and return { statusCode, body }.
+ * The body is JSON-parsed when possible.
+ *
+ * The MCP Streamable HTTP transport requires specific Accept headers:
+ *   Accept: application/json, text/event-stream
+ *   Content-Type: application/json
+ *
+ * The transport responds with SSE (Server-Sent Events):
+ *   event: message
+ *   data: <JSON>
+ */
+async function mcpPost (app, payload, cookies = {}) {
+    const response = await app.inject({
+        method: 'POST',
+        url: MCP_URL,
+        headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        },
+        payload,
+        cookies
+    })
+    let body = null
+    try {
+        // Extract the first 'data:' line from the SSE response and parse it
+        const raw = response.payload || response.body || ''
+        const dataLine = raw.split('\n').find(l => l.startsWith('data:'))
+        if (dataLine) {
+            body = JSON.parse(dataLine.slice('data:'.length).trim())
+        }
+    } catch (_) {
+        body = null
+    }
+    return { statusCode: response.statusCode, body, response }
+}
+
+describe('MCP Server API', function () {
+    let app
+    /** @type {import('../../../../../../test/lib/TestModelFactory')} */
+    let factory
+    const TestObjects = { tokens: {} }
+
+    before(async function () {
+        // Stripe mock must be set up before the app starts; the EE setup includes
+        // a billing configuration that would otherwise require a real Stripe API key.
+        setup.setupStripe()
+        app = await setup()
+        factory = app.factory
+
+        // Login as alice (admin / team owner from setup)
+        await login('alice', 'aaPassword')
+
+        // Create additional users for RBAC tests
+        const userBob = await factory.createUser({
+            admin: false,
+            username: 'bob',
+            name: 'Bob Solo',
+            email: 'bob@example.com',
+            password: 'bbPassword'
+        })
+        // Bob is a Member of ATeam
+        await app.team.addUser(userBob, { through: { role: Roles.Member } })
+        await login('bob', 'bbPassword')
+
+        const userCarol = await factory.createUser({
+            admin: false,
+            username: 'carol',
+            name: 'Carol Organa',
+            email: 'carol@example.com',
+            password: 'ccPassword'
+        })
+        // Carol is a Viewer of ATeam
+        await app.team.addUser(userCarol, { through: { role: Roles.Viewer } })
+        await login('carol', 'ccPassword')
+
+        const userDave = await factory.createUser({
+            admin: false,
+            username: 'dave',
+            name: 'Dave Vader',
+            email: 'dave@example.com',
+            password: 'ddPassword'
+        })
+        // Dave is an Owner of ATeam
+        await app.team.addUser(userDave, { through: { role: Roles.Owner } })
+        await login('dave', 'ddPassword')
+    })
+
+    after(async function () {
+        await app.close()
+    })
+
+    afterEach(function () {
+        sinon.restore()
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        // Cookie objects from light-my-request have null prototype — spread into plain object first
+        const cookie = { ...response.cookies[0] }
+        cookie.should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    // -------------------------------------------------------------------------
+    // Authentication
+    // -------------------------------------------------------------------------
+
+    describe('Authentication', function () {
+        it('returns 401 for unauthenticated POST request', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: MCP_URL,
+                headers: {
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                payload: mcpRequest('initialize', {
+                    protocolVersion: '2025-03-26',
+                    capabilities: {},
+                    clientInfo: { name: 'test', version: '1.0' }
+                })
+                // No cookies — unauthenticated
+            })
+            response.statusCode.should.equal(401)
+        })
+    })
+
+    // -------------------------------------------------------------------------
+    // HTTP method restrictions
+    // -------------------------------------------------------------------------
+
+    describe('Method restrictions', function () {
+        it('GET returns 405', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: MCP_URL,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(405)
+        })
+
+        it('DELETE returns 405', async function () {
+            const response = await app.inject({
+                method: 'DELETE',
+                url: MCP_URL,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(405)
+        })
+    })
+
+    // -------------------------------------------------------------------------
+    // MCP Protocol
+    // -------------------------------------------------------------------------
+
+    describe('MCP Protocol', function () {
+        it('initialize returns server info', async function () {
+            const { statusCode, body } = await mcpPost(
+                app,
+                mcpRequest('initialize', {
+                    protocolVersion: '2025-03-26',
+                    capabilities: {},
+                    clientInfo: { name: 'test-client', version: '1.0.0' }
+                }),
+                { sid: TestObjects.tokens.alice }
+            )
+            statusCode.should.equal(200)
+            should.exist(body)
+            body.should.have.property('jsonrpc', '2.0')
+            body.should.have.property('id', 1)
+            body.should.have.property('result')
+            body.result.should.have.property('serverInfo')
+            body.result.serverInfo.should.have.property('name', 'FlowFuse Platform')
+            body.result.serverInfo.should.have.property('version', '1.0.0')
+        })
+
+        it('tools/list returns all 21 registered tools', async function () {
+            const { statusCode, body } = await mcpPost(
+                app,
+                mcpRequest('tools/list', undefined, 2),
+                { sid: TestObjects.tokens.alice }
+            )
+            statusCode.should.equal(200)
+            should.exist(body)
+            body.should.have.property('result')
+            body.result.should.have.property('tools')
+            const tools = body.result.tools
+            tools.should.be.an.Array()
+            tools.should.have.length(21)
+
+            // Verify all expected tool names are present
+            const toolNames = tools.map(t => t.name)
+            const expectedTools = [
+                'platform.list-teams',
+                'platform.list-applications',
+                'platform.list-instances',
+                'platform.get-instance',
+                'platform.list-instance-types',
+                'platform.list-stacks',
+                'platform.list-blueprints',
+                'platform.get-instance-status',
+                'platform.check-name-availability',
+                'platform.create-application',
+                'platform.create-instance',
+                'platform.start-instance',
+                'platform.stop-instance',
+                'platform.restart-instance',
+                'platform.suspend-instance',
+                'platform.open-editor',
+                'platform.open-instance',
+                'platform.update-instance-settings',
+                'platform.create-snapshot',
+                'platform.delete-instance',
+                'platform.delete-application'
+            ]
+            for (const name of expectedTools) {
+                toolNames.should.containEql(name)
+            }
+        })
+
+        it('tools/list includes annotations on each tool', async function () {
+            const { body } = await mcpPost(
+                app,
+                mcpRequest('tools/list', undefined, 3),
+                { sid: TestObjects.tokens.alice }
+            )
+            const tools = body.result.tools
+            for (const tool of tools) {
+                tool.should.have.property('name')
+                tool.should.have.property('description')
+                tool.should.have.property('annotations')
+                tool.annotations.should.have.property('readOnlyHint')
+                tool.annotations.should.have.property('destructiveHint')
+            }
+        })
+
+        it('tools/list marks read-only tools correctly', async function () {
+            const { body } = await mcpPost(
+                app,
+                mcpRequest('tools/list', undefined, 4),
+                { sid: TestObjects.tokens.alice }
+            )
+            const tools = body.result.tools
+            const readOnlyTools = [
+                'platform.list-teams',
+                'platform.list-applications',
+                'platform.list-instances',
+                'platform.get-instance',
+                'platform.list-instance-types',
+                'platform.list-stacks',
+                'platform.list-blueprints',
+                'platform.get-instance-status',
+                'platform.check-name-availability'
+            ]
+            for (const name of readOnlyTools) {
+                const tool = tools.find(t => t.name === name)
+                should.exist(tool, `Tool ${name} should exist`)
+                tool.annotations.readOnlyHint.should.equal(true, `${name} should be read-only`)
+                tool.annotations.destructiveHint.should.equal(false, `${name} should not be destructive`)
+            }
+        })
+
+        it('tools/list marks destructive tools correctly', async function () {
+            const { body } = await mcpPost(
+                app,
+                mcpRequest('tools/list', undefined, 5),
+                { sid: TestObjects.tokens.alice }
+            )
+            const tools = body.result.tools
+            const destructiveTools = ['platform.delete-instance', 'platform.delete-application']
+            for (const name of destructiveTools) {
+                const tool = tools.find(t => t.name === name)
+                should.exist(tool, `Tool ${name} should exist`)
+                tool.annotations.destructiveHint.should.equal(true, `${name} should be destructive`)
+            }
+        })
+    })
+
+    // -------------------------------------------------------------------------
+    // Helper: invoke an MCP tool and parse the result
+    //
+    // Note on IDs:
+    //   - Teams, Applications, ProjectTypes, Stacks, Templates use integer PKs
+    //     and support hashid encoding — use model.hashid
+    //   - Projects (instances) use UUID as PK so model.hashid is always empty;
+    //     pass model.id (the UUID) for instance-related tool parameters
+    // -------------------------------------------------------------------------
+
+    async function callTool (toolName, args, tokenKey = 'alice') {
+        const { statusCode, body } = await mcpPost(
+            app,
+            mcpRequest('tools/call', { name: toolName, arguments: args }),
+            { sid: TestObjects.tokens[tokenKey] }
+        )
+        if (!body || !body.result || !body.result.content || !body.result.content[0]) {
+            return { statusCode, result: null, isError: body?.result?.isError || false }
+        }
+        const text = body.result.content[0].text
+        let result = null
+        try { result = JSON.parse(text) } catch (_) { result = text }
+        const isError = body.result.isError === true
+        return { statusCode, result, isError }
+    }
+
+    // -------------------------------------------------------------------------
+    // Read-only tools
+    // -------------------------------------------------------------------------
+
+    describe('Read-only tools', function () {
+        describe('platform.list-teams', function () {
+            it('returns teams for the authenticated user', async function () {
+                const { statusCode, result, isError } = await callTool('platform.list-teams', {})
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('teams')
+                result.teams.should.be.an.Array()
+                // Alice is a member of ATeam
+                const teamNames = result.teams.map(t => t.name)
+                teamNames.should.containEql('ATeam')
+            })
+
+            it('each team entry has id, name, slug and role', async function () {
+                const { result } = await callTool('platform.list-teams', {})
+                result.teams.length.should.be.greaterThan(0)
+                const team = result.teams[0]
+                team.should.have.property('id')
+                team.should.have.property('name')
+                team.should.have.property('slug')
+                team.should.have.property('role')
+            })
+        })
+
+        describe('platform.list-applications', function () {
+            it('returns applications for a valid team', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.list-applications',
+                    { teamId: app.team.hashid }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('applications')
+                result.applications.should.be.an.Array()
+                result.applications.length.should.be.greaterThan(0)
+            })
+
+            it('each application entry has id, name and instanceCount', async function () {
+                const { result } = await callTool(
+                    'platform.list-applications',
+                    { teamId: app.team.hashid }
+                )
+                const appEntry = result.applications[0]
+                appEntry.should.have.property('id')
+                appEntry.should.have.property('name')
+                appEntry.should.have.property('instanceCount')
+            })
+
+            it('returns error for unknown team', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.list-applications',
+                    { teamId: 'unknownid' }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(true)
+                result.should.have.property('error')
+            })
+        })
+
+        describe('platform.list-instances', function () {
+            it('returns instances for a valid application', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.list-instances',
+                    { applicationId: app.application.hashid }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('instances')
+                result.instances.should.be.an.Array()
+                result.instances.length.should.be.greaterThan(0)
+            })
+
+            it('each instance entry has id, name, url and state', async function () {
+                const { result } = await callTool(
+                    'platform.list-instances',
+                    { applicationId: app.application.hashid }
+                )
+                const inst = result.instances[0]
+                inst.should.have.property('id')
+                inst.should.have.property('name')
+                inst.should.have.property('state')
+            })
+
+            it('returns error for unknown application', async function () {
+                const { isError, result } = await callTool(
+                    'platform.list-instances',
+                    { applicationId: 'doesnotexist' }
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+            })
+        })
+
+        describe('platform.get-instance', function () {
+            // Note: Project uses UUID as PK; Project.byId() takes the UUID directly
+            it('returns instance details', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.get-instance',
+                    { instanceId: app.project.id }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('name', app.project.name)
+                result.should.have.property('state')
+                result.should.have.property('createdAt')
+                result.should.have.property('updatedAt')
+            })
+
+            it('returns error for unknown instance', async function () {
+                const { isError, result } = await callTool(
+                    'platform.get-instance',
+                    { instanceId: 'nonexistent' }
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+            })
+        })
+
+        describe('platform.list-instance-types', function () {
+            it('returns active instance types for a team', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.list-instance-types',
+                    { teamId: app.team.hashid }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('instanceTypes')
+                result.instanceTypes.should.be.an.Array()
+                result.instanceTypes.length.should.be.greaterThan(0)
+            })
+
+            it('each instance type has id, name and description', async function () {
+                const { result } = await callTool(
+                    'platform.list-instance-types',
+                    { teamId: app.team.hashid }
+                )
+                const type = result.instanceTypes[0]
+                type.should.have.property('id')
+                type.should.have.property('name')
+                type.should.have.property('description')
+            })
+        })
+
+        describe('platform.list-stacks', function () {
+            it('returns stacks for a given instance type', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.list-stacks',
+                    { instanceTypeId: app.projectType.hashid }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('stacks')
+                result.stacks.should.be.an.Array()
+                result.stacks.length.should.be.greaterThan(0)
+            })
+
+            it('each stack has id and name', async function () {
+                const { result } = await callTool(
+                    'platform.list-stacks',
+                    { instanceTypeId: app.projectType.hashid }
+                )
+                const stack = result.stacks[0]
+                stack.should.have.property('id')
+                stack.should.have.property('name')
+            })
+
+            it('returns error for invalid instance type id', async function () {
+                const { isError, result } = await callTool(
+                    'platform.list-stacks',
+                    { instanceTypeId: 'badid!!' }
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+            })
+        })
+
+        describe('platform.list-blueprints', function () {
+            it('returns blueprints for a team (may be empty if none created)', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.list-blueprints',
+                    { teamId: app.team.hashid }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('blueprints')
+                result.blueprints.should.be.an.Array()
+            })
+        })
+
+        describe('platform.get-instance-status', function () {
+            it('returns instance status', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.get-instance-status',
+                    { instanceId: app.project.id }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('name', app.project.name)
+                result.should.have.property('state')
+            })
+        })
+
+        describe('platform.check-name-availability', function () {
+            it('returns available: true for an unused instance name', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.check-name-availability',
+                    { name: 'definitely-unused-name-' + Date.now(), type: 'instance' }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('available', true)
+            })
+
+            it('returns available: false for an existing instance name', async function () {
+                const { result, isError } = await callTool(
+                    'platform.check-name-availability',
+                    { name: app.project.name, type: 'instance' }
+                )
+                isError.should.equal(false)
+                result.should.have.property('available', false)
+                result.should.have.property('reason')
+            })
+
+            it('returns available: true for any non-empty application name', async function () {
+                const { result, isError } = await callTool(
+                    'platform.check-name-availability',
+                    { name: 'Any App Name', type: 'application', teamId: app.team.hashid }
+                )
+                isError.should.equal(false)
+                result.should.have.property('available', true)
+            })
+
+            it('returns available: false for a banned instance name', async function () {
+                // 'forge' is in the banned name list
+                const { result, isError } = await callTool(
+                    'platform.check-name-availability',
+                    { name: 'forge', type: 'instance' }
+                )
+                isError.should.equal(false)
+                result.should.have.property('available', false)
+            })
+        })
+    })
+
+    // -------------------------------------------------------------------------
+    // Write tools
+    // -------------------------------------------------------------------------
+
+    describe('Write tools', function () {
+        describe('platform.create-application', function () {
+            it('creates an application in a team (as owner)', async function () {
+                const appName = 'mcp-test-app-' + Date.now()
+                const { statusCode, result, isError } = await callTool(
+                    'platform.create-application',
+                    { name: appName, teamId: app.team.hashid },
+                    'alice'
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('id')
+                result.should.have.property('name', appName)
+            })
+
+            it('rejects creation with unknown team', async function () {
+                const { isError, result } = await callTool(
+                    'platform.create-application',
+                    { name: 'some-app', teamId: 'notateam' },
+                    'alice'
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+            })
+        })
+
+        describe('platform.create-instance', function () {
+            it('creates an instance and returns navigation hint (as owner)', async function () {
+                const instanceName = 'mcp-inst-' + Date.now()
+                const { statusCode, result, isError } = await callTool(
+                    'platform.create-instance',
+                    {
+                        name: instanceName,
+                        applicationId: app.application.hashid,
+                        projectType: app.projectType.hashid,
+                        stack: app.stack.hashid,
+                        template: app.template.hashid
+                    },
+                    'alice'
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('name', instanceName)
+                // Navigation annotation
+                result.should.have.property('navigation')
+                result.navigation.should.have.property('suggestion', 'open-editor')
+                result.navigation.should.have.property('target')
+                result.navigation.target.should.match(/\/instance\/.*\/editor/)
+            })
+
+            it('rejects creation with unknown application', async function () {
+                const { isError, result } = await callTool(
+                    'platform.create-instance',
+                    {
+                        name: 'will-fail',
+                        applicationId: 'doesnotexist',
+                        projectType: app.projectType.hashid,
+                        stack: app.stack.hashid,
+                        template: app.template.hashid
+                    },
+                    'alice'
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+            })
+        })
+    })
+
+    // -------------------------------------------------------------------------
+    // Navigation tools
+    // -------------------------------------------------------------------------
+
+    describe('Navigation tools', function () {
+        describe('platform.open-editor', function () {
+            it('returns the editor URL for an instance', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.open-editor',
+                    { instanceId: app.project.id }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('target')
+                result.target.should.match(/\/instance\/.*\/editor/)
+                result.should.have.property('message')
+            })
+        })
+
+        describe('platform.open-instance', function () {
+            it('returns the instance URL for an instance', async function () {
+                const { statusCode, result, isError } = await callTool(
+                    'platform.open-instance',
+                    { instanceId: app.project.id }
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('target')
+                result.target.should.match(/\/instance\/.*/)
+                result.should.have.property('message')
+            })
+        })
+    })
+
+    // -------------------------------------------------------------------------
+    // Destructive tools
+    // -------------------------------------------------------------------------
+
+    describe('Destructive tools', function () {
+        describe('platform.delete-application', function () {
+            it('deletes an empty application', async function () {
+                // Create a fresh application with no instances
+                const emptyApp = await factory.createApplication(
+                    { name: 'mcp-deletable-app-' + Date.now() },
+                    app.team
+                )
+
+                const { statusCode, result, isError } = await callTool(
+                    'platform.delete-application',
+                    { applicationId: emptyApp.hashid },
+                    'alice'
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('status', 'okay')
+                result.should.have.property('message')
+
+                // Verify it's gone
+                const gone = await app.db.models.Application.byId(emptyApp.hashid)
+                should.not.exist(gone)
+            })
+
+            it('refuses to delete an application that has instances', async function () {
+                // app.application already has app.project inside it
+                const { isError, result } = await callTool(
+                    'platform.delete-application',
+                    { applicationId: app.application.hashid },
+                    'alice'
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+                result.error.should.match(/delete the instances/)
+            })
+        })
+
+        describe('platform.delete-instance', function () {
+            it('deletes an instance', async function () {
+                // Create a throwaway instance
+                const throwaway = await factory.createInstance(
+                    { name: 'mcp-del-inst-' + Date.now() },
+                    app.application,
+                    app.stack,
+                    app.template,
+                    app.projectType,
+                    { start: false }
+                )
+
+                const { statusCode, result, isError } = await callTool(
+                    'platform.delete-instance',
+                    // Project uses UUID as PK; pass .id not .hashid
+                    { instanceId: throwaway.id },
+                    'alice'
+                )
+                statusCode.should.equal(200)
+                isError.should.equal(false)
+                result.should.have.property('status', 'okay')
+                result.should.have.property('message')
+
+                // Verify it's gone
+                const gone = await app.db.models.Project.byId(throwaway.id)
+                should.not.exist(gone)
+            })
+
+            it('returns error for unknown instance id', async function () {
+                const { isError, result } = await callTool(
+                    'platform.delete-instance',
+                    { instanceId: 'doesnotexist' },
+                    'alice'
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+            })
+        })
+    })
+
+    // -------------------------------------------------------------------------
+    // RBAC tests
+    // -------------------------------------------------------------------------
+
+    describe('RBAC', function () {
+        describe('Viewer role', function () {
+            it('can call list-teams', async function () {
+                const { isError, result } = await callTool('platform.list-teams', {}, 'carol')
+                isError.should.equal(false)
+                result.should.have.property('teams')
+            })
+
+            it('can call list-applications', async function () {
+                const { isError, result } = await callTool(
+                    'platform.list-applications',
+                    { teamId: app.team.hashid },
+                    'carol'
+                )
+                isError.should.equal(false)
+                result.should.have.property('applications')
+            })
+
+            it('cannot create an application (insufficient permissions)', async function () {
+                const { isError, result } = await callTool(
+                    'platform.create-application',
+                    { name: 'viewer-should-not-create', teamId: app.team.hashid },
+                    'carol'
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+                result.error.should.match(/insufficient permissions|Access denied/i)
+            })
+
+            it('cannot delete an instance (insufficient permissions)', async function () {
+                const { isError, result } = await callTool(
+                    'platform.delete-instance',
+                    { instanceId: app.project.id },
+                    'carol'
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+                result.error.should.match(/insufficient permissions|Access denied/i)
+            })
+        })
+
+        describe('Member role', function () {
+            // project:create is Owner-only per forge/lib/permissions.js
+            it('can list teams', async function () {
+                const { isError, result } = await callTool('platform.list-teams', {}, 'bob')
+                isError.should.equal(false)
+                result.should.have.property('teams')
+            })
+
+            it('cannot create an application (insufficient permissions — project:create is Owner-only)', async function () {
+                const appName = 'member-app-' + Date.now()
+                const { isError, result } = await callTool(
+                    'platform.create-application',
+                    { name: appName, teamId: app.team.hashid },
+                    'bob'
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+                result.error.should.match(/insufficient permissions|Access denied/i)
+            })
+
+            it('cannot delete an instance (insufficient permissions)', async function () {
+                const { isError, result } = await callTool(
+                    'platform.delete-instance',
+                    { instanceId: app.project.id },
+                    'bob'
+                )
+                isError.should.equal(true)
+                result.should.have.property('error')
+                result.error.should.match(/insufficient permissions|Access denied/i)
+            })
+        })
+
+        describe('Owner role', function () {
+            it('can list teams', async function () {
+                const { isError, result } = await callTool('platform.list-teams', {}, 'dave')
+                isError.should.equal(false)
+                result.should.have.property('teams')
+            })
+
+            it('can create an application', async function () {
+                const appName = 'owner-app-' + Date.now()
+                const { isError, result } = await callTool(
+                    'platform.create-application',
+                    { name: appName, teamId: app.team.hashid },
+                    'dave'
+                )
+                isError.should.equal(false)
+                result.should.have.property('name', appName)
+            })
+
+            it('can delete an instance', async function () {
+                // Create a throwaway instance for dave to delete
+                const throwaway = await factory.createInstance(
+                    { name: 'owner-del-inst-' + Date.now() },
+                    app.application,
+                    app.stack,
+                    app.template,
+                    app.projectType,
+                    { start: false }
+                )
+
+                const { isError, result } = await callTool(
+                    'platform.delete-instance',
+                    { instanceId: throwaway.id },
+                    'dave'
+                )
+                isError.should.equal(false)
+                result.should.have.property('status', 'okay')
+            })
+        })
+    })
+
+    // -------------------------------------------------------------------------
+    // Instance lifecycle tools (start / stop / restart / suspend)
+    // -------------------------------------------------------------------------
+
+    describe('Instance lifecycle tools', function () {
+        let lifecycleInstance
+
+        before(async function () {
+            // Create a fresh instance for lifecycle tests
+            lifecycleInstance = await factory.createInstance(
+                { name: 'mcp-lifecycle-' + Date.now() },
+                app.application,
+                app.stack,
+                app.template,
+                app.projectType,
+                { start: false }
+            )
+        })
+
+        it('platform.stop-instance — stops a running instance', async function () {
+            // Set the instance state to running so it can be stopped
+            lifecycleInstance.state = 'running'
+            await lifecycleInstance.save()
+
+            const { statusCode, result, isError } = await callTool(
+                'platform.stop-instance',
+                // Project uses UUID as PK
+                { instanceId: lifecycleInstance.id }
+            )
+            statusCode.should.equal(200)
+            isError.should.equal(false)
+            result.should.have.property('status', 'okay')
+            result.should.have.property('state', 'stopped')
+        })
+
+        it('platform.start-instance — starts a stopped instance', async function () {
+            // Ensure instance is stopped
+            lifecycleInstance.state = 'stopped'
+            await lifecycleInstance.save()
+
+            const { statusCode, result, isError } = await callTool(
+                'platform.start-instance',
+                { instanceId: lifecycleInstance.id }
+            )
+            statusCode.should.equal(200)
+            isError.should.equal(false)
+            result.should.have.property('status', 'okay')
+            result.should.have.property('state', 'running')
+        })
+
+        it('platform.restart-instance — restarts a running instance', async function () {
+            lifecycleInstance.state = 'running'
+            await lifecycleInstance.save()
+
+            const { statusCode, result, isError } = await callTool(
+                'platform.restart-instance',
+                { instanceId: lifecycleInstance.id }
+            )
+            statusCode.should.equal(200)
+            isError.should.equal(false)
+            result.should.have.property('status', 'okay')
+            result.should.have.property('state', 'running')
+        })
+
+        it('platform.stop-instance — returns error for suspended instance', async function () {
+            lifecycleInstance.state = 'suspended'
+            await lifecycleInstance.save()
+
+            const { isError, result } = await callTool(
+                'platform.stop-instance',
+                { instanceId: lifecycleInstance.id }
+            )
+            isError.should.equal(true)
+            result.should.have.property('error')
+            result.error.should.match(/suspended/)
+        })
+
+        it('platform.restart-instance — returns error for suspended instance', async function () {
+            lifecycleInstance.state = 'suspended'
+            await lifecycleInstance.save()
+
+            const { isError, result } = await callTool(
+                'platform.restart-instance',
+                { instanceId: lifecycleInstance.id }
+            )
+            isError.should.equal(true)
+            result.should.have.property('error')
+            result.error.should.match(/suspended/)
+        })
+
+        it('platform.suspend-instance — returns error if already suspended', async function () {
+            lifecycleInstance.state = 'suspended'
+            await lifecycleInstance.save()
+
+            const { isError, result } = await callTool(
+                'platform.suspend-instance',
+                { instanceId: lifecycleInstance.id }
+            )
+            isError.should.equal(true)
+            result.should.have.property('error')
+            result.error.should.match(/suspended/)
+        })
+
+        it('platform.suspend-instance — suspends a running instance', async function () {
+            lifecycleInstance.state = 'running'
+            await lifecycleInstance.save()
+
+            // The stub container driver requires the project to be registered in its
+            // internal list (i.e. it must have been "started" via containers.start).
+            // Since we created this instance with { start: false }, we stub containers.stop
+            // to simulate a successful container stop operation.
+            sinon.stub(app.containers, 'stop').resolves()
+
+            const { statusCode, result, isError } = await callTool(
+                'platform.suspend-instance',
+                { instanceId: lifecycleInstance.id }
+            )
+            statusCode.should.equal(200)
+            isError.should.equal(false)
+            result.should.have.property('status', 'okay')
+            result.should.have.property('state', 'suspended')
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Proof of concept implementation for exposing the FlowFuse platform as an MCP server. External AI agents (Claude Code, Cursor, Claude Desktop) and the built-in expert agent can manage the platform through MCP tools.

- Stateless Streamable HTTP endpoint at `POST /api/v1/mcp` (one `McpServer` + transport per request, no server-side sessions)
- 18 platform tools (list/create/delete teams, applications, instances, snapshots, etc.) using `app.inject()` to call existing HTTP routes
- Flow-building tools bridged from the NR instance MCP server, dispatched to the user's browser via MQTT for external clients
- OAuth2 PKCE flow with pre-configured `mcp-agent` client and `.well-known` discovery endpoints
- Two-layer RBAC: MCP-specific permission check + platform route preHandlers
- MQTT topic separation (`ff/v1/mcp/` vs `ff/v1/expert/`) to prevent cross-talk
- External MCP clients must specify `instanceId` for flow tools; expert path auto-discovers the active editor session
- Frontend: tool permission management (allow/deny/prompt per tool), MCP UI components (status badges, selection lists, result cards, confirmations), OAuth consent page, MCP token management

### Prerequisites

- #7411 (PAT scopes) must land first or alongside. The current implementation uses a prototype `ffmcp_` token type that should be replaced by scoped PATs.
- Admin-owned PATs must be rejected at the MCP endpoint.

### Key files

| File | Description |
|------|-------------|
| `forge/ee/routes/mcpServer/index.js` | MCP route, tool registration, flow tool proxy |
| `forge/ee/lib/mcp/platformAutomations.js` | 18 tool definitions with Zod schemas and handlers |
| `forge/ee/lib/mcp/flowBuildingBridge.js` | Discovers flow tools from NR instance, 5-min cache |
| `forge/ee/lib/mcp/mqttDispatch.js` | Dispatches flow actions to browser via MQTT |
| `forge/comms/editorSessions.js` | Tracks active editor sessions via MQTT heartbeats |
| `forge/routes/wellKnown.js` | OAuth and MCP discovery endpoints |
| `forge/routes/auth/oauth.js` | OAuth2 PKCE for `mcp-agent` client |

## Test plan

- [ ] Run existing test suite (`mcpServer_spec.js`, 1018 lines)
- [ ] Connect via Claude Code: `claude mcp add --transport http --client-id mcp-agent flowfuse <url>`
- [ ] Verify platform tools work (list-teams, list-instances, create-instance, manage-instance, delete-instance)
- [ ] Verify flow tools work when editor is open in browser
- [ ] Verify admin PAT rejection at MCP endpoint
- [ ] Verify OAuth consent flow in browser