### PR TITLE
fix: backfill adminOptIn for existing admin PATs

### DIFF
--- a/forge/db/migrations/20260710-01-backfill-admin-pat-opt-in.js
+++ b/forge/db/migrations/20260710-01-backfill-admin-pat-opt-in.js
@@ -1,0 +1,21 @@
+/**
+ * Backfill adminOptIn for existing admin-owned PATs.
+ *
+ * The 20260706-01 migration added adminOptIn with a default of false,
+ * which broke existing admin PATs by stripping their admin capabilities.
+ * This sets adminOptIn = true for all PATs owned by admin users created up to this point.
+ */
+
+module.exports = {
+    up: async (context) => {
+        await context.sequelize.query(
+            `UPDATE "AccessTokens"
+             SET "adminOptIn" = true
+             WHERE "ownerType" = 'user'
+               AND "ownerId" IN (
+                   SELECT CAST("id" AS VARCHAR) FROM "Users" WHERE "admin" = true
+               )`
+        )
+    },
+    down: async (context) => {}
+}


### PR DESCRIPTION
## Description

The scoped PATs migration (20260706-01) added `adminOptIn` with a default of `false`, which silently broke existing admin-owned tokens by stripping their admin capabilities. 

This adds a follow-up migration that sets `adminOptIn = true` for all PATs belonging to admin users, restoring the access they had before scoped PATs were introduced. 

## Related Issue(s)

addresses backwards compatibility support for https://github.com/FlowFuse/flowfuse/issues/7445

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [x] Includes a DB migration? -> add the `area:migration` label

