### PR TITLE
Fix: guide header steps disappear after reopening expert drawer

### DIFF
--- a/frontend/src/components/expert/components/messages/components/GuideHeader.vue
+++ b/frontend/src/components/expert/components/messages/components/GuideHeader.vue
@@ -56,6 +56,11 @@ export default {
                 this.$emit('streaming-complete')
             }
         }
+    },
+    mounted () {
+        if (!this.shouldStream) {
+            this.$emit('streaming-complete')
+        }
     }
 }
 </script>


### PR DESCRIPTION
## Description

`GuideHeader.vue` only emitted `streaming-complete` from watchers on its child `StreamableContent` instances (`streamableTitle`/`streamableSummary`), which flip to `streamed: true` only when `StreamableContent`'s internal `isStreaming` toggles. That only happens when `shouldStream` is `true` (`StreamableContent.vue`'s `mounted()` only calls `stream()` in that case).

When a message re-renders already streamed (e.g. closing and reopening the expert drawer), `shouldStream` is `false`, so those watchers never fire and `GuideHeader` never emits `streaming-complete`. Since `AnswerWrapper.vue` gates the guide steps list on the guide header having completed, the steps never get their turn to render and disappear.

Fix: add a `mounted()` hook that emits `streaming-complete` directly when `shouldStream` is `false`, mirroring the same short-circuit already used in `RichContent.vue`.

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/7913

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass — one-line component fix mirroring existing sibling components' behavior; no new tests added
 - [ ] Documentation has been updated
 - [ ] Changes `flowforge.yml`? No
 - [ ] Link to Changelog Entry PR, or note why one is not needed — trivial bugfix, no user-facing changelog needed