### PR TITLE
Remove deprecated Starter and Team tiers from docs

### DIFF
--- a/docs/cloud/billing.md
+++ b/docs/cloud/billing.md
@@ -30,20 +30,20 @@ instances and Devices owned by the team.
 
 ## Billing Cycle
 
-Starter plan teams are billed monthly on the anniversary of the team creation. You will receive one bill for each team.
+Teams are billed monthly on the anniversary of the team creation. You will receive one bill for each team.
 
-For Team plan teams, Node-RED Instances and Devices are added as pro-rated charges on the current billing cycle and invoiced
+Node-RED Instances and Devices are added as pro-rated charges on the current billing cycle and invoiced
 at the end of the cycle.
 
 ## Removing Instances
 
-For Team plan teams, when a Node-RED instance is deleted your account will receive pro-rated credit for the time remaining in the billing cycle.
+When a Node-RED instance is deleted your account will receive pro-rated credit for the time remaining in the billing cycle.
 
 ## Suspended Instances
 
 Suspended Node-RED instances have no running editor, nor a runtime. You are not charged for suspended instances.
 
-For Team plan teams, when an instance is suspended your account will receive pro-rated credit for the time remaining in the billing cycle. When an
+When an instance is suspended your account will receive pro-rated credit for the time remaining in the billing cycle. When an
 instance is restarted it will be charged for the remaining time in the billing cycle.
 
 ## Managing Billing Details

--- a/docs/cloud/introduction.md
+++ b/docs/cloud/introduction.md
@@ -57,23 +57,7 @@ and click the button to resend it.
 
 ## Team Types
 
-FlowFuse Cloud has three different Team Type aimed at different sorts of users
-
-### Starter
-
-Good for getting to know the platform, allows 2 small Instances, 2 Devices and 2 Team members
-
-### Team
-
-Has access to more features e.g.
-
-- Shared Team Library
-- Project Nodes
-- Team-based Dashboard/API security
-- Email alerts for Instance crashes
-- Has access to larger Instance Types
-
-Also includes 5 Instances in the base price
+FlowFuse Cloud offers a Trial and an Enterprise Team Type, aimed at different sorts of users
 
 ### Enterprise
 
@@ -125,7 +109,7 @@ table shows what is currently allocated by instance size.
 | Medium | 768MB |
 | Large | 3840MB |
 
-Medium and Large instance types require the Teams or Enterprise tier.
+Medium and Large instance types require the Enterprise tier.
 
 ## Use of the File System
 
@@ -137,8 +121,6 @@ the Team type.
 
 | Team Type | File Storage Quota (per instance) |
 |--------|--------|
