### PR TITLE
[8064] Flaky spec > Offboarding redirect sometimes lands on login page

### DIFF
--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -306,6 +306,7 @@ export default {
                        This action cannot be undone.`,
                 confirmLabel: 'Delete'
             }, async () => {
+                await useAccountAuthStore().disconnectSubscribers()
                 userApi.deleteUser()
                     .then(() => {
                         if (this.settings['user:offboarding-required']) {

--- a/frontend/src/stores/account-auth.js
+++ b/frontend/src/stores/account-auth.js
@@ -62,6 +62,12 @@ export const useAccountAuthStore = defineStore('account-auth', {
         setRedirectUrl (url) {
             this.redirectUrlAfterLogin = url
         },
+        async disconnectSubscribers () {
+            const subscribers = getAppOrchestrator().$subscribers
+            await Promise.all(
+                Object.values(subscribers).map(subscriber => subscriber?.disconnect().catch(() => {}))
+            )
+        },
         async checkIfAuthenticated () {
             const user = await userApi.getUser()
             this.user = user
@@ -206,11 +212,7 @@ export const useAccountAuthStore = defineStore('account-auth', {
             if (useAccountSettingsStore().settings['platform:sso:only']) {
                 logoutURL = useAccountSettingsStore().settings['platform:sso:only:logoutURL'] || '/'
             }
-            const subscribers = getAppOrchestrator().$subscribers
-            const disconnect = Promise.all(
-                Object.values(subscribers).map(subscriber => subscriber?.disconnect().catch(() => {}))
-            )
-            return disconnect
+            return this.disconnectSubscribers()
                 .then(() => userApi.logout())
                 .then(() => this.clearStores())
                 .catch(_ => {})


### PR DESCRIPTION
## Description

Makes `offboarding.spec.js` less flaky by disconnecting the subscribers before deleting a user so they stop fighting each other for redirects. 

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/8064

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

