### PR TITLE
Ensure Project name and safeName used when suspending Team

### DIFF
--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -749,6 +749,8 @@ module.exports = {
                     const instanceList = await app.db.models.Project.findAll({
                         attributes: [
                             'id',
+                            'name',
+                            'safeName',
                             'state',
                             'ProjectStackId',
                             'TeamId'


### PR DESCRIPTION
part of #6957

## Description

<!-- Describe your changes in detail -->
Team.suspend() itterates over running Instances and suspends them but does not include `name` or `safeName` in Instance/Project object passed to the driver.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#6957 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

