### PR TITLE
Await team broker topic recording in ACL route

### DIFF
--- a/forge/comms/v2AuthRoutes.js
+++ b/forge/comms/v2AuthRoutes.js
@@ -155,7 +155,7 @@ module.exports = async function (app) {
                 if (action === 'publish') {
                     const m = /^ff\/v1\/([^/]+)\/c\/(.+)$/.exec(topic)
                     if (m) {
-                        app.teamBroker.addUsedTopic(m[2], m[1])
+                        await app.teamBroker.addUsedTopic(m[2], m[1])
                     }
                 }
                 reply.logProperties = { username, topic, action, result: 'allow' }
@@ -202,7 +202,7 @@ module.exports = async function (app) {
                         } else {
                             if (mqttMatch(acl.pattern, request.body.topic)) {
                                 if (acl.action === 'both' || acl.action === 'publish') {
-                                    app.teamBroker.addUsedTopic(request.body.topic, teamId)
+                                    await app.teamBroker.addUsedTopic(request.body.topic, teamId)
                                     reply.logProperties = { username, topic, action, result: 'allow' }
                                     reply.send({ result: 'allow' })
                                     return


### PR DESCRIPTION
## Summary

`app.teamBroker.addUsedTopic(...)` (defined in `forge/ee/lib/teamBroker/index.js`) performs a database upsert against `MQTTTopicSchema`, but the two call sites in the `/acls` route handler (`forge/comms/v2AuthRoutes.js`) never awaited it before sending the ACL response.

Because the write was never awaited, the handler could reply before the write actually landed, racing against any immediately following read of the team's topic list. This sometimes caused the "Add topics to list" test in `test/unit/forge/ee/routes/teamBroker/index_spec.js` to fail, since that test posts to `/api/comms/v2/acls` and then immediately reads back the topics list, expecting the just-published topic to already be present. The race is more likely to surface under the Postgres CI job than under SQLite, due to Postgres's higher write/commit latency.

## Fix

Added `await` to both `app.teamBroker.addUsedTopic(...)` call sites. Both are already inside `async` route handlers, so no other control-flow changes were needed.

Closes #7905

## Test plan

- [x] `npx mocha test/unit/forge/ee/routes/teamBroker/index_spec.js` passes, including "Add topics to list" (run repeatedly to confirm no flakiness)
- [x] `npx mocha test/unit/forge/comms/authRoutesV2_spec.js` passes
- [x] `npx eslint forge/comms/v2AuthRoutes.js` passes with no errors