### PR TITLE
[7876] Remote instances: consolidate buttons on details page and move status column on list   

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -475,10 +475,10 @@ export default {
         columns () {
             const columns = [
                 { label: 'Remote Instance', key: 'name', sortable: true, component: { is: markRaw(DeviceLink) } },
+                { label: 'Status', key: 'lastSeenAt', class: ['w-40'], sortable: true, component: { is: markRaw(DeviceOnlineStatusCell) } },
                 { label: 'Type', key: 'type', class: ['w-48'], sortable: true },
                 { label: 'Created', key: 'createdAt', class: ['w-48'], sortable: true, component: { is: markRaw(DeviceCreatedAtCell) } },
                 { label: 'Mode', key: 'mode', class: ['w-30'], sortable: true, component: { is: markRaw(DeviceModeBadge) } },
-                { label: 'Status', key: 'lastSeenAt', class: ['w-40'], sortable: true, component: { is: markRaw(DeviceOnlineStatusCell) } }
             ]
 
             if (this.displayingTeam) {

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -11,8 +11,11 @@
             </template>
             <template #status>
                 <div class="flex flex-wrap gap-2">
-                    <DeviceLastSeenBadge :last-seen-at="device.lastSeenAt" :last-seen-ms="device.lastSeenMs" :last-seen-since="device.lastSeenSince" />
-                    <StatusBadge :status="device.status" :instanceId="device.id" instanceType="device" />
+                    <DeviceOnlineStatusCell
+                        :onlineStatus="device.onlineStatus"
+                        :status="device.status"
+                        :lastSeenAt="device.lastSeenAt"
+                    />
                     <DeviceModeBadge v-if="isDevModeAvailable " :mode="device.mode" />
                 </div>
             </template>
@@ -143,7 +146,6 @@ import deviceApi from '../../api/devices.js'
 import DropdownMenu from '../../components/DropdownMenu.vue'
 import FinishSetupButton from '../../components/FinishSetup.vue'
 import SectionNavigationHeader from '../../components/SectionNavigationHeader.vue'
-import StatusBadge from '../../components/StatusBadge.vue'
 import SubscriptionExpiredBanner from '../../components/banners/SubscriptionExpired.vue'
 import TeamTrialBanner from '../../components/banners/TeamTrial.vue'
 import { useInstanceStates } from '../../composables/InstanceStates.js'
@@ -165,8 +167,8 @@ import AssignDeviceDialog from './components/AssignDeviceDialog.vue'
 
 import DeveloperModeToggle from './components/DeveloperModeToggle.vue'
 import DeviceEditorLink from './components/DeviceEditorLink.vue'
-import DeviceLastSeenBadge from './components/DeviceLastSeenBadge.vue'
 import DeviceModeBadge from './components/DeviceModeBadge.vue'
+import DeviceOnlineStatusCell from './components/DeviceOnlineStatusCell.vue'
 
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useAccountStore } from '@/stores/account.js'
@@ -186,10 +188,9 @@ export default {
         FinishSetupButton,
         DeveloperModeToggle,
         DeviceModeBadge,
-        DeviceLastSeenBadge,
+        DeviceOnlineStatusCell,
         DropdownMenu,
         SectionNavigationHeader,
-        StatusBadge,
         SubscriptionExpiredBanner,
         TeamTrialBanner,
         AssignDeviceDialog,
@@ -387,8 +388,8 @@ export default {
         ...mapActions(useContextStore, { setContextualDevice: 'setDevice' }),
         applyLiveStatus () {
             const meta = this.liveDeviceMetadata[this.device?.id]
-            if (!meta || this.device?.status === meta.status) return
-            this.device = applyLiveState(this.device, meta.status, { device: true, clearFlags: true })
+            if (!meta || (this.device?.status === meta.status && this.device?.onlineStatus === meta.onlineStatus)) return
+            this.device = applyLiveState(this.device, meta.status, { device: true, clearFlags: true, onlineStatus: meta.onlineStatus })
         },
         pollTimerElapsed: async function () {
             // Only refresh device via the timer if we are on the overview page, developer mode page


### PR DESCRIPTION
## Description

- Moves the status column to the 2nd slot after name for Team → Remote Instances, Instance → Devices & Application → Devices. 
- Consolidates the header badges on the device details page to one `Offline`/`Online`/`Never seen` badge. 

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7876

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

