### PR TITLE
Ensure Azure Git URLs accept project names

### DIFF
--- a/forge/ee/lib/gitops/backends/azure.js
+++ b/forge/ee/lib/gitops/backends/azure.js
@@ -36,7 +36,7 @@ module.exports.init = async function (app) {
             const url = new URL(repoOptions.url)
             url.username = token
 
-            const match = /^https:\/\/dev.azure.com\/(?<org>.+)\/_git\/.+$/.exec(repoOptions.url)
+            const match = /^https:\/\/dev.azure.com\/(?<org>[^/]+)(\/(?<project>[^/]+))?\/_git\/.+$/.exec(repoOptions.url)
             const orgName = match.groups?.org
 
             // 2. get user details so we can properly attribute the commit

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -298,9 +298,9 @@ export default {
             if (this.stage?.gitRepo?.url.startsWith('https://github.com')) {
                 return `${this.stage.gitRepo.url}/tree/${this.stage.gitRepo.branch || 'main'}`
             } else if (this.stage?.gitRepo?.url.startsWith('https://dev.azure.com')) {
-                const regex = /^https:\/\/dev.azure.com\/(?<org>.+)\/_git\/(?<repo>.+)$/
+                const regex = /^https:\/\/dev.azure.com\/(?<org>[^/]+)(\/(?<project>[^/]+))?\/_git\/(?<repo>.+)$/
                 const match = regex.exec(this.stage.gitRepo.url)
-                return `https://dev.azure.com/${match.groups.org}/${match.groups.repo}/_git/${match.groups.repo}?path=%2F&version=GB${this.stage.gitRepo.branch || 'main'}`
+                return `https://dev.azure.com/${match.groups.org}/${match.groups.project || match.groups.repo}/_git/${match.groups.repo}?path=%2F&version=GB${this.stage.gitRepo.branch || 'main'}`
             }
             return `${this.stage.gitRepo.url}/tree/${this.stage.gitRepo.branch || 'main'}`
         }

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -665,7 +665,7 @@ export default {
         },
         gitPlaceholder () {
             if (this.selectedGitTokenType === 'azure') {
-                return 'e.g. https://dev.azure.com/[org]/_git/[repo]'
+                return 'e.g. https://dev.azure.com/[org]/[project]/_git/[repo]'
             } else if (this.selectedGitTokenType === 'generic') {
                 return 'e.g. https://git.example.com/org/repo.git'
             }
@@ -726,7 +726,7 @@ export default {
             if (url === '') {
                 this.errors.url = ''
             } else if (type === 'github' || type === 'azure') {
-                this.errors.url = (/^https:\/\/github\.com\/[^/]+\/[^/]+$/.test(url) || /^https:\/\/dev\.azure\.com\/[^/]+\/_git\/[^/]+$/.test(url))
+                this.errors.url = (/^https:\/\/github\.com\/[^/]+\/[^/]+$/.test(url) || /^https:\/\/dev\.azure\.com\/[^/]+\/[^/]\/_git\/[^/]+$/.test(url))
                     ? ''
                     : 'Please enter a valid GitHub or Azure DevOps repository URL'
             } else {


### PR DESCRIPTION
fixes #8055

## Description

<!-- Describe your changes in detail -->
Previous version was using the WebUI URL which hides the project name Updated to allow either but validate with project id as required.

e.g. Web UI `https://dev.azure.com/org/_git/repo`

git URL `https://dev.azure.com/org/project/_git/repo`



## Related Issue(s)

<!-- What issue does this PR relate to? -->
fixes #8055

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

