### PR TITLE
Re-enable the documentation checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,6 @@ on:
       - 'docs/**'
 jobs:
   test:
-    if: false
     runs-on: ubuntu-latest
     name: Test Documentation links
     steps:
@@ -24,7 +23,6 @@ jobs:
       - name: Test Documentation Links
         run: npm run test:docs
   test-with-website:
-    if: false
     runs-on: ubuntu-latest
     name: Test Documentation with website
     steps:

--- a/docs/device-agent/deploy.md
+++ b/docs/device-agent/deploy.md
@@ -43,7 +43,7 @@ When running in the default of Fleet Mode, the device agent does not allow local
 Node-RED editor. This ensures the Remote Instance is running the deployed snapshot without modification.
 
 When running on FlowFuse Cloud, or a premium licensed FlowFuse instance (with the
-[MQTT broker enabled](https://flowfuse.com/docs/contribute/local/#setting-up-mosquitto-(optional)))
+[MQTT broker enabled](https://flowfuse.com/docs/contribute/local/#setting-up-mosquitto-optional))
 the Remote Instance can be placed in Developer Mode that enables remote access to the editor. 
 
 This can then be used to develop the flows directly on the Remote Instance and a new snapshot
@@ -72,7 +72,7 @@ Access to the editor is only available when:
 * The Remote Instance is in Developer Mode
 
 * When running on FlowFuse Cloud, or a premium licensed FlowFuse instance (with the
-[MQTT broker enabled](https://flowfuse.com/docs/contribute/local/#setting-up-mosquitto-(optional))
+[MQTT broker enabled](https://flowfuse.com/docs/contribute/local/#setting-up-mosquitto-optional)
 the Remote Instance can be placed in Developer Mode that enables remote access to the editor.
 
 * Local access to the editor can be enabled by defining a Username & Password in the Device 

--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -91,7 +91,7 @@ Before you begin, ensure you have the following:
 
 For a production-ready environment, we also recommend: 
 * **Database:** Prepare dedicated database on a external database server (see [FAQ](#how-to-use-external-database-server%3F) for more details)
-* **TLS Certification:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](#enable-https-(optional)))
+* **TLS Certification:** Prepare TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](#enable-https-optional))
 
 ### Requirements
 
@@ -291,7 +291,7 @@ Once ready, [start the application](#start-flowfuse-platform) .
 
 ### How can I provide my own TLS certificate?
 
-If you have your own TLS certificate, you can use it in FlowFuse platform installation as well. See [Enable HTTPS](#enable-https-(optional)) section for more details.
+If you have your own TLS certificate, you can use it in FlowFuse platform installation as well. See [Enable HTTPS](#enable-https-optional) section for more details.
 
 Additionally, if your TLS certificate is issued by a private Certificate Authority, you will need to perform some additional configuration to make hosted Node-RED instances trust the CA. See [What additional configuration is required when the TLS certificate is issued by a private Certificate Authority](#what-additional-configuration-is-required-when-the-tls-certificate-is-issued-by-a-private-certificate-authority%3F) for the step-by-step instructions.
 

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -142,7 +142,7 @@ This release introduces an MQTT Broker into the FlowFuse platform used to commun
 between devices and the core platform.
 
 For LocalFS users, they will need to manually setup the broker and ensure it is
-properly configured. The documentation for this is available [here](../contribute/local#setting-up-mosquitto-(optional))
+properly configured. The documentation for this is available [here](../contribute/local#setting-up-mosquitto-optional)
 
 #### LocalFS Users
 


### PR DESCRIPTION
Deletes the two `if: false` lines, so the doc link checks run again and broken links get caught before publishing.

**Merge after https://github.com/FlowFuse/website/pull/5473.** `test-with-website` needs that PR in order to build a docs PR against its own docs. Before it, this fails on `Missing script: "docs"`.

Should also restore the `needs` on `publish` that #8029 drops.

`test` is blocked by something unrelated and repo-wide: `npm ci` rejects the lockfile with `lock file's globals@17.8.0 does not satisfy globals@17.9.0`. `Build and contenerize` fails the same way.

Also fixes five broken `(optional)` anchors in `docs/`. An unescaped `(` ends a markdown link target, so they point at nothing. They are also what makes this PR's own checks run, since the workflow only triggers on `docs/**`.