### PR TITLE
[191] Mobile signup page parity

### DIFF
--- a/frontend/src/layouts/Box.vue
+++ b/frontend/src/layouts/Box.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="ff-layout--box">
         <div class="ff-layout--box--wrapper" :class="{'md:grid-cols-2 max-w-6xl': !!$slots['splash-content'], 'max-w-2xl': !$slots['splash-content']}">
-            <div v-if="!!$slots['splash-content']" class="ff-layout--box--left hidden md:flex">
+            <div v-if="!!$slots['splash-content']" class="ff-layout--box--left flex">
                 <div class="ff-layout--box--content">
                     <div class="ff-logo">
                         <img class="ff-logo--light" src="/ff-logo--wordmark--light.png">

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -44,7 +44,10 @@ $nav_height: 60px;
 
     &.ff--center-box {
         flex-direction: column;
-        min-height: fit-content;
+        justify-content: safe center;
+        min-height: 0;
+        max-height: 100vh;
+        max-height: 100dvh;
         overflow: auto;
 
         .ff-layout--box--wrapper {
@@ -102,6 +105,26 @@ $nav_height: 60px;
 
 .ff-layout--box--content {
     width: 100%;
+}
+
+@media screen and (max-width: ($ff-screen-md - 1px)) {
+    .ff-signup {
+        .ff-layout--box--wrapper {
+            flex-direction: column;
+            gap: 0;
+        }
+        .ff-layout--box--left,
+        .ff-layout--box--right {
+            height: auto;
+        }
+        .ff-layout--box--left .ff-layout--box--content {
+            padding: 32px 24px 0;
+        }
+        .ff-layout--box--right .ff-layout--box--content {
+            min-height: 0;
+            padding-top: 16px;
+        }
+    }
 }
 
 .ff-layout--box--right .ff-layout--box--content {


### PR DESCRIPTION
## Description

Renders the full desktop signup content (logo + value-prop copy) on mobile by stacking it above the form instead of hiding it, addressing the near-zero mobile conversion on `/account/create`. Also fixes the shared `auth-box` layout so tall content scrolls within the viewport instead of being clipped. Was s pre-existing issue affecting the signup and other centered auth pages.

<img width="387" height="772" alt="Screenshot 2026-07-23 at 11 57 33 AM" src="https://github.com/user-attachments/assets/48dacee6-2a25-4314-8b48-312a86b5d900" />


## Related Issue(s)

Resolves https://github.com/FlowFuse/engineering/issues/191

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

