### PR TITLE
fix(expert): scope platform-automation token to a dedicated owner type

### DIFF
--- a/forge/db/controllers/AccessToken.js
+++ b/forge/db/controllers/AccessToken.js
@@ -149,7 +149,7 @@ module.exports = {
     /**
      * Create an AccessToken for the editor.
      */
-    createTokenForUser: async function (app, user, expiresAt, scope = [], includeRefresh) {
+    createTokenForUser: async function (app, user, expiresAt, scope = [], includeRefresh, ownerType = 'user') {
         const userId = typeof user === 'number' ? user : user.id
         const token = generateToken(32, 'ffu')
         const refreshToken = includeRefresh ? generateToken(32, 'ffu') : null
@@ -162,7 +162,7 @@ module.exports = {
             expiresAt,
             scope,
             ownerId: '' + userId,
-            ownerType: 'user'
+            ownerType
         })
         return { token, expiresAt, refreshToken }
     },

--- a/forge/ee/lib/expert/index.js
+++ b/forge/ee/lib/expert/index.js
@@ -5,6 +5,8 @@ const TOKEN_CACHE_NAME = 'ExpertMCPAccessTokenCache'
 
 const EXPERT_MCP_SCOPE = 'ff-expert:mcp'
 const EXPERT_MCP_PLATFORM_SCOPE = 'ff-expert:platform'
+// Dedicated owner type so platform-automation tokens are not treated as general user tokens
+const EXPERT_MCP_PLATFORM_OWNER_TYPE = 'user:expert-mcp'
 
 const EXPERT_MCP_SCOPES = [
     EXPERT_MCP_SCOPE,
@@ -113,11 +115,12 @@ module.exports = fp(async function (app, _opts) {
         }
 
         const expiresAt = new Date(Date.now() + TOKEN_TTL)
-        // TODO: change to a new method explicitly for Expert Automations
         const { token } = await app.db.controllers.AccessToken.createTokenForUser(
             user,
             expiresAt,
-            [EXPERT_MCP_PLATFORM_SCOPE]
+            [EXPERT_MCP_PLATFORM_SCOPE],
+            undefined,
+            EXPERT_MCP_PLATFORM_OWNER_TYPE
         )
 
         const entry = { token }

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -110,7 +110,7 @@ async function init (app, opts) {
                         // delete one time code immediately (spent)
                         await accessToken.destroy()
                     }
-                    if (accessToken.ownerType === 'user') {
+                    if (accessToken.ownerType === 'user' || accessToken.ownerType === 'user:expert-mcp') {
                         request.session.User = await app.db.models.User.findOne({ where: { id: +accessToken.ownerId } })
                         // Unlike a cookie based session, we'll allow user tokens to continue
                         // working if password has expired or email isn't verified
@@ -157,6 +157,11 @@ async function init (app, opts) {
                             reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
                             return
                         }
+                    }
+                    if (accessToken.scope?.includes('ff-expert:platform') && accessToken.ownerType !== 'user:expert-mcp') {
+                        // this scope is only valid on the dedicated platform-automation token type
+                        reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+                        return
                     }
                     return
                 }

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -69,7 +69,7 @@ module.exports = fp(async function (app, opts) {
                 // Permission disabled via admin settings
                 reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
                 throw new Error()
-            } else if (permission.role && permission.role !== Roles.Admin && (!request.session.scope || request.session.ownerType === 'user')) {
+            } else if (permission.role && permission.role !== Roles.Admin && (!request.session.scope || request.session.ownerType === 'user' || request.session.ownerType === 'user:expert-mcp')) {
                 // The user is required to have a role in the team associated with
                 // this request
                 if (!request.teamMembership) {
@@ -115,10 +115,9 @@ module.exports = fp(async function (app, opts) {
                 // We also need to check against the list of implicit scopes for
                 // a given token type (ie device/project)
 
-                // temp hack
-                // TODO: Consider using custom ownerType e.g. `user:expert-mcp`
-                // so that any other routes that permit a "user" token will not be accessible via this token type
-                if (request.session.ownerType === 'user' && request.session.scope?.includes('ff-expert:platform')) {
+                // The dedicated platform-automation token is server-minted, role-bounded above,
+                // and not a general user token, so it may reach the routes its tools call.
+                if (request.session.ownerType === 'user:expert-mcp' && request.session.scope?.includes('ff-expert:platform')) {
                     return
                 }
 

--- a/test/unit/forge/routes/auth/permissions_spec.js
+++ b/test/unit/forge/routes/auth/permissions_spec.js
@@ -56,6 +56,20 @@ describe('Permissions API', async () => {
         }
 
     }
+    // Dedicated platform-automation token: ownerType 'user:expert-mcp' + ff-expert:platform scope
+    const EXPERT_PLATFORM_TOKEN_TEAM_MEMBER = {
+        session: { User: { id: 'u123' }, ownerType: 'user:expert-mcp', scope: ['ff-expert:platform'] },
+        teamMembership: { role: Roles.Member }
+    }
+    const EXPERT_PLATFORM_TOKEN_TEAM_OWNER = {
+        session: { User: { id: 'u123' }, ownerType: 'user:expert-mcp', scope: ['ff-expert:platform'] },
+        teamMembership: { role: Roles.Owner }
+    }
+    // A plain user token must not gain broad access by carrying the platform scope
+    const USER_TOKEN_EXPERT_PLATFORM_SCOPE_TEAM_MEMBER = {
+        session: { User: { id: 'u123' }, ownerType: 'user', scope: ['ff-expert:platform'] },
+        teamMembership: { role: Roles.Member }
+    }
 
     let rbacApplicationEnabled = false
 
@@ -221,6 +235,19 @@ describe('Permissions API', async () => {
                 })
                 it('Prevents project token accessing any other scope', async () => {
                     expectFail(await sendRequest('team:delete', PROJECT_TOKEN_NO_SCOPE))
+                })
+            })
+
+            describe('expert platform token', () => {
+                it('Allows a role-permitted route despite the scope not listing it', async () => {
+                    expectPass(await sendRequest('team:read', EXPERT_PLATFORM_TOKEN_TEAM_MEMBER))
+                })
+                it('Stays bounded by the user role', async () => {
+                    expectFail(await sendRequest('team:edit', EXPERT_PLATFORM_TOKEN_TEAM_MEMBER))
+                    expectPass(await sendRequest('team:edit', EXPERT_PLATFORM_TOKEN_TEAM_OWNER))
+                })
+                it('Does not grant broad access to a plain user token carrying the scope', async () => {
+                    expectFail(await sendRequest('team:read', USER_TOKEN_EXPERT_PLATFORM_SCOPE_TEAM_MEMBER))
                 })
             })
         })


### PR DESCRIPTION
## Description

Scopes the Expert platform-automation access token to a dedicated `user:expert-mcp` owner type instead of a general `user` token.

Previously the token was minted as an ordinary `user` token carrying the `ff-expert:platform` scope, and the permission layer let any `user`-owned token with that scope through the scope check. Because no route guards on `ff-expert:platform`, that effectively made the token behave like a full user session (bounded only by the user's team role) rather than one limited to the platform-automation endpoints.

This change:

- Adds an optional `ownerType` argument to `AccessToken.createTokenForUser` (defaults to `user`, so existing callers are unchanged).
- Mints the platform-automation token with `ownerType: 'user:expert-mcp'`.
- Loads the session user for the new owner type, and rejects any token that carries the `ff-expert:platform` scope unless its owner type is `user:expert-mcp` (mirrors the existing `ff-expert:mcp` guard).
- Restricts the permission pass to the `user:expert-mcp` owner type, while keeping the team-role check in effect so the token cannot exceed the user's own role.

Net effect: the token still works for the generic team/application calls its tools make, but it is no longer a general user token and the scope cannot appear on any other token type.

## Related Issue(s)

Targets the `mcp-over-mqtt` branch (PR #7645).

## Checklist

- [x] Suitable unit/system level tests have been added and they pass
- [ ] Documentation has been updated

## Testing

- `test/unit/forge/routes/auth/permissions_spec.js` extended: the expert token reaches a role-permitted route despite the scope not listing it; it stays bounded by the user role; and a plain `user` token carrying the scope gets no broad access. 30 passing.
- `test/unit/forge/routes/auth/index_spec.js` and `test/unit/forge/db/controllers/AccessToken_spec.js` still pass (signature change and new guard do not regress). 55 passing.
- eslint clean on all changed files.
