### PR TITLE
Fix expert chat input focus on drawer open and after MQTT response

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -158,9 +158,12 @@ module.exports = function (env, argv) {
             new DotenvPlugin(),
             new DefinePlugin({
                 __VUE_OPTIONS_API__: true,
-                __VUE_PROD_DEVTOOLS__: devMode
+                __VUE_PROD_DEVTOOLS__: devMode,
+                __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: devMode,
+                'process.env.hotReloading': devMode && process.env.NODE_RUN_HOT === 'hot'
             })
         ],
+        cache: { type: 'filesystem' },
         optimization: {
             moduleIds: 'deterministic',
             runtimeChunk: 'single',
@@ -182,8 +185,42 @@ module.exports = function (env, argv) {
             }
         },
         devServer: {
-            port: 3000,
-            historyApiFallback: true
+            client: {
+                overlay: { errors: true, warnings: false },
+                logging: 'error'
+            },
+            port: 8080,
+            historyApiFallback: true,
+            static: {
+                directory: getPath('frontend/dist')
+            },
+            compress: true,
+            hot: true,
+            liveReload: false,
+            devMiddleware: {
+                writeToDisk: true
+            },
+            proxy: [
+                {
+                    context: ['/api/v1', '/account/', '/storage', '/ee/billing'],
+                    target: 'http://localhost:3000',
+                    // target: 'https://forge.flowfuse.local',
+                    changeOrigin: true
+                },
+                {
+                    context: ['/api'],
+                    target: 'https://registry.npmjs.com',
+                    changeOrigin: true,
+                    pathRewrite: { '^/api': '' }
+                },
+                {
+                    context: ['/api/**/projects/**/resources/stream', '/api/**/devices/**/editor/proxy/comms'],
+                    target: 'ws://localhost:3000',
+                    // target: 'https://forge.flowfuse.local',
+                    ws: true,
+                    changeOrigin: true
+                }
+            ]
         },
         watchOptions: {
             poll: 1000,

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -158,12 +158,9 @@ module.exports = function (env, argv) {
             new DotenvPlugin(),
             new DefinePlugin({
                 __VUE_OPTIONS_API__: true,
-                __VUE_PROD_DEVTOOLS__: devMode,
-                __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: devMode,
-                'process.env.hotReloading': devMode && process.env.NODE_RUN_HOT === 'hot'
+                __VUE_PROD_DEVTOOLS__: devMode
             })
         ],
-        cache: { type: 'filesystem' },
         optimization: {
             moduleIds: 'deterministic',
             runtimeChunk: 'single',
@@ -185,42 +182,8 @@ module.exports = function (env, argv) {
             }
         },
         devServer: {
-            client: {
-                overlay: { errors: true, warnings: false },
-                logging: 'error'
-            },
-            port: 8080,
-            historyApiFallback: true,
-            static: {
-                directory: getPath('frontend/dist')
-            },
-            compress: true,
-            hot: true,
-            liveReload: false,
-            devMiddleware: {
-                writeToDisk: true
-            },
-            proxy: [
-                {
-                    context: ['/api/v1', '/account/', '/storage', '/ee/billing'],
-                    target: 'http://localhost:3000',
-                    // target: 'https://forge.flowfuse.local',
-                    changeOrigin: true
-                },
-                {
-                    context: ['/api'],
-                    target: 'https://registry.npmjs.com',
-                    changeOrigin: true,
-                    pathRewrite: { '^/api': '' }
-                },
-                {
-                    context: ['/api/**/projects/**/resources/stream', '/api/**/devices/**/editor/proxy/comms'],
-                    target: 'ws://localhost:3000',
-                    // target: 'https://forge.flowfuse.local',
-                    ws: true,
-                    changeOrigin: true
-                }
-            ]
+            port: 3000,
+            historyApiFallback: true
         },
         watchOptions: {
             poll: 1000,

--- a/frontend/src/components/drawers/expert/ExpertDrawer.vue
+++ b/frontend/src/components/drawers/expert/ExpertDrawer.vue
@@ -35,7 +35,7 @@
                 </button>
             </div>
         </div>
-        <ExpertPanel />
+        <ExpertPanel ref="panel" />
     </div>
 </template>
 
@@ -90,9 +90,9 @@ export default {
         }
     },
     mounted () {
-        // Wait for drawer slide-in animation to complete (300ms) before focusing
+        // Wait for drawer slide-in animation to complete (300ms) before focusing the chat input
         setTimeout(() => {
-            this.$refs.drawer?.focus()
+            this.$refs.panel?.focusInput()
         }, 350)
     },
     methods: {

--- a/frontend/src/components/expert/Expert.vue
+++ b/frontend/src/components/expert/Expert.vue
@@ -18,7 +18,7 @@
         <!-- Updates Available Banner -->
         <update-banner v-if="isEditorContext && isInstanceRunning" />
 
-        <expert-chat-input @stop="handleStopGeneration" />
+        <expert-chat-input ref="chatInput" @stop="handleStopGeneration" />
     </div>
 </template>
 
@@ -153,6 +153,9 @@ export default {
         ]),
         ...mapActions(useProductExpertInsightsAgentStore, ['getCapabilities']),
         ...mapActions(useProductAssistantStore, ['reset']),
+        focusInput () {
+            this.$refs.chatInput?.focusInput()
+        },
         handleStopGeneration () {
             if (this.abortController) {
                 this.abortController.abort()

--- a/frontend/src/components/expert/components/ExpertChatInput.vue
+++ b/frontend/src/components/expert/components/ExpertChatInput.vue
@@ -242,6 +242,11 @@ export default {
         }
     },
     watch: {
+        isWaitingForResponse (waiting, wasWaiting) {
+            if (wasWaiting && !waiting) {
+                this.$nextTick(() => this.$refs.textarea?.focus())
+            }
+        },
         pendingInput (text) {
             if (text) {
                 this.inputText = text
@@ -282,6 +287,9 @@ export default {
     methods: {
         ...mapActions(useProductAssistantStore, ['resetContextSelection']),
         ...mapActions(useProductExpertStore, ['startOver', 'handleQuery', 'setPendingInput', 'setComposerCommand', 'setQuestionCadence', 'setPlanMode', 'fetchToolCatalog']),
+        focusInput () {
+            this.$refs.textarea?.focus()
+        },
         openSettings () {
             this.$refs.settingsDialog.show()
         },
@@ -295,15 +303,10 @@ export default {
                 this.togglePinWithWidth()
             }
 
-            // handleQuery renders the reply itself (see the store); the composer only needs
-            // to refocus the input once the turn is on its way.
-            this.handleQuery({ query: message })
-                .then(() => {
-                    this.$nextTick(() => {
-                        this.$refs.textarea.focus()
-                    })
-                })
-                .catch(e => e)
+            // handleQuery renders the reply itself (see the store); the isWaitingForResponse
+            // watcher refocuses the input once the response completes (works for both HTTP
+            // and MQTT, where the promise resolves before the actual response arrives).
+            this.handleQuery({ query: message }).catch(e => e)
 
             this.inputText = ''
             this.requestingPlanChange = false


### PR DESCRIPTION
## Description

- Focus the chat textarea (not the drawer container) when the expert drawer is manually opened, so the user can start typing immediately
- Refocus the chat input after a response completes, using a watcher on `isWaitingForResponse` instead of chaining `.then()` on `handleQuery()`. The old approach relied on the HTTP promise lifecycle where `handleQuery` resolves after the full response. Over MQTT, `sendMqttQuery` returns immediately, so the `.then()` refocus fired before the response arrived and any DOM updates from the actual response would blur the input with nothing to restore it.                                                                          
                   

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7931

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