-| Starter | 1GB |
-| Team | 10GB |
 | Enterprise | 100GB |
 
 Files can be manually uploaded to an instance using the [Static Asset Service](https://flowfuse.com/blog/2024/08/flowfuse-2-8-release/#static-assets-service).
@@ -155,8 +137,6 @@ The amount of data that can be stored in context is determined by the Team type.
 
 | Team Type | Context Store Quota (per instance) |
 |--------|--------|
-| Starter | 10MB |
-| Team | 100MB |
 | Enterprise | 1GB |
 
 
@@ -181,16 +161,16 @@ Node-RED inside the FlowFuse Cloud platform.
 
 MQTT Connections to an external broker using the standard MQTT nodes will work fine as the connection is initiated by Node-RED.
 
-FlowFuse provides an MQTT broker for general use by Enterprise Team's Node-RED instances. See the following section.
+FlowFuse provides an MQTT broker for Enterprise Node-RED instances. See the following section.
 
 Also the Project Nodes can be used to easily pass messages between Node-RED instances running in the
 platform.
 
 #### Enterprise Team Broker
 
-Both Team and Enterprise level teams come with their own MQTT broker. You can provision clients from the broker tab in the left hand menu.
+Enterprise teams come with their own MQTT broker. You can provision clients from the broker tab in the left hand menu.
 
-Enterprise level Teams can register up to 20 and Teams level Teams can register up to 5 clients as part of their plan. The ability to purchase additional packs of clients will come in a near future release.
+Enterprise level Teams can register up to 20 clients as part of their plan. The ability to purchase additional packs of clients will come in a near future release.
 
 The broker is available on `broker.flowfuse.cloud` and supports the following connection types:
 

--- a/docs/cloud/introduction.md
+++ b/docs/cloud/introduction.md
@@ -61,7 +61,7 @@ FlowFuse Cloud offers a Trial and an Enterprise Team Type, aimed at different so
 
 ### Enterprise
 
-All features from the Team Level plus
+Enterprise includes:
 
  - HA for Instances
  - SSO

--- a/docs/contribute/feature-flags.md
+++ b/docs/contribute/feature-flags.md
@@ -13,8 +13,7 @@ When adding features to the platform it is sometimes a requirement to be able to
 restrict the feature to licensed platforms, and furthermore to certain types of team
 on the platform.
 
-Most typically this will be a feature that should only be available to the `Team`
-or `Enterprise` tiers on FlowFuse Cloud.
+Most typically this will be a feature that should only be available to the `Enterprise` tier on FlowFuse Cloud.
 
 This is a quick guide for how to add a feature flag - both at the platform-wide
 level and against individual `TeamTypes`.

--- a/docs/user/custom-npm-packages.md
+++ b/docs/user/custom-npm-packages.md
@@ -20,7 +20,7 @@ catalogue file. FlowFuse has two solutions for this:
 
 If you want to create a Node-RED node for private use by Instances in your 
 FlowFuse Team then you can publish them to the FlowFuse Custom Node Registry 
-(available to Teams and Enterprise level teams on FlowFuse Cloud).
+(available to Enterprise level teams on FlowFuse Cloud).
 
 ### Publishing Nodes
 
@@ -90,7 +90,7 @@ _Screenshot of the contents of a FlowFUse catalogue appearing in the "install" t
 
 ## 3rd Party NPM Registries or Private npmjs.org packages
 
-The following features are available to Team and Enterprise users of FlowFuse
+The following features are available to Enterprise users of FlowFuse
 Cloud.
 
 ### NPM Registries

--- a/docs/user/devops-pipelines.md
+++ b/docs/user/devops-pipelines.md
@@ -104,7 +104,7 @@ When a Device Group stage is triggered, it will push the current active snapshot
 
 Git Repository stages can be used to push and pull snapshots to and from a remote Git repository. FlowFuse supports GitHub, Azure DevOps, and any other Git server that is accessible over HTTPS, for example GitLab, Bitbucket, Gitea, or a self-hosted instance.
 
-> This feature is available to Team and Enterprise tier teams on FlowFuse Cloud, and to Enterprise licensed self-hosted installations from version 2.32 onwards. Support for generic HTTPS Git servers (anything other than GitHub and Azure DevOps) requires version 2.32 or later.
+> This feature is available to Enterprise tier teams on FlowFuse Cloud, and to Enterprise licensed self-hosted installations from version 2.32 onwards. Support for generic HTTPS Git servers (anything other than GitHub and Azure DevOps) requires version 2.32 or later.
 
 ##### Adding a Git token
 

--- a/docs/user/expert/chat.md
+++ b/docs/user/expert/chat.md
@@ -70,7 +70,7 @@ Some prompts that work well:
 
 The more specific your prompt, the closer the result will be to what you need. Include node names, topic paths, endpoints, or field names where you have them. Expert will use them directly rather than substituting placeholders.
 
-> Availability: This feature is in open beta on FlowFuse Cloud (Starter, Team, and Enterprise tiers), no request needed. It is also available on Self-Hosted Enterprise: [contact us](https://flowfuse.com/contact-us/?subject=FlowFuse%20Expert%20Application%20Building) to get it set up as Self-hosted requires a provisioning token and the bridge to be configured on the instance. Agentic flow building works on both Hosted and Remote Instances, and requires the nr-assistant plugin at v0.16.0 or newer. FlowFuse Expert will let you know when an update is available in your instance's immersive editor.
+> Availability: This feature is in open beta on FlowFuse Cloud, no request needed. It is also available on Self-Hosted Enterprise: [contact us](https://flowfuse.com/contact-us/?subject=FlowFuse%20Expert%20Application%20Building) to get it set up as Self-hosted requires a provisioning token and the bridge to be configured on the instance. Agentic flow building works on both Hosted and Remote Instances, and requires the nr-assistant plugin at v0.16.0 or newer. FlowFuse Expert will let you know when an update is available in your instance's immersive editor.
 
 #### Context: What the Expert Can See
 

--- a/docs/user/introduction.md
+++ b/docs/user/introduction.md
@@ -27,7 +27,7 @@ Alternatively, you can click on that instance and then you will find the "Open E
 
 ### Creating Additional Instances
 
-For utilizing various other FlowFuse features (e.g., DevOps Pipelines), it's highly beneficial to create a second Node-RED instance. A second Node-RED instance is included in both our Starter Tier and the Trial Phase of FlowFuse Cloud.
+For utilizing various other FlowFuse features (e.g., DevOps Pipelines), it's highly beneficial to create a second Node-RED instance. A second Node-RED instance is included in the Trial Phase of FlowFuse Cloud.
 
 **From the Home Page:**
 

--- a/docs/user/persistent-context.md
+++ b/docs/user/persistent-context.md
@@ -1,6 +1,6 @@
 # FlowFuse Persistent Context
 
-Some Node-RED flows require the ability to persist context values between restarts and FlowFuse stack updates. By default, context data in Node-RED is ephemeral, meaning it does not survive restarts or stack updates. With FlowFuse Starter, Team and Enterprise tiers, however, you can enable **persistent context storage**, ensuring that your context values persist across restarts, upgrades, and more.
+Some Node-RED flows require the ability to persist context values between restarts and FlowFuse stack updates. By default, context data in Node-RED is ephemeral, meaning it does not survive restarts or stack updates. With FlowFuse's paid plans, however, you can enable **persistent context storage**, ensuring that your context values persist across restarts, upgrades, and more.
 
 ## Usage
 

--- a/docs/user/projectnodes.md
+++ b/docs/user/projectnodes.md
@@ -16,7 +16,7 @@ For example, a single Node-RED instance may contain a set of utility flows that
 you want to reuse in other instances. Rather than copy the flows around, the
 Project Nodes allow you to easily call those flows and get the result back.
 
-The project nodes are only available in the Team and Enterprise tiers of FlowFuse.
+The project nodes are only available in the Enterprise tier of FlowFuse.
 
 ### Nodes
 

--- a/docs/user/snapshots.md
+++ b/docs/user/snapshots.md
@@ -235,7 +235,7 @@ A limit of 10 auto snapshots will be kept, with the oldest being deleted when a 
 Devices can optionally disable auto snapshots, in the developer mode tab. This can be helpful to
 avoid excessive data usage when a device is in the field or on a cellular connection.
 
-NOTE: This feature is only available to Team and Enterprise tier teams
+NOTE: This feature is only available to Enterprise tier teams
 
 ### Previewing Snapshots
 

--- a/docs/user/static-asset-service.md
+++ b/docs/user/static-asset-service.md
@@ -16,7 +16,7 @@ The Static Asset Service allows you to store files permanently within your FlowF
 ### FlowFuse Cloud
 
 - A Instance Stack with a launcher version of 2.8.0 or greater.
-- Pro or Enterprise Team Type.
+- Enterprise Team Type.
 
 ### Self-Hosted
 


### PR DESCRIPTION
## Summary

Removes the deprecated Starter and Team tiers from the platform docs (the source of flowfuse.com/docs), as part of the Product Repackaging effort (Phase 2). Enterprise is kept. No new packaging (Edge/Hub/Fleet) is introduced here.

- `docs/cloud/introduction.md`: removed the Starter and Team Team-Type blocks; reworded the Team Types lead-in to Trial and Enterprise; trimmed the File Storage and Context Store quota tables to the Enterprise row; neutralized the MQTT broker lines; removed an orphaned Team-tier client-count clause and the Enterprise "Team Level plus" reference.
- `docs/cloud/billing.md`: dropped the deprecated plan names from the billing-cycle, removal and suspension sections (billing mechanics unchanged).
- `docs/user/introduction.md`, `docs/user/persistent-context.md`, `docs/user/expert/chat.md`: neutralized tier name-drops.

Please do not merge yet: this should land with the Product Repackaging launch.

- `docs/user/projectnodes.md`, `snapshots.md`, `devops-pipelines.md`, `custom-npm-packages.md`, `static-asset-service.md`, `contribute/feature-flags.md`: feature-availability gates that named the deprecated tier ("Team and Enterprise", "Pro or Enterprise") now name Enterprise only, the tier that is kept. This narrows the stated availability in the interim; it will be reconciled with the new packaging at launch.

Interim framing of what remains is Open Source, Trial, and Enterprise. A Trial Team Type description and Trial/Open-Source quota figures are pending the new packaging; Enterprise values are kept and nothing was fabricated.
