### PR TITLE
fix: use a shared subscription for the Expert platform request bridge source

### DIFF
--- a/forge/ee/lib/expert/emxq-bridge/templates.js
+++ b/forge/ee/lib/expert/emxq-bridge/templates.js
@@ -46,7 +46,7 @@ const sourceChat = {
     enable: true,
     parameters: {
         qos: 1,
-        topic: 'ff/v1/expert/+/+/+/+/support/chat/response'
+        topic: '$share/expert/ff/v1/expert/+/+/+/+/support/chat/response'
     },
     resource_opts: {
         health_check_interval: '15s'
@@ -62,7 +62,7 @@ const sourceInflight = {
     enable: true,
     parameters: {
         qos: 1,
-        topic: 'ff/v1/expert/+/+/+/+/support/inflight/+/request'
+        topic: '$share/expert/ff/v1/expert/+/+/+/+/support/inflight/+/request'
     },
     resource_opts: {
         health_check_interval: '15s'

--- a/forge/ee/lib/expert/emxq-bridge/templates.js
+++ b/forge/ee/lib/expert/emxq-bridge/templates.js
@@ -78,7 +78,7 @@ const sourcePlatform = {
     enable: true,
     parameters: {
         qos: 1,
-        topic: 'ff/v1/expert/+/+/platform/+/request'
+        topic: '$share/expert/ff/v1/expert/+/+/platform/+/request'
     },
     resource_opts: {
         health_check_interval: '15s'


### PR DESCRIPTION
## Problem
The bridge connector from the FF App Instance Broker to the Expert Broker is provisioned on every EMQX node. The platform-request source subscription was a plain MQTT subscription, so with N EMQX nodes each platform action ran N times, visible as duplicate snapshots, and as a 400 on create-instance when a second, racing execution collided with the `Project.safeName` uniqueness check.

## Fix
Subscribe to the platform-request topic as a shared subscription (`$share/expert/...`), matching the group name the app broker client already uses for the same topic (`forge/comms/commsClient.js`). This ensures only one node ingests each request, so the platform executes it exactly once. Per-tenant isolation is unaffected, it's enforced by the Expert Broker's licence-id mountpoint, not by the group name.

## Testing
- Reproduced locally with a 2-node EMQX broker: before the fix, a single snapshot request produced two identical snapshots; after patching the running broker's subscription to the shared form, the same request produced exactly one.
- `test/unit/forge/ee/lib/expert/tasks/emqx-bridge/setup_spec.js` passes unchanged.

Closes FlowFuse/engineering#190
