### PR TITLE
Enabled Expert Insights by default for self-hosted

### DIFF
--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -49,15 +49,15 @@ module.exports = fp(async function (app, opts) {
         // Set the assistant inline completions Feature Flag
         app.config.features.register('assistantInlineCompletions', isAssistantConfigured, true)
 
-        // Set the expert assistant Feature Flag
-        app.config.features.register('expertAssistant', isAiEnabled && (app.config?.expert?.enabled ?? false), true)
-
         // Set the expert platform automation Feature Flag (MCP platform tools server)
         app.config.features.register('expertPlatformAutomation', isAiEnabled && (app.config?.expert?.enabled ?? false), true)
 
-        // temporary until FF Expert Insights can be enabled on Self Hosted EE instance
+        // Set the expert assistant Feature Flag
+        app.config.features.register('expertAssistant', isAiEnabled && (app.config?.expert?.enabled ?? false), true)
+
+        // Set the Expert Insights flag
         const isInsightsEnabled = isAiEnabled && app.config?.expert?.enabled && app.config?.expert?.insights?.enabled
-        app.config.features.register('expertInsights', isInsightsEnabled ?? false, false)
+        app.config.features.register('expertInsights', isInsightsEnabled ?? false, true)
     }
 
     // Set the Team Library Feature Flag


### PR DESCRIPTION
## Description

The feature flag was purposefully disabled to avoid connectivity issues for self-hosted customers due to the lack of MQTT bridging support. Now that MQTT bridging has been enabled, we can safely enable Insights by default for on-premise deployments.

## Related Issue(s)

part of https://github.com/FlowFuse/engineering/issues/142

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

