### PR TITLE
Gate docs publishing on the two documentation checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,9 +75,9 @@ jobs:
   publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    # Deliberately gated on nothing while `test` and `test-with-website` are disabled:
-    # a skipped job skips whatever needs it, which is why merging a docs change stopped
-    # triggering a website rebuild. Restore the `needs` when those two come back.
+    needs:
+      - test
+      - test-with-website
     name: Publish Documentation
     steps:
       - name: Generate token


### PR DESCRIPTION
#8029 removed the `needs` from the `publish` job so docs could keep publishing while
`test` and `test-with-website` were switched off, with a comment to restore it once they
came back. #8024 switched them back on but left the gate off.

The result is visible on the run for #8024 on `main`: `Publish Documentation` completed
successfully while `Test Documentation with website` was still running. The checks report,
but a docs merge with a broken link still triggers the website rebuild.

This restores the `needs` and drops the stale comment.
