### PR TITLE
docs: explain upgrading the Node-RED version via Stacks

### DIFF
--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -25,6 +25,9 @@ Details of how to upgrade can be found for each deployment model:
 - [Docker](../install/docker/README.md#upgrade)
 - [Kubernetes](../install/kubernetes/README.md#upgrade)
 
+To upgrade the version of Node-RED your Instances run (for example, moving to
+Node-RED 5.0), see [Upgrading the Node-RED version](./nodered-version.md).
+
 ### Upgrading to 2.6.0
 
 #### Required AWS EKS configuration change

--- a/docs/upgrade/nodered-version.md
+++ b/docs/upgrade/nodered-version.md
@@ -1,0 +1,79 @@
+---
+navTitle: Upgrading the Node-RED version
+meta:
+   description: Upgrade the Node-RED version your self-hosted FlowFuse Instances run by creating a new Stack, using the move to Node-RED 5.0 as a worked example.
+   tags:
+     - nodered
+     - stack
+     - upgrade
+     - flowfuse
+     - self-hosted
+---
+
+# Upgrading the Node-RED version
+
+A new major version of Node-RED - such as Node-RED 5.0 - does **not** arrive
+through an in-editor or in-platform "update" button. The version of Node-RED an
+Instance runs is defined by its [Stack](../user/concepts.md#stack). To move to a
+new major version you add it as a new Stack, then point your Instances at it.
+
+This page uses the move to **Node-RED 5.0** as a worked example, but the same
+steps apply to any major Node-RED version upgrade.
+
+## Why there's no update button
+
+The notification and one-click upgrade you may have seen applies to new *versions
+of an existing Stack* (see [Managing Stacks](../admin/introduction.md#managing-stacks)).
+Crossing a major Node-RED version is different: you create a new Stack that pins
+the new container, rather than upgrading the existing Stack in place. This keeps
+the two versions side by side so you can move Instances over at your own pace.
+
+## Before you start
+
+- You will need access to **Admin Settings**.
+- Add the new Node-RED version as a **distinct new Stack** rather than editing your
+  existing Stack. Keeping them separate means your current Instances stay on their
+  existing version until you choose to move them, and you can switch back from an
+  Instance's settings if needed.
+
+## Create the new Stack
+
+1. Go to **Admin Settings → Stacks**.
+2. Click **Create Stack**.
+3. Set the **Container Location** to the image for the new Node-RED version. The
+   exact value depends on your deployment model - see the deployment-specific
+   guides below. For Node-RED 5.0 on Docker or Kubernetes this is
+   `flowfuse/node-red:2.31.2-5.0.x`; the full list of pre-built tags is on
+   [Docker Hub](https://hub.docker.com/r/flowfuse/node-red/tags).
+4. Save the Stack. It is now available when you create or migrate Instances.
+
+For the details of how the Container Location is specified for each deployment
+model, see:
+
+- [Local Stacks](../contribute/local/stacks.md)
+- [Docker Stacks](../install/docker/stacks.md)
+- [Kubernetes Stacks](../install/kubernetes/stacks.md)
+
+## Use the new Stack
+
+### For a new Instance
+
+Select the new Stack when you create the Instance. It starts on the new Node-RED
+version right away.
+
+### For an existing Instance
+
+Move the Instance onto the new Stack by following
+[Changing the Stack](../user/changestack.md): open the Instance's **Settings**
+tab and use **Change Instance Stack** to select the new Stack. The Instance
+restarts on the new Stack.
+
+## Good to know
+
+- You can switch an Instance back to its previous Stack from the same Settings
+  page, as long as the old Stack still exists.
+- Test the new version on a single Instance before moving production workloads
+  across.
+
+Questions? [Reach out to FlowFuse support](https://flowfuse.com/support/) - we're
+happy to help.

--- a/docs/upgrade/nodered-version.md
+++ b/docs/upgrade/nodered-version.md
@@ -1,7 +1,7 @@
 ---
 navTitle: Upgrading the Node-RED version
 meta:
-   description: Upgrade the Node-RED version your self-hosted FlowFuse Instances run by creating a new Stack, using the move to Node-RED 5.0 as a worked example.
+   description: Upgrade the Node-RED version your self-hosted FlowFuse Instances run by creating a new Stack and moving Instances onto it.
    tags:
      - nodered
      - stack
@@ -17,8 +17,8 @@ through an in-editor or in-platform "update" button. The version of Node-RED an
 Instance runs is defined by its [Stack](../user/concepts.md#stack). To move to a
 new major version you add it as a new Stack, then point your Instances at it.
 
-This page uses the move to **Node-RED 5.0** as a worked example, but the same
-steps apply to any major Node-RED version upgrade.
+This page uses the move to **Node-RED 5.0** as an example, but the same steps
+apply to any major Node-RED version upgrade.
 
 ## Why there's no update button
 
@@ -67,13 +67,3 @@ Move the Instance onto the new Stack by following
 [Changing the Stack](../user/changestack.md): open the Instance's **Settings**
 tab and use **Change Instance Stack** to select the new Stack. The Instance
 restarts on the new Stack.
-
-## Good to know
-
-- You can switch an Instance back to its previous Stack from the same Settings
-  page, as long as the old Stack still exists.
-- Test the new version on a single Instance before moving production workloads
-  across.
-
-Questions? [Reach out to FlowFuse support](https://flowfuse.com/support/) - we're
-happy to help.

--- a/docs/upgrade/nodered-version.md
+++ b/docs/upgrade/nodered-version.md
@@ -27,6 +27,8 @@ of an existing Stack* (see [Managing Stacks](../admin/introduction.md#managing-s
 Crossing a major Node-RED version is different: you create a new Stack that pins
 the new container, rather than upgrading the existing Stack in place. This keeps
 the two versions side by side so you can move Instances over at your own pace.
+It also ensures major version upgrades are not automatically applied by the 
+Scheduled Maintenance feature.
 
 ## Before you start
 

--- a/docs/upgrade/nodered-version.md
+++ b/docs/upgrade/nodered-version.md
@@ -47,6 +47,7 @@ Scheduled Maintenance feature.
    guides below. For Node-RED 5.0 on Docker or Kubernetes this is
    `flowfuse/node-red:2.31.2-5.0.x`; the full list of pre-built tags is on
    [Docker Hub](https://hub.docker.com/r/flowfuse/node-red/tags).
+   (tags are of the form [FlowFuse Version]-[Node-RED Version])
 4. Save the Stack. It is now available when you create or migrate Instances.
 
 For the details of how the Container Location is specified for each deployment


### PR DESCRIPTION
## Description

Self-hosted customers upgrading to a new major Node-RED version (e.g. **Node-RED 5.0**) are looking for an in-platform "update" button that doesn't exist — the Node-RED version is defined by an Instance's Stack, so the upgrade is done by creating a new Stack and moving Instances onto it.

This adds a generalised guide covering that process, using the move to 5.0 as the worked example, and links it from the upgrade overview.

### Changes
- New page `docs/upgrade/nodered-version.md` — **Upgrading the Node-RED version**. Explains why there's no update button, how to create the new Stack, and how to move new/existing Instances onto it. References the per-deployment Stacks docs and the existing [Changing the Stack](https://flowfuse.com/docs/user/changestack/) guide.
- Linked the new page from `docs/upgrade/README.md`.

### Context
Came out of a support thread this morning (Nolte Küchen asking how to get to 5.0; related Maastricht upgrade ticket). Written to be general so it applies to any future major Node-RED version, not just 5.0.

### Notes for reviewers
- Container Location example for NR5 is `flowfuse/node-red:2.31.2-5.0.x` — please sanity-check that tag.
- I used the live UI term **"Change Instance Stack"** (per `changestack.md`) rather than the draft's "Change Node-RED Version".