### PR TITLE
Switch to v5 mqtt protocol in commsClient configuration

### DIFF
--- a/forge/comms/commsClient.js
+++ b/forge/comms/commsClient.js
@@ -25,6 +25,7 @@ class CommsClient extends EventEmitter {
                 username: 'forge_platform',
                 password: await this.app.settings.get('commsToken'),
                 reconnectPeriod: 5000,
+                protocolVersion: 5,
                 will: {
                     topic: 'ff/v1/platform/leader',
                     payload: JSON.stringify({ id: this.platformId, vote: -1 })


### PR DESCRIPTION
## Description

Updated the MQTT client initialisation in `commsClient.js` to explicitly set `protocolVersion: 5`, ensuring the client uses MQTT version 5 for communication. 
Amongst other improvements, this gives us:
* Ability to use correlationData and userProperties for insights (and other future requirements) avoiding the need to embed meta data things like transaction/session ids (that are required for insights) into the payload
* proper broker-initiated DISCONNECT reason code & reason string (v4 just drops the socket silently - ppoor diagnostics)
  

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

