### PR TITLE
fix(expert): prevent human chat bubble overflowing past panel width

### DIFF
--- a/frontend/src/components/expert/components/messages/components/MessageBubble.vue
+++ b/frontend/src/components/expert/components/messages/components/MessageBubble.vue
@@ -70,6 +70,8 @@ export default {
         color: var(--ff-color-text-on-brand);
         border-bottom-right-radius: 0.125rem;
         width: fit-content;
+        max-width: 100%;
+        min-width: 0;
         align-self: end;
     }
 


### PR DESCRIPTION
human-message used width: fit-content with no max-width, so unbreakable markdown content (long code lines, wide tables) could force the bubble wider than its container. ai-message never hit this since it stretches to a fixed width by default. Cap human-message the same way.

## Description

### Before
<img width="1279" height="1263" alt="Screenshot 2026-07-29 at 22 31 18" src="https://github.com/user-attachments/assets/9379c29e-8a48-40dd-b918-59992faabce5" />

### After
<img width="1276" height="1242" alt="Screenshot 2026-07-29 at 22 33 54" src="https://github.com/user-attachments/assets/8dfd35a4-8896-445e-925f-26ffdd76b824" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

