### PR TITLE
docs: fix typo in hardware introduction

### DIFF
--- a/docs/hardware/introduction.md
+++ b/docs/hardware/introduction.md
@@ -20,7 +20,7 @@ The FlowFuse Device Agent can be installed on any Mac, Linux, or Windows-support
 <a href="https://developer.community.boschrexroth.com/t5/Store-and-How-to/FlowFuse-Node-RED/ba-p/82135"><img src="https://upload.wikimedia.org/wikipedia/commons/0/0d/Logo_of_Bosch_Rexroth_AG.svg"  width="150" height="75"></a>
 
 - [ctrlX - Node-RED App](/docs/hardware/ctrlx-node-red.md)
-- [ctrlX - Device Agent App](/docs/hardware/ctrlx-device-agent.md) - will be availble soon
+- [ctrlX - Device Agent App](/docs/hardware/ctrlx-device-agent.md) - will be available soon
 
 ## Other Hardware Guides
 


### PR DESCRIPTION
Fixes a small typo in the hardware introduction: `availble` → `available`.

This is a documentation-only change.