### PR TITLE
feat(mcp): shared query schema fragments for platform tools

### DIFF
--- a/forge/ee/lib/mcp/schemas.js
+++ b/forge/ee/lib/mcp/schemas.js
@@ -1,0 +1,92 @@
+const { z } = require('zod')
+
+// Hosted instances are Projects (UUID primary key); the other entities use hashids.
+const teamId = z.string().describe('The ID or hashid of the team')
+const applicationId = z.string().describe('The ID or hashid of the application')
+const hostedInstanceId = z.string().uuid().describe('The UUID of the hosted instance')
+const remoteInstanceId = z.string().describe('The ID or hashid of the remote instance')
+const snapshotId = z.string().describe('The hashid of the snapshot')
+
+// Query fragments composed per tool by spreading only the ones the backing
+// route's finder actually honors. Not the same as the route's declared query
+// schema: most list routes reuse a generic PaginationParams that advertises
+// page/sort/dir/order even when the finder ignores them. Match the finder.
+
+const cursorParam = {
+    cursor: z.string().optional().describe('Opaque cursor from a previous page')
+}
+const limitParam = {
+    limit: z.number().int().min(1).max(50).default(10).describe('Maximum number of records to return (1-50, default 10)')
+}
+const basePagination = { ...cursorParam, ...limitParam }
+
+// Only Device.getAll and Project.byTeam read page and compute an offset.
+const pageParam = {
+    page: z.number().int().min(1).optional().default(1).describe('1-based page number (offset pagination)')
+}
+
+const searchQuery = {
+    query: z.string().optional().describe('Free-text search filter')
+}
+
+// Only Project.byTeam honors sort; no finder reads the legacy `order` alias.
+const sortParams = {
+    sort: z.string().optional().describe('Field name to sort by'),
+    dir: z.enum(['asc', 'desc']).optional().describe('Sort direction')
+}
+
+// scope is route-specific (its enum differs per entity), so each tool declares it inline.
+const auditLogFilters = {
+    event: z.union([z.string(), z.array(z.string())]).optional().describe('Filter by audit event name, or an array of event names'),
+    username: z.string().optional().describe('Filter by the username that triggered the event')
+}
+
+const cursorParamKeys = Object.keys(cursorParam)
+const limitParamKeys = Object.keys(limitParam)
+const basePaginationKeys = Object.keys(basePagination)
+const pageParamKeys = Object.keys(pageParam)
+const searchQueryKeys = Object.keys(searchQuery)
+const sortParamsKeys = Object.keys(sortParams)
+const auditLogFilterKeys = Object.keys(auditLogFilters)
+
+// Serialise the given query keys from args onto a url: only defined values,
+// URL-encoded, an array value appended once per element.
+function appendQuery (url, args, keys) {
+    const params = new URLSearchParams()
+    for (const key of keys) {
+        const value = args[key]
+        if (value === undefined || value === null) {
+            continue
+        }
+        if (Array.isArray(value)) {
+            value.forEach(v => params.append(key, v))
+        } else {
+            params.append(key, value)
+        }
+    }
+    const queryString = params.toString()
+    return queryString ? `${url}?${queryString}` : url
+}
+
+module.exports = {
+    teamId,
+    applicationId,
+    hostedInstanceId,
+    remoteInstanceId,
+    snapshotId,
+    cursorParam,
+    limitParam,
+    basePagination,
+    pageParam,
+    searchQuery,
+    sortParams,
+    auditLogFilters,
+    cursorParamKeys,
+    limitParamKeys,
+    basePaginationKeys,
+    pageParamKeys,
+    searchQueryKeys,
+    sortParamsKeys,
+    auditLogFilterKeys,
+    appendQuery
+}

