### PR TITLE
Refactor common code

### DIFF
--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -318,6 +318,116 @@ module.exports.init = async function (app) {
     }
 
     /**
+     * Given a group-name match (from the `ff-SLUG-ROLE` regex), check if it is an
+     * Application override group of the form `ff-<team>[<application>]-<role>` and,
+     * if so, record the desired application role in `desiredTeamApplicationroles`.
+     *
+     * @param {object} desiredTeamApplicationroles Accumulator keyed by team hashid -> { applicationHashid: role }
+     * @param {RegExpExecArray} match The result of running the `ff-(.+)-([^-]+)$` regex on the group name
+     * @param {object} providerOpts The SSO Provider configuration object
+     * @returns {Promise<boolean>} true if the group was an Application override group (and should not
+     *   be treated as a plain team-role group), false otherwise.
+     */
+    async function recordApplicationOverride (desiredTeamApplicationroles, match, providerOpts) {
+        const applicationRolesMatch = /(.+)\[(.+)\]/.exec(match[1])
+        if (!applicationRolesMatch) {
+            // Not an Application override group
+            return false
+        }
+        const teamSlug = applicationRolesMatch[1]
+        const applicationId = applicationRolesMatch[2]
+        const applicationRole = Roles[match[2]]
+        // From here on this is an Application override group - return true even if
+        // we cannot apply it, so the caller does not treat it as a team-role group.
+        if (applicationRole === undefined) {
+            // Unrecognised role name - ignore
+            return true
+        }
+        // Check if this team is allowed to be managed for this SSO provider before
+        // doing any database lookups.
+        if (!(providerOpts.groupAllTeams || (providerOpts.groupTeams || []).includes(teamSlug))) {
+            return true
+        }
+        const team = await app.db.models.Team.bySlug(teamSlug)
+        if (!team) {
+            // Unrecognised team - ignore
+            return true
+        }
+        const application = await team.hasApplication(applicationId)
+        if (!application) {
+            // Unrecognised application - ignore
+            return true
+        }
+        if (!desiredTeamApplicationroles[team.hashid]) {
+            desiredTeamApplicationroles[team.hashid] = {}
+        }
+        // In case we have multiple assertions for a single application,
+        // ensure we keep the highest level of access
+        desiredTeamApplicationroles[team.hashid][application.hashid] = Math.max(
+            desiredTeamApplicationroles[team.hashid][application.hashid] || 0,
+            applicationRole
+        )
+        return true
+    }
+
+    /**
+     * Apply the desired per-application role overrides to a user's team memberships
+     * and clear any SSO-managed overrides that are no longer desired.
+     *
+     * This is shared between the SAML and LDAP flows.
+     *
+     * @param {*} user The FF User object who is logging in
+     * @param {object} desiredTeamApplicationroles Accumulator keyed by team hashid -> { applicationHashid: role }
+     * @param {object} providerOpts The SSO Provider configuration object
+     */
+    async function applyApplicationOverrides (user, desiredTeamApplicationroles, providerOpts) {
+        app.log.debug(`Desired Application Roles for ${user.username} ${JSON.stringify(desiredTeamApplicationroles)}`)
+        // Work out which teams currently have SSO-managed overrides so we can clear
+        // any that are no longer desired. Only teams in scope of this provider are
+        // considered.
+        const existingOverrideTeamIds = new Set(
+            ((await app.db.models.TeamMember.getTeamsForUser(user.id, true)) || [])
+                .filter(teamMembership => {
+                    if (!teamMembership.permissions) {
+                        return false
+                    }
+                    // If the user is allowed to be a member of teams outside of SSO
+                    // control, only manage overrides on teams this provider controls.
+                    if (providerOpts.groupMapping && providerOpts.groupOtherTeams) {
+                        return (providerOpts.groupTeams || []).includes(teamMembership.Team.slug)
+                    }
+                    return true
+                })
+                .map(teamMembership => teamMembership.Team.hashid)
+        )
+        app.log.debug(`Existing Application Roles for ${user.username} ${JSON.stringify([...existingOverrideTeamIds])}`)
+
+        // First pass - apply the desired overrides. Done sequentially so that the
+        // apply and clear passes cannot race on the same membership.
+        for (const [teamId, overrides] of Object.entries(desiredTeamApplicationroles)) {
+            const membership = await app.db.models.TeamMember.getTeamMembership(user.id, teamId)
+            if (membership) {
+                const newPermissions = { applications: overrides, sso: true }
+                await app.db.controllers.Team.changeUserTeamPermissions(teamId, user.hashid, newPermissions)
+                // This team has been dealt with - don't clear it in the second pass
+                existingOverrideTeamIds.delete(teamId)
+            } else {
+                app.log.debug(`User ${user.name} not a member of Team ${teamId} so not overriding Application access`)
+            }
+        }
+
+        // Second pass - any remaining teams had overrides that are no longer
+        // desired, so clear them.
+        for (const teamId of existingOverrideTeamIds) {
+            const membership = await app.db.models.TeamMember.getTeamMembership(user.id, teamId)
+            if (membership) {
+                membership.permissions = {}
+                await membership.save()
+            }
+        }
+    }
+
+    /**
      * Update a user's team memberships according to the SAML Assertions
      * received when they logged in.
      *
@@ -352,26 +462,8 @@ module.exports.init = async function (app) {
                 // Generate a slug->role object (desiredTeamMemberships)
                 const match = /^ff-(.+)-([^-]+)$/.exec(shortGA)
                 if (match) {
-                    // check for Application Overide groups
-                    const applicationRolesMatch = /(.+)\[(.+)\]/.exec(match[1])
-                    if (applicationRolesMatch) {
-                        const teamSlug = applicationRolesMatch[1]
-                        const applicationId = applicationRolesMatch[2]
-                        const applicationRoleName = match[2]
-                        const applicationRole = Roles[applicationRoleName]
-                        const team = await app.db.models.Team.bySlug(teamSlug)
-                        const application = await team.hasApplication(applicationId)
-                        if (application) {
-                            if (providerOpts.groupAllTeams || (providerOpts.groupTeams || []).includes(teamSlug)) {
-                                if (desiredTeamApplicationroles[team.hashid]) {
-                                    desiredTeamApplicationroles[team.hashid][application.hashid] = Math.max(desiredTeamApplicationroles[team.hashid][application.hashid] || 0, applicationRole)
-                                } else {
-                                    desiredTeamApplicationroles[team.hashid] = {}
-                                    desiredTeamApplicationroles[team.hashid][application.hashid] = applicationRole
-                                }
-                            }
-                        }
-                    } else {
+                    // check for Application override groups of the form `ff-<team>[<application>]-<role>`
+                    if (!await recordApplicationOverride(desiredTeamApplicationroles, match, providerOpts)) {
                         const teamSlug = match[1]
                         const teamRoleName = match[2]
                         const teamRole = Roles[teamRoleName]
@@ -483,52 +575,8 @@ module.exports.init = async function (app) {
             }
 
             await Promise.all(promises)
-            // Now all group membership updated apply application overrides
-
-            app.log.debug(`Desired Application Roles for ${user.username} ${JSON.stringify(desiredTeamApplicationroles)}`)
-            // This needs to do 2 passes, get all the memberships that exist and compare to new list
-            const existingApplicationOveridesList = (await app.db.models.TeamMember.getTeamsForUser(user.id, true))?.filter(teamMambership => {
-                // check if users are allowed to be in other groups, filter out groups not SSO controlled
-                if (providerOpts.groupMapping && providerOpts.groupOtherTeams) {
-                    if (providerOpts.groupTeams.includes(teamMambership.Team.slug)) {
-                        return !!teamMambership.permissions
-                    } else {
-                        return false
-                    }
-                } else {
-                    return !!teamMambership.permissions
-                }
-            }) || []
-            const existingApplicationOverides = existingApplicationOveridesList.reduce((prev, tm) => {
-                const n = {}
-                n[tm.Team.hashid] = {
-                    overides: tm.permissions
-                }
-                return {
-                    ...prev,
-                    ...n
-                }
-            }, {})
-            app.log.debug(`Existing Application Roles for ${user.username} ${JSON.stringify(existingApplicationOverides)}`)
-            const applicationPromises = []
-            for (const [teamId, overides] of Object.entries(desiredTeamApplicationroles)) {
-                const membership = await app.db.models.TeamMember.getTeamMembership(user.id, teamId)
-                if (membership) {
-                    const newPermissions = { applications: overides, sso: true }
-                    applicationPromises.push(app.db.controllers.Team.changeUserTeamPermissions(teamId, user.hashid, newPermissions))
-                    // need to remove from existingApplicationOvervides
-                    delete existingApplicationOverides[teamId]
-                } else {
-                    app.log.debug(`User ${user.name} not a member of Team ${teamId} so not overriding Application access`)
-                }
-            }
-            // Any teamIds in existingApplicationOverides are no longer in the desired list, so remove them
-            for (const teamId of Object.keys(existingApplicationOverides)) {
-                const tm = await app.db.models.TeamMember.getTeamMembership(user.hashid, teamId)
-                tm.permissions = {}
-                applicationPromises.push(tm.save())
-            }
-            await Promise.all(applicationPromises)
+            // Now all group membership has been updated, apply application overrides
+            await applyApplicationOverrides(user, desiredTeamApplicationroles, providerOpts)
         } else {
             const missingGroupAssertions = new Error(`SAML response missing ${providerOpts.groupAssertionName} assertion`)
             missingGroupAssertions.code = 'unknown_sso_user'
@@ -559,26 +607,8 @@ module.exports.init = async function (app) {
             }
             const match = groupRegEx.exec(shortCN)
             if (match) {
-                // check for Application Overide groups
-                const applicationRolesMatch = /(.+)\[(.+)\]/.exec(match[1])
-                if (applicationRolesMatch) {
-                    const teamSlug = applicationRolesMatch[1]
-                    const applicationId = applicationRolesMatch[2]
-                    const applicationRoleName = match[2]
-                    const applicationRole = Roles[applicationRoleName]
-                    const team = await app.db.models.Team.bySlug(teamSlug)
-                    const application = await team.hasApplication(applicationId)
-                    if (application) {
-                        if (providerOpts.groupAllTeams || (providerOpts.groupTeams || []).includes(teamSlug)) {
-                            if (desiredTeamApplicationroles[team.hashid]) {
-                                desiredTeamApplicationroles[team.hashid][application.hashid] = Math.max(desiredTeamApplicationroles[team.hashid][application.hashid] || 0, applicationRole)
-                            } else {
-                                desiredTeamApplicationroles[team.hashid] = {}
-                                desiredTeamApplicationroles[team.hashid][application.hashid] = applicationRole
-                            }
-                        }
-                    }
-                } else {
+                // check for Application override groups of the form `ff-<team>[<application>]-<role>`
+                if (!await recordApplicationOverride(desiredTeamApplicationroles, match, providerOpts)) {
                     app.log.debug(`Found group ${searchEntries[i].cn} for user ${user.username}`)
                     const teamSlug = match[1]
                     const teamRoleName = match[2]
@@ -689,48 +719,8 @@ module.exports.init = async function (app) {
         }
 
         await Promise.all(promises)
-        // Now all group membership updated apply application overrides
-        // This needs to do 2 passes, get all the memberships that exist and compare to new list
-        const existingApplicationOveridesList = (await app.db.models.TeamMember.getTeamsForUser(user.id, true))?.filter(teamMambership => {
-            // check if users are allowed to be in other groups, filter out groups not SSO controlled
-            if (providerOpts.groupMapping && providerOpts.groupOtherTeams) {
-                if (providerOpts.groupTeams.includes(teamMambership.Team.slug)) {
-                    return !!teamMambership.permissions
-                } else {
-                    return false
-                }
-            } else {
-                return !!teamMambership.permissions
-            }
-        }) || []
-        const existingApplicationOverides = existingApplicationOveridesList.reduce((prev, tm) => {
-            const n = {}
-            n[tm.Team.hashid] = {
-                overides: tm.permissions
-            }
-            return {
-                ...prev,
-                ...n
-            }
-        }, {})
-        const applicationPromises = []
-        for (const [teamId, overides] of Object.entries(desiredTeamApplicationroles)) {
-            const membership = await app.db.models.TeamMember.getTeamMembership(user.id, teamId)
-            if (membership) {
-                const newPermissions = { applications: overides, sso: true }
-                applicationPromises.push(app.db.controllers.Team.changeUserTeamPermissions(teamId, user.hashid, newPermissions))
-                // need to remove from existingApplicationOvervides
-                delete existingApplicationOverides.teamId
-            } else {
-                app.log.debug(`User ${user.name} not a member of Team ${teamId} so not overriding Application access`)
-            }
-        }
-        for (const teamId of Object.keys(existingApplicationOverides)) {
-            const tm = await app.db.models.TeamMember.getTeamMembership(user.hashid, teamId)
-            tm.permissions = {}
-            applicationPromises.push(tm.save())
-        }
-        await Promise.all(applicationPromises)
+        // Now all group membership has been updated, apply application overrides
+        await applyApplicationOverrides(user, desiredTeamApplicationroles, providerOpts)
     }
 
     return {

--- a/test/unit/forge/ee/lib/sso/index_spec.js
+++ b/test/unit/forge/ee/lib/sso/index_spec.js
@@ -515,6 +515,59 @@ NOY6Z1oJnpttQ9gwyV8euQ3C0Wcjf3+OVQ==
                 const teamMembership = await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)
                 should(teamMembership).not.be.ok()
             })
+
+            it('applies highest role when multiple overrides for one application', async function () {
+                await app.sso.updateTeamMembership({
+                    'ff-roles': [
+                        'ff-ateam-member',
+                        'ff-ateam[application-1]-viewer',
+                        'ff-ateam[application-1]-owner'
+                    ]
+                }, app.user, {
+                    groupAssertionName: 'ff-roles',
+                    groupAllTeams: true,
+                    groupPrefixLength: 0,
+                    groupSuffixLength: 0
+                })
+                const teamMembership = await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)
+                teamMembership.permissions.applications.should.have.property(app.application.hashid, Roles.Owner)
+            })
+
+            it('ignores override for an unknown application', async function () {
+                await app.sso.updateTeamMembership({
+                    'ff-roles': [
+                        'ff-ateam-member',
+                        'ff-ateam[does-not-exist]-owner'
+                    ]
+                }, app.user, {
+                    groupAssertionName: 'ff-roles',
+                    groupAllTeams: true,
+                    groupPrefixLength: 0,
+                    groupSuffixLength: 0
+                })
+                // Team membership should still be applied, with no application overrides
+                const teamMembership = await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)
+                teamMembership.should.have.property('role', Roles.Member)
+                should(teamMembership.permissions?.applications || {}).be.empty()
+            })
+
+            it('ignores override for an unknown team without erroring', async function () {
+                // A malformed/unknown team in an override group must not throw and
+                // must not stop regular team memberships being applied
+                await app.sso.updateTeamMembership({
+                    'ff-roles': [
+                        'ff-ateam-member',
+                        'ff-nosuchteam[application-1]-owner'
+                    ]
+                }, app.user, {
+                    groupAssertionName: 'ff-roles',
+                    groupAllTeams: true,
+                    groupPrefixLength: 0,
+                    groupSuffixLength: 0
+                })
+                const teamMembership = await app.db.models.TeamMember.getTeamMembership(app.user.id, teams.ATeam.id)
+                teamMembership.should.have.property('role', Roles.Member)
+            })
         })
     })
     describe('find expired SSO SAML Certs', async function () {


### PR DESCRIPTION
Extracts the common code between the LDAP and SAML paths as the logic is fiddly and we don't want two copies to maintain.