### PR TITLE
[7578] Hosted Instances search field auto-submits and clears input when no matching results are found

### DIFF
--- a/frontend/src/pages/team/Instances.vue
+++ b/frontend/src/pages/team/Instances.vue
@@ -32,10 +32,10 @@
             <div class="banner-wrapper">
                 <FeatureUnavailableToTeam v-if="!instancesAvailable" />
             </div>
-            <ff-loading v-if="loading && !instancesMap.size" message="Loading Instances..." />
+            <ff-loading v-if="loading && !instancesMap.size && searchTerm === null" message="Loading Instances..." />
             <template v-else-if="instancesAvailable">
                 <ff-data-table
-                    v-if="instances.length > 0 || searchTerm"
+                    v-if="instances.length > 0 || searchTerm !== null"
                     data-el="instances-table" :columns="columns" :rows="instances" :show-search="true"
                     search-placeholder="Search Instances..."
                     :initialSortKey="sort.key" :initialSortOrder="sort.order"
@@ -221,7 +221,7 @@ export default {
             page: 1,
             pageSize: 25,
             totalRows: 0,
-            searchTerm: '',
+            searchTerm: null,
             sort: {
                 key: 'flowLastUpdatedAt',
                 order: 'desc'


### PR DESCRIPTION

## Description

Problem was search box lives inside `ff-data-table` so empty results swapped the table for the loading spinner, unmounting it and wiping the input. 

The fix: `searchTerm` starts `null`, becomes a string once touched (`''` when cleared). Spinner only when `searchTerm === null`; table stays mounted while `searchTerm !== null`. So it never unmounts mid-search. No new flags.

## Related Issue(s)

Resolves #7578 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

