### PR TITLE
Store device nodejs version

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -47,6 +47,9 @@ module.exports = {
             if (state.nodeRedVersion) {
                 device.set('nodeRedVersion', state.nodeRedVersion)
             }
+            if (state.nodejsVersion) {
+                device.set('nodejsVersion', state.nodejsVersion)
+            }
             device.set('editorAffinity', state.affinity || null)
             if (!state.snapshot || state.snapshot === '0') {
                 if (device.activeSnapshotId !== null) {

--- a/forge/db/migrations/20260622-01-add-device-nodejs-ver.js
+++ b/forge/db/migrations/20260622-01-add-device-nodejs-ver.js
@@ -1,0 +1,15 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context, Sequelize) => {
+        await context.addColumn('Devices', 'nodejsVersion', {
+            type: DataTypes.STRING,
+            allowNull: true
+        })
+    },
+    down: async (context, Squelize) => { }
+}

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -404,7 +404,6 @@ module.exports = {
                     let nodeRedVersion = '3.0.2' // default to older Node-RED
                     if (SemVer.satisfies(SemVer.coerce(this.agentVersion), '>=1.11.2')) {
                         // 1.11.2 includes fix for ESM loading of GOT, so lets use 'latest' as before
-                        // pinning to NR 4.1.x while we fix the device agent
                         if (this.nodejsVersion) {
                             if (SemVer.satisfies(SemVer.coerce(this.nodejsVersion), '>=22.9.0')) {
                                 nodeRedVersion = 'latest'

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -53,7 +53,8 @@ module.exports = {
             get () {
                 return this.ownerType === 'application'
             }
-        }
+        },
+        nodejsVersion: { type: DataTypes.STRING, allowNull: true }
     },
     associations: function (M) {
         this.belongsTo(M.Application)
@@ -404,7 +405,13 @@ module.exports = {
                     if (SemVer.satisfies(SemVer.coerce(this.agentVersion), '>=1.11.2')) {
                         // 1.11.2 includes fix for ESM loading of GOT, so lets use 'latest' as before
                         // pinning to NR 4.1.x while we fix the device agent
-                        nodeRedVersion = '~4.1.11'
+                        if (this.nodejsVersion) {
+                            if (SemVer.satisfies(SemVer.coerce(this.nodejsVersion), '>=22.9.0')) {
+                                nodeRedVersion = 'latest'
+                            }
+                        } else {
+                            nodeRedVersion = '~4.1.11'
+                        }
                     }
                     return nodeRedVersion
                 },

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -767,7 +767,7 @@ describe('Device API', async function () {
                 result.should.have.property('modules').and.be.an.Object()
                 result.modules.should.have.property('node-red', '3.0.2')
             })
-            it('agent >= v1.11.2 is instructed to use Node-RED@latest', async function () {
+            it('agent >= v1.11.2 is instructed to use Node-RED@4.1.11 if NodeJS version unknown', async function () {
                 const agentVersion = '1.11.2' // min agent version required for NR 3.1 (as this agent handles ESM issue)
                 const device = await createDevice({ name: 'Ad1a', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice, agentVersion })
                 // assign the new device to application
@@ -792,6 +792,35 @@ describe('Device API', async function () {
                 result.should.have.property('name', 'Starter Snapshot')
                 result.should.have.property('modules').and.be.an.Object()
                 result.modules.should.have.property('node-red', '~4.1.11')
+            })
+            it('agent >= v1.11.2 is instructed to use Node-RED@latest if NodeJS >=22.9.0', async function () {
+                const agentVersion = '1.11.2' // min agent version required for NR 3.1 (as this agent handles ESM issue)
+                const device = await createDevice({ name: 'Ad1b', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice, agentVersion })
+                const dbDevice = await app.db.models.Device.byId(device.id)
+                dbDevice.nodejsVersion = 'v24.0.0'
+                await dbDevice.save()
+                // assign the new device to application
+                await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/devices/${device.id}`,
+                    body: {
+                        application: TestObjects.Application1.hashid
+                    },
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                // get the snapshot for this device
+                const response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/devices/${device.id}/live/snapshot`,
+                    headers: {
+                        authorization: `Bearer ${device.credentials.token}`
+                    }
+                })
+                const result = response.json()
+                result.should.have.property('id')
+                result.should.have.property('name', 'Starter Snapshot')
+                result.should.have.property('modules').and.be.an.Object()
+                result.modules.should.have.property('node-red', 'latest')
             })
             it('snapshot uploaded without node-red dependency is always delivered to a device with the node-red:version', async function () {
                 const agentVersion = '1.11.2' // min agent version required for NR 3.1 (as this agent handles ESM issue)


### PR DESCRIPTION
fixes #7551 
## Description

<!-- Describe your changes in detail -->

Adds `nodejsVersion` to Device table

Uses this to pick the correct default snapshot Node-RED version

paired with https://github.com/FlowFuse/device-agent/pull/657

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#7551

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

