### PR TITLE
fix: normalise Expert inbound origins to bare origin

### DIFF
--- a/frontend/src/stores/product-assistant.js
+++ b/frontend/src/stores/product-assistant.js
@@ -296,16 +296,26 @@ export const useProductAssistantStore = defineStore('product-assistant', {
             return state.debugLogEntries || []
         },
         allowedInboundOrigins () {
-            const allowedOrigins = [window.origin]
+            const allowedOrigins = new Set([window.origin])
             const instance = useContextStore().instance
             const device = useContextStore().device
-            if (instance?.url) allowedOrigins.push(instance.url)
-            if (device?.editor?.url) {
-                // todo this might not be needed because it's just the path to the editor tunnel, not an actual origin
-                //   and the only origin we might receive messages is the current window origin
-                allowedOrigins.push(device.editor.url)
+            // instance.url / device.editor.url can carry an editor path (httpAdminRoot) or a
+            // trailing slash, but a MessageEvent's origin is always a bare scheme://host:port.
+            // Reduce each entry to its origin so the comparison in handleMessage matches.
+            const addOrigin = (url) => {
+                try {
+                    allowedOrigins.add(new URL(url).origin)
+                } catch {
+                    // not a parseable URL - ignore
+                }
             }
-            return allowedOrigins
+            if (instance?.url) {
+                addOrigin(instance.url)
+            }
+            if (device?.editor?.url) {
+                addOrigin(device.editor.url)
+            }
+            return [...allowedOrigins]
         },
         isEditorRunning: (state) => {
             // NOTE: this is achieved via dynamic event registration for 'flows:loaded' and 'runtime-state' events,

--- a/test/unit/frontend/stores/product-assistant.spec.js
+++ b/test/unit/frontend/stores/product-assistant.spec.js
@@ -233,6 +233,22 @@ describe('product-assistant store', () => {
                 contextStore.setDevice({ id: 'dev-1', editor: { url: 'http://device.local' } })
                 expect(store.allowedInboundOrigins).toContain('http://device.local')
             })
+
+            it('reduces an instance url carrying an editor path to its bare origin', () => {
+                const contextStore = useContextStore()
+                const store = useProductAssistantStore()
+                contextStore.setInstance({ id: 'inst-1', url: 'https://node-red.local/admin' })
+                expect(store.allowedInboundOrigins).toContain('https://node-red.local')
+                expect(store.allowedInboundOrigins).not.toContain('https://node-red.local/admin')
+            })
+
+            it('reduces an instance url with a trailing slash to its bare origin', () => {
+                const contextStore = useContextStore()
+                const store = useProductAssistantStore()
+                contextStore.setInstance({ id: 'inst-1', url: 'https://node-red.local/' })
+                expect(store.allowedInboundOrigins).toContain('https://node-red.local')
+                expect(store.allowedInboundOrigins).not.toContain('https://node-red.local/')
+            })
         })
 
         describe('isEditorRunning', () => {


### PR DESCRIPTION
## Description

Fixes #7782.

The Expert panel dropped every inbound `postMessage` sent by the nr-assistant editor plugin on instances that run the editor under a non-root `httpAdminRoot`, logging `Received message from unknown origin. Ignoring.` on repeat. With the messages rejected, the Expert never received `assistant-ready` and the panel did not populate.

`allowedInboundOrigins` compared the incoming `MessageEvent.origin` against `instance.url` / `device.editor.url` directly. Those are full editor URLs that can carry the editor path (`httpAdminRoot`) or a trailing slash, but a `MessageEvent` origin is always a bare `scheme://host:port`, so the strict `includes()` check never matched.

Example (instance with `httpAdminRoot: '/admin'`):

- allow-list entry: `https://my-instance.flowfuse.cloud/admin`
- `event.origin`: `https://my-instance.flowfuse.cloud`

This normalises each allow-list entry to its origin via `new URL(url).origin` before comparison. Instances served at the bare origin are unchanged.

## Testing

`test/unit/frontend/stores/product-assistant.spec.js` gains two regression cases: an `instance.url` carrying an editor path and one with a trailing slash both resolve to the bare origin. Full suite passes (89 tests).
