### PR TITLE
Fix: related flows hidden after non-streamed render

### DIFF
--- a/frontend/src/components/expert/components/messages/components/resources/FlowsList.vue
+++ b/frontend/src/components/expert/components/messages/components/resources/FlowsList.vue
@@ -4,7 +4,7 @@
         <h4 class="section-title">
             <streamable-content v-model="streamingTitle" :should-stream="shouldStream" />
         </h4>
-        <div v-if="streamingTitle.streamed" class="resources-grid">
+        <div v-if="!shouldStream || streamingTitle.streamed" class="resources-grid">
             <FlowResourceCard
                 v-for="(flow, index) in visibleItems" :key="index"
                 :flow="flow"


### PR DESCRIPTION
## Description

`FlowsList.vue` was the only resource list component missing the `!shouldStream ||` fallback that `ResourcesList.vue`, `PackagesList.vue`, and `SuggestionsList.vue` already have:

```
<div v-if="streamingTitle.streamed" class="resources-grid">
```

When `shouldStream` is `false` (instant render, no typing animation), `StreamableContent`'s `mounted()` never calls `stream()`, so its `isStreaming` watcher — the thing that emits `streaming-complete` and flips `streamed: true` — never fires. `streamingTitle.streamed` then stays `false` forever, and the flow cards stay hidden behind the `v-if` indefinitely, even though the title text above them renders fine.

Fix: add the same `!shouldStream ||` fallback used by the sibling list components.

Found while testing #7932 (Expert chat persistence): once a message is re-mounted with `shouldStream: false` (e.g. after a page refresh restores an already-answered conversation), any flows-list section in that message reliably disappears.

Related to #7436 (not closing it) — that issue describes resources/steps going missing after a website-to-instance handoff, a different trigger path (`hydrateMessages` forces `_streamed: false`, so `shouldStream` is `true` there) that doesn't hit this exact bug, but may share the same class of root cause and is worth re-checking once this lands.

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/7949
Relates to https://github.com/FlowFuse/flowfuse/issues/7436

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass — one-line template fix mirroring existing sibling components' tested behavior; no new tests added
 - [ ] Documentation has been updated
 - [ ] Changes `flowforge.yml`? No
 - [ ] Link to Changelog Entry PR, or note why one is not needed — trivial bugfix, no user-facing changelog needed