### PR TITLE
Resync package-lock.json for globals 17.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14769,9 +14769,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "17.8.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-            "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+            "version": "17.9.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+            "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -36598,9 +36598,9 @@
             }
         },
         "globals": {
-            "version": "17.8.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-            "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+            "version": "17.9.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+            "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
             "dev": true
         },
         "globalthis": {


### PR DESCRIPTION
## Description

`npm ci` began failing on `main` because the lockfile pinned `globals@17.8.0` while `package.json`'s `^17.7.0` now resolves to the newly-published `17.9.0`. This resyncs `package-lock.json` to `17.9.0`. Its a dev-only, lint-time dependency (used solely by `eslint.config.mjs`), so there's no runtime impact.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

