### PR TITLE
fix: sanitise OpenMetrics metric names in admin stats endpoint

### DIFF
--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -110,9 +110,12 @@ module.exports = async function (app) {
         let result = {}
         const rootKey = root ? `${root}_` : ''
         for (const [key, value] of Object.entries(obj)) {
-            const formattedKey = `${rootKey}${key}`.replace(/[A-Z]/g, m => {
-                return '_' + m.toLowerCase()
-            })
+            const formattedKey = `${rootKey}${key}`
+                .replace(/[A-Z]/g, m => '_' + m.toLowerCase())
+                // OpenMetrics names must match [a-zA-Z_:][a-zA-Z0-9_:]* - fold
+                // any other char (spaces etc from data like team type names) to _
+                .replace(/[^a-zA-Z0-9_:]/g, '_')
+                .replace(/_{2,}/g, '_')
             if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
                 result[formattedKey] = value
             } else {

--- a/test/unit/forge/routes/api/admin_spec.js
+++ b/test/unit/forge/routes/api/admin_spec.js
@@ -91,6 +91,34 @@ describe('Admin API', async function () {
             result.should.match(/\n$/)
         })
 
+        it('sanitises openmetrics keys derived from data (e.g. team type names with spaces)', async function () {
+            // Team type names are admin-editable and can contain spaces/uppercase,
+            // which are invalid in OpenMetrics metric names
+            const spacedType = await app.db.models.TeamType.create({ name: 'Team Type Two', active: true, properties: {} })
+            await app.db.models.Team.create({ name: 'ETeam', TeamTypeId: spacedType.id })
+
+            await login('alice', 'aaPassword')
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/admin/stats',
+                headers: {
+                    accept: 'application/openmetrics-text'
+                },
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.body
+
+            // The team type name has been folded to a valid metric name
+            result.should.match(/flowforge_teams_by_type_team_type_two 1\n/)
+            // No metric line has a space or dash inside its name (only the
+            // single space separating name from value is allowed)
+            result.split('\n').filter(Boolean).forEach(line => {
+                const name = line.slice(0, line.lastIndexOf(' '))
+                name.should.match(/^[a-zA-Z_:][a-zA-Z0-9_:]*$/)
+            })
+        })
+
         describe('access token management', () => {
             async function getStatsAccessTokens () {
                 return app.db.models.AccessToken.findAll({ where: { scope: 'platform:stats' } })


### PR DESCRIPTION
## Description

> [!IMPORTANT]  
> The code introduced in this pull request was created with AI assistance. Please keep this in mind while performing your review.

Admin stats OpenMetrics output (`GET /api/v1/admin/stats` with `Accept: application/openmetrics-text`) emitted invalid metric names when a name segment was derived from user data containing spaces or other characters, ie. a team type named "Team Type" produced flowforge_teams_by_type_team _type 5, breaking scraper parsing.

The `flattenObject` function now folds any character outside `[a-zA-Z0-9_:]` to `_` and collapses repeated underscores, so every emitted metric name matches the OpenMetrics naming rules regardless of team type naming. Only the OpenMetrics branch changes; the JSON response is unchanged. Added a unit test covering a team type name with a space and uppercase.

## Related Issue(s)

Fixes https://github.com/FlowFuse/flowfuse/issues/7789

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

