### PR TITLE
fix: enable default maintenance schedule for opt-out tiers on instance creation

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -555,7 +555,7 @@ module.exports = {
             await team.ensureTeamTypeExists()
             if (team.TeamType.getProperty('autoStackUpdate')) {
                 const autoStackUpdate = team.TeamType.getProperty('autoStackUpdate')
-                if (autoStackUpdate.enabled && !autoStackUpdate.allowDisable) {
+                if (autoStackUpdate.enabled) {
                     const days = autoStackUpdate.days
                     const hours = autoStackUpdate.hours
                     // generate random day and hour in ranges


### PR DESCRIPTION
## Description

New instances only got a scheduled maintenance window applied at creation when the team type had `autoStackUpdate.enabled` **and** `allowDisable === false`. That combination only matches enforced tiers (Starter), so opt-out tiers (Pro/Enterprise, `allowDisable: true`) were created with no schedule even though the tier has maintenance enabled by default.

This changes the creation-time check in `forge/db/controllers/Project.js` to apply the default schedule whenever the tier has `autoStackUpdate.enabled`, regardless of `allowDisable`. `allowDisable` governs whether a user can later turn maintenance off, not whether it is on by default at creation.

```diff
-                if (autoStackUpdate.enabled && !autoStackUpdate.allowDisable) {
+                if (autoStackUpdate.enabled) {
```

No tier regresses: for `allowDisable: false` tiers the condition is unchanged in effect (`enabled` was already required), and the daily enforcement job (`enforce-team-rules.js`) is intentionally left scoped to `allowDisable === false` so opt-out tiers are not force-re-enabled after a user opts out.

## Scope

This is the forward fix only: it stops new Pro/Enterprise instances being created without a schedule. Retroactively applying a schedule to existing instances that were created without one is deliberately **out of scope** here and tracked separately (see #7821 and #6349), as it needs customer comms and restart rate-limiting (#6872).

## Related

- Fixes #7821
- Delivers the behaviour intended by #6766
- Epic #4608

## Checklist

- [x] Minimal, targeted change
- [ ] Regression test for the creation path on an opt-out tier (sensible follow-up; existing tests cover only the enforcement job)
