### PR TITLE
Scoped PATs: clean up team scope entries on member removal

### DIFF
--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -134,6 +134,37 @@ module.exports = {
             }
             await userRole.destroy()
 
+            // Clean up scoped PAT entries that reference this team.
+            // Find which tokens had scopes for this team, remove those
+            // entries, then delete any tokens left with zero team scopes
+            // (they were scoped exclusively to the removed team and would
+            // otherwise silently escalate to team-global access).
+            const affectedScopes = await app.db.models.AccessTokenTeamScope.findAll({
+                where: { UserId: user.id, TeamId: team.id },
+                attributes: ['AccessTokenId']
+            })
+            const affectedTokenIds = affectedScopes.map(s => s.AccessTokenId)
+            if (affectedTokenIds.length > 0) {
+                await app.db.sequelize.transaction(async (t) => {
+                    await app.db.models.AccessTokenTeamScope.destroy({
+                        where: { UserId: user.id, TeamId: team.id },
+                        transaction: t
+                    })
+                    for (const tokenId of affectedTokenIds) {
+                        const remaining = await app.db.models.AccessTokenTeamScope.count({
+                            where: { AccessTokenId: tokenId },
+                            transaction: t
+                        })
+                        if (remaining === 0) {
+                            await app.db.models.AccessToken.destroy({
+                                where: { id: tokenId },
+                                transaction: t
+                            })
+                        }
+                    }
+                })
+            }
+
             await app.db.controllers.StorageSession.removeUserFromTeamSessions(user, team)
 
             return true

