### PR TITLE
Fix device agent setup for windows PowerShell instructions in quickstart.md

### DIFF
--- a/docs/device-agent/quickstart.md
+++ b/docs/device-agent/quickstart.md
@@ -43,6 +43,7 @@ If you already have Node.js v22+ installed, or need to customize the setup, chec
 
 1. Open a powershell terminal with elevated permission:
   ```bash
+# From Windows Run dialog or a terminal window, enter:
 powershell -Command "Start-Process 'powershell' -Verb RunAs"
 ```
 

--- a/docs/device-agent/quickstart.md
+++ b/docs/device-agent/quickstart.md
@@ -138,4 +138,3 @@ Here are a few to get you started:
 * [Logs](../user/logs.md)
 
 
-[^1]: Run `powershell -Command "Start-Process 'cmd' -Verb runAs` to launching an elevated command prompt window (e.g. as an admin user)

--- a/docs/device-agent/quickstart.md
+++ b/docs/device-agent/quickstart.md
@@ -43,7 +43,7 @@ If you already have Node.js v22+ installed, or need to customize the setup, chec
 
 1. Open a powershell terminal with elevated permission:
   ```bash
-powershell -Command "Start-Process 'cmd' -Verb RunAs"
+powershell -Command "Start-Process 'powershell' -Verb RunAs"
 ```
 
 2. Run the follow command in the elevated terminal to download and run the installer:

--- a/docs/device-agent/quickstart.md
+++ b/docs/device-agent/quickstart.md
@@ -46,9 +46,9 @@ If you already have Node.js v22+ installed, or need to customize the setup, chec
 powershell -Command "Start-Process 'cmd' -Verb RunAs"
 ```
 
-2. Run the follow command in that terminal to download and run the installer:
+2. Run the follow command in the elevated terminal to download and run the installer:
   ```bash
-powershell -c "irm https://flowfuse.github.io/device-agent/get.ps1 | iex; .\flowfuse-device-agent-installer.exe"
+Set-Location $env:USERPROFILE; powershell -c "irm https://flowfuse.github.io/device-agent/get.ps1 | iex"; .\flowfuse-device-agent-installer.exe
 ```
 
 {% note %}


### PR DESCRIPTION


## Description

Updated instructions for windows running the installer in the quickstart guide.

In short, when the elevated command is ran, the new terminal always opens in `c:\windows\system32`. This will cause the downloads to occur in the system32 dir - if even permitted (depends on how terminal was fired up and by who).  Essentially, this can lead to System errors (Access Denied) or stale versions running if previously executed.

The solution is to ensure the user dir is first selected before any web downloads occur.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

