### PR TITLE
Use shared subscription group for Expert platform requests

### DIFF
--- a/forge/comms/commsClient.js
+++ b/forge/comms/commsClient.js
@@ -232,8 +232,12 @@ class CommsClient extends EventEmitter {
                 'ff/v1/+/d/+/resources/heartbeat',
                 // Platform sync messages
                 'ff/v1/platform/sync',
-                // Listen for Expert platform requests
-                'ff/v1/expert/+/+/platform/+/request'
+                // Listen for Expert platform requests.
+                // Uses a dedicated shared subscription group. The group name defines the set
+                // of consumers that share the workload, so keeping Expert separate from the
+                // "platform" group prevents unrelated features from sharing a consumer pool and
+                // allows them to scale independently.
+                '$share/expert/ff/v1/expert/+/+/platform/+/request'
             ])
         }
     }


### PR DESCRIPTION
## Description

Changed the subscription topic for Expert platform requests to use the `$share/expert/` prefix. This is to prevent replicas performing parallel expert platform actions.

## Related Issue(s)

closes #7786 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