--- a/test/unit/forge/ee/lib/mcp/schemas_spec.js
+++ b/test/unit/forge/ee/lib/mcp/schemas_spec.js
@@ -1,0 +1,76 @@
+const should = require('should') // eslint-disable-line no-unused-vars
+
+const FF_UTIL = require('flowforge-test-utils')
+
+const {
+    teamId,
+    applicationId,
+    hostedInstanceId,
+    remoteInstanceId,
+    snapshotId,
+    basePagination,
+    cursorParamKeys,
+    limitParamKeys,
+    basePaginationKeys,
+    pageParamKeys,
+    searchQueryKeys,
+    sortParamsKeys,
+    auditLogFilterKeys,
+    appendQuery
+} = FF_UTIL.require('forge/ee/lib/mcp/schemas')
+
+describe('MCP shared query schemas', function () {
+    describe('entity-id params', function () {
+        it('hashid params accept any non-empty string', function () {
+            for (const param of [teamId, applicationId, remoteInstanceId, snapshotId]) {
+                param.parse('aBc123').should.equal('aBc123')
+            }
+        })
+        it('hostedInstanceId accepts a UUID and rejects a hashid', function () {
+            hostedInstanceId.parse('4f8c1e2a-1b2c-4d3e-8f90-abcdef123456').should.be.a.String()
+            hostedInstanceId.safeParse('aBc123').success.should.equal(false)
+        })
+    })
+
+    describe('fragment composition', function () {
+        it('basePagination is cursor plus limit only (no page)', function () {
+            basePaginationKeys.should.eql(['cursor', 'limit'])
+        })
+        it('page, search and sort are separate opt-in fragments', function () {
+            cursorParamKeys.should.eql(['cursor'])
+            limitParamKeys.should.eql(['limit'])
+            pageParamKeys.should.eql(['page'])
+            searchQueryKeys.should.eql(['query'])
+            sortParamsKeys.should.eql(['sort', 'dir'])
+            auditLogFilterKeys.should.eql(['event', 'username'])
+        })
+        it('key list matches the shape object it describes', function () {
+            basePaginationKeys.should.eql(Object.keys(basePagination))
+        })
+    })
+
+    describe('appendQuery', function () {
+        it('returns the url unchanged when no supported params are set', function () {
+            appendQuery('/api/v1/x', {}, basePaginationKeys).should.equal('/api/v1/x')
+        })
+        it('returns the url unchanged when only unsupported keys are present', function () {
+            appendQuery('/api/v1/x', { teamId: 'abc' }, basePaginationKeys).should.equal('/api/v1/x')
+        })
+        it('serialises only the defined, supported params', function () {
+            appendQuery('/api/v1/x', { limit: 10, page: 2, cursor: undefined }, [...basePaginationKeys, ...pageParamKeys])
+                .should.equal('/api/v1/x?limit=10&page=2')
+        })
+        it('url-encodes values', function () {
+            appendQuery('/api/v1/x', { query: 'a b&c' }, searchQueryKeys)
+                .should.equal('/api/v1/x?query=a+b%26c')
+        })
+        it('appends an array value once per element', function () {
+            appendQuery('/api/v1/x', { event: ['flows.created', 'flows.deleted'] }, auditLogFilterKeys)
+                .should.equal('/api/v1/x?event=flows.created&event=flows.deleted')
+        })
+        it('skips null and undefined but keeps other values', function () {
+            appendQuery('/api/v1/x', { limit: null, page: 1 }, [...basePaginationKeys, ...pageParamKeys])
+                .should.equal('/api/v1/x?page=1')
+        })
+    })
+})


### PR DESCRIPTION
## Description

Adds `forge/ee/lib/mcp/schemas.js`, a shared module of composable zod query fragments that the Story 5 read tools compose from instead of redefining pagination/search/sort/audit-log fields in each tool file:

- `basePagination` (`cursor`, `limit`, `page`) - spread by every paginated list tool
- `searchQuery`, `sortParams`, `auditLogFilters` - opt-in add-ons a tool spreads only when its route supports them
- `paginationParams` (base + search + sort) and `auditLogQuery` (paginationParams + audit filters) - pre-composed for the frequent cases

The module lives at `forge/ee/lib/mcp/schemas.js`, one level above `tools/`, so the tool loader does not register it as a tool module.

This is the foundational piece the read-tool PRs build on; those PRs are branched from this branch and their bases will retarget to `main` once this merges.

Closes #7669