### PR TITLE
[7550] Fix rbac specs failing in CI 

### DIFF
--- a/test/e2e/frontend/cypress/tests-ee/rbac/rbac-dashboard-contextual.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/rbac/rbac-dashboard-contextual.spec.js
@@ -24,7 +24,11 @@ describe.skip('FlowFuse - RBAC Dashboard Contextual permissions', () => {
                 instances = response.body.projects
             })
             .then(() => {
-                cy.intercept('GET', `/api/*/teams/${team.id}/devices*`).as('getDevices')
+                cy.intercept({
+                    method: 'GET',
+                    pathname: `/api/v1/teams/${team.id}/devices`,
+                    query: { page: '1' }
+                }).as('getDevices')
                 cy.get('[data-nav="team-devices"]').click()
                 return cy.wait('@getDevices')
             })

--- a/test/e2e/frontend/cypress/tests-ee/rbac/rbac-member-contextual.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/rbac/rbac-member-contextual.spec.js
@@ -24,7 +24,11 @@ describe('FlowFuse - RBAC Member Contextual permissions', () => {
                 instances = response.body.projects
             })
             .then(() => {
-                cy.intercept('GET', `/api/*/teams/${team.id}/devices*`).as('getDevices')
+                cy.intercept({
+                    method: 'GET',
+                    pathname: `/api/v1/teams/${team.id}/devices`,
+                    query: { page: '1' }
+                }).as('getDevices')
                 cy.get('[data-nav="team-devices"]').click()
                 return cy.wait('@getDevices')
             })

--- a/test/e2e/frontend/cypress/tests-ee/rbac/rbac-owner-contextual.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/rbac/rbac-owner-contextual.spec.js
@@ -24,7 +24,11 @@ describe('FlowFuse - RBAC Owner Contextual permissions', () => {
                 instances = response.body.projects
             })
             .then(() => {
-                cy.intercept('GET', `/api/*/teams/${team.id}/devices*`).as('getDevices')
+                cy.intercept({
+                    method: 'GET',
+                    pathname: `/api/v1/teams/${team.id}/devices`,
+                    query: { page: '1' }
+                }).as('getDevices')
                 cy.get('[data-nav="team-devices"]').click()
                 return cy.wait('@getDevices')
             })

--- a/test/e2e/frontend/cypress/tests-ee/rbac/rbac-viewer-contextual.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/rbac/rbac-viewer-contextual.spec.js
@@ -24,7 +24,11 @@ describe('FlowFuse - RBAC Viewer Contextual permissions', () => {
                 instances = response.body.projects
             })
             .then(() => {
-                cy.intercept('GET', `/api/*/teams/${team.id}/devices*`).as('getDevices')
+                cy.intercept({
+                    method: 'GET',
+                    pathname: `/api/v1/teams/${team.id}/devices`,
+                    query: { page: '1' }
+                }).as('getDevices')
                 cy.get('[data-nav="team-devices"]').click()
                 return cy.wait('@getDevices')
             })


### PR DESCRIPTION
## Description

These specs flaked because the Remote Instances page fires two concurrent `/teams/{id}/devices` requests on load, the full list and a nameless statusOnly poll, and the `before()` hook's intercept matched both.

It intermittently captured the response without device names and every `devices.find(i => i.name === …)` returned `undefined`. The fix narrows the intercept to the full request (which always carries `page=1`, unlike the statusOnly poll), making the captured data match up. 

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7550

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

