### PR TITLE
Add hint to SSO SAML authentication query parameters

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -403,7 +403,8 @@ module.exports = {
                     let nodeRedVersion = '3.0.2' // default to older Node-RED
                     if (SemVer.satisfies(SemVer.coerce(this.agentVersion), '>=1.11.2')) {
                         // 1.11.2 includes fix for ESM loading of GOT, so lets use 'latest' as before
-                        nodeRedVersion = 'latest'
+                        // pinning to NR 4.1.x while we fix the device agent
+                        nodeRedVersion = '~4.1.11'
                     }
                     return nodeRedVersion
                 },

--- a/forge/db/models/OAuthSession.js
+++ b/forge/db/models/OAuthSession.js
@@ -21,7 +21,7 @@ module.exports = {
     finders: function (M) {
         return {
             static: {
-                getAndRemoveById: async (id) => {
+                getAndRemoveById: async (id, remove = true) => {
                     const cachedValue = await this.findOne({
                         where: { id }
                     })
@@ -32,7 +32,9 @@ module.exports = {
                             result = cachedValue.value
                         }
                         // These are single use - so always destroy
-                        await cachedValue.destroy()
+                        if (remove) {
+                            await cachedValue.destroy()
+                        }
                     }
                     return result
                 }

--- a/forge/ee/routes/sso/auth.js
+++ b/forge/ee/routes/sso/auth.js
@@ -62,9 +62,6 @@ module.exports = fp(async function (app, opts) {
                         provider: providerId,
                         redirectTo: decodeURIComponent(request.query.r || '/')
                     })
-                    opts.additionalAuthorizeParams = {
-                        login_hint: request.query.u
-                    }
                     done(null, opts)
                     return
                 } else {

--- a/forge/ee/routes/sso/auth.js
+++ b/forge/ee/routes/sso/auth.js
@@ -62,6 +62,9 @@ module.exports = fp(async function (app, opts) {
                         provider: providerId,
                         redirectTo: decodeURIComponent(request.query.r || '/')
                     })
+                    opts.additionalAuthorizeParams = {
+                        login_hint: request.query.u
+                    }
                     done(null, opts)
                     return
                 } else {

--- a/forge/ee/routes/sso/auth.js
+++ b/forge/ee/routes/sso/auth.js
@@ -76,6 +76,19 @@ module.exports = fp(async function (app, opts) {
                         provider: providerId,
                         redirectTo: decodeURIComponent(request.query.r || '/')
                     })
+
+                    if (opts.sendIdpHint && request.query.t) {
+                        const target = await app.db.models.OAuthSession.getAndRemoveById(request.query.t, false)
+                        try {
+                            const redirect = new URL(target.redirect_uri)
+                            opts.additionalAuthorizeParams = {
+                                kc_idp_hint: redirect.host
+                            }
+                        } catch (err) {
+                            // ignore error in parsing URL and send no hint
+                        }
+                    }
+
                     done(null, opts)
                     return
                 } else {

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -259,7 +259,8 @@ export default {
             }
         },
         async directSSO (id) {
-            window.location = `/ee/sso/login?p=${id}${this.$route.query.r ? `&r=${this.$route.query.r}` : ''}`
+            const matched = this.redirectUrlAfterLogin.match(/^\/account\/request\/([a-zA-Z0-9\-_]+)(\/editor)?/)
+            window.location = `/ee/sso/login?p=${id}${this.$route.query.r ? `&r=${this.$route.query.r}` : ''}${matched[1] ? `&t=${matched[1]}` : ''}`
         }
     }
 }

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -259,8 +259,8 @@ export default {
             }
         },
         async directSSO (id) {
-            const matched = this.redirectUrlAfterLogin.match(/^\/account\/request\/([a-zA-Z0-9\-_]+)(\/editor)?/)
-            window.location = `/ee/sso/login?p=${id}${this.$route.query.r ? `&r=${this.$route.query.r}` : ''}${matched[1] ? `&t=${matched[1]}` : ''}`
+            const matched = this.redirectUrlAfterLogin.match(/^\/account\/request\/([a-zA-Z0-9\-_]+)(\/editor)?$/)
+            window.location = `/ee/sso/login?p=${id}${this.$route.query.r ? `&r=${this.$route.query.r}` : ''}${matched?.[1] ? `&t=${matched[1]}` : ''}`
         }
     }
 }

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -132,6 +132,7 @@
                         <FormRow v-model="input.options.groupAdmin" type="checkbox">Manage Admin roles using group assertions</FormRow>
                         <FormRow v-if="input.options.groupAdmin" v-model="input.options.groupAdminName" :error="groupAdminNameError" class="pl-4">Admin Users SAML Group name</FormRow>
                     </div>
+                    <FormRow v-if="input.type === 'saml'" v-model="input.options.sendIdpHint" type="checkbox">Send hostname as hint to IDP (KeyCloak only)</FormRow>
                     <FormRow v-model="input.options.provisionNewUsers" type="checkbox">Allow Provisioning of New Users on first login</FormRow>
                     <FormRow v-model="input.options.sessionExpiry" :error="sessionExpiryError" type="number">
                         Custom Session Expiry (hours)
@@ -188,7 +189,8 @@ export default {
                     groupMapping: false,
                     groupAdminName: '',
                     groupPrefixLength: 0,
-                    groupSuffixLength: 0
+                    groupSuffixLength: 0,
+                    sendIdpHint: false
                 }
             },
             errors: {},
@@ -318,6 +320,7 @@ export default {
                     if (!opts.options.tls) {
                         delete opts.options.tls
                         delete opts.options.tlsVerifyServer
+                        delete opts.options.sendIdpHint
                     }
                     // if (opts.options.provisionNewUsers) {
                     //     delete opts.options.provisionNewUsers
@@ -354,7 +357,8 @@ export default {
                     groupAdminName: 'ff-admins',
                     groupAssertionName: 'ff-roles',
                     groupPrefixLength: 0,
-                    groupSuffixLength: 0
+                    groupSuffixLength: 0,
+                    sendIdpHint: false
                 }
             } else {
                 this.loading = true
@@ -386,6 +390,7 @@ export default {
                 this.input.options.groupAssertionName = this.input.options.groupAssertionName || 'ff-roles'
                 // groupTeams is stored as an array - convert to multi-line string for the edit form
                 this.input.options.groupTeams = (this.input.options.groupTeams || []).join('\n')
+                this.input.options.sendIdpHint = this.input.options.sendIdpHint ?? false
             } else {
                 // eslint-disable-next-line no-template-curly-in-string
                 this.input.options.userFilter = this.input.options.userFilter || '(uid=${username})'


### PR DESCRIPTION
fixes #7350 

## Description

<!-- Describe your changes in detail -->
Adds a flag to the SAML SSO configuration that will trigger the hostname of the initial entry point URL to be sent to the SAML provider as a query string argument.

<img width="614" height="611" alt="image" src="https://github.com/user-attachments/assets/7b6daef3-e641-4422-aed5-5665ba2f071e" />


First pass only supports KeyCloak's `kc_idp_hint` query parameter, but there may be scope to expand to other SAML providers or to make it more generic.

Also would be useful to look at if we can send the email address when in interactive mode

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#7350 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

