### PR TITLE
Let docs publish run while the checks are disabled

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,9 +77,9 @@ jobs:
   publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: 
-      - test
-      - test-with-website
+    # Deliberately gated on nothing while `test` and `test-with-website` are disabled:
+    # a skipped job skips whatever needs it, which is why merging a docs change stopped
+    # triggering a website rebuild. Restore the `needs` when those two come back.
     name: Publish Documentation
     steps:
       - name: Generate token


### PR DESCRIPTION
Merging a `docs/**` change used to trigger a website rebuild. It stopped, because `publish` waits on the two doc checks, those checks are switched off, and GitHub skips any job that waits on a skipped one. Docs now only reach the site when the website rebuilds for its own reasons.

Dropping the wait restores the trigger.

Only observable after merging: `publish` runs on pushes to `main`, never on a PR.

Re-enabling the checks is separate work in #8024, which should put the wait back.