### PR TITLE
fix(tables): include schema in tables list, fix data queries and show schema in UI

### DIFF
--- a/forge/ee/lib/tables/drivers/postgres-localfs.js
+++ b/forge/ee/lib/tables/drivers/postgres-localfs.js
@@ -126,7 +126,7 @@ module.exports = {
             const teamClient = libPg.newClient({ ...this._options.database, database: team.hashid })
             try {
                 await teamClient.connect()
-                const res = await teamClient.query('SELECT "tablename" FROM "pg_catalog"."pg_tables" WHERE "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\'')
+                const res = await teamClient.query('SELECT "tablename", "schemaname" FROM "pg_catalog"."pg_tables" WHERE "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\'')
                 if (res.rows && res.rows.length > 0) {
                     const tables = res.rows.map(row => {
                         return {
@@ -202,8 +202,12 @@ module.exports = {
             const teamClient = libPg.newClient({ ...this._options.database, database: team.hashid })
             try {
                 await teamClient.connect()
+                // look up the table's schema instead of relying on the default search_path ("public")
+                const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [table])
+                const schemaName = schemaRes.rows[0]?.schemaname || 'public'
+                const escapedSchema = libPg.pg.escapeIdentifier(schemaName)
                 const escapedTable = libPg.pg.escapeIdentifier(table)
-                const query = `SELECT * FROM ${escapedTable} LIMIT $1`
+                const query = `SELECT * FROM ${escapedSchema}.${escapedTable} LIMIT $1`
                 const res = await teamClient.query(query, [rows || 10])
                 if (res.rows && res.rows.length > 0) {
                     return {

--- a/forge/ee/lib/tables/drivers/postgres-localfs.js
+++ b/forge/ee/lib/tables/drivers/postgres-localfs.js
@@ -154,7 +154,7 @@ module.exports = {
             throw new Error(`Failed to retrieve tables for team ${team.hashid}: ${err.message}`)
         }
     },
-    getTable: async function (team, database, table) {
+    getTable: async function (team, database, table, schemaName) {
         // SELECT column_name, data_type, is_nullable, column_default
         // FROM information_schema.columns
         // WHERE table_name = 'your_table_name';
@@ -166,7 +166,18 @@ module.exports = {
             const teamClient = libPg.newClient({ ...this._options.database, database: team.hashid })
             try {
                 await teamClient.connect()
-                const res = await teamClient.query('SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1', [table])
+                let resolvedSchema = schemaName
+                if (!resolvedSchema) {
+                    const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [table])
+                    resolvedSchema = schemaRes.rows[0]?.schemaname
+                }
+                let query = 'SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1'
+                const params = [table]
+                if (resolvedSchema) {
+                    query += ' AND table_schema = $2'
+                    params.push(resolvedSchema)
+                }
+                const res = await teamClient.query(query, params)
                 if (res.rows && res.rows.length > 0) {
                     return res.rows.map(row => {
                         const col = {
@@ -192,7 +203,7 @@ module.exports = {
             throw new Error(`Failed to retrieve table ${table} for team ${team.hashid}: ${err.message}`)
         }
     },
-    getTableData: async function (team, database, table, pagination) {
+    getTableData: async function (team, database, table, pagination, schemaName) {
         const rows = Math.min(parseInt(pagination.limit) || 10, 10)
         const databaseExists = await this._app.db.models.Table.byId(team.id, database)
         if (!databaseExists || databaseExists.TeamId !== team.id) {
@@ -202,12 +213,14 @@ module.exports = {
             const teamClient = libPg.newClient({ ...this._options.database, database: team.hashid })
             try {
                 await teamClient.connect()
-                // look up the table's schema instead of relying on the default search_path ("public")
-                const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [table])
-                const schemaName = schemaRes.rows[0]?.schemaname || 'public'
-                const escapedSchema = libPg.pg.escapeIdentifier(schemaName)
+                let resolvedSchema = schemaName
+                if (!resolvedSchema) {
+                    const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [table])
+                    resolvedSchema = schemaRes.rows[0]?.schemaname
+                }
                 const escapedTable = libPg.pg.escapeIdentifier(table)
-                const query = `SELECT * FROM ${escapedSchema}.${escapedTable} LIMIT $1`
+                const qualifiedTable = resolvedSchema ? `${libPg.pg.escapeIdentifier(resolvedSchema)}.${escapedTable}` : escapedTable
+                const query = `SELECT * FROM ${qualifiedTable} LIMIT $1`
                 const res = await teamClient.query(query, [rows || 10])
                 if (res.rows && res.rows.length > 0) {
                     return {
@@ -311,7 +324,7 @@ module.exports = {
             throw new Error(`Failed to create table ${tableName} for team ${team.hashid}: ${err.message}`)
         }
     },
-    dropTable: async function (team, databaseId, tableName) {
+    dropTable: async function (team, databaseId, tableName, schemaName) {
         const databaseExists = await this._app.db.models.Table.byId(team.id, databaseId)
         if (!databaseExists || databaseExists.TeamId !== team.id) {
             throw new Error(`Database ${databaseId} for team ${team.hashid} does not exist`)
@@ -321,7 +334,14 @@ module.exports = {
             const teamClient = libPg.newClient(options)
             try {
                 await teamClient.connect()
-                await teamClient.query(`DROP TABLE ${libPg.pg.escapeIdentifier(tableName)}`)
+                let resolvedSchema = schemaName
+                if (!resolvedSchema) {
+                    const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [tableName])
+                    resolvedSchema = schemaRes.rows[0]?.schemaname
+                }
+                const escapedTable = libPg.pg.escapeIdentifier(tableName)
+                const qualifiedTable = resolvedSchema ? `${libPg.pg.escapeIdentifier(resolvedSchema)}.${escapedTable}` : escapedTable
+                await teamClient.query(`DROP TABLE ${qualifiedTable}`)
             } finally {
                 teamClient.end()
             }

--- a/forge/ee/lib/tables/drivers/postgres-supavisor.js
+++ b/forge/ee/lib/tables/drivers/postgres-supavisor.js
@@ -220,7 +220,7 @@ module.exports = {
             throw new Error(`Failed to retrieve tables for team ${team.hashid}: ${err.message}`)
         }
     },
-    getTable: async function (team, databaseId, tableName) {
+    getTable: async function (team, databaseId, tableName, schemaName) {
         // SELECT column_name, data_type, is_nullable, column_default
         // FROM information_schema.columns
         // WHERE table_name = 'your_table_name';
@@ -232,7 +232,18 @@ module.exports = {
             const teamClient = libPg.newClient({ ...this._options.backend, database: team.hashid })
             try {
                 await teamClient.connect()
-                const res = await teamClient.query('SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1', [tableName])
+                let resolvedSchema = schemaName
+                if (!resolvedSchema) {
+                    const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [tableName])
+                    resolvedSchema = schemaRes.rows[0]?.schemaname
+                }
+                let query = 'SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1'
+                const params = [tableName]
+                if (resolvedSchema) {
+                    query += ' AND table_schema = $2'
+                    params.push(resolvedSchema)
+                }
+                const res = await teamClient.query(query, params)
                 if (res.rows && res.rows.length > 0) {
                     return res.rows.map(row => {
                         const col = {
@@ -258,7 +269,7 @@ module.exports = {
             throw new Error(`Failed to retrieve table ${tableName} for team ${team.hashid}: ${err.message}`)
         }
     },
-    getTableData: async function (team, database, table, pagination) {
+    getTableData: async function (team, database, table, pagination, schemaName) {
         const rows = Math.min(parseInt(pagination.limit) || 10, 10)
         const databaseExists = await this._app.db.models.Table.byId(team.id, database)
         if (!databaseExists || databaseExists.TeamId !== team.id) {
@@ -268,12 +279,14 @@ module.exports = {
             const teamClient = libPg.newClient({ ...this._options.backend, database: team.hashid })
             try {
                 await teamClient.connect()
-                // look up the table's schema instead of relying on the default search_path ("public")
-                const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [table])
-                const schemaName = schemaRes.rows[0]?.schemaname || 'public'
-                const escapedSchema = libPg.pg.escapeIdentifier(schemaName)
+                let resolvedSchema = schemaName
+                if (!resolvedSchema) {
+                    const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [table])
+                    resolvedSchema = schemaRes.rows[0]?.schemaname
+                }
                 const escapedTable = libPg.pg.escapeIdentifier(table)
-                const query = `SELECT * FROM ${escapedSchema}.${escapedTable} LIMIT $1`
+                const qualifiedTable = resolvedSchema ? `${libPg.pg.escapeIdentifier(resolvedSchema)}.${escapedTable}` : escapedTable
+                const query = `SELECT * FROM ${qualifiedTable} LIMIT $1`
                 const res = await teamClient.query(query, [rows || 10])
                 if (res.rows && res.rows.length > 0) {
                     return {
@@ -384,7 +397,7 @@ module.exports = {
             throw new Error(`Failed to create table ${tableName} for team ${team.hashid}: ${err.message}`)
         }
     },
-    dropTable: async function (team, databaseId, tableName) {
+    dropTable: async function (team, databaseId, tableName, schemaName) {
         const databaseExists = await this._app.db.models.Table.byId(team.id, databaseId)
         if (!databaseExists || databaseExists.TeamId !== team.id) {
             throw new Error(`Database ${databaseId} for team ${team.hashid} does not exist`)
@@ -401,7 +414,14 @@ module.exports = {
             const teamClient = libPg.newClient(options)
             try {
                 await teamClient.connect()
-                await teamClient.query(`DROP TABLE ${libPg.pg.escapeIdentifier(tableName)}`)
+                let resolvedSchema = schemaName
+                if (!resolvedSchema) {
+                    const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [tableName])
+                    resolvedSchema = schemaRes.rows[0]?.schemaname
+                }
+                const escapedTable = libPg.pg.escapeIdentifier(tableName)
+                const qualifiedTable = resolvedSchema ? `${libPg.pg.escapeIdentifier(resolvedSchema)}.${escapedTable}` : escapedTable
+                await teamClient.query(`DROP TABLE ${qualifiedTable}`)
             } finally {
                 teamClient.end()
             }

--- a/forge/ee/lib/tables/drivers/postgres-supavisor.js
+++ b/forge/ee/lib/tables/drivers/postgres-supavisor.js
@@ -192,7 +192,7 @@ module.exports = {
             const teamClient = libPg.newClient({ ...this._options.backend, database: team.hashid })
             try {
                 await teamClient.connect()
-                const res = await teamClient.query('SELECT "tablename" FROM "pg_catalog"."pg_tables" WHERE "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\'')
+                const res = await teamClient.query('SELECT "tablename", "schemaname" FROM "pg_catalog"."pg_tables" WHERE "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\'')
                 if (res.rows && res.rows.length > 0) {
                     const tables = res.rows.map(row => {
                         return {
@@ -268,8 +268,12 @@ module.exports = {
             const teamClient = libPg.newClient({ ...this._options.backend, database: team.hashid })
             try {
                 await teamClient.connect()
+                // look up the table's schema instead of relying on the default search_path ("public")
+                const schemaRes = await teamClient.query('SELECT "schemaname" FROM "pg_catalog"."pg_tables" WHERE "tablename" = $1 AND "schemaname" != \'pg_catalog\' AND "schemaname" != \'information_schema\' LIMIT 1', [table])
+                const schemaName = schemaRes.rows[0]?.schemaname || 'public'
+                const escapedSchema = libPg.pg.escapeIdentifier(schemaName)
                 const escapedTable = libPg.pg.escapeIdentifier(table)
-                const query = `SELECT * FROM ${escapedTable} LIMIT $1`
+                const query = `SELECT * FROM ${escapedSchema}.${escapedTable} LIMIT $1`
                 const res = await teamClient.query(query, [rows || 10])
                 if (res.rows && res.rows.length > 0) {
                     return {

--- a/forge/ee/lib/tables/wrapper.js
+++ b/forge/ee/lib/tables/wrapper.js
@@ -53,16 +53,16 @@ module.exports = {
             throw new Error('Database driver does not support getTables')
         }
     },
-    getTable: async (team, databaseId, tableName) => {
+    getTable: async (team, databaseId, tableName, schemaName) => {
         if (this._driver.getTable) {
-            return this._driver.getTable(team, databaseId, tableName)
+            return this._driver.getTable(team, databaseId, tableName, schemaName)
         } else {
             throw new Error('Database driver does not support getTable')
         }
     },
-    getTableData: async (team, databaseId, table, paginationOptions) => {
+    getTableData: async (team, databaseId, table, paginationOptions, schemaName) => {
         if (this._driver.getTableData) {
-            return this._driver.getTableData(team, databaseId, table, paginationOptions)
+            return this._driver.getTableData(team, databaseId, table, paginationOptions, schemaName)
         } else {
             throw new Error('Database driver does not support getTableData')
         }
@@ -92,10 +92,10 @@ module.exports = {
             throw new Error('Database driver does not support createTable')
         }
     },
-    dropTable: async (team, databaseId, table) => {
+    dropTable: async (team, databaseId, table, schemaName) => {
         if (this._driver.dropTable) {
             this._app.log.info(`Removing table '${table}' to database '${databaseId}' for '${team.hashid}'`)
-            return this._driver.dropTable(team, databaseId, table)
+            return this._driver.dropTable(team, databaseId, table, schemaName)
         } else {
             throw new Error('Database driver does not support dropTable')
         }

--- a/forge/ee/routes/tables/index.js
+++ b/forge/ee/routes/tables/index.js
@@ -309,12 +309,12 @@ module.exports = async function (app) {
     })
 
     /**
-     * @name /api/v1/teams/:teamId/databases/:databaseId/tables/:tableName
+     * @name /api/v1/teams/:teamId/databases/:databaseId/tables/:tableName/:schemaName?
      * @description Get a specific table schema in a team database
      * @static
      * @memberof forge.routes.api.team.tables
      */
-    app.get('/:databaseId/tables/:tableName', {
+    app.get('/:databaseId/tables/:tableName/:schemaName?', {
         preHandler: app.needsPermission('team:database:list'),
         schema: {
             summary: '',
@@ -323,7 +323,8 @@ module.exports = async function (app) {
                 type: 'object',
                 properties: {
                     databaseId: { type: 'string' },
-                    tableName: { type: 'string' }
+                    tableName: { type: 'string' },
+                    schemaName: { type: 'string' }
                 }
             },
             response: {
@@ -340,7 +341,7 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         // get the table schema
-        const table = await app.tables.getTable(request.team, request.params.databaseId, request.params.tableName)
+        const table = await app.tables.getTable(request.team, request.params.databaseId, request.params.tableName, request.params.schemaName)
         if (!table) {
             return reply.status(404).send({ code: 'table_not_found', error: 'Table not found' })
         }
@@ -348,12 +349,12 @@ module.exports = async function (app) {
     })
 
     /**
-     * @name /api/v1/teams/:teamId/databases/:databaseId/tables/:tableName
+     * @name /api/v1/teams/:teamId/databases/:databaseId/tables/:tableName/:schemaName?
      * @description Delete a specific table schema in a team database
      * @static
      * @memberof forge.routes.api.team.tables
      */
-    app.delete('/:databaseId/tables/:tableName', {
+    app.delete('/:databaseId/tables/:tableName/:schemaName?', {
         preHandler: app.needsPermission('team:database:create'),
         schema: {
             summary: '',
@@ -362,7 +363,8 @@ module.exports = async function (app) {
                 type: 'object',
                 properties: {
                     databaseId: { type: 'string' },
-                    tableName: { type: 'string' }
+                    tableName: { type: 'string' },
+                    schemaName: { type: 'string' }
                 }
             },
             response: {
@@ -378,9 +380,11 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
+        const requestedSchema = request.params.schemaName
         const tables = await app.tables.getTables(request.team, request.params.databaseId)
-        if (tables.tables.filter((t) => t.name === request.params.tableName).length === 1) {
-            await app.tables.dropTable(request.team, request.params.databaseId, request.params.tableName)
+        const matches = tables.tables.filter((t) => t.name === request.params.tableName && (!requestedSchema || t.schema === requestedSchema))
+        if (matches.length === 1) {
+            await app.tables.dropTable(request.team, request.params.databaseId, request.params.tableName, requestedSchema)
             reply.status(204).send()
             await app.auditLog.Team.tables.table.deleted(request.session?.User || 'system', null, request.team, request.database, request.params.tableName)
         } else {
@@ -389,12 +393,12 @@ module.exports = async function (app) {
     })
 
     /**
-     * @name /api/v1/teams/:teamId/databases/:databaseId/tables/:tableName/data
+     * @name /api/v1/teams/:teamId/databases/:databaseId/tables/:tableName/data/:schemaName?
      * @description Get sample data from a specific table in a team database
      * @static
      * @memberof forge.routes.api.team.tables
      */
-    app.get('/:databaseId/tables/:tableName/data', {
+    app.get('/:databaseId/tables/:tableName/data/:schemaName?', {
         preHandler: app.needsPermission('team:database:list'),
         schema: {
             summary: '',
@@ -403,7 +407,8 @@ module.exports = async function (app) {
                 type: 'object',
                 properties: {
                     databaseId: { type: 'string' },
-                    tableName: { type: 'string' }
+                    tableName: { type: 'string' },
+                    schemaName: { type: 'string' }
                 }
             },
             query: { $ref: 'PaginationParams' },
@@ -435,7 +440,7 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
-        const data = await app.tables.getTableData(request.team, request.params.databaseId, request.params.tableName, paginationOptions)
+        const data = await app.tables.getTableData(request.team, request.params.databaseId, request.params.tableName, paginationOptions, request.params.schemaName)
         reply.send(data)
     })
 }

--- a/frontend/src/api/tables.js
+++ b/frontend/src/api/tables.js
@@ -15,13 +15,15 @@ const createDatabase = (teamId, name) => {
         .then(res => res.data)
 }
 
-const getTableSchema = (teamId, databaseId, tableName) => {
-    return client.get(`/api/v1/teams/${teamId}/databases/${databaseId}/tables/${tableName}`)
+const getTableSchema = (teamId, databaseId, tableName, schemaName) => {
+    const suffix = schemaName ? `/${schemaName}` : ''
+    return client.get(`/api/v1/teams/${teamId}/databases/${databaseId}/tables/${tableName}${suffix}`)
         .then(res => res.data)
 }
 
-const getTableData = (teamId, databaseId, tableName) => {
-    return client.get(`/api/v1/teams/${teamId}/databases/${databaseId}/tables/${tableName}/data`)
+const getTableData = (teamId, databaseId, tableName, schemaName) => {
+    const suffix = schemaName ? `/${schemaName}` : ''
+    return client.get(`/api/v1/teams/${teamId}/databases/${databaseId}/tables/${tableName}/data${suffix}`)
         .then(res => res.data.rows)
 }
 
@@ -30,8 +32,9 @@ const createTable = (teamId, databaseId, payload) => {
         .then(res => res.data)
 }
 
-const deleteTable = (teamId, databaseId, tableName) => {
-    return client.delete(`/api/v1/teams/${teamId}/databases/${databaseId}/tables/${tableName}`)
+const deleteTable = (teamId, databaseId, tableName, schemaName) => {
+    const suffix = schemaName ? `/${schemaName}` : ''
+    return client.delete(`/api/v1/teams/${teamId}/databases/${databaseId}/tables/${tableName}${suffix}`)
         .then(res => res.data)
 }
 

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsHeader.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsHeader.vue
@@ -12,9 +12,9 @@
             <ArrowPathIcon class="ff-icon ff-icon-md" aria-hidden="true" />
         </button>
         <span v-if="selectedTable" class="table-title truncate">
-            {{ selectedTable.name }}
-            <span class="schema-label">{{ selectedTable.dbSchema }}</span>
+            {{ selectedTable.dbSchema }}.{{ selectedTable.name }}
         </span>
+        <TextCopier v-if="selectedTable" :text="qualifiedTableName" :show-text="false" />
     </section>
 </template>
 
@@ -25,12 +25,13 @@ import { mapActions, mapState } from 'pinia'
 import MenuCollapse from '../../.././../../../components/icons/menu-collapse.js'
 import MenuExpand from '../../.././../../../components/icons/menu-expand.js'
 
+import TextCopier from '@/components/TextCopier.vue'
 import { useContextStore } from '@/stores/context.js'
 import { useProductTablesStore } from '@/stores/product-tables.js'
 
 export default {
     name: 'RowsHeader',
-    components: { MenuCollapse, MenuExpand, ArrowPathIcon },
+    components: { MenuCollapse, MenuExpand, ArrowPathIcon, TextCopier },
     props: {
         menuCollapsed: {
             type: Boolean,
@@ -40,7 +41,10 @@ export default {
     emits: ['toggle-collapse'],
     computed: {
         ...mapState(useContextStore, ['team']),
-        ...mapState(useProductTablesStore, ['tableSelection', 'selectedTable'])
+        ...mapState(useProductTablesStore, ['tableSelection', 'selectedTable']),
+        qualifiedTableName () {
+            return `"${this.selectedTable.dbSchema}"."${this.selectedTable.name}"`
+        }
     },
     methods: {
         ...mapActions(useProductTablesStore, ['getTableData', 'setTableLoadingState']),
@@ -70,12 +74,6 @@ export default {
     .table-title {
         font-weight: bold;
         color: var(--ff-color-text-deep);
-
-        .schema-label {
-            font-weight: normal;
-            font-size: 0.75rem;
-            color: var(--ff-color-text-subtle);
-        }
     }
 }
 </style>

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsHeader.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsHeader.vue
@@ -11,6 +11,10 @@
         >
             <ArrowPathIcon class="ff-icon ff-icon-md" aria-hidden="true" />
         </button>
+        <span v-if="selectedTable" class="table-title truncate">
+            {{ selectedTable.name }}
+            <span class="schema-label">{{ selectedTable.dbSchema }}</span>
+        </span>
     </section>
 </template>
 
@@ -36,7 +40,7 @@ export default {
     emits: ['toggle-collapse'],
     computed: {
         ...mapState(useContextStore, ['team']),
-        ...mapState(useProductTablesStore, ['tableSelection'])
+        ...mapState(useProductTablesStore, ['tableSelection', 'selectedTable'])
     },
     methods: {
         ...mapActions(useProductTablesStore, ['getTableData', 'setTableLoadingState']),
@@ -57,9 +61,21 @@ export default {
     margin-bottom: 15px;
     padding-bottom: 15px;
     border-bottom: 1px solid var(--ff-color-border);
+    align-items: center;
 
     .toggle-collapse, .refresh-table {
         border: 1px solid transparent;
+    }
+
+    .table-title {
+        font-weight: bold;
+        color: var(--ff-color-text-deep);
+
+        .schema-label {
+            font-weight: normal;
+            font-size: 0.75rem;
+            color: var(--ff-color-text-subtle);
+        }
     }
 }
 </style>

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsHeader.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsHeader.vue
@@ -53,7 +53,8 @@ export default {
             return this.getTableData({
                 teamId: this.team.id,
                 databaseId: this.$route.params.id,
-                tableName: this.tableSelection
+                tableName: this.tableSelection?.name,
+                schemaName: this.tableSelection?.dbSchema
             }).finally(() => this.setTableLoadingState(false))
         }
     }

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsList.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/components/RowsList.vue
@@ -57,16 +57,19 @@ export default defineComponent({
         }
     },
     watch: {
-        tableSelection (tableName) {
+        tableSelection (table) {
+            if (!table) return
             this.getTableSchema({
                 teamId: this.team.id,
                 databaseId: this.$route.params.id,
-                tableName
+                tableName: table.name,
+                schemaName: table.dbSchema
             })
                 .then(() => this.getTableData({
                     teamId: this.team.id,
                     databaseId: this.$route.params.id,
-                    tableName
+                    tableName: table.name,
+                    schemaName: table.dbSchema
                 }))
                 .catch(e => e)
         }

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/components/TablesList.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/components/TablesList.vue
@@ -29,6 +29,7 @@
                     <PencilSquareIcon class="ff-icon ff-icon-sm edit" @click="showSchema(table)" />
                 </span>
                 <span class="truncate">{{ table.name }}</span>
+                <span class="schema-label truncate">{{ table.dbSchema }}</span>
             </li>
         </ul>
 
@@ -122,10 +123,18 @@ export default defineComponent({
         .item {
             display: flex;
             gap: 5px;
+            padding: 0 12px;
             line-height: 2;
             align-items: center;
             transition: ease-in-out .3s;
             cursor: pointer;
+
+            .schema-label {
+                margin-left: auto;
+                flex-shrink: 0;
+                font-size: 0.75rem;
+                color: var(--ff-color-text-subtle);
+            }
 
             &:hover, &.active {
                 color: var(--ff-color-focus);

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/components/TablesList.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/components/TablesList.vue
@@ -21,8 +21,8 @@
                 v-for="table in filteredTables" :key="table.id"
                 :title="table.name"
                 class="item relative"
-                :class="{active: table.name === tableSelection}"
-                @click="updateTableSelection(table.name)"
+                :class="{active: table.name === tableSelection?.name && table.dbSchema === tableSelection?.dbSchema}"
+                @click="updateTableSelection({ name: table.name, dbSchema: table.dbSchema })"
             >
                 <span class="icon-toggle">
                     <TableCellsIcon class="ff-icon ff-icon-sm" />

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/CreateTable.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/CreateTable.vue
@@ -13,6 +13,7 @@
                 <div v-if="errors.name" data-el="form-row-error" class="ml-4 text-red-400 text-xs">
                     {{ errors.name }}
                 </div>
+                <p class="schema-hint">This table will be created in your database's default schema.</p>
             </div>
             <div class="section table-columns">
                 <h3>Define Columns</h3>
@@ -185,6 +186,12 @@ export default defineComponent({
 
            .columns {
                margin-bottom: 20px;
+           }
+
+           .schema-hint {
+               margin-top: 8px;
+               font-size: 0.75rem;
+               color: var(--ff-color-text-subtle);
            }
        }
     }

--- a/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/TableSchema.vue
+++ b/frontend/src/pages/team/Tables/Table/TableExplorer/drawers/TableSchema.vue
@@ -62,7 +62,8 @@ export default defineComponent({
             }, () => this.deleteTable({
                 teamId: this.team.id,
                 databaseId: this.$route.params.id,
-                tableName: this.table.name
+                tableName: this.table.name,
+                schemaName: this.table.dbSchema
             })
                 .then(() => this.getTables(this.$route.params.id))
                 .then(() => this.closeRightDrawer())

--- a/frontend/src/stores/product-tables.js
+++ b/frontend/src/stores/product-tables.js
@@ -58,6 +58,9 @@ export const useProductTablesStore = defineStore('product-tables', {
         async getTables (databaseId) {
             const team = useContextStore().team
             let tables = await tablesApi.getTables(team.id, databaseId)
+            // dbSchema (the Postgres schema/namespace) is kept separate from `schema`,
+            // which getTableSchema below repurposes to hold the table's column definitions
+            tables = tables.map(({ schema, ...table }) => ({ ...table, dbSchema: schema }))
             tables = [...tables].sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }))
             this.tables[databaseId] = tables
             if (tables.length > 0) this.tableSelection = tables[0].name

--- a/frontend/src/stores/product-tables.js
+++ b/frontend/src/stores/product-tables.js
@@ -38,7 +38,7 @@ export const useProductTablesStore = defineStore('product-tables', {
         },
         selectedTable: (state) => {
             if (Object.keys(state.tables).includes(state.databaseSelection)) {
-                return state.tables[state.databaseSelection]?.find(t => t.name === state.tableSelection)
+                return state.tables[state.databaseSelection]?.find(t => t.name === state.tableSelection?.name && t.dbSchema === state.tableSelection?.dbSchema)
             }
             return null
         }
@@ -63,30 +63,32 @@ export const useProductTablesStore = defineStore('product-tables', {
             tables = tables.map(({ schema, ...table }) => ({ ...table, dbSchema: schema }))
             tables = [...tables].sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }))
             this.tables[databaseId] = tables
-            if (tables.length > 0) this.tableSelection = tables[0].name
+            if (tables.length > 0) this.tableSelection = { name: tables[0].name, dbSchema: tables[0].dbSchema }
             return tables
         },
         clearState () { this.$reset() },
-        updateTableSelection (tableName) { this.tableSelection = tableName },
+        updateTableSelection (table) { this.tableSelection = table },
         updateDatabaseSelection (databaseId) { this.databaseSelection = databaseId },
-        async getTableSchema ({ databaseId, tableName, teamId }) {
-            const schema = await tablesApi.getTableSchema(teamId, databaseId, tableName)
+        async getTableSchema ({ databaseId, tableName, teamId, schemaName }) {
+            const schema = await tablesApi.getTableSchema(teamId, databaseId, tableName, schemaName)
             schema.forEach(col => { col.safeName = hashString(col.name) })
             Object.keys(this.tables[databaseId]).forEach(key => {
-                if (this.tables[databaseId][key].name === tableName) {
-                    this.tables[databaseId][key].schema = schema
+                const table = this.tables[databaseId][key]
+                if (table.name === tableName && (!schemaName || table.dbSchema === schemaName)) {
+                    table.schema = schema
                 }
             })
         },
-        async getTableData ({ databaseId, tableName, teamId }) {
-            const data = await tablesApi.getTableData(teamId, databaseId, tableName)
+        async getTableData ({ databaseId, tableName, teamId, schemaName }) {
+            const data = await tablesApi.getTableData(teamId, databaseId, tableName, schemaName)
             const payload = {
                 data,
                 safe: data.map(row => Object.fromEntries(Object.entries(row).map(([k, v]) => [hashString(k), v])))
             }
             Object.keys(this.tables[databaseId]).forEach(key => {
-                if (this.tables[databaseId][key].name === tableName) {
-                    this.tables[databaseId][key].payload = payload
+                const table = this.tables[databaseId][key]
+                if (table.name === tableName && (!schemaName || table.dbSchema === schemaName)) {
+                    table.payload = payload
                 }
             })
         },
@@ -100,8 +102,8 @@ export const useProductTablesStore = defineStore('product-tables', {
             })
             return tablesApi.createTable(team.id, databaseId, { name: this.newTable.name, columns: sanitizedColumns })
         },
-        deleteTable ({ teamId, databaseId, tableName }) {
-            return tablesApi.deleteTable(teamId, databaseId, tableName)
+        deleteTable ({ teamId, databaseId, tableName, schemaName }) {
+            return tablesApi.deleteTable(teamId, databaseId, tableName, schemaName)
         },
         addNewTableColumn () { this.newTable.columns.push({ ...emptyColumn }) },
         removeNewTableColumn (columnKey) { this.newTable.columns.splice(columnKey, 1) },

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -9813,7 +9813,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/teams/{teamId}/databases/{databaseId}/tables/{tableName}": {
+    "/api/v1/teams/{teamId}/databases/{databaseId}/tables/{tableName}/{schemaName}?": {
         parameters: {
             query?: never;
             header?: never;
@@ -9827,6 +9827,7 @@ export interface paths {
                 path: {
                     databaseId: string;
                     tableName: string;
+                    schemaName: string;
                 };
                 cookie?: never;
             };
@@ -9870,6 +9871,7 @@ export interface paths {
                 path: {
                     databaseId: string;
                     tableName: string;
+                    schemaName: string;
                 };
                 cookie?: never;
             };
@@ -9909,7 +9911,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/teams/{teamId}/databases/{databaseId}/tables/{tableName}/data": {
+    "/api/v1/teams/{teamId}/databases/{databaseId}/tables/{tableName}/data/{schemaName}?": {
         parameters: {
             query?: never;
             header?: never;
@@ -9931,6 +9933,7 @@ export interface paths {
                 path: {
                     databaseId: string;
                     tableName: string;
+                    schemaName: string;
                 };
                 cookie?: never;
             };

--- a/test/unit/forge/ee/lib/tables/drivers/postgres-localfs_spec.js
+++ b/test/unit/forge/ee/lib/tables/drivers/postgres-localfs_spec.js
@@ -287,7 +287,7 @@ describe('Tables: Postgres LocalFS Driver', function () {
             const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
             result.rows.should.eql([{ id: 1, name: 'foo' }])
             client.connect.calledOnce.should.be.true()
-            client.query.calledWith('SELECT * FROM "table1" LIMIT $1', [5]).should.be.true()
+            client.query.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
             client.end.calledOnce.should.be.true()
         })
         it('should return empty array if no rows', async function () {
@@ -305,8 +305,25 @@ describe('Tables: Postgres LocalFS Driver', function () {
             const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
             result.rows.should.eql([])
             client.connect.calledOnce.should.be.true()
-            client.query.calledWith('SELECT * FROM "table1" LIMIT $1', [5]).should.be.true()
+            client.query.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
             client.end.calledOnce.should.be.true()
+        })
+        it('should look up and use the table\'s actual schema when it is not in public', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'other_schema' }] })
+            query.onSecondCall().resolves({ rows: [{ id: 1, name: 'foo' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
+            result.rows.should.eql([{ id: 1, name: 'foo' }])
+            query.secondCall.calledWith('SELECT * FROM "other_schema"."table1" LIMIT $1', [5]).should.be.true()
         })
         it('should throw if db does not exist', async function () {
             app.db.models.Table.byId.resolves(null)

--- a/test/unit/forge/ee/lib/tables/drivers/postgres-localfs_spec.js
+++ b/test/unit/forge/ee/lib/tables/drivers/postgres-localfs_spec.js
@@ -243,13 +243,50 @@ describe('Tables: Postgres LocalFS Driver', function () {
             const dbObj = { TeamId: 1 }
             app.db.models.Table.byId.resolves(dbObj)
             await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'public' }] })
+            query.onSecondCall().resolves({ rows: [{ column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, is_generated: 'NEVER' }] })
             pgClients[team.hashid] = {
                 connect: sinon.stub().resolves(),
-                query: sinon.stub().resolves({ rows: [{ column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, is_generated: 'NEVER' }] }),
+                query,
                 end: sinon.stub().resolves()
             }
             const result = await driver.getTable(team, team.hashid, 'table1')
             result.should.eql([{ name: 'id', type: 'int4', nullable: false, default: null, generated: false }])
+            query.secondCall.calledWith('SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1 AND table_schema = $2', ['table1', 'public']).should.be.true()
+        })
+        it('should use the given schemaName without looking it up', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub().resolves({ rows: [{ column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, is_generated: 'NEVER' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTable(team, team.hashid, 'table1', 'reports')
+            result.should.eql([{ name: 'id', type: 'int4', nullable: false, default: null, generated: false }])
+            query.calledOnce.should.be.true()
+            query.calledWith('SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1 AND table_schema = $2', ['table1', 'reports']).should.be.true()
+        })
+        it('should query without a schema qualifier when the table\'s schema cannot be resolved', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [] })
+            query.onSecondCall().resolves({ rows: [{ column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, is_generated: 'NEVER' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTable(team, team.hashid, 'table1')
+            result.should.eql([{ name: 'id', type: 'int4', nullable: false, default: null, generated: false }])
+            query.secondCall.calledWith('SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1', ['table1']).should.be.true()
         })
         it('should throw if table is not found', async function () {
             const team = { id: 1, hashid: 't1hash' }
@@ -277,17 +314,19 @@ describe('Tables: Postgres LocalFS Driver', function () {
             const dbObj = { TeamId: 1 }
             app.db.models.Table.byId.resolves(dbObj)
             await driver.init(app, options)
-            // Patch Client for getTableData
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'public' }] })
+            query.onSecondCall().resolves({ rows: [{ id: 1, name: 'foo' }] })
             pgClients[team.hashid] = {
                 connect: sinon.stub().resolves(),
-                query: sinon.stub().resolves({ rows: [{ id: 1, name: 'foo' }] }),
+                query,
                 end: sinon.stub().resolves()
             }
             const client = pgClients[team.hashid] // Use the team hashid as key
             const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
             result.rows.should.eql([{ id: 1, name: 'foo' }])
             client.connect.calledOnce.should.be.true()
-            client.query.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
+            query.secondCall.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
             client.end.calledOnce.should.be.true()
         })
         it('should return empty array if no rows', async function () {
@@ -295,17 +334,19 @@ describe('Tables: Postgres LocalFS Driver', function () {
             const dbObj = { TeamId: 1 }
             app.db.models.Table.byId.resolves(dbObj)
             await driver.init(app, options)
-            // Patch Client for getTableData
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'public' }] })
+            query.onSecondCall().resolves({ rows: [] })
             pgClients[team.hashid] = {
                 connect: sinon.stub().resolves(),
-                query: sinon.stub().resolves({ rows: [] }),
+                query,
                 end: sinon.stub().resolves()
             }
             const client = pgClients[team.hashid] // Use the team hashid as key
             const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
             result.rows.should.eql([])
             client.connect.calledOnce.should.be.true()
-            client.query.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
+            query.secondCall.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
             client.end.calledOnce.should.be.true()
         })
         it('should look up and use the table\'s actual schema when it is not in public', async function () {
@@ -325,10 +366,98 @@ describe('Tables: Postgres LocalFS Driver', function () {
             result.rows.should.eql([{ id: 1, name: 'foo' }])
             query.secondCall.calledWith('SELECT * FROM "other_schema"."table1" LIMIT $1', [5]).should.be.true()
         })
+        it('should not run the schema lookup and use the given schema when schemaName is provided', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub().resolves({ rows: [{ id: 1, name: 'foo' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 }, 'reports')
+            result.rows.should.eql([{ id: 1, name: 'foo' }])
+            query.calledOnce.should.be.true()
+            query.calledWith('SELECT * FROM "reports"."table1" LIMIT $1', [5]).should.be.true()
+        })
+        it('should query without a schema qualifier when the table\'s schema cannot be resolved', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [] })
+            query.onSecondCall().resolves({ rows: [{ id: 1, name: 'foo' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
+            result.rows.should.eql([{ id: 1, name: 'foo' }])
+            query.secondCall.calledWith('SELECT * FROM "table1" LIMIT $1', [5]).should.be.true()
+        })
         it('should throw if db does not exist', async function () {
             app.db.models.Table.byId.resolves(null)
             await driver.init(app, options)
             await driver.getTableData({ id: 1, hashid: 't1hash' }, 'dbid', 'table1', 5).should.be.rejectedWith('Database dbid for team t1hash does not exist')
+        })
+    })
+
+    describe('dropTable', function () {
+        it('should look up the schema and drop the qualified table', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1, credentials: { host: 'localhost', port: 5432, database: 't1hash', user: 't1hash', password: 'secret' } }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'reports' }] })
+            query.onSecondCall().resolves({ rows: [] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            await driver.dropTable(team, team.hashid, 'table1')
+            query.secondCall.calledWith('DROP TABLE "reports"."table1"').should.be.true()
+        })
+        it('should use the given schemaName without looking it up', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1, credentials: { host: 'localhost', port: 5432, database: 't1hash', user: 't1hash', password: 'secret' } }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub().resolves({ rows: [] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            await driver.dropTable(team, team.hashid, 'table1', 'reports')
+            query.calledOnce.should.be.true()
+            query.calledWith('DROP TABLE "reports"."table1"').should.be.true()
+        })
+        it('should drop without a schema qualifier when the table\'s schema cannot be resolved', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1, credentials: { host: 'localhost', port: 5432, database: 't1hash', user: 't1hash', password: 'secret' } }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [] })
+            query.onSecondCall().resolves({ rows: [] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            await driver.dropTable(team, team.hashid, 'table1')
+            query.secondCall.calledWith('DROP TABLE "table1"').should.be.true()
+        })
+        it('should throw if db does not exist', async function () {
+            app.db.models.Table.byId.resolves(null)
+            await driver.init(app, options)
+            await driver.dropTable({ id: 1, hashid: 't1hash' }, 'dbid', 'table1').should.be.rejectedWith('Database dbid for team t1hash does not exist')
         })
     })
 })

--- a/test/unit/forge/ee/lib/tables/drivers/postgres-supavisor_spec.js
+++ b/test/unit/forge/ee/lib/tables/drivers/postgres-supavisor_spec.js
@@ -282,13 +282,50 @@ describe('Tables: Postgres Supavisor Driver', function () {
             const dbObj = { TeamId: 1 }
             app.db.models.Table.byId.resolves(dbObj)
             await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'public' }] })
+            query.onSecondCall().resolves({ rows: [{ column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, is_generated: 'NEVER' }] })
             pgClients[team.hashid] = {
                 connect: sinon.stub().resolves(),
-                query: sinon.stub().resolves({ rows: [{ column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, is_generated: 'NEVER' }] }),
+                query,
                 end: sinon.stub().resolves()
             }
             const result = await driver.getTable(team, team.hashid, 'table1')
             result.should.eql([{ name: 'id', type: 'int4', nullable: false, default: null, generated: false }])
+            query.secondCall.calledWith('SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1 AND table_schema = $2', ['table1', 'public']).should.be.true()
+        })
+        it('should use the given schemaName without looking it up', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub().resolves({ rows: [{ column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, is_generated: 'NEVER' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTable(team, team.hashid, 'table1', 'reports')
+            result.should.eql([{ name: 'id', type: 'int4', nullable: false, default: null, generated: false }])
+            query.calledOnce.should.be.true()
+            query.calledWith('SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1 AND table_schema = $2', ['table1', 'reports']).should.be.true()
+        })
+        it('should query without a schema qualifier when the table\'s schema cannot be resolved', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [] })
+            query.onSecondCall().resolves({ rows: [{ column_name: 'id', udt_name: 'int4', is_nullable: 'NO', column_default: null, is_generated: 'NEVER' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTable(team, team.hashid, 'table1')
+            result.should.eql([{ name: 'id', type: 'int4', nullable: false, default: null, generated: false }])
+            query.secondCall.calledWith('SELECT column_name, udt_name, is_nullable, column_default, character_maximum_length, is_generated FROM information_schema.columns WHERE table_name = $1', ['table1']).should.be.true()
         })
         it('should throw if table is not found', async function () {
             const team = { id: 1, hashid: 't1hash' }
@@ -316,17 +353,19 @@ describe('Tables: Postgres Supavisor Driver', function () {
             const dbObj = { TeamId: 1 }
             app.db.models.Table.byId.resolves(dbObj)
             await driver.init(app, options)
-            // Patch Client for getTableData
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'public' }] })
+            query.onSecondCall().resolves({ rows: [{ id: 1, name: 'foo' }] })
             pgClients[team.hashid] = {
                 connect: sinon.stub().resolves(),
-                query: sinon.stub().resolves({ rows: [{ id: 1, name: 'foo' }] }),
+                query,
                 end: sinon.stub().resolves()
             }
             const client = pgClients[team.hashid] // Use the team hashid as key
             const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
             result.rows.should.eql([{ id: 1, name: 'foo' }])
             client.connect.calledOnce.should.be.true()
-            client.query.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
+            query.secondCall.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
             client.end.calledOnce.should.be.true()
         })
         it('should return empty array if no rows', async function () {
@@ -334,17 +373,19 @@ describe('Tables: Postgres Supavisor Driver', function () {
             const dbObj = { TeamId: 1 }
             app.db.models.Table.byId.resolves(dbObj)
             await driver.init(app, options)
-            // Patch Client for getTableData
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'public' }] })
+            query.onSecondCall().resolves({ rows: [] })
             pgClients[team.hashid] = {
                 connect: sinon.stub().resolves(),
-                query: sinon.stub().resolves({ rows: [] }),
+                query,
                 end: sinon.stub().resolves()
             }
             const client = pgClients[team.hashid] // Use the team hashid as key
             const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
             result.rows.should.eql([])
             client.connect.calledOnce.should.be.true()
-            client.query.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
+            query.secondCall.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
             client.end.calledOnce.should.be.true()
         })
         it('should look up and use the table\'s actual schema when it is not in public', async function () {
@@ -364,10 +405,98 @@ describe('Tables: Postgres Supavisor Driver', function () {
             result.rows.should.eql([{ id: 1, name: 'foo' }])
             query.secondCall.calledWith('SELECT * FROM "other_schema"."table1" LIMIT $1', [5]).should.be.true()
         })
+        it('should not run the schema lookup and use the given schema when schemaName is provided', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub().resolves({ rows: [{ id: 1, name: 'foo' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 }, 'reports')
+            result.rows.should.eql([{ id: 1, name: 'foo' }])
+            query.calledOnce.should.be.true()
+            query.calledWith('SELECT * FROM "reports"."table1" LIMIT $1', [5]).should.be.true()
+        })
+        it('should query without a schema qualifier when the table\'s schema cannot be resolved', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [] })
+            query.onSecondCall().resolves({ rows: [{ id: 1, name: 'foo' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
+            result.rows.should.eql([{ id: 1, name: 'foo' }])
+            query.secondCall.calledWith('SELECT * FROM "table1" LIMIT $1', [5]).should.be.true()
+        })
         it('should throw if db does not exist', async function () {
             app.db.models.Table.byId.resolves(null)
             await driver.init(app, options)
             await driver.getTableData({ id: 1, hashid: 't1hash' }, 'dbid', 'table1', 5).should.be.rejectedWith('Database dbid for team t1hash does not exist')
+        })
+    })
+
+    describe('dropTable', function () {
+        it('should look up the schema and drop the qualified table', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'reports' }] })
+            query.onSecondCall().resolves({ rows: [] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            await driver.dropTable(team, team.hashid, 'table1')
+            query.secondCall.calledWith('DROP TABLE "reports"."table1"').should.be.true()
+        })
+        it('should use the given schemaName without looking it up', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub().resolves({ rows: [] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            await driver.dropTable(team, team.hashid, 'table1', 'reports')
+            query.calledOnce.should.be.true()
+            query.calledWith('DROP TABLE "reports"."table1"').should.be.true()
+        })
+        it('should drop without a schema qualifier when the table\'s schema cannot be resolved', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [] })
+            query.onSecondCall().resolves({ rows: [] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            await driver.dropTable(team, team.hashid, 'table1')
+            query.secondCall.calledWith('DROP TABLE "table1"').should.be.true()
+        })
+        it('should throw if db does not exist', async function () {
+            app.db.models.Table.byId.resolves(null)
+            await driver.init(app, options)
+            await driver.dropTable({ id: 1, hashid: 't1hash' }, 'dbid', 'table1').should.be.rejectedWith('Database dbid for team t1hash does not exist')
         })
     })
 })

--- a/test/unit/forge/ee/lib/tables/drivers/postgres-supavisor_spec.js
+++ b/test/unit/forge/ee/lib/tables/drivers/postgres-supavisor_spec.js
@@ -326,7 +326,7 @@ describe('Tables: Postgres Supavisor Driver', function () {
             const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
             result.rows.should.eql([{ id: 1, name: 'foo' }])
             client.connect.calledOnce.should.be.true()
-            client.query.calledWith('SELECT * FROM "table1" LIMIT $1', [5]).should.be.true()
+            client.query.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
             client.end.calledOnce.should.be.true()
         })
         it('should return empty array if no rows', async function () {
@@ -344,8 +344,25 @@ describe('Tables: Postgres Supavisor Driver', function () {
             const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
             result.rows.should.eql([])
             client.connect.calledOnce.should.be.true()
-            client.query.calledWith('SELECT * FROM "table1" LIMIT $1', [5]).should.be.true()
+            client.query.calledWith('SELECT * FROM "public"."table1" LIMIT $1', [5]).should.be.true()
             client.end.calledOnce.should.be.true()
+        })
+        it('should look up and use the table\'s actual schema when it is not in public', async function () {
+            const team = { id: 1, hashid: 't1hash' }
+            const dbObj = { TeamId: 1 }
+            app.db.models.Table.byId.resolves(dbObj)
+            await driver.init(app, options)
+            const query = sinon.stub()
+            query.onFirstCall().resolves({ rows: [{ schemaname: 'other_schema' }] })
+            query.onSecondCall().resolves({ rows: [{ id: 1, name: 'foo' }] })
+            pgClients[team.hashid] = {
+                connect: sinon.stub().resolves(),
+                query,
+                end: sinon.stub().resolves()
+            }
+            const result = await driver.getTableData(team, team.hashid, 'table1', { limit: 5 })
+            result.rows.should.eql([{ id: 1, name: 'foo' }])
+            query.secondCall.calledWith('SELECT * FROM "other_schema"."table1" LIMIT $1', [5]).should.be.true()
         })
         it('should throw if db does not exist', async function () {
             app.db.models.Table.byId.resolves(null)

--- a/test/unit/frontend/stores/product-tables.spec.js
+++ b/test/unit/frontend/stores/product-tables.spec.js
@@ -77,15 +77,23 @@ describe('product-tables store', () => {
         it('selectedTable returns the matching table', () => {
             const store = useProductTablesStore()
             store.databaseSelection = 'db-1'
-            store.tableSelection = 'users'
+            store.tableSelection = { name: 'users', dbSchema: undefined }
             store.tables = { 'db-1': [{ name: 'users' }, { name: 'orders' }] }
             expect(store.selectedTable).toEqual({ name: 'users' })
+        })
+
+        it('selectedTable matches on both name and dbSchema', () => {
+            const store = useProductTablesStore()
+            store.databaseSelection = 'db-1'
+            store.tableSelection = { name: 'users', dbSchema: 'reports' }
+            store.tables = { 'db-1': [{ name: 'users', dbSchema: 'public' }, { name: 'users', dbSchema: 'reports' }] }
+            expect(store.selectedTable).toEqual({ name: 'users', dbSchema: 'reports' })
         })
 
         it('selectedTable returns undefined when no selection matches', () => {
             const store = useProductTablesStore()
             store.databaseSelection = 'db-1'
-            store.tableSelection = 'unknown'
+            store.tableSelection = { name: 'unknown', dbSchema: undefined }
             store.tables = { 'db-1': [{ name: 'users' }] }
             expect(store.selectedTable).toBeUndefined()
         })
@@ -117,7 +125,7 @@ describe('product-tables store', () => {
             await store.getTables('db-1')
             expect(store.tables['db-1'][0].name).toBe('accounts')
             expect(store.tables['db-1'][1].name).toBe('orders')
-            expect(store.tableSelection).toBe('accounts')
+            expect(store.tableSelection).toEqual({ name: 'accounts', dbSchema: undefined })
         })
 
         it('does not set tableSelection when no tables returned', async () => {
@@ -152,8 +160,8 @@ describe('product-tables store', () => {
     describe('updateTableSelection / updateDatabaseSelection', () => {
         it('sets tableSelection', () => {
             const store = useProductTablesStore()
-            store.updateTableSelection('orders')
-            expect(store.tableSelection).toBe('orders')
+            store.updateTableSelection({ name: 'orders', dbSchema: 'public' })
+            expect(store.tableSelection).toEqual({ name: 'orders', dbSchema: 'public' })
         })
 
         it('sets databaseSelection', () => {
@@ -171,6 +179,16 @@ describe('product-tables store', () => {
             await store.getTableSchema({ databaseId: 'db-1', tableName: 'users', teamId: 'team-1' })
             expect(store.tables['db-1'][0].schema[0].safeName).toBe('safe_id')
         })
+
+        it('only updates the table matching both name and schemaName when schemaName is given', async () => {
+            const store = useProductTablesStore()
+            store.tables = { 'db-1': [{ name: 'users', dbSchema: 'public' }, { name: 'users', dbSchema: 'reports' }] }
+            tablesApi.getTableSchema.mockResolvedValue([{ name: 'id', type: 'int' }])
+            await store.getTableSchema({ databaseId: 'db-1', tableName: 'users', teamId: 'team-1', schemaName: 'reports' })
+            expect(tablesApi.getTableSchema).toHaveBeenCalledWith('team-1', 'db-1', 'users', 'reports')
+            expect(store.tables['db-1'][0].schema).toBeUndefined()
+            expect(store.tables['db-1'][1].schema[0].safeName).toBe('safe_id')
+        })
     })
 
     describe('getTableData', () => {
@@ -182,6 +200,25 @@ describe('product-tables store', () => {
             const table = store.tables['db-1'][0]
             expect(table.payload.data).toEqual([{ id: 1, name: 'Alice' }])
             expect(table.payload.safe[0].safe_id).toBe(1)
+        })
+
+        it('only updates the table matching both name and schemaName when schemaName is given', async () => {
+            const store = useProductTablesStore()
+            store.tables = { 'db-1': [{ name: 'users', dbSchema: 'public' }, { name: 'users', dbSchema: 'reports' }] }
+            tablesApi.getTableData.mockResolvedValue([{ id: 1, name: 'Alice' }])
+            await store.getTableData({ databaseId: 'db-1', tableName: 'users', teamId: 'team-1', schemaName: 'reports' })
+            expect(tablesApi.getTableData).toHaveBeenCalledWith('team-1', 'db-1', 'users', 'reports')
+            expect(store.tables['db-1'][0].payload).toBeUndefined()
+            expect(store.tables['db-1'][1].payload.data).toEqual([{ id: 1, name: 'Alice' }])
+        })
+    })
+
+    describe('deleteTable', () => {
+        it('passes schemaName through to the API', async () => {
+            const store = useProductTablesStore()
+            tablesApi.deleteTable.mockResolvedValue({})
+            await store.deleteTable({ teamId: 'team-1', databaseId: 'db-1', tableName: 'users', schemaName: 'reports' })
+            expect(tablesApi.deleteTable).toHaveBeenCalledWith('team-1', 'db-1', 'users', 'reports')
         })
     })
 

--- a/test/unit/frontend/stores/product-tables.spec.js
+++ b/test/unit/frontend/stores/product-tables.spec.js
@@ -126,6 +126,14 @@ describe('product-tables store', () => {
             await store.getTables('db-1')
             expect(store.tableSelection).toBeNull()
         })
+
+        it('maps the API schema field to dbSchema, leaving schema free for column definitions', async () => {
+            const store = useProductTablesStore()
+            tablesApi.getTables.mockResolvedValue([{ name: 'orders', schema: 'reports' }])
+            await store.getTables('db-1')
+            expect(store.tables['db-1'][0].dbSchema).toBe('reports')
+            expect(store.tables['db-1'][0].schema).toBeUndefined()
+        })
     })
 
     describe('clearState', () => {


### PR DESCRIPTION
## Summary
- The tables list endpoint never returned a table's schema, even though the response schema documents it. The Postgres drivers only selected `tablename`, not `schemaname`.
- The table data endpoint 500'd for any table outside the `public` schema, because the query used an unqualified identifier that only resolves via Postgres's default `search_path`.
- `getTable`, `getTableData`, and `dropTable` now accept an optional trailing `schemaName` path segment, so a specific table can be targeted when the same name exists in more than one schema. This is backwards compatible (omitting it keeps the existing auto-detection), so no v1 to v2 migration was needed. Schema resolution never assumes `public` as a fallback.
- The Tables UI now surfaces schema throughout: a muted label next to each table name in the list, `schema_name.table_name` (with a copy button) in the detail view header, and `tableSelection` in the frontend store is now a `{name, dbSchema}` identity so the right table is always addressed even when names collide across schemas.
- The create-table drawer no longer implies a schema picker is coming; it notes the table will be created in the database's default schema, since there's no endpoint yet to list a database's schemas.

Closes FlowFuse/engineering#208
Closes FlowFuse/engineering#209
Closes FlowFuse/engineering#210

## Test plan
- [x] Unit tests added/updated for both Postgres drivers (getTables schema field, getTable/getTableData/dropTable schema resolution with and without an explicit schemaName, and the no-hardcoded-schema fallback path)
- [x] Unit tests added/updated for the frontend store (dbSchema mapping, schema-aware tableSelection, schema-scoped getTableSchema/getTableData/deleteTable)
- [x] Verified manually against a real Postgres instance: created a table in a non-public schema, confirmed it appears in the tables list with the correct schema and that its sample data loads without error
