### PR TITLE
[7644] Dropdowns that allow manual input will not accept inputs that are prefix of offered options  

### DIFF
--- a/frontend/src/ui-components/components/form/ComboBox.vue
+++ b/frontend/src/ui-components/components/form/ComboBox.vue
@@ -220,7 +220,7 @@ export default {
                 .map(normalize)
         },
         customValue () {
-            const noMatchingOptions = this.filteredOptions.filter(option => option.value.includes(this.query)).length === 0
+            const noMatchingOptions = this.filteredOptions.filter(option => option.value === this.query).length === 0
             const hasQuery = this.query !== ''
 
             return (hasQuery && noMatchingOptions)


### PR DESCRIPTION
## Description

Fixed a bug in the `ff-combobox` where typing a value that was a prefix of an existing option (e.g. 4.1.1 when 4.1.10 and 4.1.11 are offered) would not let you use your typed value. The custom "Use ..." option is now suppressed only on an exact match rather than any substring match.

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7644

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

