### PR TITLE
fix(mcp): forward device comms to platform automation tool calls

### DIFF
--- a/forge/comms/platformAutomation.js
+++ b/forge/comms/platformAutomation.js
@@ -115,7 +115,7 @@ class PlatformAutomationHandler {
                     }
 
                     const { formatResponse } = require('../ee/lib/mcp/toolLoader')
-                    const response = await tool.handler(args, { inject })
+                    const response = await tool.handler(args, { inject, comms: this.app.comms?.devices })
                     result = formatResponse(response)
                 }
                 break

--- a/test/unit/forge/comms/platformAutomation_spec.js
+++ b/test/unit/forge/comms/platformAutomation_spec.js
@@ -134,6 +134,49 @@ describe('PlatformAutomationHandler', function () {
         })
     })
 
+    describe('platform_get_remote_instance_status', function () {
+        afterEach(function () {
+            delete app.comms
+        })
+
+        it('forwards device comms to the tool so it can query live state', async function () {
+            app.comms = {
+                devices: {
+                    sendCommandAwaitReply: sinon.stub().resolves({ state: 'running', health: 'ok', snapshot: 'snapshot-1' })
+                }
+            }
+            const tool = handler.findTool('platform_get_remote_instance_status')
+
+            const res = await invokeToolCall({
+                userId: app.adminUser.hashid,
+                toolName: 'platform_get_remote_instance_status',
+                args: { teamId: app.team.hashid, remoteInstanceId: 'device-1' },
+                meta: { toolDefinition: { annotations: tool.annotations } }
+            })
+
+            res.ok.should.be.true()
+            res.result.should.have.property('state', 'running')
+            app.comms.devices.sendCommandAwaitReply.calledOnce.should.be.true()
+            app.comms.devices.sendCommandAwaitReply.firstCall.args[0].should.equal(app.team.hashid)
+            app.comms.devices.sendCommandAwaitReply.firstCall.args[1].should.equal('device-1')
+        })
+
+        it('returns a structured error, not a false "comms unavailable", when no comms is configured', async function () {
+            delete app.comms
+            const tool = handler.findTool('platform_get_remote_instance_status')
+
+            const res = await invokeToolCall({
+                userId: app.adminUser.hashid,
+                toolName: 'platform_get_remote_instance_status',
+                args: { teamId: app.team.hashid, remoteInstanceId: 'device-1' },
+                meta: { toolDefinition: { annotations: tool.annotations } }
+            })
+
+            res.ok.should.be.true()
+            res.result.should.have.property('error', 'Device communications not available')
+        })
+    })
+
     describe('end-to-end audit trail', function () {
         it('tool call produces audit entry with source mcp:expert and toolName', async function () {
             const tool = handler.findTool('platform_create_application')


### PR DESCRIPTION
Closes #7912

`platform_get_remote_instance_status` always returned `Device communications not available`,
even when the target device was online, because the platform-automation MQTT bridge
(`forge/comms/platformAutomation.js`) only passed `inject` to tool handlers, never `comms`.
The regular MCP tool loader (`forge/ee/lib/mcp/toolLoader.js`) already forwarded `comms`
correctly, so this only affected calls made through the Expert.

Forwards `comms: this.app.comms?.devices` alongside `inject`, matching the tool loader.

Added test coverage in `test/unit/forge/comms/platformAutomation_spec.js`:
- comms is forwarded to the tool so it can return live state instead of the old error
- a missing comms configuration still degrades gracefully with a structured error

Tested against a running device agent: before the fix, the tool always returned
`Device communications not available` regardless of device state. After the fix,
it returns the real live status, e.g.:

    {
      "state": "running",
      "health": { "uptime": 694, "snapshotRestartCount": 0 },
      "snapshot": "0"
    }