### PR TITLE
[7997] Dashboards - move the drawer toggle to the right side  

### DIFF
--- a/frontend/src/components/dashboard/DashboardViewer.vue
+++ b/frontend/src/components/dashboard/DashboardViewer.vue
@@ -36,7 +36,7 @@
 
         <div class="ff-layout--immersive--content dashboards-viewer--content">
             <DashboardView v-if="selectedInstance" :instance="selectedInstance" :disable-events="isResizing" />
-            <DrawerTrigger :is-hidden="drawerOpen" @toggle="drawersStore.toggleEditorImmersiveDrawer" />
+            <DrawerTrigger :is-hidden="drawerOpen" side="right" @toggle="drawersStore.toggleEditorImmersiveDrawer" />
         </div>
 
         <template v-if="!statusChannelLive">

--- a/frontend/src/components/immersive-editor/DrawerTrigger.vue
+++ b/frontend/src/components/immersive-editor/DrawerTrigger.vue
@@ -2,23 +2,25 @@
     <button
         title="Toggle drawer"
         class="drawer-trigger"
-        :class="{ 'hidden': isHidden, 'nr5-plus': isNr5Plus }"
+        :class="{ 'hidden': isHidden, 'nr5-plus': isNr5Plus, 'side-right': side === 'right' }"
         :aria-label="isHidden ? 'Open drawer' : 'Close drawer'"
         :aria-expanded="!isHidden"
         type="button"
         @click="$emit('toggle')"
     >
         <img src="../../images/icons/ff-minimal-grey.svg" alt="FlowFuse logo">
-        <ChevronRightIcon class="ff-btn--icon" />
+        <ChevronLeftIcon v-if="side === 'right'" class="ff-btn--icon" />
+        <ChevronRightIcon v-else class="ff-btn--icon" />
     </button>
 </template>
 
 <script>
-import { ChevronRightIcon } from '@heroicons/vue/24/outline'
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/outline'
 
 export default {
     name: 'DrawerTrigger',
     components: {
+        ChevronLeftIcon,
         ChevronRightIcon
     },
     props: {
@@ -29,6 +31,10 @@ export default {
         isNr5Plus: {
             type: Boolean,
             default: false
+        },
+        side: {
+            type: String,
+            default: 'left'
         }
     },
     emits: ['toggle']
@@ -94,6 +100,20 @@ export default {
     &.hidden {
         // Move completely off-screen: own width (100%) + extra margin (20px)
         transform: translateX(calc(-100% - 20px));
+    }
+
+    &.side-right {
+        left: auto;
+        right: 0;
+        flex-direction: row-reverse;
+        padding: 8px 8px 8px 2px;
+        border-left: 1px solid var(--ff-color-border-strong);
+        border-right: none;
+        border-radius: 10px 0 0 10px;
+
+        &.hidden {
+            transform: translateX(calc(100% + 20px));
+        }
     }
 
     &:hover {


### PR DESCRIPTION
## Description

This move the drawer toggle to the right side for the dashboard only. We should revisit this since it creates inconsistency with the immersive editor but this is a quick fix for now. 

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/7997

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

