### PR TITLE
Apply review follow-ups to Cloud billing and quota docs

### DIFF
--- a/docs/cloud/billing.md
+++ b/docs/cloud/billing.md
@@ -30,14 +30,14 @@ instances and Devices owned by the team.
 
 ## Billing Cycle
 
-Teams are billed monthly on the anniversary of the team creation. You will receive one bill for each team.
+If you've signed up to FlowFuse Cloud without a yearly contract agreed upon with our sales team, your FlowFuse teams are billed monthly on the anniversary of the team creation. You will receive one bill for each team.
 
-Node-RED Instances and Devices are added as pro-rated charges on the current billing cycle and invoiced
+Hosted and Remote Instances which are added beyond the included amount are pro-rated charges on the current billing cycle and invoiced
 at the end of the cycle.
 
 ## Removing Instances
 
-When a Node-RED instance is deleted your account will receive pro-rated credit for the time remaining in the billing cycle.
+When an instance is deleted your account will receive pro-rated credit for the time remaining in the billing cycle.
 
 ## Suspended Instances
 

--- a/docs/cloud/introduction.md
+++ b/docs/cloud/introduction.md
@@ -116,12 +116,8 @@ Medium and Large instance types require the Enterprise tier.
 FlowFuse Cloud hosted instances have access to a persistent file-system that will
 retain the files stored on it across restarts of the instance.
 
-A quota limit is applied to how much data can be stored, which varies based on
-the Team type.
-
-| Team Type | File Storage Quota (per instance) |
-|--------|--------|
-| Enterprise | 100GB |
+A quota limit is applied to how much data can be stored, based on the Team type.
+Enterprise teams have a file storage quota of 100GB per instance.
 
 Files can be manually uploaded to an instance using the [Static Asset Service](https://flowfuse.com/blog/2024/08/flowfuse-2-8-release/#static-assets-service).
 
@@ -134,10 +130,7 @@ FlowFuse Cloud provides an optional context store that can be used to persist
 the data.
 
 The amount of data that can be stored in context is determined by the Team type.
-
-| Team Type | Context Store Quota (per instance) |
-|--------|--------|
-| Enterprise | 1GB |
+Enterprise teams have a context store quota of 1GB per instance.
 
 
 ## Network Connections


### PR DESCRIPTION
## Summary

Follow-up to #7930, which was merged without applying the review suggestions left on it.

- `docs/cloud/billing.md`: applied the three review suggestions verbatim. The billing-cycle sentence now carves out teams on a yearly contract agreed with sales; the pro-rated charge sentence now names Hosted and Remote Instances and the included amount; the removal sentence now says "an instance" rather than "a Node-RED instance". Billing mechanics are unchanged.
- `docs/cloud/introduction.md`: the File Storage and Context Store quota tables were left with a single row each after the deprecated tiers were removed, which reads oddly. Both are now prose stating the Enterprise figure (100GB and 1GB per instance). No figures changed.

Out of scope: the open question on whether the Small/Medium/Large instance size choice should be deprecated for users is unanswered, so `introduction.md` line 112 is left as is.