### PR TITLE
docs: declare sidebar group order in section frontmatter

### DIFF
--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: FlowFuse Self-Hosted
+navGroupOrder: 4
 navOrder: 4
 navTitle: Administering FlowFuse
 redirect:

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: FlowFuse User Manuals
+navGroupOrder: 1
 navOrder: 2
 navTitle: FlowFuse API
 meta:

--- a/docs/cloud/README.md
+++ b/docs/cloud/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: FlowFuse Cloud
+navGroupOrder: 3
 navOrder: 3
 navTitle: FlowFuse Cloud
 redirect:

--- a/docs/community-support.md
+++ b/docs/community-support.md
@@ -1,5 +1,6 @@
 ---
 navGroup: Support
+navGroupOrder: 5
 navOrder: 1
 navTitle: Community Support
 redirect: 

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: Contributing
+navGroupOrder: 6
 navTitle: Contributing to FlowFuse
 redirect:
   to: /docs/contribute/introduction

--- a/docs/debugging/README.md
+++ b/docs/debugging/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: Support
+navGroupOrder: 5
 navTitle: Debugging Node-RED issues
 meta:
   description: Learn how to troubleshoot unresponsive Node-RED instances using Safe Mode.

--- a/docs/device-agent/README.md
+++ b/docs/device-agent/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: Device Agent
+navGroupOrder: 2
 navTitle: Device Agent
 redirect:
   to: /docs/device-agent/introduction

--- a/docs/hardware/README.md
+++ b/docs/hardware/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: Device Agent
+navGroupOrder: 2
 navTitle: Hardware Guides
 redirect:
   to: /docs/hardware/introduction

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: FlowFuse Self-Hosted
+navGroupOrder: 4
 navTitle: Installing FlowFuse
 redirect:
   to: /docs/install/introduction

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: FlowFuse User Manuals
+navGroupOrder: 1
 navOrder: 3
 navTitle: Migrating a Node-RED project to FlowFuse
 redirect:

--- a/docs/premium-support.md
+++ b/docs/premium-support.md
@@ -1,5 +1,6 @@
 ---
 navGroup: Support
+navGroupOrder: 5
 navOrder: 3
 navTitle: Premium Support
 meta:

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: FlowFuse Self-Hosted
+navGroupOrder: 4
 navTitle: Quick Start
 navOrder: 1
 meta:

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: FlowFuse Self-Hosted
+navGroupOrder: 4
 navOrder: 3
 navTitle: Upgrading FlowFuse
 meta:

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,5 +1,6 @@
 ---
 navGroup: FlowFuse User Manuals
+navGroupOrder: 1
 navOrder: 1
 navTitle: Using FlowFuse
 redirect:


### PR DESCRIPTION
The docs sidebar groups sections under a `navGroup` heading, but the order of those headings is a hardcoded array in the website repo (`GROUP_ORDER` in `nuxt/composables/useDocsNav.ts`), even though the group names themselves are declared here. Adding, renaming or reordering a group needed a website change.

This adds `navGroupOrder` alongside each `navGroup`. The website ranks a heading by the lowest `navGroupOrder` of its sections, so the whole docs structure (paths, page order, group names, group order) now lives in this repo.

Values reproduce the order the site renders today. Merge this before the website side, which drops the array: https://github.com/FlowFuse/website/pull/5513
