### PR TITLE
Scoped PATs: block broker credential endpoints for PAT-authenticated requests

### DIFF
--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -401,7 +401,7 @@ module.exports = async function (app) {
     })
 
     app.post('/expert-agent-creds', {
-        preHandler: app.needsPermission('platform:expert-agent:creds'),
+        preHandler: [app.blockPAT, app.needsPermission('platform:expert-agent:creds')],
         schema: {
             summary: 'Regenerate expert agent credentials - admin-only',
             tags: ['Platform'],

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -875,7 +875,7 @@ module.exports = async function (app) {
      * Start device logging
      */
     app.post('/:deviceId/logs', {
-        preHandler: app.needsPermission('device:read'),
+        preHandler: [app.blockPAT, app.needsPermission('device:read')],
         schema: {
             summary: 'Start device logging',
             tags: ['Devices'],
@@ -909,10 +909,10 @@ module.exports = async function (app) {
     })
 
     /**
-     * Start device resouce stream
+     * Start a device resource stream
      */
     app.post('/:deviceId/resources', {
-        preHandler: app.needsPermission('device:read'),
+        preHandler: [app.blockPAT, app.needsPermission('device:read')],
         schema: {
             summary: 'Start device logging',
             tags: ['Devices'],

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -952,7 +952,7 @@ module.exports = async function (app) {
      * @name /api/v1/teams/:teamId/comms-credentials
      */
     app.post('/:teamId/comms-credentials', {
-        preHandler: app.needsPermission('team:read'),
+        preHandler: [app.blockPAT, app.needsPermission('team:read')],
         schema: {
             summary: 'Issue team-channel broker credentials for the current user/session',
             tags: ['Teams'],

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -435,7 +435,7 @@ module.exports = async function (app) {
      * Initialize expert chat
      */
     app.post('/expert-creds', {
-        // preHandler: app.needsPermission('xxx'), // all users can start an expert chat, but we might want to add a permission later
+        preHandler: app.blockPAT,
         schema: {
             summary: 'Initialize expert chat',
             tags: ['User'],

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -1542,6 +1542,76 @@ describe('User API', async function () {
                 })
                 writeResponse.statusCode.should.equal(200)
             })
+
+            describe('broker credential endpoints blocked for PATs', async function () {
+                let patToken
+
+                before(async function () {
+                    await login('alice', 'aaPassword')
+                    const createResponse = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/user/tokens',
+                        cookies: { sid: TestObjects.tokens.alice },
+                        payload: { name: 'Broker Test PAT', scope: '', adminOptIn: true }
+                    })
+                    createResponse.statusCode.should.equal(200)
+                    patToken = createResponse.json().token
+                })
+
+                it('PAT cannot call POST /user/expert-creds', async function () {
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/user/expert-creds',
+                        headers: { authorization: `Bearer ${patToken}` },
+                        payload: { sessionId: 'abcd1234' }
+                    })
+                    response.statusCode.should.equal(403)
+                    response.json().should.have.property('code', 'pat_cannot_create_pat')
+                })
+
+                it('cookie session can call POST /user/expert-creds', async function () {
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/user/expert-creds',
+                        cookies: { sid: TestObjects.tokens.alice },
+                        payload: { sessionId: 'abcd1234' }
+                    })
+                    response.statusCode.should.equal(200)
+                })
+
+                it('PAT cannot call POST /teams/:teamId/comms-credentials', async function () {
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: `/api/v1/teams/${TestObjects.ATeam.hashid}/comms-credentials`,
+                        headers: { authorization: `Bearer ${patToken}` },
+                        payload: { sessionId: 'abcd1234' } // somewhat defeats the purpose of this test but better safe than sorry
+                    })
+                    response.statusCode.should.equal(403)
+                    response.json().should.have.property('code', 'pat_cannot_create_pat')
+                })
+
+                it('PAT cannot call POST /devices/:deviceId/logs', async function () {
+                    const device = await app.factory.createDevice({ name: 'broker-test-device' }, TestObjects.ATeam, null, TestObjects.application)
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: `/api/v1/devices/${device.hashid}/logs`,
+                        headers: { authorization: `Bearer ${patToken}` }
+                    })
+                    response.statusCode.should.equal(403)
+                    response.json().should.have.property('code', 'pat_cannot_create_pat')
+                })
+
+                it('PAT cannot call POST /devices/:deviceId/resources', async function () {
+                    const device = await app.factory.createDevice({ name: 'broker-test-device-2' }, TestObjects.ATeam, null, TestObjects.application)
+                    const response = await app.inject({
+                        method: 'POST',
+                        url: `/api/v1/devices/${device.hashid}/resources`,
+                        headers: { authorization: `Bearer ${patToken}` }
+                    })
+                    response.statusCode.should.equal(403)
+                    response.json().should.have.property('code', 'pat_cannot_create_pat')
+                })
+            })
         })
     })
 


### PR DESCRIPTION
## Description

PAT-authenticated requests are now blocked from obtaining MQTT broker credentials. 

These credentials operate outside the HTTP request lifecycle, so PAT restrictions (team scope, read-only, admin opt-out) cannot be enforced on the resulting MQTT connections. This closes a privilege escalation path where a scoped PAT could obtain unrestricted broker access.
                                                                                                              
The existing blockPAT preHandler is added to all credential-issuing endpoints:                                                                                                                                                                                                                                              
- POST /api/v1/user/expert-creds                                                                                                                                                                                                                                                                                            
- POST /api/v1/devices/:deviceId/logs                                                                                                                                                                                                                                                                                     
- POST /api/v1/devices/:deviceId/resources                                                                                                                                                                                                                                                                                  
- POST /api/v1/teams/:teamId/comms-credentials                                                                                                                                                                                                                                                                            
- POST /api/v1/admin/expert-agent-creds

These endpoints exist for browser-based UI features (device log streaming, team notifications, expert chat) that use cookie sessions. Cookie sessions are unaffected.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7513

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

