### PR TITLE
[7569] Device editor: redirect parent instead of iframe (flowfuse frontend)

### DIFF
--- a/frontend/src/components/immersive-editor/RemoteInstanceEditorWrapper.vue
+++ b/frontend/src/components/immersive-editor/RemoteInstanceEditorWrapper.vue
@@ -26,6 +26,7 @@ import LoadingScreenWrapper from './LoadingScreenWrapper.vue'
 export default {
     name: 'RemoteInstanceEditorWrapper',
     components: { LoadingScreenWrapper },
+    inject: ['$services'],
     props: {
         device: {
             required: false,
@@ -61,9 +62,20 @@ export default {
             default:
                 return this.device.status
             }
+        },
+        editorOrigin () {
+            if (!this.device?.editor?.url) {
+                return null
+            }
+            try {
+                return new URL(this.device.editor.url, window.location.origin).origin
+            } catch (e) {
+                return null
+            }
         }
     },
     mounted () {
+        window.addEventListener('message', this.eventListener)
         // Dispatch a synthetic mousemove every 25 minutes to keep PostHog's idle
         // session timer alive. PostHog resets its recording after ~30 minutes of
         // inactivity on the parent page — but the user may be actively working
@@ -73,11 +85,40 @@ export default {
         }, 25 * 60 * 1000)
     },
     beforeUnmount () {
+        window.removeEventListener('message', this.eventListener)
         clearInterval(this.posthogKeepAliveInterval)
         // Remove from DOM before unmount so rrweb doesn't try to access the
         // cross-origin contentWindow during teardown.
         if (this.$refs.iframe) {
             this.$refs.iframe.parentNode?.removeChild(this.$refs.iframe)
+        }
+    },
+    methods: {
+        eventListener (event) {
+            if (!this.editorOrigin || event.origin !== this.editorOrigin) {
+                return
+            }
+            switch (event.data?.type) {
+            case 'load':
+                this.emitMessage('prevent-redirect', true)
+                break
+            case 'navigate':
+                window.location.href = event.data.payload
+                break
+            case 'logout':
+                this.$router.push({ name: 'device-overview', params: { id: this.device.id } })
+                break
+            default:
+            }
+        },
+        emitMessage (type, payload = {}) {
+            if (this.$refs.iframe?.contentWindow && this.editorOrigin) {
+                this.$services.postMessage.sendMessage({
+                    message: { type, payload },
+                    target: this.$refs.iframe.contentWindow,
+                    targetOrigin: this.editorOrigin
+                })
+            }
         }
     }
 }

--- a/frontend/src/components/immersive-editor/RemoteInstanceEditorWrapper.vue
+++ b/frontend/src/components/immersive-editor/RemoteInstanceEditorWrapper.vue
@@ -106,7 +106,9 @@ export default {
                 window.location.href = event.data.payload
                 break
             case 'logout':
-                this.$router.push({ name: 'device-overview', params: { id: this.device.id } })
+                if (this.device) {
+                    this.$router.push({ name: 'device-overview', params: { id: this.device.id } })
+                }
                 break
             default:
             }


### PR DESCRIPTION
## Description

- See details here: https://github.com/FlowFuse/flowfuse/issues/7569#issue-4693165485
- See test plan here: https://github.com/FlowFuse/flowfuse/issues/7549#issuecomment-4734724176

### ⚠️ This is part of a 3 part change that all should go in parallel. 

**Parent epic:**  First party theme event handlers not loaded when no FlowFuse theme is active
[ #7549](https://github.com/FlowFuse/flowfuse/issues/7549) 

**Subtasks:** 

1. Load FlowFuse editor behaviour regardless of theme (nr-launcher)
https://github.com/FlowFuse/flowfuse/issues/7553
2. Load FlowFuse editor behavior regardless of theme (device-agent)
https://github.com/FlowFuse/flowfuse/issues/7554
3. Device editor: redirect parent instead of iframe (flowfuse frontend)
https://github.com/FlowFuse/flowfuse/issues/7569

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7569

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

