### PR TITLE
Introduce status field to Device model for better representation of state

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -54,6 +54,20 @@ module.exports = {
                 return this.ownerType === 'application'
             }
         },
+        /** @type {'online'|'offline'|'not-seen'} a virtual column derived from `lastSeenAt`: `not-seen` if never seen, `online` if seen within the last 30 minutes, otherwise `offline` */
+        status: {
+            type: DataTypes.VIRTUAL(DataTypes.ENUM('online', 'offline', 'not-seen')),
+            get () {
+                const lastSeenAt = this.lastSeenAt
+                // Caveat: if `lastSeenAt` is not selected in the query it will be `undefined`
+                // here and the device reports `not-seen` regardless of its true state.
+                if (!lastSeenAt) {
+                    return 'not-seen'
+                }
+                const ageMs = Date.now() - new Date(lastSeenAt).getTime()
+                return ageMs <= (30 * 60 * 1000) ? 'online' : 'offline'
+            }
+        },
         nodejsVersion: { type: DataTypes.STRING, allowNull: true }
     },
     associations: function (M) {

--- a/test/unit/forge/db/models/Device_spec.js
+++ b/test/unit/forge/db/models/Device_spec.js
@@ -208,6 +208,35 @@ describe('Device model', function () {
             should(settings).be.an.Object().and.have.a.property('autoSnapshot', false)
         })
     })
+    describe('Virtual fields', function () {
+        let app
+        before(async function () {
+            app = await setup()
+        })
+        after(async function () {
+            await app.close()
+        })
+        beforeEach(async () => {
+            // increase license limits
+            app.license.defaults.devices = 20
+            app.license.defaults.instances = 20
+        })
+
+        describe('status', function () {
+            it('is "not-seen" when lastSeenAt is null', async function () {
+                const device = await app.db.models.Device.create({ name: 'D1', type: 'PI', credentialSecret: '', lastSeenAt: null })
+                device.status.should.equal('not-seen')
+            })
+            it('is "online" when lastSeenAt is within the last 30 minutes', async function () {
+                const device = await app.db.models.Device.create({ name: 'D2', type: 'PI', credentialSecret: '', lastSeenAt: new Date(Date.now() - (29 * 60 * 1000)) })
+                device.status.should.equal('online')
+            })
+            it('is "offline" when lastSeenAt is older than 30 minutes', async function () {
+                const device = await app.db.models.Device.create({ name: 'D4', type: 'PI', credentialSecret: '', lastSeenAt: new Date(Date.now() - (31 * 60 * 1000)) })
+                device.status.should.equal('offline')
+            })
+        })
+    })
     describe('Relations', function () {
         let app
         let Application, Project, Team, Device


### PR DESCRIPTION
## Description

This pull request adds a new virtual `status` field to the `Device` model and introduces comprehensive unit tests to verify its behavior. The main goal is to provide a simple way to determine if a device is "online", "offline", or "not-seen" based on the `lastSeenAt` timestamp.

**Device model enhancements:**

* Added a virtual `status` field to the `Device` model, which returns `"not-seen"` if the device has never been seen, `"online"` if seen within the last 30 minutes, and `"offline"` otherwise.

**Testing improvements:**

* Added unit tests for the new `status` virtual field in `Device_spec.js`, covering all possible status values ("not-seen", "online", "offline") based on different `lastSeenAt` values.

## Related Issue(s)

closes #7826

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

