### PR TITLE
Enabled Expert Insights by default for self-hosted

### DIFF
--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -39,7 +39,7 @@ module.exports = fp(async function (app, opts) {
         await app.register(require('./expert'))
 
         // Set the AI Features Flag (global gate for all AI features)
-        const isAiEnabled = app.config?.ai?.enabled ?? true
+        const isAiEnabled = !!(app.config?.ai?.enabled ?? true)
         app.config.features.register('ai', isAiEnabled, true)
 
         // Set the Generate Snapshot Description Feature Flag
@@ -56,7 +56,10 @@ module.exports = fp(async function (app, opts) {
         app.config.features.register('expertAssistant', isAiEnabled && (app.config?.expert?.enabled ?? false), true)
 
         // Set the Expert Insights flag
-        const isInsightsEnabled = isAiEnabled && app.config?.expert?.enabled && app.config?.expert?.insights?.enabled
+        const isInsightsEnabled = isAiEnabled &&
+            !!app.config?.expert?.enabled &&
+            (Object.prototype.hasOwnProperty.call(app.config?.expert ?? {}, 'insights') ? !!app.config?.expert?.insights?.enabled : true)
+
         app.config.features.register('expertInsights', isInsightsEnabled ?? false, true)
     }
 


### PR DESCRIPTION
## Description

Fixes the partial enablement of the insights feature for self hosted.

## Related Issue(s)

fixes the partial implementation done in https://github.com/FlowFuse/flowfuse/pull/7773

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

