### PR TITLE
fix(tables): make the feature-gate 404 message explicit

### DIFF
--- a/forge/ee/routes/tables/index.js
+++ b/forge/ee/routes/tables/index.js
@@ -11,7 +11,7 @@ module.exports = async function (app) {
             }
             await request.team.ensureTeamTypeExists()
             if (!request.team.getFeatureProperty('tables', false)) {
-                reply.code(404).send({ code: 'not_found', error: 'Not Found - not available on team' })
+                reply.code(404).send({ code: 'not_found', error: 'Not Found - FlowFuse Tables is not enabled for this team' })
                 return // eslint-disable-line no-useless-return
             }
         }


### PR DESCRIPTION
## Summary
When FlowFuse Tables isn't enabled for a team's plan, every route under `/api/v1/teams/:teamId/databases` returns a plain 404: `{ code: 'not_found', error: 'Not Found - not available on team' }`. This is indistinguishable from a genuine "that database/table doesn't exist" response.

This came up while adding FlowFuse Tables as an MCP tool for Expert (see #7990): an LLM agent calling these tools has no signal that the feature simply isn't enabled versus the resource not existing, so it can't usefully tell the user "enable Tables for your team" instead of "that doesn't exist".

We discussed two options: augmenting the response with a new `reason`/`reasonCode` field (backward compatible, but introduces a new convention with no precedent in the codebase), versus just making the existing message explicit. Went with the latter since it's a plain string with no established contract around its exact wording, matches the clearest existing precedent (`forge/routes/api/assistant.js:185`), and needs no new convention.

Status code and `code` field are unchanged, only the `error` message now names the feature.

## Test plan
- [x] Lint passes
- No existing test asserts the old message text