### PR TITLE
ci: Fix database setup steps in the pre-staging init script

### DIFF
--- a/.github/scripts/initial-setup.sh
+++ b/.github/scripts/initial-setup.sh
@@ -136,6 +136,7 @@ create_stack() {
 DBPASSWORD=$(kubectl --namespace "pr-$PR_NUMBER" get secret flowfuse-pr-$PR_NUMBER-postgresql -o jsonpath='{.data.password}' | base64 -d)
 kubectl run flowfuse-setup-0 \
   --namespace "pr-$PR_NUMBER" \
+  --label="app=flowforge" \
   -it --rm \
   --restart=Never \
   --env="PGPASSWORD=$DBPASSWORD" \
@@ -147,6 +148,7 @@ kubectl run flowfuse-setup-0 \
 ### Mark platform as configured
 kubectl run flowfuse-setup-1 \
   --namespace "pr-$PR_NUMBER" \
+  --label="app=flowforge" \
   -it --rm \
   --restart=Never \
   --env="PGPASSWORD=$DBPASSWORD" \
@@ -159,6 +161,7 @@ kubectl run flowfuse-setup-1 \
 ### Configure access token
 kubectl run flowfuse-setup-2 \
   --namespace "pr-$PR_NUMBER" \
+  --label="app=flowforge" \
   -it --rm \
   --restart=Never \
   --env="PGPASSWORD=$DBPASSWORD" \


### PR DESCRIPTION
## Description

This pull request ensures that proper labels are applied to the flowfuse-setup-* pods created by the pre-staging initialization script to allow establishing a database connection.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