--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -401,7 +401,7 @@ module.exports = async function (app) {
     })
 
     app.post('/expert-agent-creds', {
-        preHandler: app.needsPermission('platform:expert-agent:creds'),
+        preHandler: [app.blockPAT, app.needsPermission('platform:expert-agent:creds')],
         schema: {
             summary: 'Regenerate expert agent credentials - admin-only',
             tags: ['Platform'],

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -875,7 +875,7 @@ module.exports = async function (app) {
      * Start device logging
      */
     app.post('/:deviceId/logs', {
-        preHandler: app.needsPermission('device:read'),
+        preHandler: [app.blockPAT, app.needsPermission('device:read')],
         schema: {
             summary: 'Start device logging',
             tags: ['Devices'],
@@ -909,10 +909,10 @@ module.exports = async function (app) {
     })
 
     /**
-     * Start device resouce stream
+     * Start a device resource stream
      */
     app.post('/:deviceId/resources', {
-        preHandler: app.needsPermission('device:read'),
+        preHandler: [app.blockPAT, app.needsPermission('device:read')],
         schema: {
             summary: 'Start device logging',
             tags: ['Devices'],

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -952,7 +952,7 @@ module.exports = async function (app) {
      * @name /api/v1/teams/:teamId/comms-credentials
      */
     app.post('/:teamId/comms-credentials', {
-        preHandler: app.needsPermission('team:read'),
+        preHandler: [app.blockPAT, app.needsPermission('team:read')],
         schema: {
             summary: 'Issue team-channel broker credentials for the current user/session',
             tags: ['Teams'],

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -435,7 +435,7 @@ module.exports = async function (app) {
      * Initialize expert chat
      */
     app.post('/expert-creds', {
-        // preHandler: app.needsPermission('xxx'), // all users can start an expert chat, but we might want to add a permission later
+        preHandler: app.blockPAT,
         schema: {
             summary: 'Initialize expert chat',
             tags: ['User'],

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -204,14 +204,17 @@ const getPersonalAccessTokens = async () => {
 }
 
 /**
- * Create new User Personal Access Token
+ * Create a new User Personal Access Token
  * See [routes/api/user.js](../../../forge/routes/api/user.js)
  * @param {string} name
  * @param {string} scope
  * @param {number} expiresAt
+ * @param {boolean} readOnly
+ * @param {boolean} adminOptIn
+ * @param {Array<string>} teamIds
  */
-const createPersonalAccessToken = async (name, scope, expiresAt) => {
-    return client.post('/api/v1/user/tokens', { name, scope, expiresAt }).then(res => res.data)
+const createPersonalAccessToken = async (name, scope, expiresAt, { readOnly, adminOptIn, teamIds } = {}) => {
+    return client.post('/api/v1/user/tokens', { name, scope, expiresAt, readOnly, adminOptIn, teamIds }).then(res => res.data)
 }
 
 /**
@@ -224,10 +227,18 @@ const deletePersonalAccessToken = async (id) => {
 }
 
 /**
- * Update User Personal Token
+ * Update User Personal Access Token
+ * See [routes/api/user.js](../../../forge/routes/api/user.js)
+ * @param {string} id The token ID to update
+ * @param {string} scope The token scope
+ * @param {number} expiresAt Expiration timestamp
+ * @param {Object} options Optional configuration
+ * @param {boolean} options.readOnly Whether the token is read-only
+ * @param {boolean} options.adminOptIn Whether admin opt-in is enabled
+ * @param {Array<string>} options.teamIds Array of team IDs the token is scoped to
  */
-const updatePersonalAccessToken = async (id, scope, expiresAt) => {
-    return client.put('/api/v1/user/tokens/' + id, { scope, expiresAt })
+const updatePersonalAccessToken = async (id, scope, expiresAt, { readOnly, adminOptIn, teamIds } = {}) => {
+    return client.put('/api/v1/user/tokens/' + id, { scope, expiresAt, readOnly, adminOptIn, teamIds }).then(res => res.data)
 }
 
 const enableMFA = async () => {

--- a/frontend/src/pages/account/Security/Tokens.vue
+++ b/frontend/src/pages/account/Security/Tokens.vue
@@ -9,7 +9,7 @@
         <template #actions>
             <ff-button data-action="new-token" @click="newToken()">
                 <template #icon-left>
-                    <PlusSmallIcon />
+                    <PlusIcon />
                 </template>
                 Add Token
             </ff-button>
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-import { PlusSmallIcon } from '@heroicons/vue/24/outline'
+import { PlusIcon } from '@heroicons/vue/24/outline'
 import { markRaw } from 'vue'
 
 import userApi from '../../../api/user.js'
@@ -40,10 +40,13 @@ import ExpiryCell from '../components/ExpiryCell.vue'
 import TokenCreated from './dialogs/TokenCreated.vue'
 import TokenDialog from './dialogs/TokenDialog.vue'
 
+import { pluralize } from '@/composables/strings/String.js'
+import { useAccountAuthStore } from '@/stores/account-auth.js'
+
 export default {
     name: 'PersonalAccessTokens',
     components: {
-        PlusSmallIcon,
+        PlusIcon,
         SectionTopMenu,
         TokenDialog,
         TokenCreated
@@ -51,10 +54,67 @@ export default {
     data () {
         return {
             loading: false,
-            tokens: [],
-            columns: [
+            tokens: []
+        }
+    },
+    computed: {
+        isAdmin () {
+            return useAccountAuthStore().isAdminUser
+        },
+        columns () {
+            return [
                 { label: 'Name', key: 'name', sortable: true },
-                // { label: 'Scope', key: 'scope' },
+                {
+                    label: 'Teams',
+                    key: 'teams',
+                    sortable: false,
+                    component: {
+                        is: markRaw({
+                            name: 'TeamsCell',
+                            props: ['teams'],
+                            template: '<span :title="tooltip" style="cursor:help">{{ label }}</span>',
+                            computed: {
+                                label () {
+                                    if (!this.teams || this.teams.length === 0) {
+                                        return 'All Teams'
+                                    }
+                                    return 'Team Scoped'
+                                },
+                                tooltip () {
+                                    if (!this.teams || this.teams.length === 0) {
+                                        return 'This token has access to all teams in your account'
+                                    }
+                                    return `This Token is scoped to the following ${pluralize('team', this.teams.length)}: \n${this.teams.map(t => t.name).join('\n')}`
+                                }
+                            }
+                        })
+                    }
+                },
+                {
+                    label: 'Read Only',
+                    key: 'readOnly',
+                    sortable: false,
+                    component: {
+                        is: markRaw({
+                            name: 'ReadOnlyCell',
+                            props: ['readOnly'],
+                            template: '<span v-if="readOnly" class="ff-badge ff-badge--info">Read Only</span><span v-else></span>'
+                        })
+                    }
+                },
+                {
+                    label: 'Admin Access',
+                    key: 'adminOptIn',
+                    sortable: false,
+                    hidden: !this.isAdmin,
+                    component: {
+                        is: markRaw({
+                            name: 'AdminOptInCell',
+                            props: ['adminOptIn'],
+                            template: '<span v-if="adminOptIn" class="text-green-500">&#x2714;</span><span v-else class="text-red-500">&#x2718;</span>'
+                        })
+                    }
+                },
                 {
                     label: 'Expires',
                     key: 'expiresAt',
@@ -62,7 +122,7 @@ export default {
                         is: markRaw(ExpiryCell)
                     }
                 }
-            ]
+            ].filter(col => !col.hidden)
         }
     },
     mounted () {

--- a/frontend/src/pages/account/Security/dialogs/TokenDialog.vue
+++ b/frontend/src/pages/account/Security/dialogs/TokenDialog.vue
@@ -2,23 +2,72 @@
     <ff-dialog ref="dialog" data-el="add-token-dialog" :header="(token ? 'Edit' : 'Add') + ' Token'" :confirm-label="token ? 'Save' : 'Create'" :disablePrimary="disableConfirm" @confirm="confirm()">
         <template #default>
             <form class="space-y-4" @submit.prevent>
-                <FormRow v-model="input.name" data-form="token-name" :disabled="edit">
-                    Token name
-                </FormRow>
-                <ff-checkbox v-model="input.expires" data-form="expiry-toggle" label="Add Expiry Date" />
-                <FormRow v-model="input.expiresAt" data-form="token-expiry" type="date" :disabled="!input.expires">
-                    Expires
-                    <!-- <template v-slot:description>Expires</template> -->
-                </FormRow>
+                <p class="text-sm text-gray-500">
+                    Personal access tokens allow external tools and scripts to authenticate with the platform API on your behalf.
+                    Configure the token's permissions below to control what it can access.
+                </p>
+
+                <!-- Token Name -->
+                <div class="border-t pt-4">
+                    <label class="block text-sm font-medium mb-1">Token Name</label>
+                    <p class="text-gray-500 text-sm mb-2">A descriptive name to help you identify this token later.</p>
+                    <FormRow v-model="input.name" data-form="token-name" :disabled="edit" />
+                </div>
+
+                <!-- Expiry -->
+                <div class="border-t pt-4">
+                    <label class="block text-sm font-medium mb-1">Expiry</label>
+                    <p class="text-gray-500 text-sm mb-2">Set an expiration date after which the token will stop working. Recommended for security.</p>
+                    <ff-checkbox v-model="input.expires" data-form="expiry-toggle" label="Add Expiry Date" />
+                    <div v-if="input.expires" class="mt-2 ml-6">
+                        <FormRow v-model="input.expiresAt" data-form="token-expiry" type="date" />
+                    </div>
+                </div>
+
+                <!-- Read Only -->
+                <div class="border-t pt-4">
+                    <label class="block text-sm font-medium mb-1">Access Level</label>
+                    <p class="text-gray-500 text-sm mb-2">Restrict this token to read-only operations. Write operations like creating, updating, or deleting resources will be denied.</p>
+                    <ff-checkbox v-model="input.readOnly" data-form="readonly-toggle" label="Read Only" />
+                </div>
+
+                <!-- Team Scope -->
+                <div class="border-t pt-4">
+                    <label class="block text-sm font-medium mb-1">Team Scope</label>
+                    <p class="text-gray-500 text-sm mb-2">Limit this token to specific teams. If none are selected, the token can access all teams you belong to.</p>
+                    <div v-if="teams.length > 0" class="space-y-2 ml-2">
+                        <ff-checkbox
+                            v-for="team in teams"
+                            :key="team.id"
+                            :model-value="input.teamIds.includes(team.id)"
+                            :label="team.name"
+                            :data-form="'team-scope-' + team.id"
+                            @update:model-value="toggleTeam(team.id)"
+                        />
+                    </div>
+                    <div v-if="input.teamIds.length === 0" class="mt-2 text-sm text-yellow-600">
+                        This token will have access to all teams you belong to, including teams you join in the future.
+                    </div>
+                </div>
+
+                <!-- Admin Opt-In -->
+                <div v-if="isAdmin" class="border-t pt-4">
+                    <label class="block text-sm font-medium mb-1">Admin Access</label>
+                    <p class="text-gray-500 text-sm mb-2">By default, tokens do not carry admin privileges even if your account is an admin. Enable this to grant admin-level access to the token.</p>
+                    <ff-checkbox v-model="input.adminOptIn" data-form="admin-optin-toggle" label="Enable Admin Privileges" />
+                </div>
             </form>
         </template>
     </ff-dialog>
 </template>
 
 <script>
-import userApi from '../../../../api/user.js'
+import { mapState } from 'pinia'
 
 import FormRow from '../../../../components/FormRow.vue'
+
+import userApi from '@/api/user.js'
+import { useAccountAuthStore, useAccountStore } from '@/stores/index.js'
 
 export default {
     name: 'TokenDialog',
@@ -35,7 +84,10 @@ export default {
                     id: null,
                     name: '',
                     expiresAt: null,
-                    expires: false
+                    expires: false,
+                    readOnly: false,
+                    adminOptIn: false,
+                    teamIds: []
                 }
                 this.edit = false
             },
@@ -43,13 +95,16 @@ export default {
                 this.token = row
                 this.input = {
                     id: row.id,
-                    name: row.name
+                    name: row.name,
+                    readOnly: row.readOnly ?? false,
+                    adminOptIn: row.adminOptIn ?? false,
+                    teamIds: (row.teams ?? []).map(t => t.id)
                 }
                 if (row.expiresAt === null) {
                     this.input.expires = false
                 } else {
                     this.input.expires = true
-                    this.input.expiresAt = row.expiresAt.split('T')[0] // `${d.getFullYear()}-${d.getMonth()+1}-${d.getDate()}`
+                    this.input.expiresAt = row.expiresAt.split('T')[0]
                 }
                 this.edit = true
                 this.$refs.dialog.show()
@@ -65,35 +120,41 @@ export default {
                 name: '',
                 scope: {},
                 expiresAt: null,
-                expires: true
+                expires: true,
+                readOnly: false,
+                adminOptIn: false,
+                teamIds: []
             },
             edit: false
         }
     },
     computed: {
-        dialogTitle () {
-            if (this.token) {
-                return 'Update token'
-            } else {
-                return 'Create token'
-            }
+        ...mapState(useAccountStore, ['teams']),
+        isAdmin () {
+            return useAccountAuthStore().isAdminUser
         },
         disableConfirm () {
             if (!this.input.name) {
                 return true
             }
-            if (!this.input.expires) {
-                return false
-            } else {
-                if (this.input.expiresAt) {
-                    return false
-                }
-            }
-            return true
+            return this.input.expires && !this.input.expiresAt
         }
     },
     methods: {
+        toggleTeam (teamId) {
+            const idx = this.input.teamIds.indexOf(teamId)
+            if (idx === -1) {
+                this.input.teamIds.push(teamId)
+            } else {
+                this.input.teamIds.splice(idx, 1)
+            }
+        },
         confirm: async function () {
+            const scopeOpts = {
+                readOnly: this.input.readOnly,
+                adminOptIn: this.input.adminOptIn,
+                teamIds: this.edit ? this.input.teamIds : (this.input.teamIds.length > 0 ? this.input.teamIds : undefined)
+            }
             if (!this.edit) {
                 let array = []
                 if (this.input.scope) {
@@ -106,7 +167,7 @@ export default {
                 if (this.input.expires) {
                     request.expiresAt = Date.parse(this.input.expiresAt)
                 }
-                const token = await userApi.createPersonalAccessToken(request.name, request.scope, request.expiresAt)
+                const token = await userApi.createPersonalAccessToken(request.name, request.scope, request.expiresAt, scopeOpts)
                 this.$emit('token-created', token)
             } else {
                 let array = []
@@ -124,7 +185,7 @@ export default {
                 }
 
                 try {
-                    await userApi.updatePersonalAccessToken(request.id, request.scope, request.expiresAt)
+                    await userApi.updatePersonalAccessToken(request.id, request.scope, request.expiresAt, scopeOpts)
                 } catch (err) {
                     console.error(err)
                 }

--- a/test/e2e/frontend/cypress/tests/account/tokens.spec.js
+++ b/test/e2e/frontend/cypress/tests/account/tokens.spec.js
@@ -13,9 +13,18 @@ describe('FlowFuse - Personal Access Tokens', () => {
         cy.get('[data-action="new-token"]').click()
         cy.get('[data-el="add-token-dialog"]').should('be.visible')
 
-        // expiry disabled by default
+        // expiry unchecked and date field hidden by default
         cy.get('[data-form="expiry-toggle"] input').should('not.be.checked')
-        cy.get('[data-form="token-expiry"] input').should('be.disabled')
+        cy.get('[data-form="token-expiry"]').should('not.exist')
+
+        // read-only unchecked by default
+        cy.get('[data-form="readonly-toggle"] input').should('not.be.checked')
+
+        // admin opt-in unchecked by default (alice is admin so it should be visible)
+        cy.get('[data-form="admin-optin-toggle"] input').should('not.be.checked')
+
+        // team scope warning visible when no teams selected
+        cy.contains('This token will have access to all teams you belong to').should('be.visible')
 
         cy.get('[data-el="add-token-dialog"]').within(() => {
             // check primary is disabled by default
@@ -28,6 +37,22 @@ describe('FlowFuse - Personal Access Tokens', () => {
         })
 
         cy.get('[data-el="add-token-dialog"]').should('not.be.visible')
+    })
+
+    it('expiry date field appears when expiry is toggled on', () => {
+        cy.get('[data-action="new-token"]').click()
+
+        // date field should not exist initially
+        cy.get('[data-form="token-expiry"]').should('not.exist')
+
+        // toggle expiry on
+        cy.get('[data-form="expiry-toggle"]').click()
+        cy.get('[data-form="token-expiry"]').should('exist')
+        cy.get('[data-form="token-expiry"] input').should('not.be.disabled')
+
+        // toggle expiry off
+        cy.get('[data-form="expiry-toggle"]').click()
+        cy.get('[data-form="token-expiry"]').should('not.exist')
     })
 
     it('can be added without an expiry', () => {
@@ -87,6 +112,66 @@ describe('FlowFuse - Personal Access Tokens', () => {
         cy.get('[data-el="tokens-table"] tbody').find('tr').last().should('contain', '31')
         cy.get('[data-el="tokens-table"] tbody').find('tr').last().should('contain', '12')
         cy.get('[data-el="tokens-table"] tbody').find('tr').last().should('contain', '2050')
+    })
+
+    it('can be added with read-only enabled', () => {
+        cy.intercept('POST', '/api/*/user/tokens').as('addPersonalAccessToken')
+
+        cy.get('[data-action="new-token"]').click()
+        cy.get('[data-form="token-name"] input').type('ReadOnly Token')
+        cy.get('[data-form="readonly-toggle"]').click()
+
+        cy.get('[data-el="add-token-dialog"] [data-action="dialog-confirm"]').click()
+
+        cy.wait('@addPersonalAccessToken').its('request.body').should('have.property', 'readOnly', true)
+
+        cy.get('[data-el="add-token-confirmation"]').should('be.visible')
+        cy.get('[data-el="add-token-confirmation"] [data-action="token-confirmation-done"]').click()
+
+        // token list should show Read Only badge
+        cy.get('[data-el="tokens-table"] tbody').find('tr').last().should('contain', 'Read Only')
+    })
+
+    it('can be added with team scope', () => {
+        cy.intercept('POST', '/api/*/user/tokens').as('addPersonalAccessToken')
+
+        cy.get('[data-action="new-token"]').click()
+        cy.get('[data-form="token-name"] input').type('Team Scoped Token')
+
+        // select the first team
+        cy.get('[data-form^="team-scope-"]').first().click()
+
+        // warning should disappear when a team is selected
+        cy.contains('This token will have access to all teams you belong to').should('not.exist')
+
+        cy.get('[data-el="add-token-dialog"] [data-action="dialog-confirm"]').click()
+
+        cy.wait('@addPersonalAccessToken').its('request.body').should('have.property', 'teamIds')
+
+        cy.get('[data-el="add-token-confirmation"]').should('be.visible')
+        cy.get('[data-el="add-token-confirmation"] [data-action="token-confirmation-done"]').click()
+
+        // token list should show Team Scoped
+        cy.get('[data-el="tokens-table"] tbody').find('tr').last().should('contain', 'Team Scoped')
+    })
+
+    it('can be added with admin opt-in', () => {
+        cy.intercept('POST', '/api/*/user/tokens').as('addPersonalAccessToken')
+
+        cy.get('[data-action="new-token"]').click()
+        cy.get('[data-form="token-name"] input').type('Admin Token')
+        cy.get('[data-form="admin-optin-toggle"]').click()
+
+        cy.get('[data-el="add-token-dialog"] [data-action="dialog-confirm"]').click()
+
+        cy.wait('@addPersonalAccessToken').its('request.body').should('have.property', 'adminOptIn', true)
+
+        cy.get('[data-el="add-token-confirmation"]').should('be.visible')
+        cy.get('[data-el="add-token-confirmation"] [data-action="token-confirmation-done"]').click()
+    })
+
+    it('token list shows All Teams for unscoped tokens', () => {
+        cy.get('[data-el="tokens-table"] tbody').find('tr').first().should('contain', 'All Teams')
     })
 
     it('can be removed', () => {

--- a/test/unit/forge/routes/api/teamMembers_spec.js
+++ b/test/unit/forge/routes/api/teamMembers_spec.js
@@ -637,4 +637,109 @@ describe('Team Members API', function () {
             secondResponse.statusCode.should.equal(200)
         })
     })
+
+    describe('PAT team scope cleanup on member removal', function () {
+        before(async function () {
+            if (app) await app.close()
+            app = await setup()
+            TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+            TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam', TeamTypeId: app.defaultTeamType.id })
+            TestObjects.CTeam = await app.db.models.Team.create({ name: 'CTeam', TeamTypeId: app.defaultTeamType.id })
+            delete TestObjects.DTeam
+        })
+        after(async function () {
+            await app.close()
+        })
+
+        it('removing user from team deletes AccessTokenTeamScope entries for that team', async function () {
+            await setupUsers()
+            // bob is member of ATeam and BTeam. Create a PAT scoped to both.
+            const token = await app.db.controllers.AccessToken.createPersonalAccessToken(
+                TestObjects.bob, '', null, 'Multi Team PAT',
+                { teamIds: [TestObjects.ATeam.hashid, TestObjects.BTeam.hashid] }
+            )
+
+            // Verify both scopes exist
+            let scopes = await app.db.models.AccessTokenTeamScope.findAll({
+                where: { UserId: TestObjects.bob.id }
+            })
+            scopes.should.have.length(2)
+
+            // Remove bob from ATeam
+            await app.db.controllers.Team.removeUser(TestObjects.ATeam, TestObjects.bob)
+
+            // ATeam scope should be gone, BTeam scope should remain
+            scopes = await app.db.models.AccessTokenTeamScope.findAll({
+                where: { UserId: TestObjects.bob.id }
+            })
+            scopes.should.have.length(1)
+            scopes[0].TeamId.should.equal(TestObjects.BTeam.id)
+
+            // Token itself should still exist
+            const tokenRecord = await app.db.models.AccessToken.findOne({
+                where: { id: app.db.models.AccessToken.decodeHashid(token.id) }
+            })
+            should(tokenRecord).not.be.null()
+        })
+
+        it('deletes token when last team scope is removed', async function () {
+            await setupUsers()
+            // bob is member of ATeam. Create a PAT scoped only to ATeam.
+            const token = await app.db.controllers.AccessToken.createPersonalAccessToken(
+                TestObjects.bob, '', null, 'Single Team PAT',
+                { teamIds: [TestObjects.ATeam.hashid] }
+            )
+            const tokenId = app.db.models.AccessToken.decodeHashid(token.id)
+
+            // Remove bob from ATeam: last scope removed, token should be deleted
+            await app.db.controllers.Team.removeUser(TestObjects.ATeam, TestObjects.bob)
+
+            const tokenRecord = await app.db.models.AccessToken.findOne({ where: { id: tokenId } })
+            should(tokenRecord).be.null()
+
+            const scopes = await app.db.models.AccessTokenTeamScope.findAll({
+                where: { UserId: TestObjects.bob.id }
+            })
+            scopes.should.have.length(0)
+        })
+
+        it('team-agnostic tokens are unaffected by membership removal', async function () {
+            await setupUsers()
+            // Create a PAT with no team scopes
+            const token = await app.db.controllers.AccessToken.createPersonalAccessToken(
+                TestObjects.bob, '', null, 'Global PAT'
+            )
+            const tokenId = app.db.models.AccessToken.decodeHashid(token.id)
+
+            // Remove bob from ATeam
+            await app.db.controllers.Team.removeUser(TestObjects.ATeam, TestObjects.bob)
+
+            // Token should still exist
+            const tokenRecord = await app.db.models.AccessToken.findOne({ where: { id: tokenId } })
+            should(tokenRecord).not.be.null()
+        })
+
+        it('tokens scoped to other teams are unaffected', async function () {
+            await setupUsers()
+            // Create a PAT scoped only to BTeam
+            const token = await app.db.controllers.AccessToken.createPersonalAccessToken(
+                TestObjects.bob, '', null, 'BTeam Only PAT',
+                { teamIds: [TestObjects.BTeam.hashid] }
+            )
+            const tokenId = app.db.models.AccessToken.decodeHashid(token.id)
+
+            // Remove bob from ATeam (not BTeam)
+            await app.db.controllers.Team.removeUser(TestObjects.ATeam, TestObjects.bob)
+
+            // Token and its BTeam scope should be untouched
+            const tokenRecord = await app.db.models.AccessToken.findOne({ where: { id: tokenId } })
+            should(tokenRecord).not.be.null()
+
+            const scopes = await app.db.models.AccessTokenTeamScope.findAll({
+                where: { AccessTokenId: tokenId }
+            })
+            scopes.should.have.length(1)
+            scopes[0].TeamId.should.equal(TestObjects.BTeam.id)
+        })
+    })
 })

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -1542,6 +1542,76 @@ describe('User API', async function () {
                 })
                 writeResponse.statusCode.should.equal(200)
             })
+
+            describe('broker credential endpoints blocked for PATs', async function () {
+                let patToken
+
+                before(async function () {
+                    await login('alice', 'aaPassword')
+                    const createResponse = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/user/tokens',
+                        cookies: { sid: TestObjects.tokens.alice },
+                        payload: { name: 'Broker Test PAT', scope: '', adminOptIn: true }
+                    })
+                    createResponse.statusCode.should.equal(200)
+                    patToken = createResponse.json().token
+                })
+
+                it('PAT cannot call POST /user/expert-creds', async function () {
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/user/expert-creds',
+                        headers: { authorization: `Bearer ${patToken}` },
+                        payload: { sessionId: 'abcd1234' }
+                    })
+                    response.statusCode.should.equal(403)
+                    response.json().should.have.property('code', 'pat_cannot_create_pat')
+                })
+
+                it('cookie session can call POST /user/expert-creds', async function () {
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/user/expert-creds',
+                        cookies: { sid: TestObjects.tokens.alice },
+                        payload: { sessionId: 'abcd1234' }
+                    })
+                    response.statusCode.should.equal(200)
+                })
+
+                it('PAT cannot call POST /teams/:teamId/comms-credentials', async function () {
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: `/api/v1/teams/${TestObjects.ATeam.hashid}/comms-credentials`,
+                        headers: { authorization: `Bearer ${patToken}` },
+                        payload: { sessionId: 'abcd1234' } // somewhat defeats the purpose of this test but better safe than sorry
+                    })
+                    response.statusCode.should.equal(403)
+                    response.json().should.have.property('code', 'pat_cannot_create_pat')
+                })
+
+                it('PAT cannot call POST /devices/:deviceId/logs', async function () {
+                    const device = await app.factory.createDevice({ name: 'broker-test-device' }, TestObjects.ATeam, null, TestObjects.application)
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: `/api/v1/devices/${device.hashid}/logs`,
+                        headers: { authorization: `Bearer ${patToken}` }
+                    })
+                    response.statusCode.should.equal(403)
+                    response.json().should.have.property('code', 'pat_cannot_create_pat')
+                })
+
+                it('PAT cannot call POST /devices/:deviceId/resources', async function () {
+                    const device = await app.factory.createDevice({ name: 'broker-test-device-2' }, TestObjects.ATeam, null, TestObjects.application)
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: `/api/v1/devices/${device.hashid}/resources`,
+                        headers: { authorization: `Bearer ${patToken}` }
+                    })
+                    response.statusCode.should.equal(403)
+                    response.json().should.have.property('code', 'pat_cannot_create_pat')
+                })
+            })
         })
     })
 


### PR DESCRIPTION
## Description

When a user is removed from a team, delete their `AccessTokenTeamScope` entries for that team so scoped tokens no longer eference a team they don't belong to. 

If removing the entry leaves a token with zero remaining team scopes, the token itself is deleted to prevent silent escalation to team-global access. The scope deletion and any token cleanup run inside a transaction.                                                                                          
                                                                                                                                                            
Team and user deletions are already handled by CASCADE constraints on the foreign keys.                                                                     

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7481

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

