### PR TITLE
[7883] Paginating hosted instances can return an incorrect count which leads to a blank page at the end of results

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -609,7 +609,8 @@ module.exports = {
                         include.push({
                             model: M.ProjectSettings,
                             attributes: ['id', 'key', 'value', 'ProjectId'],
-                            where: { key: 'settings' }
+                            where: { key: 'settings' },
+                            required: false
                         })
                     }
 
@@ -839,7 +840,8 @@ module.exports = {
                             {
                                 model: M.ProjectSettings,
                                 attributes: ['id', 'key', 'value', 'ProjectId'],
-                                where: { key: 'settings' }
+                                where: { key: 'settings' },
+                                required: false
                             },
                             {
                                 model: M.Application,

--- a/test/unit/forge/routes/api/search_spec.js
+++ b/test/unit/forge/routes/api/search_spec.js
@@ -342,6 +342,24 @@ describe('Search API', function () {
             })
         })
 
+        it('finds an instance that is missing its settings row', async function () {
+            const teamHashId = app.db.models.Team.encodeHashid(TestObjects.BTeam.id)
+            await app.db.models.ProjectSettings.destroy({ where: { ProjectId: TestObjects.App1Instance1.id, key: 'settings' } })
+            try {
+                const response = await app.inject({
+                    method: 'GET',
+                    url: '/api/v1/search/instances',
+                    query: { team: teamHashId, query: 'instance-app-one-abc' },
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.results.map(r => r.name).should.containEql('instance-app-one-abc')
+            } finally {
+                await TestObjects.App1Instance1.updateSetting('settings', { header: { title: 'instance-app-one-abc' } })
+            }
+        })
+
         it('returns empty results for valid team but blank query', async function () {
             const teamHashId = app.db.models.Team.encodeHashid(TestObjects.BTeam.id)
             const response = await app.inject({

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -651,6 +651,22 @@ describe('Team API', function () {
             result.should.have.property('projects').and.be.an.Array()
             result.projects.should.have.a.property('length', 4)
         })
+        it('Counts and returns instances missing their settings row', async function () {
+            const instances = await app.db.models.Project.byTeam(TestObjects.ATeam.hashid)
+            const victim = instances.find((p) => p.name === 'list-instance-1')
+            await app.db.models.ProjectSettings.destroy({ where: { ProjectId: victim.id, key: KEY_SETTINGS } })
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/projects?page=1&limit=25`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.meta.should.have.property('total', 4)
+            result.projects.should.have.length(4)
+            result.projects.map((p) => p.name).should.containEql('list-instance-1')
+        })
         it('Filters the project list by live state', async function () {
             const warningInstance = await app.factory.createInstance(
                 { name: 'list-instance-warning' },


### PR DESCRIPTION
## Description

See https://github.com/FlowFuse/flowfuse/issues/7883#issue-4939137202

> TLDR: Instances missing a settings row were counted but not returned, inflating the total and leaving a blank last page. Fixed the join so they're both counted and returned.

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7883

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

