### PR TITLE
docs: Fix team type names on the `Static asset service` page

### DIFF
--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -276,7 +276,7 @@ postgresql:
 
 Apply changes with [platform startup command](#start-flowfuse-platform).
 
-Check the [FlowFuse Helm chart documentation](https://github.com/FlowFuse/helm/tree/main/helm/flowforge#postgresql) for more details about the parameters that can be configured for the PostgreSQL database.
+Check the [FlowFuse Helm chart documentation](https://github.com/FlowFuse/helm/tree/main/helm/flowfuse#postgresql) for more details about the parameters that can be configured for the PostgreSQL database.
 
 ### How to backup embedded database?
 

--- a/docs/user/static-asset-service.md
+++ b/docs/user/static-asset-service.md
@@ -16,7 +16,7 @@ The Static Asset Service allows you to store files permanently within your FlowF
 ### FlowFuse Cloud
 
 - A Instance Stack with a launcher version of 2.8.0 or greater.
-- Team or Enterprise Team Type.
+- Pro or Enterprise Team Type.
 
 ### Self-Hosted
 


### PR DESCRIPTION
## Description

This pull request aligns Team Type names for the Static asset service with the current tier's naming convention on the corresponding documentation page.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

