### PR TITLE
fix(mcp): stop empty UI-tool errors and tighten tool-usage guardrails

### DIFF
--- a/forge/ee/lib/mcp/tools/applications.js
+++ b/forge/ee/lib/mcp/tools/applications.js
@@ -36,8 +36,8 @@ module.exports = [
         description: `FlowFuse platform automation tool:
             Gets all the hosted instances that live inside an application.
             A hosted instance is a Node-RED that runs on the same environment as the FlowFuse platform.
-            Use this to see which hosted instances an application has. Each result includes the instance name, URL, and basic settings.
-            To get the full details of one specific hosted instance, call platform_get_hosted_instance with its ID.
+            Use this to see which hosted instances an application has. Each result includes the instance id, name, URL, and basic settings.
+            This list does not include an instance's specification (its instance type, stack, or template). To read an instance's specification, for example to create another instance matching it, call platform_get_hosted_instance with the instance id.
             To check if hosted instances are currently running or stopped, call platform_get_application_instances_status instead.`,
         annotations: { readOnlyHint: true, destructiveHint: false },
         inputSchema: {

--- a/forge/ee/lib/mcp/tools/applications.js
+++ b/forge/ee/lib/mcp/tools/applications.js
@@ -148,6 +148,7 @@ module.exports = [
         description: `FlowFuse platform automation tool:
             Creates a new application in a team.
             An application is a container that groups together hosted instances and remote instances that work together.
+            Before creating, call platform_list_applications for this team to check whether an application with this name already exists. If one does, tell the user and ask whether to use the existing one or create a new one with the same name - do not create a duplicate without asking.
             After the application is created, ask the user if they want to be taken to it. If they do, use the ui_navigate tool with the route name "Application" and params { id: <the new application id> }.`,
         annotations: { readOnlyHint: false, destructiveHint: false },
         inputSchema: {

--- a/forge/ee/lib/mcp/tools/applications.js
+++ b/forge/ee/lib/mcp/tools/applications.js
@@ -37,7 +37,7 @@ module.exports = [
             Gets all the hosted instances that live inside an application.
             A hosted instance is a Node-RED that runs on the same environment as the FlowFuse platform.
             Use this to see which hosted instances an application has. Each result includes the instance id, name, URL, and basic settings.
-            This list does not include an instance's specification (its instance type, stack, or template). To read an instance's specification, for example to create another instance matching it, call platform_get_hosted_instance with the instance id.
+            This list does not include an instance's specification (its instance type, stack, or template). To read an instance's specification, for example to duplicate it, call platform_get_hosted_instance with the instance id.
             To check if hosted instances are currently running or stopped, call platform_get_application_instances_status instead.`,
         annotations: { readOnlyHint: true, destructiveHint: false },
         inputSchema: {

--- a/forge/ee/lib/mcp/tools/applications.js
+++ b/forge/ee/lib/mcp/tools/applications.js
@@ -148,7 +148,7 @@ module.exports = [
         description: `FlowFuse platform automation tool:
             Creates a new application in a team.
             An application is a container that groups together hosted instances and remote instances that work together.
-            Before creating, call platform_list_applications for this team to check whether an application with this name already exists. If one does, tell the user and ask whether to use the existing one or create a new one with the same name - do not create a duplicate without asking.
+            Before invoking this tool, call platform_list_applications for this team to check whether an application with this name already exists. If one exists, ask the user whether to use the existing one or create a new one with the same name - DO NOT create a duplicate application without asking first.
             After the application is created, ask the user if they want to be taken to it. If they do, use the ui_navigate tool with the route name "Application" and params { id: <the new application id> }.`,
         annotations: { readOnlyHint: false, destructiveHint: false },
         inputSchema: {

--- a/forge/ee/lib/mcp/tools/devices.js
+++ b/forge/ee/lib/mcp/tools/devices.js
@@ -96,7 +96,7 @@ module.exports = [
             A remote instance is a Node-RED that runs on the user's own hardware rather than on the same environment as the FlowFuse platform.
             This only registers the device on the platform, it does not install anything on the user's hardware.
             The response includes credentials that the user will need to configure on their device to connect it to the platform.
-            If the user wants to assign it to an application, call platform_assign_remote_instance_to_application after creation.
+            If the user names or references an application for this device, call platform_assign_remote_instance_to_application immediately after creation. Otherwise, ask the user whether they want it assigned to an application.
             After the device is created, ask the user if they want to be taken to it. If they do, use the ui_navigate tool with the route name "device-overview" and params { id: <the new device id> }.`,
         annotations: { readOnlyHint: false, destructiveHint: false },
         inputSchema: {

--- a/forge/ee/lib/mcp/tools/devices.js
+++ b/forge/ee/lib/mcp/tools/devices.js
@@ -96,7 +96,7 @@ module.exports = [
             A remote instance is a Node-RED that runs on the user's own hardware rather than on the same environment as the FlowFuse platform.
             This only registers the device on the platform, it does not install anything on the user's hardware.
             The response includes credentials that the user will need to configure on their device to connect it to the platform.
-            If the user names or references an application for this device, call platform_assign_remote_instance_to_application immediately after creation. Otherwise, ask the user whether they want it assigned to an application.
+            If the user named an application for this device, call platform_assign_remote_instance_to_application immediately after creation. If not, ask before assigning. A best practice is to always assign the remote instance to an application.
             After the device is created, ask the user if they want to be taken to it. If they do, use the ui_navigate tool with the route name "device-overview" and params { id: <the new device id> }.`,
         annotations: { readOnlyHint: false, destructiveHint: false },
         inputSchema: {

--- a/forge/ee/lib/mcp/tools/instances.js
+++ b/forge/ee/lib/mcp/tools/instances.js
@@ -94,7 +94,7 @@ module.exports = [
             2. If they want a specific Node-RED version or stack, or just the latest. Call platform_list_stacks for the chosen instance type to get the options. If the user has no preference, use the instance type's defaultStack, which is the latest recommended version.
             3. If they want to start from a blueprint (pre-built starter flows). Call platform_list_blueprints to show them what is available. This is optional.
             4. Call platform_list_templates to get the template. If only one template exists, use it automatically. If there are multiple, ask the user which one to use.
-            5. Call platform_check_hosted_instance_name_availability to make sure the chosen name is not already taken.
+            5. Call platform_check_hosted_instance_name_availability to make sure the chosen name is not already taken. This step is required, not optional - skipping it is the most common cause of a failed creation. If the name is taken, do not silently pick a new one yourself - propose a few alternative options (e.g. with a suffix) and let the user choose, then check that chosen name's availability too.
             When generating a name, always use hyphens to separate multiple words (e.g. "my-new-instance" not "my new instance").
             After the instance is created, wait a few seconds to give it time to boot up, then ask the user if they want to be taken to it. If they do, use the ui_navigate tool with the route name "instance-overview" and params { id: <the new instance id> }.`,
         annotations: { readOnlyHint: false, destructiveHint: false },

--- a/forge/ee/lib/mcp/tools/instances.js
+++ b/forge/ee/lib/mcp/tools/instances.js
@@ -90,7 +90,7 @@ module.exports = [
             Creates a new hosted Node-RED instance inside an application. The instance starts automatically after creation.
             Before calling this tool, gather the required parameters:
             1. Call platform_list_hosted_instance_types first to see what instance types are available on this platform, then ask the user which one they want.
-            2. If they want a specific Node-RED version or stack, or just the latest. Call platform_list_stacks to get the options. If the user has no preference, use the latest available stack.
+            2. If they want a specific Node-RED version or stack, or just the latest. Call platform_list_stacks for the chosen instance type to get the options. If the user has no preference, use the instance type's defaultStack, which is the latest recommended version.
             3. If they want to start from a blueprint (pre-built starter flows). Call platform_list_blueprints to show them what is available. This is optional.
             4. Call platform_list_templates to get the template. If only one template exists, use it automatically. If there are multiple, ask the user which one to use.
             5. Call platform_check_hosted_instance_name_availability to make sure the chosen name is not already taken.

--- a/forge/ee/lib/mcp/tools/instances.js
+++ b/forge/ee/lib/mcp/tools/instances.js
@@ -8,7 +8,8 @@ module.exports = [
             Gets the full details of one specific hosted instance.
             A hosted instance is a Node-RED that runs on the same environment as the FlowFuse platform.
             Use this when you already have a hosted instance ID and need to know everything about it:
-            its name, URL, settings, what application and team it belongs to, and its current state.
+            its name, URL, settings, what application and team it belongs to, its current state, and its specification (the instance type, stack, and template it uses).
+            Read the specification from this tool whenever you need to know or compare what an existing instance is running, for example to answer a question about it or to create another instance matching it.
             If you need to list all hosted instances first, call platform_get_application_hosted_instances.
             To check the live running status, call platform_get_hosted_instance_status instead.`,
         annotations: { readOnlyHint: true, destructiveHint: false },

--- a/forge/ee/lib/mcp/tools/instances.js
+++ b/forge/ee/lib/mcp/tools/instances.js
@@ -90,8 +90,8 @@ module.exports = [
         description: `FlowFuse platform automation tool:
             Creates a new hosted Node-RED instance inside an application. The instance starts automatically after creation.
             Before calling this tool, gather the required parameters:
-            1. Call platform_list_hosted_instance_types first to see what instance types are available on this platform, then ask the user which one they want.
-            2. If they want a specific Node-RED version or stack, or just the latest. Call platform_list_stacks for the chosen instance type to get the options. If the user has no preference, use the instance type's defaultStack, which is the latest recommended version.
+            1. Call platform_list_hosted_instance_types first to see what instance types (and their stacks) this team can create, then ask the user which one they want.
+            2. If they want a specific Node-RED version or stack, or just the latest. Use platform_list_hosted_instance_types with the chosen projectType to see its stacks. If the user has no preference, use the instance type's defaultStack, which is the latest recommended version.
             3. If they want to start from a blueprint (pre-built starter flows). Call platform_list_blueprints to show them what is available. This is optional.
             4. Call platform_list_templates to get the template. If only one template exists, use it automatically. If there are multiple, ask the user which one to use.
             5. Call platform_check_hosted_instance_name_availability to make sure the chosen name is not already taken. This step is required, not optional - skipping it is the most common cause of a failed creation. If the name is taken, do not silently pick a new one yourself - propose a few alternative options (e.g. with a suffix) and let the user choose, then check that chosen name's availability too.
@@ -102,7 +102,7 @@ module.exports = [
             name: z.string().regex(/^[a-zA-Z][a-zA-Z0-9-]*$/).describe('Name for the new hosted instance. When generating a name, always use hyphens to separate multiple words (e.g. "my-new-instance" not "my new instance").'),
             applicationId: z.string().describe('The ID or hashid of the application'),
             projectType: z.string().describe('The ID of the hosted instance type (use platform_list_hosted_instance_types to find valid values)'),
-            stack: z.string().describe('The ID of the stack (use platform_list_stacks to find valid values)'),
+            stack: z.string().describe('The ID of the stack (use platform_list_hosted_instance_types to find valid values)'),
             template: z.string().describe('The ID of the template (use platform_list_templates to find valid values)'),
             flowBlueprintId: z.string().optional().describe('Optional blueprint ID to initialize the hosted instance with starter flows (use platform_list_blueprints to find valid values)')
         },

--- a/forge/ee/lib/mcp/tools/instances.js
+++ b/forge/ee/lib/mcp/tools/instances.js
@@ -9,7 +9,7 @@ module.exports = [
             A hosted instance is a Node-RED that runs on the same environment as the FlowFuse platform.
             Use this when you already have a hosted instance ID and need to know everything about it:
             its name, URL, settings, what application and team it belongs to, its current state, and its specification (the instance type, stack, and template it uses).
-            Read the specification from this tool whenever you need to know or compare what an existing instance is running, for example to answer a question about it or to create another instance matching it.
+            Read the specification from this tool whenever you need to know or compare what an existing instance is running, for example to duplicate it.
             If you need to list all hosted instances first, call platform_get_application_hosted_instances.
             To check the live running status, call platform_get_hosted_instance_status instead.`,
         annotations: { readOnlyHint: true, destructiveHint: false },

--- a/forge/ee/lib/mcp/tools/platform.js
+++ b/forge/ee/lib/mcp/tools/platform.js
@@ -1,8 +1,13 @@
+const { z } = require('zod')
+
 module.exports = [
     {
         name: 'platform_list_hosted_instance_types',
         title: 'List Hosted Instance Types',
-        description: 'FlowFuse platform automation tool: List all available hosted instance types. Use this to find valid projectType values when creating a hosted instance.',
+        description: `FlowFuse platform automation tool:
+            Lists the available hosted instance types.
+            Use this to find valid projectType values when creating a hosted instance.
+            Each type includes a defaultStack, which is the recommended (latest) stack for that type.`,
         annotations: { readOnlyHint: true, destructiveHint: false },
         inputSchema: {},
         handler: async (args, { inject }) => {
@@ -13,11 +18,16 @@ module.exports = [
     {
         name: 'platform_list_stacks',
         title: 'List Stacks',
-        description: 'FlowFuse platform automation tool: List all available stacks (Node-RED versions). Use this to find valid stack values when creating a hosted instance.',
+        description: `FlowFuse platform automation tool:
+            Lists the available stacks (Node-RED versions) for a given hosted instance type.
+            Use this to find valid stack values when creating a hosted instance.
+            When the user has no preference, use the instance type's defaultStack (from platform_list_hosted_instance_types), which is the latest recommended version.`,
         annotations: { readOnlyHint: true, destructiveHint: false },
-        inputSchema: {},
+        inputSchema: {
+            instanceType: z.string().describe('The ID of the hosted instance type to list stacks for (use platform_list_hosted_instance_types to find valid values)')
+        },
         handler: async (args, { inject }) => {
-            const response = await inject({ method: 'GET', url: '/api/v1/stacks' })
+            const response = await inject({ method: 'GET', url: `/api/v1/stacks?projectType=${args.instanceType}` })
             return response
         }
     },

--- a/forge/ee/lib/mcp/tools/platform.js
+++ b/forge/ee/lib/mcp/tools/platform.js
@@ -1,34 +1,80 @@
 const { z } = require('zod')
 
+function getProperty (properties, key) {
+    let value = properties
+    for (const part of key.split('.')) {
+        if (value === undefined || value === null || !Object.hasOwn(value, part)) {
+            return undefined
+        }
+        value = value[part]
+    }
+    return value
+}
+
+function getTeamProperty (team, key, defaultValue) {
+    const teamValue = getProperty(team.properties, key)
+    if (teamValue !== undefined) {
+        return teamValue
+    }
+    const teamTypeValue = getProperty(team.type?.properties, key)
+    return teamTypeValue !== undefined ? teamTypeValue : defaultValue
+}
+
 module.exports = [
     {
         name: 'platform_list_hosted_instance_types',
         title: 'List Hosted Instance Types',
         description: `FlowFuse platform automation tool:
-            Lists the available hosted instance types.
-            Use this to find valid projectType values when creating a hosted instance.
+            Lists the hosted instance types available to a team, each with its stacks (Node-RED versions) nested inside.
+            Use this to find valid projectType and stack values when creating a hosted instance.
+            Each type is flagged available (allowed for the team's plan) and creatable (the team can create a new instance of this type right now, within its limits).
+            By default only creatable types are returned - pass creatableOnly: false to also see types the team cannot currently create.
+            Pass projectType to look up one specific instance type and only see its stacks.
             Each type includes a defaultStack, which is the recommended (latest) stack for that type.`,
         annotations: { readOnlyHint: true, destructiveHint: false },
-        inputSchema: {},
-        handler: async (args, { inject }) => {
-            const response = await inject({ method: 'GET', url: '/api/v1/project-types' })
-            return response
-        }
-    },
-    {
-        name: 'platform_list_stacks',
-        title: 'List Stacks',
-        description: `FlowFuse platform automation tool:
-            Lists the available stacks (Node-RED versions) for a given hosted instance type.
-            Use this to find valid stack values when creating a hosted instance.
-            When the user has no preference, use the instance type's defaultStack (from platform_list_hosted_instance_types), which is the latest recommended version.`,
-        annotations: { readOnlyHint: true, destructiveHint: false },
         inputSchema: {
-            instanceType: z.string().describe('The ID of the hosted instance type to list stacks for (use platform_list_hosted_instance_types to find valid values)')
+            teamId: z.string().describe('The ID or hashid of the team to check instance type availability for'),
+            projectType: z.string().optional().describe('Optional ID of one hosted instance type to look up, to only return that type and its stacks'),
+            creatableOnly: z.boolean().default(true).optional().describe('Whether to only include instance types the team can currently create. Defaults to true.')
         },
         handler: async (args, { inject }) => {
-            const response = await inject({ method: 'GET', url: `/api/v1/stacks?projectType=${args.instanceType}` })
-            return response
+            const teamResponse = await inject({ method: 'GET', url: `/api/v1/teams/${args.teamId}` })
+            if (teamResponse.statusCode >= 400) {
+                return { content: teamResponse.json(), code: teamResponse.statusCode, isError: true }
+            }
+            const team = teamResponse.json()
+
+            const typesResponse = await inject({ method: 'GET', url: '/api/v1/project-types' })
+            if (typesResponse.statusCode >= 400) {
+                return { content: typesResponse.json(), code: typesResponse.statusCode, isError: true }
+            }
+
+            let types = typesResponse.json().types
+            if (args.projectType) {
+                types = types.filter(type => type.id === args.projectType)
+            }
+
+            const creatableOnly = args.creatableOnly !== false
+            const decoratedTypes = []
+            for (const type of types) {
+                const available = getTeamProperty(team, `instances.${type.id}.active`, false)
+                const creatableForTeam = getTeamProperty(team, `instances.${type.id}.creatable`, true)
+                const limit = getTeamProperty(team, `instances.${type.id}.limit`, null)
+                const existingCount = team.instanceCountByType?.[type.id] || 0
+                const withinLimit = limit === null || limit === undefined || limit < 0 || existingCount < limit
+                const creatable = available && creatableForTeam && withinLimit
+
+                if (creatableOnly && !creatable) {
+                    continue
+                }
+
+                const stacksResponse = await inject({ method: 'GET', url: `/api/v1/stacks?projectType=${type.id}` })
+                const stacks = stacksResponse.statusCode < 400 ? stacksResponse.json().stacks : []
+
+                decoratedTypes.push({ ...type, available, creatable, stacks })
+            }
+
+            return { types: decoratedTypes }
         }
     },
     {

--- a/frontend/src/mcp/tools/errors.ts
+++ b/frontend/src/mcp/tools/errors.ts
@@ -1,0 +1,17 @@
+// Some thrown errors carry no message, only extra own properties, so fall back to
+// those instead of losing the reason.
+export function describeError (err: unknown): string {
+    if (err instanceof Error) {
+        if (err.message) {
+            return err.message
+        }
+        const details = { ...err }
+        return Object.keys(details).length
+            ? `${err.name}: ${JSON.stringify(details)}`
+            : err.name
+    }
+    if (typeof err === 'string' && err) {
+        return err
+    }
+    return JSON.stringify(err) ?? 'Unknown error'
+}

--- a/frontend/src/mcp/tools/navigation.ts
+++ b/frontend/src/mcp/tools/navigation.ts
@@ -30,12 +30,23 @@ const tools: McpToolDefinition[] = [
         async handler (args, { router }) {
             const { route: routeName, params } = args as { route: string, params?: Record<string, string> }
 
-            const resolved = router.resolve({ name: routeName, params })
+            let resolved
+            try {
+                resolved = router.resolve({ name: routeName, params })
+            } catch {
+                // router.resolve throws (rather than returning matched: []) for an unknown route name
+                resolved = null
+            }
             if (!resolved || !resolved.matched.length) {
-                return { success: false, error: `Route "${routeName}" not found` }
+                return { success: false, error: `Route "${routeName}" not found - use ui_list_routes to see valid route names` }
             }
 
-            await router.push({ name: routeName, params })
+            try {
+                await router.push({ name: routeName, params })
+            } catch (err) {
+                const message = err instanceof Error && err.message ? err.message : `Navigation to "${routeName}" failed`
+                return { success: false, error: message }
+            }
             return { success: true, route: routeName, path: resolved.fullPath }
         }
     }

--- a/frontend/src/mcp/tools/navigation.ts
+++ b/frontend/src/mcp/tools/navigation.ts
@@ -9,6 +9,7 @@ const tools: McpToolDefinition[] = [
             Use ui_list_routes to discover valid route names and the parameters they need.
             Before navigating, call ui_get_context to remember what page the user is currently on, so you can go back if something goes wrong.
             After calling this tool, call ui_get_context again to verify the navigation actually worked and the user ended up on the right page.
+            success: true only means the route name matched and the browser was pushed to that URL - it does not confirm that an id param refers to a real entity, which is why the ui_get_context check above is required, not optional.
             If the navigation failed, it might be because a newly created entity has not finished setting up yet. Wait a few seconds and try the navigation again.
             If it still does not work after retrying, navigate the user back to the page they were on before and let them know what happened.`,
         annotations: { readOnlyHint: true, destructiveHint: false },
@@ -21,7 +22,7 @@ const tools: McpToolDefinition[] = [
                 },
                 params: {
                     type: 'object',
-                    description: 'Route parameters (e.g. { id: "abc123" } or { team_slug: "my-team" })',
+                    description: 'Route parameters (e.g. { id: "abc123" } or { team_slug: "my-team" }). Each id must be the entity\'s real id (hashid) as returned by a list/get tool - never its display name.',
                     additionalProperties: { type: 'string' }
                 }
             },

--- a/frontend/src/mcp/tools/navigation.ts
+++ b/frontend/src/mcp/tools/navigation.ts
@@ -1,3 +1,5 @@
+import { describeError } from './errors'
+
 import type { McpToolDefinition } from '@/types'
 
 const tools: McpToolDefinition[] = [
@@ -45,8 +47,7 @@ const tools: McpToolDefinition[] = [
             try {
                 await router.push({ name: routeName, params })
             } catch (err) {
-                const message = err instanceof Error && err.message ? err.message : `Navigation to "${routeName}" failed`
-                return { success: false, error: message }
+                return { success: false, error: `Navigation to "${routeName}" failed: ${describeError(err)}` }
             }
             return { success: true, route: routeName, path: resolved.fullPath }
         }

--- a/frontend/src/mcp/tools/navigation.ts
+++ b/frontend/src/mcp/tools/navigation.ts
@@ -9,7 +9,7 @@ const tools: McpToolDefinition[] = [
             Use ui_list_routes to discover valid route names and the parameters they need.
             Before navigating, call ui_get_context to remember what page the user is currently on, so you can go back if something goes wrong.
             After calling this tool, call ui_get_context again to verify the navigation actually worked and the user ended up on the right page.
-            success: true only means the route name matched and the browser was pushed to that URL - it does not confirm that an id param refers to a real entity, which is why the ui_get_context check above is required, not optional.
+            { success: true } only confirms the route name matched and the browser navigated. It does not confirm that an id param points to a real entity, which is why the ui_get_context check above is required.
             If the navigation failed, it might be because a newly created entity has not finished setting up yet. Wait a few seconds and try the navigation again.
             If it still does not work after retrying, navigate the user back to the page they were on before and let them know what happened.`,
         annotations: { readOnlyHint: true, destructiveHint: false },

--- a/frontend/src/mcp/tools/routes.ts
+++ b/frontend/src/mcp/tools/routes.ts
@@ -4,7 +4,7 @@ import type { McpToolDefinition } from '@/types'
 
 function getRouteList (router: Router) {
     return router.getRoutes()
-        .filter(route => route.name && !route.redirect)
+        .filter(route => route.name)
         .map(route => ({
             name: route.name as string,
             path: route.path,

--- a/frontend/src/services/automations.service.ts
+++ b/frontend/src/services/automations.service.ts
@@ -3,6 +3,24 @@ import { BaseService } from './service.contract'
 import allTools from '@/mcp/tools'
 import type { AutomationsServiceI, CreateServiceOptions, McpToolDefinition, McpToolWireDefinition } from '@/types'
 
+// Some thrown errors (e.g. vue-router's production-build NavigationFailure) carry
+// no message, only extra own properties, so fall back to those instead of losing the reason.
+function describeError (err: unknown): string {
+    if (err instanceof Error) {
+        if (err.message) {
+            return err.message
+        }
+        const details = { ...err }
+        return Object.keys(details).length
+            ? `${err.name}: ${JSON.stringify(details)}`
+            : err.name
+    }
+    if (typeof err === 'string' && err) {
+        return err
+    }
+    return JSON.stringify(err) ?? 'Unknown error'
+}
+
 class AutomationsService extends BaseService implements AutomationsServiceI {
     private $tools: Map<string, McpToolDefinition>
 
@@ -46,8 +64,7 @@ class AutomationsService extends BaseService implements AutomationsServiceI {
         try {
             return await tool.handler(args, { router: this.$router! })
         } catch (err) {
-            const message = err instanceof Error ? err.message : String(err)
-            return { error: `Tool "${toolName}" failed: ${message}` }
+            return { error: `Tool "${toolName}" failed: ${describeError(err)}` }
         }
     }
 }

--- a/frontend/src/services/automations.service.ts
+++ b/frontend/src/services/automations.service.ts
@@ -1,25 +1,8 @@
 import { BaseService } from './service.contract'
 
 import allTools from '@/mcp/tools'
+import { describeError } from '@/mcp/tools/errors'
 import type { AutomationsServiceI, CreateServiceOptions, McpToolDefinition, McpToolWireDefinition } from '@/types'
-
-// Some thrown errors (e.g. vue-router's production-build NavigationFailure) carry
-// no message, only extra own properties, so fall back to those instead of losing the reason.
-function describeError (err: unknown): string {
-    if (err instanceof Error) {
-        if (err.message) {
-            return err.message
-        }
-        const details = { ...err }
-        return Object.keys(details).length
-            ? `${err.name}: ${JSON.stringify(details)}`
-            : err.name
-    }
-    if (typeof err === 'string' && err) {
-        return err
-    }
-    return JSON.stringify(err) ?? 'Unknown error'
-}
 
 class AutomationsService extends BaseService implements AutomationsServiceI {
     private $tools: Map<string, McpToolDefinition>

--- a/test/unit/frontend/mcp/tools/navigation.spec.js
+++ b/test/unit/frontend/mcp/tools/navigation.spec.js
@@ -1,0 +1,61 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import navigationTools from '../../../../../frontend/src/mcp/tools/navigation.ts'
+
+const navigateTool = navigationTools.find((tool) => tool.name === 'ui_navigate')
+
+function createRouterError () {
+    // vue-router throws an Error with no message for an unknown route name (only
+    // extra own properties like `type`/`location`), which is what this reproduces.
+    return Object.assign(new Error(), { type: 1, location: { name: 'application-overview' } })
+}
+
+describe('ui_navigate tool', () => {
+    test('returns a structured error when the route name does not resolve', async () => {
+        const router = {
+            resolve: vi.fn().mockImplementation(() => { throw createRouterError() }),
+            push: vi.fn()
+        }
+
+        const result = await navigateTool.handler({ route: 'application-overview', params: { id: 'abc' } }, { router })
+
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('application-overview')
+        expect(result.error).toContain('ui_list_routes')
+        expect(router.push).not.toHaveBeenCalled()
+    })
+
+    test('returns a structured error when resolve matches nothing', async () => {
+        const router = {
+            resolve: vi.fn().mockReturnValue({ matched: [], fullPath: '/x' }),
+            push: vi.fn()
+        }
+
+        const result = await navigateTool.handler({ route: 'some-path-only-route' }, { router })
+
+        expect(result).toEqual({ success: false, error: 'Route "some-path-only-route" not found - use ui_list_routes to see valid route names' })
+    })
+
+    test('navigates and reports success for a valid route', async () => {
+        const router = {
+            resolve: vi.fn().mockReturnValue({ matched: [{ name: 'application-activity' }], fullPath: '/team/t/applications/a/activity' }),
+            push: vi.fn().mockResolvedValue(undefined)
+        }
+
+        const result = await navigateTool.handler({ route: 'application-activity', params: { id: 'a' } }, { router })
+
+        expect(result).toEqual({ success: true, route: 'application-activity', path: '/team/t/applications/a/activity' })
+        expect(router.push).toHaveBeenCalledWith({ name: 'application-activity', params: { id: 'a' } })
+    })
+
+    test('returns a structured error when push rejects', async () => {
+        const router = {
+            resolve: vi.fn().mockReturnValue({ matched: [{ name: 'application-activity' }], fullPath: '/x' }),
+            push: vi.fn().mockRejectedValue(new Error('navigation aborted'))
+        }
+
+        const result = await navigateTool.handler({ route: 'application-activity' }, { router })
+
+        expect(result).toEqual({ success: false, error: 'navigation aborted' })
+    })
+})

--- a/test/unit/frontend/mcp/tools/navigation.spec.js
+++ b/test/unit/frontend/mcp/tools/navigation.spec.js
@@ -56,6 +56,6 @@ describe('ui_navigate tool', () => {
 
         const result = await navigateTool.handler({ route: 'application-activity' }, { router })
 
-        expect(result).toEqual({ success: false, error: 'navigation aborted' })
+        expect(result).toEqual({ success: false, error: 'Navigation to "application-activity" failed: navigation aborted' })
     })
 })

--- a/test/unit/frontend/mcp/tools/routes.spec.js
+++ b/test/unit/frontend/mcp/tools/routes.spec.js
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest'
+
+import routesTools from '../../../../../frontend/src/mcp/tools/routes.ts'
+
+const listRoutesTool = routesTools.find((tool) => tool.name === 'ui_list_routes')
+
+describe('ui_list_routes tool', () => {
+    test('includes named redirect-only routes, such as an application landing route', () => {
+        const router = {
+            getRoutes: () => [
+                {
+                    name: 'Application',
+                    path: '/team/:team_slug/applications/:id',
+                    redirect: () => ({ name: 'ApplicationInstances' }),
+                    meta: {}
+                },
+                {
+                    name: 'application-activity',
+                    path: '/team/:team_slug/applications/:id/activity',
+                    meta: {}
+                }
+            ]
+        }
+
+        const { routes } = listRoutesTool.handler({}, { router })
+
+        expect(routes.map((route) => route.name)).toContain('Application')
+    })
+
+    test('excludes unnamed routes', () => {
+        const router = {
+            getRoutes: () => [
+                { name: undefined, path: '/some/internal/alias', meta: {} },
+                { name: 'application-activity', path: '/activity', meta: {} }
+            ]
+        }
+
+        const { routes } = listRoutesTool.handler({}, { router })
+
+        expect(routes.map((route) => route.name)).toEqual(['application-activity'])
+    })
+})

--- a/test/unit/frontend/services/automations.service.spec.js
+++ b/test/unit/frontend/services/automations.service.spec.js
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const mockTool = {
+    name: 'mock_tool',
+    title: 'Mock Tool',
+    description: 'A mock tool',
+    inputSchema: { type: 'object', properties: {} },
+    handler: vi.fn()
+}
+
+vi.mock('../../../../frontend/src/mcp/tools/index.js', () => {
+    return { default: [mockTool] }
+})
+
+async function loadAutomationsService () {
+    vi.resetModules()
+    return await import('../../../../frontend/src/services/automations.service.ts')
+}
+
+describe('automations.service', () => {
+    afterEach(() => {
+        mockTool.handler.mockReset()
+    })
+
+    test('dispatch returns an error for an unknown tool name', async () => {
+        const { createAutomationsService } = await loadAutomationsService()
+        const service = createAutomationsService({ app: {}, router: {}, services: {} })
+
+        const result = await service.dispatch('does_not_exist', {})
+
+        expect(result).toEqual({ error: 'Unknown UI tool: does_not_exist' })
+    })
+
+    test('dispatch surfaces a thrown Error message', async () => {
+        mockTool.handler.mockRejectedValue(new Error('boom'))
+        const { createAutomationsService } = await loadAutomationsService()
+        const service = createAutomationsService({ app: {}, router: {}, services: {} })
+
+        const result = await service.dispatch('mock_tool', {})
+
+        expect(result).toEqual({ error: 'Tool "mock_tool" failed: boom' })
+    })
+
+    test('dispatch never returns an empty reason when the thrown Error has no message', async () => {
+        const err = Object.assign(new Error(), { type: 1, location: { name: 'application-overview' } })
+        mockTool.handler.mockRejectedValue(err)
+        const { createAutomationsService } = await loadAutomationsService()
+        const service = createAutomationsService({ app: {}, router: {}, services: {} })
+
+        const result = await service.dispatch('mock_tool', {})
+
+        expect(result.error).not.toBe('Tool "mock_tool" failed: ')
+        expect(result.error).toContain('application-overview')
+    })
+
+    test('dispatch handles a thrown non-Error value', async () => {
+        mockTool.handler.mockRejectedValue('a plain string failure')
+        const { createAutomationsService } = await loadAutomationsService()
+        const service = createAutomationsService({ app: {}, router: {}, services: {} })
+
+        const result = await service.dispatch('mock_tool', {})
+
+        expect(result).toEqual({ error: 'Tool "mock_tool" failed: a plain string failure' })
+    })
+})


### PR DESCRIPTION
Stacked on #7908.

## Summary

- `ui_navigate` (and any other UI automation tool) could return `Tool "X" failed: ` with nothing after the colon, because vue-router throws an `Error` with no `message` in production for an unknown route name, and the dispatcher's catch collapsed straight to `err.message`. The dispatcher now falls back to the error's own properties so the reason is never lost. `ui_navigate` also now catches `resolve`/`push` directly and returns a clean, structured failure. `ui_list_routes` no longer hides named redirect-only routes (like an application's landing route) from discovery.
- Tightened a few tool descriptions so an id param can't be mistaken for a display name, and so `platform_create_application` / `platform_create_remote_instance` / `platform_create_hosted_instance` are explicit about checking for name collisions before creating and asking the user instead of guessing.

## Closes

- Closes FlowFuse/engineering#188
- Closes FlowFuse/engineering#185
- Closes FlowFuse/engineering#182
- Closes FlowFuse/engineering#183

## Test plan

- [x] `npx vitest run --config ./config/vitest.config.ts test/unit/frontend/mcp/tools/navigation.spec.js test/unit/frontend/mcp/tools/routes.spec.js test/unit/frontend/services/automations.service.spec.js` - all passing
- [x] `npx eslint` on all touched files - clean