### PR TITLE
Fix self-hosted Expert default service URL and log chat transport

### DIFF
--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -132,11 +132,11 @@ module.exports = {
 
         if (config.assistant?.enabled === true && !config.assistant.service?.url) {
             config.assistant.service = config.assistant.service || {}
-            config.assistant.service.url = 'https://expert.flowfuse/v1/openai'
+            config.assistant.service.url = 'https://expert.flowfuse.com/v1/openai'
         }
         if (config.expert?.enabled === true && !config.expert.service?.url) {
             config.expert.service = config.expert.service || {}
-            config.expert.service.url = 'https://expert.flowfuse/v4/expert'
+            config.expert.service.url = 'https://expert.flowfuse.com/v4/expert'
         }
 
         const defaultLogging = {

--- a/forge/ee/lib/expert/index.js
+++ b/forge/ee/lib/expert/index.js
@@ -24,6 +24,20 @@ module.exports = fp(async function (app, _opts) {
     const TOKEN_TTL = app.config.expert?.tokenCache?.ttl || 5 * 60 * 1000 // Default 5 minutes
     const TOKEN_REMAINING_LIMIT = 15000 // token life edge window (avoid using tokens about to expire)
 
+    // Log the Expert chat transport at startup. With the team broker enabled chat uses
+    // the MQTT bridge (needs expert.centralBroker.server); otherwise it uses the HTTP url.
+    if (serviceEnabled) {
+        const teamBrokerEnabled = app.config.broker?.teamBroker?.enabled === true
+        if (expertBridgeEnabled) {
+            const ssl = app.config.expert?.centralBroker?.ssl ?? true
+            app.log.info(`Expert enabled: chat via MQTT bridge to ${app.config.expert.centralBroker.server} (ssl=${ssl})`)
+        } else if (teamBrokerEnabled) {
+            app.log.warn('Expert enabled with the team broker on, but expert.centralBroker.server is not set: MQTT chat has no bridge and will not receive responses. Set expert.centralBroker.server (host:port).')
+        } else {
+            app.log.info(`Expert enabled: chat via HTTP service url ${expertUrl}`)
+        }
+    }
+
     app.housekeeper.registerTask(require('./tasks/startup'))
     app.housekeeper.registerTask(require('./tasks/weekly'))
 


### PR DESCRIPTION
## Description

Two small fixes to make self-hosted Expert setup less error-prone.

**1. Correct the default service URLs**

When `expert.service.url` (or `assistant.service.url`) is omitted, the platform fills in a default. Those defaults pointed at `https://expert.flowfuse/...` — missing the `.com`, so the host has no DNS record. Any deployment relying on the documented "url is optional" behaviour hit `getaddrinfo ENOTFOUND expert.flowfuse` (e.g. from the `/mcp/tools` catalog fetch). Added the missing `.com` to both defaults.

**2. Log the Expert chat transport on startup**

When Expert is enabled, log which transport chat will use:
- MQTT bridge, when `expert.centralBroker.server` is set (logs the broker + ssl).
- HTTP service url, otherwise.
- A warning when the team broker is enabled but `expert.centralBroker.server` is unset — that combination means chat uses MQTT but the bridge is never provisioned, which previously failed silently with nothing in the logs.

## Impact

Config-load default change and added logging only. No behavioural change for correctly configured deployments.