### PR TITLE
[8074] Data Farm > Teams 1 - store + team list

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -122,6 +122,7 @@ import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 import { useUxDrawersStore } from '@/stores/ux-drawers.js'
 import { useUxToursStore } from '@/stores/ux-tours.js'
 
@@ -135,7 +136,8 @@ export default {
         ...mapState(useUxDrawersStore, ['leftDrawer', 'hiddenLeftDrawer', 'editorImmersiveDrawer']),
         ...mapState(useAccountAuthStore, ['user']),
         ...mapState(useContextStore, ['team']),
-        ...mapState(useAccountStore, ['teams', 'notifications', 'hasAvailableTeams', 'defaultUserTeam']),
+        ...mapState(useAccountStore, ['notifications']),
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList', hasAvailableTeams: 'hasAvailableTeams', defaultUserTeam: 'defaultUserTeam' }),
         ...mapState(useAccountSettingsStore, ['canCreateTeam', 'featuresCheck']),
         navigationOptions () {
             return [

--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -51,6 +51,7 @@ import NavItem from './NavItem.vue'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'FFTeamSelection',
@@ -66,7 +67,7 @@ export default {
     },
     computed: {
         ...mapState(useContextStore, ['team']),
-        ...mapState(useAccountStore, ['teams', 'hasAvailableTeams']),
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList', hasAvailableTeams: 'hasAvailableTeams' }),
         ...mapState(useAccountSettingsStore, ['canCreateTeam']),
         teamOptions () {
             return [

--- a/frontend/src/components/TeamTypeTile.vue
+++ b/frontend/src/components/TeamTypeTile.vue
@@ -35,7 +35,7 @@ import { mapState } from 'pinia'
 import { useHubspotHelper } from '../composables/Hubspot.js'
 
 import { useAccountAuthStore } from '@/stores/account-auth.js'
-import { useAccountStore } from '@/stores/account.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'TeamTypeTile',
@@ -59,7 +59,7 @@ export default {
         return { talkToSalesCalendarModal }
     },
     computed: {
-        ...mapState(useAccountStore, ['teams']),
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList' }),
         ...mapState(useAccountAuthStore, ['user']),
         pricing: function () {
             const billingDescriptionKey = this.billingInterval === 'year' ? 'yrDescription' : 'description'

--- a/frontend/src/components/multi-step-forms/device/MultiStepDeviceForm.vue
+++ b/frontend/src/components/multi-step-forms/device/MultiStepDeviceForm.vue
@@ -28,9 +28,9 @@ import ApplicationStep from '../instance/steps/ApplicationStep.vue'
 import DeviceStep from './steps/DeviceStep.vue'
 import TeamStep from './steps/TeamStep.vue'
 
-import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
 import { useDataFarmApplicationsStore } from '@/stores/data-farm-applications'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 const TEAM_STEP_SLUG = 'team'
 const APPLICATION_SLUG = 'application'
@@ -83,7 +83,7 @@ export default {
     },
     computed: {
         ...mapState(useContextStore, ['team', 'isFreeTeamType']),
-        ...mapState(useAccountStore, ['teams']),
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList' }),
         formSteps () {
             return [
                 {

--- a/frontend/src/components/multi-step-forms/device/steps/TeamStep.vue
+++ b/frontend/src/components/multi-step-forms/device/steps/TeamStep.vue
@@ -28,6 +28,7 @@ import { mapState } from 'pinia'
 
 import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'TeamStep',
@@ -40,7 +41,7 @@ export default {
     emits: ['next-step', 'step-updated'],
     computed: {
         ...mapState(useContextStore, ['team']),
-        ...mapState(useAccountStore, ['teams'])
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList' })
     },
     mounted () {
         this.$emit('step-updated', {

--- a/frontend/src/components/multi-step-forms/instance/MultiStepApplicationsInstanceForm.vue
+++ b/frontend/src/components/multi-step-forms/instance/MultiStepApplicationsInstanceForm.vue
@@ -29,9 +29,9 @@ import InstanceStep from './steps/InstanceStep.vue'
 import TeamStep from './steps/TeamStep.vue'
 import FlowsStep from './steps/flows-step/index.vue'
 
-import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
 import { useDataFarmApplicationsStore } from '@/stores/data-farm-applications'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 const TEAM_STEP_SLUG = 'team'
 const APPLICATION_SLUG = 'application'
@@ -89,7 +89,7 @@ export default {
     },
     computed: {
         ...mapState(useContextStore, ['team', 'isFreeTeamType']),
-        ...mapState(useAccountStore, ['teams']),
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList' }),
         formSteps () {
             return [
                 {

--- a/frontend/src/components/multi-step-forms/instance/steps/TeamStep.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/TeamStep.vue
@@ -28,6 +28,7 @@ import { mapState } from 'pinia'
 
 import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'TeamStep',
@@ -40,7 +41,7 @@ export default {
     emits: ['next-step', 'step-updated'],
     computed: {
         ...mapState(useContextStore, ['team']),
-        ...mapState(useAccountStore, ['teams'])
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList' })
     },
     mounted () {
         this.$emit('step-updated', {

--- a/frontend/src/mixins/Navigation.js
+++ b/frontend/src/mixins/Navigation.js
@@ -1,12 +1,12 @@
 import { mapState } from 'pinia'
 
-import { useAccountStore } from '@/stores'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     computed: {
         ...mapState(useContextStore, ['team']),
-        ...mapState(useAccountStore, ['defaultUserTeam']),
+        ...mapState(useDataFarmTeamsStore, ['defaultUserTeam']),
         homeLink () {
             if (this.team?.slug) {
                 return { name: 'Team', params: { team_slug: this.team.slug } }

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -47,8 +47,8 @@ import TeamTypeSelection from '../components/TeamTypeSelection.vue'
 
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
-import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 import { useUxLoadingStore } from '@/stores/ux-loading.js'
 
 export default {
@@ -65,7 +65,7 @@ export default {
     },
     computed: {
         ...mapState(useContextStore, ['team']),
-        ...mapState(useAccountStore, ['teams', 'defaultUserTeam']),
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList', defaultUserTeam: 'defaultUserTeam' }),
         ...mapState(useAccountSettingsStore, ['settings']),
         ...mapState(useAccountAuthStore, ['user', 'redirectUrlAfterLogin']),
         ...mapState(useUxLoadingStore, ['appLoader']),

--- a/frontend/src/pages/account/Security/dialogs/TokenDialog.vue
+++ b/frontend/src/pages/account/Security/dialogs/TokenDialog.vue
@@ -67,7 +67,8 @@ import { mapState } from 'pinia'
 import FormRow from '../../../../components/FormRow.vue'
 
 import userApi from '@/api/user.js'
-import { useAccountAuthStore, useAccountStore } from '@/stores/index.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
+import { useAccountAuthStore } from '@/stores/index.js'
 
 export default {
     name: 'TokenDialog',
@@ -129,7 +130,7 @@ export default {
         }
     },
     computed: {
-        ...mapState(useAccountStore, ['teams']),
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList' }),
         isAdmin () {
             return useAccountAuthStore().isAdminUser
         },

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -74,6 +74,7 @@ import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 import { useThemeStore } from '@/stores/theme.ts'
 
 export default {
@@ -110,7 +111,7 @@ export default {
     },
     computed: {
         ...mapState(useAccountSettingsStore, ['settings']),
-        ...mapState(useAccountStore, { storeTeams: 'teams' }),
+        ...mapState(useDataFarmTeamsStore, { storeTeams: 'teamList' }),
         themeLabel () {
             const opt = this.themeOptions.find(o => o.value === useThemeStore().mode)
             return opt ? opt.label : ''
@@ -332,9 +333,9 @@ export default {
                     .then(() => {
                         alerts.emit('Team successfully deleted', 'confirmation')
                         // refresh teams
-                        return useAccountStore().refreshTeams()
+                        return useDataFarmTeamsStore().fetchTeamList()
                     }).then(() => {
-                        const teams = useAccountStore().teams
+                        const teams = useDataFarmTeamsStore().teamList
                         const team = useContextStore().team
                         // check if the active team is one deleted
                         if (team?.id === teamId) {

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -20,6 +20,7 @@ import TeamCell from '../../../components/tables/cells/TeamCell.vue'
 import Alerts from '../../../services/alerts.js'
 
 import { useAccountStore } from '@/stores/account.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'UserInviteTable',
@@ -51,7 +52,7 @@ export default {
             await userApi.acceptTeamInvitation(invite.id, invite.team.id)
             await useAccountStore().getNotifications()
             await useAccountStore().getInvitations()
-            await useAccountStore().refreshTeams()
+            await useDataFarmTeamsStore().fetchTeamList()
             Alerts.emit(`Invite to "${invite.team.name}" has been accepted.`, 'confirmation')
             // navigate to team dashboad once invite accepted
             useAccountStore().setTeam(invite.team.slug)

--- a/frontend/src/pages/account/Teams/Teams.vue
+++ b/frontend/src/pages/account/Teams/Teams.vue
@@ -22,6 +22,7 @@ import CreateTeamButton from '../components/CreateTeamButton.vue'
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useAccountStore } from '@/stores/account.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'AccountTeams',
@@ -39,7 +40,7 @@ export default {
         }
     },
     computed: {
-        ...mapState(useAccountStore, ['teams']),
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList' }),
         ...mapState(useAccountSettingsStore, ['settings']),
         ...mapState(useAccountAuthStore, ['user']),
         teamCount () {
@@ -70,7 +71,7 @@ export default {
                 try {
                     await teamApi.removeTeamMember(row.id, this.user.id)
                     alerts.emit(`${this.user.username} successfully removed from ${row.name}`, 'confirmation')
-                    await useAccountStore().refreshTeams()
+                    await useDataFarmTeamsStore().fetchTeamList()
                     if (!this.teamCount) {
                         await useAccountStore().setTeam(null)
                     }

--- a/frontend/src/pages/team/Settings/General.vue
+++ b/frontend/src/pages/team/Settings/General.vue
@@ -83,8 +83,8 @@ import alerts from '../../../services/alerts.js'
 
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
-import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'TeamSettingsGeneral',
@@ -177,7 +177,7 @@ export default {
 
             teamApi.updateTeam(this.team.id, options).then(async result => {
                 this.editing = false
-                await useAccountStore().refreshTeams()
+                await useDataFarmTeamsStore().fetchTeamList()
                 await useContextStore().refreshTeam()
                 alerts.emit('Team Settings updated.', 'confirmation')
             }).catch(err => {

--- a/frontend/src/pages/team/Settings/TeamAdminTools.vue
+++ b/frontend/src/pages/team/Settings/TeamAdminTools.vue
@@ -232,8 +232,8 @@ import ConfirmTeamManualBillingDialog from '../dialogs/ConfirmTeamManualBillingD
 import ExtendTeamTrialDialog from '../dialogs/ExtendTeamTrialDialog.vue'
 
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
-import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'TeamAdminTools',
@@ -372,7 +372,7 @@ export default {
         },
         async setupManualBilling (teamTypeId) {
             billingApi.setupManualBilling(this.team.id, teamTypeId).then(async () => {
-                await useAccountStore().refreshTeams()
+                await useDataFarmTeamsStore().fetchTeamList()
                 await useContextStore().refreshTeam()
             }).catch(err => {
                 console.warn(err)
@@ -385,7 +385,7 @@ export default {
                 text: 'Are you sure you want to re-enable billing for this team?'
             }, async () => {
                 billingApi.disableManualBilling(this.team.id).then(async () => {
-                    await useAccountStore().refreshTeams()
+                    await useDataFarmTeamsStore().fetchTeamList()
                     await useContextStore().refreshTeam()
                 }).catch(err => {
                     console.warn(err)
@@ -398,7 +398,7 @@ export default {
         async extendTrial (endDate) {
             const newEndDate = Date.parse(`${endDate}T12:00:00.000Z`)
             billingApi.setTrialExpiry(this.team.id, newEndDate).then(async () => {
-                await useAccountStore().refreshTeams()
+                await useDataFarmTeamsStore().fetchTeamList()
                 await useContextStore().refreshTeam()
             }).catch(err => {
                 console.warn(err)

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -107,8 +107,8 @@ import Product from '../../services/product.js'
 
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
-import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'ChangeTeamType',
@@ -341,7 +341,7 @@ export default {
             }
 
             teamApi.updateTeam(this.team.id, opts).then(async result => {
-                await useAccountStore().refreshTeams()
+                await useDataFarmTeamsStore().fetchTeamList()
                 await useContextStore().refreshTeam()
                 // send posthog event
                 Product.capture('$ff-team-type-changed', {

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -99,6 +99,7 @@ import slugify from '../../utils/slugify.js'
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useAccountStore } from '@/stores/account.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 
 export default {
     name: 'CreateTeam',
@@ -171,7 +172,7 @@ export default {
         }
     },
     computed: {
-        ...mapState(useAccountStore, ['teams']),
+        ...mapState(useDataFarmTeamsStore, { teams: 'teamList' }),
         ...mapState(useAccountSettingsStore, ['features']),
         ...mapState(useAccountAuthStore, ['user']),
         formValid () {
@@ -255,7 +256,7 @@ export default {
             }
 
             teamApi.create(opts).then(async result => {
-                await useAccountStore().refreshTeams()
+                await useDataFarmTeamsStore().fetchTeamList()
                 await useAccountStore().setTeam(result)
                 // are we in EE?
                 if (result.billingURL) {

--- a/frontend/src/stores/account-auth.js
+++ b/frontend/src/stores/account-auth.js
@@ -12,6 +12,7 @@ import { useAccountStore } from '@/stores/account.js'
 import { useContextStore } from '@/stores/context.js'
 import { useCookieConsentStore } from '@/stores/cookie-consent'
 import { useDataFarmApplicationsStore } from '@/stores/data-farm-applications'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 import { useProductAssistantStore } from '@/stores/product-assistant.js'
 import { useProductBrokersStore } from '@/stores/product-brokers.js'
 import { useProductExpertInsightsAgentStore } from '@/stores/product-expert-insights-agent.js'
@@ -101,10 +102,9 @@ export const useAccountAuthStore = defineStore('account-auth', {
                 // check notifications count
                 await useAccountStore().getInvitations()
 
-                const teams = await teamApi.getTeams()
-                useAccountStore().setTeams(teams.teams)
+                const teams = await useDataFarmTeamsStore().fetchTeamList()
 
-                if (teams.count === 0) {
+                if (teams.length === 0) {
                     useUxLoadingStore().clearAppLoader()
                     useAccountStore().setTeam(null)
                     if (/^\/team\//.test(router.currentRoute.value.path)) {
@@ -126,7 +126,7 @@ export const useAccountAuthStore = defineStore('account-auth', {
                     if (!/^\/(application|device|instance)\//.test(redirectUrlAfterLogin || router.currentRoute.value.path)) {
                         // Assume we'll load the users default team, or the first in their team list
                         // if no default has been set
-                        let teamId = user.defaultTeam || teams.teams[0].id
+                        let teamId = user.defaultTeam || teams[0].id
                         let teamSlug = null
 
                         // Check the url to see if it is a /team/XYZ path - which
@@ -236,6 +236,7 @@ export const useAccountAuthStore = defineStore('account-auth', {
             useContextStore().$reset()
             useCookieConsentStore().reset()
             useDataFarmApplicationsStore().reset()
+            useDataFarmTeamsStore().reset()
             useProductTablesStore().$reset()
             useProductBrokersStore().$reset()
             useProductAssistantStore().$reset()

--- a/frontend/src/stores/account.js
+++ b/frontend/src/stores/account.js
@@ -5,7 +5,6 @@ import teamApi from '@/api/team.js'
 import userApi from '@/api/user.js'
 import getAppOrchestrator from '@/services/app.orchestrator'
 import product from '@/services/product.js'
-import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useContextStore } from '@/stores/context.js'
 import { useDataFarmApplicationsStore } from '@/stores/data-farm-applications'
 import { useProductTablesStore } from '@/stores/product-tables.js'
@@ -23,7 +22,6 @@ function disconnectTeamSubscribers () {
 
 export const useAccountStore = defineStore('account', {
     state: () => ({
-        teams: [],
         teamBlueprints: {},
         pendingTeamChange: false,
         notifications: [],
@@ -35,10 +33,6 @@ export const useAccountStore = defineStore('account', {
             return state.teamBlueprints[teamId] || []
         },
         defaultBlueprint () { return this.blueprints?.find(blueprint => blueprint.default) },
-        defaultUserTeam: (state) => {
-            const defaultTeamId = useAccountAuthStore().user?.defaultTeam || state.teams[0]?.id
-            return state.teams.find(team => team.id === defaultTeamId)
-        },
         notificationsCount: state => state.notifications?.length || 0,
         unreadNotificationsCount: state => {
             const unread = state.notifications?.filter(n => !n.read) || []
@@ -53,13 +47,9 @@ export const useAccountStore = defineStore('account', {
         },
         hasNotifications () { return this.notificationsCount > 0 },
         teamInvitations: state => state.invitations,
-        teamInvitationsCount: state => state.invitations?.length || 0,
-        hasAvailableTeams: state => state.teams.length > 0
+        teamInvitationsCount: state => state.invitations?.length || 0
     },
     actions: {
-        setTeams (teams) {
-            this.teams = teams
-        },
         async setTeam (team) {
             const context = useContextStore()
             const currentTeam = context.team
@@ -103,10 +93,6 @@ export const useAccountStore = defineStore('account', {
                 disconnectTeamSubscribers()
             }
             this.pendingTeamChange = false
-        },
-        async refreshTeams () {
-            const teams = await teamApi.getTeams()
-            this.teams = teams.teams
         },
         async getTeamBlueprints (teamId) {
             const response = await flowBlueprintsApi.getFlowBlueprintsForTeam(teamId)

--- a/frontend/src/stores/data-farm-teams.ts
+++ b/frontend/src/stores/data-farm-teams.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+import teamApi from '@/api/team.js'
+import { useAccountAuthStore } from '@/stores/account-auth.js'
+import type { UserTeamList } from '@/types'
+
+type TeamListEntry = UserTeamList[number]
+
+export const useDataFarmTeamsStore = defineStore('data-farm-teams', () => {
+    const teamList = ref<TeamListEntry[]>([])
+
+    const hasAvailableTeams = computed(() => teamList.value.length > 0)
+    const defaultUserTeam = computed(() => {
+        const defaultTeamId = useAccountAuthStore().user?.defaultTeam || teamList.value[0]?.id
+        return teamList.value.find(team => team.id === defaultTeamId) ?? null
+    })
+
+    async function fetchTeamList (): Promise<TeamListEntry[]> {
+        const response = await teamApi.getTeams()
+        teamList.value = response.teams ?? []
+        return teamList.value
+    }
+
+    function reset (): void {
+        teamList.value = []
+    }
+
+    return {
+        teamList,
+        hasAvailableTeams,
+        defaultUserTeam,
+        fetchTeamList,
+        reset
+    }
+})

--- a/test/unit/frontend/stores/account.spec.js
+++ b/test/unit/frontend/stores/account.spec.js
@@ -32,10 +32,6 @@ vi.mock('@/stores/product-tables.js', () => ({
     useProductTablesStore: () => ({ clearState: vi.fn() })
 }))
 
-vi.mock('@/stores/account-auth.js', () => ({
-    useAccountAuthStore: () => ({ user: { id: 'u1', defaultTeam: 'team-1' } })
-}))
-
 // Shared mutable state used by the context store mock
 const mockContext = {
     team: null,
@@ -67,7 +63,6 @@ describe('account store', () => {
     describe('initial state', () => {
         it('initializes with default state', () => {
             const store = useAccountStore()
-            expect(store.teams).toEqual([])
             expect(store.teamBlueprints).toEqual({})
             expect(store.pendingTeamChange).toBe(false)
             expect(store.notifications).toEqual([])
@@ -113,25 +108,6 @@ describe('account store', () => {
                     ]
                 }
                 expect(store.defaultBlueprint).toEqual({ id: 'bp-2', default: true })
-            })
-        })
-
-        describe('defaultUserTeam', () => {
-            it('returns the team matching the user defaultTeam', () => {
-                const store = useAccountStore()
-                const team1 = { id: 'team-1', name: 'Alpha' }
-                const team2 = { id: 'team-2', name: 'Beta' }
-                store.teams = [team1, team2]
-                // mock returns user.defaultTeam = 'team-1'
-                expect(store.defaultUserTeam).toEqual(team1)
-            })
-
-            it('falls back to undefined when no defaultTeam match', () => {
-                const store = useAccountStore()
-                const team1 = { id: 'team-99', name: 'Other' }
-                store.teams = [team1]
-                // user.defaultTeam = 'team-1' but only 'team-99' exists
-                expect(store.defaultUserTeam).toBeUndefined()
             })
         })
 
@@ -196,31 +172,9 @@ describe('account store', () => {
                 expect(store.teamInvitationsCount).toBe(1)
             })
         })
-
-        describe('hasAvailableTeams', () => {
-            it('returns false when teams is empty', () => {
-                const store = useAccountStore()
-                expect(store.hasAvailableTeams).toBe(false)
-            })
-
-            it('returns true when teams exist', () => {
-                const store = useAccountStore()
-                store.teams = [{ id: 'team-1' }]
-                expect(store.hasAvailableTeams).toBe(true)
-            })
-        })
     })
 
     describe('actions', () => {
-        describe('setTeams', () => {
-            it('replaces the teams array', () => {
-                const store = useAccountStore()
-                const teams = [{ id: 'team-1' }, { id: 'team-2' }]
-                store.setTeams(teams)
-                expect(store.teams).toEqual(teams)
-            })
-        })
-
         describe('setTeam', () => {
             it('refreshes context membership but skips full reload when same team is already set (by id)', async () => {
                 const store = useAccountStore()
@@ -341,12 +295,10 @@ describe('account store', () => {
         describe('$reset', () => {
             it('restores default state', async () => {
                 const store = useAccountStore()
-                store.teams = [{ id: 'team-1' }]
                 store.invitations = [{ id: 'inv-1' }]
 
                 store.$reset()
 
-                expect(store.teams).toEqual([])
                 expect(store.invitations).toEqual([])
                 expect(store.pendingTeamChange).toBe(false)
             })

--- a/test/unit/frontend/stores/data-farm-teams.spec.js
+++ b/test/unit/frontend/stores/data-farm-teams.spec.js
@@ -1,0 +1,109 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import teamApi from '@/api/team.js'
+import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
+
+const authState = vi.hoisted(() => ({ user: null }))
+
+vi.mock('@/stores/account-auth.js', () => ({
+    useAccountAuthStore: () => authState
+}))
+
+describe('data-farm-teams store', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        authState.user = null
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('starts empty', () => {
+        const store = useDataFarmTeamsStore()
+        expect(store.teamList).toEqual([])
+        expect(store.hasAvailableTeams).toBe(false)
+        expect(store.defaultUserTeam).toBe(null)
+    })
+
+    describe('fetchTeamList', () => {
+        it('fetches and normalises the team list', async () => {
+            vi.spyOn(teamApi, 'getTeams').mockResolvedValue({ teams: [{ id: 't1', name: 'One' }, { id: 't2', name: 'Two' }] })
+            const store = useDataFarmTeamsStore()
+
+            const result = await store.fetchTeamList()
+
+            expect(store.teamList.map(t => t.id)).toEqual(['t1', 't2'])
+            expect(store.teamList.map(t => t.name)).toEqual(['One', 'Two'])
+            expect(store.hasAvailableTeams).toBe(true)
+            expect(result).toEqual(store.teamList)
+        })
+
+        it('replaces the list on refetch', async () => {
+            vi.spyOn(teamApi, 'getTeams')
+                .mockResolvedValueOnce({ teams: [{ id: 't1' }] })
+                .mockResolvedValueOnce({ teams: [{ id: 't2' }] })
+            const store = useDataFarmTeamsStore()
+
+            await store.fetchTeamList()
+            await store.fetchTeamList()
+
+            expect(store.teamList.map(t => t.id)).toEqual(['t2'])
+        })
+
+        it('handles an empty list', async () => {
+            vi.spyOn(teamApi, 'getTeams').mockResolvedValue({ teams: [] })
+            const store = useDataFarmTeamsStore()
+
+            await store.fetchTeamList()
+
+            expect(store.teamList).toEqual([])
+            expect(store.hasAvailableTeams).toBe(false)
+        })
+    })
+
+    describe('defaultUserTeam', () => {
+        it('is the first team when the user has no default', async () => {
+            vi.spyOn(teamApi, 'getTeams').mockResolvedValue({ teams: [{ id: 't1' }, { id: 't2' }] })
+            const store = useDataFarmTeamsStore()
+
+            await store.fetchTeamList()
+
+            expect(store.defaultUserTeam.id).toBe('t1')
+        })
+
+        it('is the user default team when set', async () => {
+            authState.user = { defaultTeam: 't2' }
+            vi.spyOn(teamApi, 'getTeams').mockResolvedValue({ teams: [{ id: 't1' }, { id: 't2' }] })
+            const store = useDataFarmTeamsStore()
+
+            await store.fetchTeamList()
+
+            expect(store.defaultUserTeam.id).toBe('t2')
+        })
+
+        it('is null when the default team is not in the list', async () => {
+            authState.user = { defaultTeam: 'gone' }
+            vi.spyOn(teamApi, 'getTeams').mockResolvedValue({ teams: [{ id: 't1' }] })
+            const store = useDataFarmTeamsStore()
+
+            await store.fetchTeamList()
+
+            expect(store.defaultUserTeam).toBe(null)
+        })
+    })
+
+    describe('reset', () => {
+        it('clears the list', async () => {
+            vi.spyOn(teamApi, 'getTeams').mockResolvedValue({ teams: [{ id: 't1' }] })
+            const store = useDataFarmTeamsStore()
+            await store.fetchTeamList()
+
+            store.reset()
+
+            expect(store.teamList).toEqual([])
+            expect(store.hasAvailableTeams).toBe(false)
+        })
+    })
+})


### PR DESCRIPTION
## Description

See https://github.com/FlowFuse/flowfuse/issues/8074#issue-5072875309

1. Moves the team list into a new `data-farm-teams` store — out of `account.js`, consumers repointed.
2. One `fetchTeamList()` for bootstrap + all refetches. Replaces the old getTeams/refreshTeams split.
3. Scoped to swapping the list's source only, `active-team` + `context` pass-through and the subscriber are deferred to PR 2. 

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/8074

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

