### PR TITLE
Fix device groups bulk ops assignment (F4)

### DIFF
--- a/forge/routes/api/teamDevices.js
+++ b/forge/routes/api/teamDevices.js
@@ -505,13 +505,18 @@ module.exports = async function (app) {
                 let deviceGroup
                 let changeCount
                 let actualRemoveDevices
-                const transaction = await app.db.sequelize.transaction()
                 const infoBuilder = []
                 const decodedDeviceIds = request.body.devices.map(hashid => hashid && app.db.models.Device.decodeHashid(hashid))
                 const devicesCollection = await app.db.models.Device.getAll({}, { id: decodedDeviceIds }, {
                     includeDeviceGroup: true,
                     includeApplication: true
                 })
+
+                // Ensure every device belongs to the team in the URL
+                if (devicesCollection.devices.some(d => d.TeamId !== request.team.id)) {
+                    throw new ControllerError('invalid_input', 'All devices must belong to the same team', 400)
+                }
+
                 const devicesByGroup = devicesCollection.devices.filter(device => device.DeviceGroup)
                     .reduce((acc, device) => {
                         const groupId = device.DeviceGroup?.id || null
@@ -525,6 +530,7 @@ module.exports = async function (app) {
                         return acc
                     }, {})
 
+                const transaction = await app.db.sequelize.transaction()
                 try {
                     if (request.body.deviceGroup === '') {
                         // if the device group is present but empty, we need to bulk unassign devices from their respective device group
@@ -538,6 +544,10 @@ module.exports = async function (app) {
 
                         if (!deviceGroup) {
                             throw new ControllerError('invalid_input', 'Invalid device group', 400)
+                        }
+                        // The target group must belong to the team in the URL
+                        if (deviceGroup.Application?.TeamId !== request.team.id) {
+                            throw new ControllerError('invalid_input', 'Device group must belong to the same team', 400)
                         }
 
                         // we first need to bulk unassign devices from their respective device group except the device group we're assigning to

--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -1058,6 +1058,11 @@ describe('Team Devices API', function () {
                 let group1
                 let group2
                 let auditLogSpy
+                // A device group and an app-owned device that belong to BTeam
+                let bTeamGroup
+                const bTeamDevices = {
+                    device1: null
+                }
 
                 beforeEach(async function () {
                     // Create device groups
@@ -1076,6 +1081,11 @@ describe('Team Devices API', function () {
                     await aTeamDevices.device3.update({ DeviceGroupId: group2.id })
                     // device4 remains unassigned
 
+                    // Create a BTeam group and an app-owned BTeam device assigned to it
+                    bTeamGroup = await factory.createApplicationDeviceGroup({ name: 'b-group 1' }, TestObjects.BTeamApplication)
+                    bTeamDevices.device1 = await factory.createDevice({ name: 'group-test-device-b1' }, TestObjects.BTeam, null, TestObjects.BTeamApplication)
+                    await bTeamDevices.device1.update({ DeviceGroupId: bTeamGroup.id })
+
                     // Spy on audit log
                     auditLogSpy = sinon.spy(app.auditLog.Application.application.deviceGroup, 'membersChanged')
                 })
@@ -1083,10 +1093,10 @@ describe('Team Devices API', function () {
                 afterEach(async function () {
                     await app.db.models.Device.destroy({
                         where: {
-                            name: ['group-test-device-1', 'group-test-device-2', 'group-test-device-3', 'group-test-device-4']
+                            name: ['group-test-device-1', 'group-test-device-2', 'group-test-device-3', 'group-test-device-4', 'group-test-device-b1']
                         }
                     })
-                    await app.db.models.DeviceGroup.destroy({ where: { id: [group1.id, group2.id] } })
+                    await app.db.models.DeviceGroup.destroy({ where: { id: [group1.id, group2.id, bTeamGroup.id] } })
                     auditLogSpy.restore()
                 })
 
@@ -1222,6 +1232,47 @@ describe('Team Devices API', function () {
                             deviceGroup: group1.hashid
                         })
                         response.statusCode.should.equal(400)
+                    })
+                })
+
+                describe('isolation', function () {
+                    // Bob (ATeam owner) should not be able to add a BTeam device to a BTeam group.
+                    it('Rejects reassigning another team\'s device via own team endpoint (400)', async function () {
+                        const response = await bulkUpdateDeviceGroup(TestObjects.ATeam.hashid, TestObjects.tokens.bob, {
+                            devices: [bTeamDevices.device1.hashid],
+                            deviceGroup: bTeamGroup.hashid
+                        })
+                        response.statusCode.should.equal(400)
+                        response.json().should.have.property('error').and.match(/same team/)
+                        // Ensure group membership is unchanged
+                        const device = await app.db.models.Device.findByPk(bTeamDevices.device1.id)
+                        device.should.have.property('DeviceGroupId', bTeamGroup.id)
+                    })
+
+                    // Bob (ATeam owner) should not be able to unassign a BTeam device from its group.
+                    it('Rejects unassigning another team\'s device via own team endpoint (400)', async function () {
+                        const response = await bulkUpdateDeviceGroup(TestObjects.ATeam.hashid, TestObjects.tokens.bob, {
+                            devices: [bTeamDevices.device1.hashid],
+                            deviceGroup: ''
+                        })
+                        response.statusCode.should.equal(400)
+                        response.json().should.have.property('error').and.match(/same team/)
+                        // Ensure the device is still in its group
+                        const device = await app.db.models.Device.findByPk(bTeamDevices.device1.id)
+                        device.should.have.property('DeviceGroupId', bTeamGroup.id)
+                    })
+
+                    // Bob (ATeam owner) should not be able to add his own device to a BTeam group.
+                    it('Rejects assigning an own-team device to another team\'s group (400)', async function () {
+                        const response = await bulkUpdateDeviceGroup(TestObjects.ATeam.hashid, TestObjects.tokens.bob, {
+                            devices: [aTeamDevices.device4.hashid],
+                            deviceGroup: bTeamGroup.hashid
+                        })
+                        response.statusCode.should.equal(400)
+                        response.json().should.have.property('error').and.match(/same team/)
+                        // Ensure the device was not added to the foreign group
+                        const device = await app.db.models.Device.findByPk(aTeamDevices.device4.id)
+                        device.should.have.property('DeviceGroupId', null)
                     })
                 })
 


### PR DESCRIPTION
## Description


Fixes device group assignment issue F4 - see linked issue for details

> [!note]
> To avoid conflicts, this is branched off [F3](https://github.com/FlowFuse/flowfuse/pull/7897) 
> Recommend that is merged before this one - to keep reviews easier 

## Related Issue(s)

see linked issue

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

