### PR TITLE
Add application-level dashboard-instances API endpoint

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -732,6 +732,27 @@ module.exports = {
                         ]
                     })
                 },
+                byApplicationForDashboard: async (applicationHashId) => {
+                    const applicationId = M.Application.decodeHashid(applicationHashId)
+                    return this.findAll({
+                        include: [
+                            {
+                                model: M.Team,
+                                attributes: ['hashid', 'id', 'name', 'slug', 'links', 'TeamTypeId', 'suspended']
+                            },
+                            {
+                                model: M.Application,
+                                where: { id: applicationId },
+                                attributes: ['hashid', 'id', 'name', 'description', 'links']
+                            },
+                            {
+                                model: M.ProjectSettings,
+                                attributes: ['id', 'key', 'value', 'ProjectId'],
+                                where: { key: 'settings' }
+                            }
+                        ]
+                    })
+                },
                 countByState: async (states, team, applicationId, membership, isAdmin) => {
                     let teamId = team.id
                     if (typeof teamId === 'string') {

--- a/forge/routes/api/application.js
+++ b/forge/routes/api/application.js
@@ -279,6 +279,82 @@ module.exports = async function (app) {
     })
 
     /**
+     * Get application instances that have dashboards installed
+     * @name /api/v1/applications/:id/dashboard-instances
+     * @memberof forge.routes.api.application
+     */
+    app.get('/:applicationId/dashboard-instances', {
+        preHandler: app.needsPermission('team:projects:list-dashboards'),
+        schema: {
+            summary: 'Get a list of application instances that have dashboards',
+            tags: ['Applications'],
+            params: {
+                type: 'object',
+                properties: {
+                    applicationId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        count: { type: 'number' },
+                        projects: { $ref: 'DashboardInstancesSummaryList' }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        const projects = await app.db.models.Project.byApplicationForDashboard(request.application.hashid)
+        if (projects && projects.length > 0) {
+            const filtered = projects.filter(project => {
+                return project.ProjectSettings.filter(settingEntry => {
+                    const isSettingsEntry = settingEntry.key === 'settings'
+                    let hasDashboardInstalled = false
+                    if (
+                        isSettingsEntry &&
+                        Object.prototype.hasOwnProperty.call(settingEntry.value, 'palette') &&
+                        Object.prototype.hasOwnProperty.call(settingEntry.value.palette, 'modules')
+                    ) {
+                        hasDashboardInstalled = !!settingEntry.value.palette.modules.find(module => module.name === '@flowfuse/node-red-dashboard')
+                    }
+                    return isSettingsEntry && hasDashboardInstalled
+                }).length > 0
+            })
+
+            if (filtered.length === 0) {
+                return reply.send({
+                    count: 0,
+                    projects: []
+                })
+            }
+
+            await Promise.all(filtered.map(async project => {
+                const projectState = await project.liveState()
+                project.state = projectState.meta.state
+                project.flowLastUpdatedAt = projectState.flowLastUpdatedAt
+                project.settings = {
+                    dashboard2UI: '/dashboard'
+                }
+            }))
+
+            const result = await app.db.views.Project.dashboardInstancesSummaryList(filtered)
+            return reply.send({
+                count: result.length,
+                projects: result
+            })
+        } else {
+            return reply.send({
+                count: 0,
+                projects: []
+            })
+        }
+    })
+
+    /**
      * Get a list of devices owned by this application
      * @name /api/v1/applications/:id/devices
      * @static

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -3376,6 +3376,56 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/applications/{applicationId}/dashboard-instances": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a list of application instances that have dashboards */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    applicationId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            count?: number;
+                            projects?: components["schemas"]["DashboardInstancesSummaryList"];
+                        };
+                    };
+                };
+                /** @description Default Response */
+                "4XX": {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["APIError"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/applications/{applicationId}/devices": {
         parameters: {
             query?: never;

--- a/test/unit/forge/routes/api/application_spec.js
+++ b/test/unit/forge/routes/api/application_spec.js
@@ -725,4 +725,176 @@ describe('Application API', function () {
             response.statusCode.should.equal(403)
         })
     })
+
+    describe('List dashboard instances', async function () {
+        it('Returns only instances with a dashboard installed', async function () {
+            const sid = await login('bob', 'bbPassword')
+            const application = await app.factory.createApplication({ name: generateName('app') }, TestObjects.BTeam)
+
+            await app.factory.createInstance(
+                { name: generateName('instance') },
+                application,
+                app.stack,
+                app.template,
+                app.projectType,
+                {
+                    start: false,
+                    settings: {
+                        palette: { modules: [{ name: '@flowfuse/node-red-dashboard', version: '~1.15.0', local: true }] }
+                    }
+                }
+            )
+            await app.factory.createInstance(
+                { name: generateName('instance') },
+                application,
+                app.stack,
+                app.template,
+                app.projectType,
+                {
+                    start: false
+                }
+            )
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/applications/${application.hashid}/dashboard-instances`,
+                cookies: { sid }
+            })
+
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('count', 1)
+            result.should.have.property('projects').and.be.an.Array()
+            result.projects.should.have.a.property('length', 1)
+        })
+
+        it('Returns empty list when no instances have dashboards', async function () {
+            const sid = await login('bob', 'bbPassword')
+            const application = await app.factory.createApplication({ name: generateName('app') }, TestObjects.BTeam)
+
+            await app.factory.createInstance(
+                { name: generateName('instance') },
+                application,
+                app.stack,
+                app.template,
+                app.projectType,
+                {
+                    start: false,
+                    settings: {}
+                }
+            )
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/applications/${application.hashid}/dashboard-instances`,
+                cookies: { sid }
+            })
+
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('count', 0)
+            result.should.have.property('projects').and.be.an.Array()
+            result.projects.should.have.a.property('length', 0)
+        })
+
+        it('Returns empty list when application has no instances', async function () {
+            const sid = await login('bob', 'bbPassword')
+            const application = await app.factory.createApplication({ name: generateName('app') }, TestObjects.BTeam)
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/applications/${application.hashid}/dashboard-instances`,
+                cookies: { sid }
+            })
+
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('count', 0)
+            result.should.have.property('projects').and.be.an.Array()
+            result.projects.should.have.a.property('length', 0)
+        })
+
+        it('Non team members cannot access the endpoint', async function () {
+            const sid = await login('dave', 'ddPassword')
+            const application = await app.factory.createApplication({ name: generateName('app') }, TestObjects.BTeam)
+
+            await app.factory.createInstance(
+                { name: generateName('instance') },
+                application,
+                app.stack,
+                app.template,
+                app.projectType,
+                {
+                    start: false,
+                    settings: {
+                        palette: { modules: [{ name: '@flowfuse/node-red-dashboard', version: '~1.15.0', local: true }] }
+                    }
+                }
+            )
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/applications/${application.hashid}/dashboard-instances`,
+                cookies: { sid }
+            })
+
+            response.statusCode.should.equal(404)
+        })
+
+        it('Unauthenticated requests return 401', async function () {
+            const application = await app.factory.createApplication({ name: generateName('app') }, TestObjects.BTeam)
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/applications/${application.hashid}/dashboard-instances`,
+                cookies: { sid: 'invalid-session' }
+            })
+
+            response.statusCode.should.equal(401)
+        })
+
+        it('Does not include instances from other applications', async function () {
+            const sid = await login('bob', 'bbPassword')
+            const application1 = await app.factory.createApplication({ name: generateName('app') }, TestObjects.BTeam)
+            const application2 = await app.factory.createApplication({ name: generateName('app') }, TestObjects.BTeam)
+
+            await app.factory.createInstance(
+                { name: generateName('instance') },
+                application1,
+                app.stack,
+                app.template,
+                app.projectType,
+                {
+                    start: false,
+                    settings: {
+                        palette: { modules: [{ name: '@flowfuse/node-red-dashboard', version: '~1.15.0', local: true }] }
+                    }
+                }
+            )
+            await app.factory.createInstance(
+                { name: generateName('instance') },
+                application2,
+                app.stack,
+                app.template,
+                app.projectType,
+                {
+                    start: false,
+                    settings: {
+                        palette: { modules: [{ name: '@flowfuse/node-red-dashboard', version: '~1.15.0', local: true }] }
+                    }
+                }
+            )
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/applications/${application1.hashid}/dashboard-instances`,
+                cookies: { sid }
+            })
+
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('count', 1)
+            result.projects.should.have.a.property('length', 1)
+        })
+    })
 })


### PR DESCRIPTION
## Description

Adds `GET /api/v1/applications/:appId/dashboard-instances`, the app-scoped equivalent of the existing team-level endpoint. Filters to instances that have `@flowfuse/node-red-dashboard` installed and uses the `team:projects:list-dashboards` permission so it's reachable by the dashboard-only role.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7872

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

