### PR TITLE
feat: rename help, admin parent, and user settings route names to kebab-case

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -144,7 +144,7 @@ export default {
                     icon: Cog8ToothIcon,
                     tag: 'user-settings',
                     onclick: this.$router.push,
-                    onclickparams: { name: 'User Settings' },
+                    onclickparams: { name: 'user-settings' },
                     hidden: false
                 },
                 {
@@ -152,7 +152,7 @@ export default {
                     icon: AdjustmentsVerticalIcon,
                     tag: 'admin-settings',
                     onclick: this.$router.push,
-                    onclickparams: { name: 'Admin Settings' },
+                    onclickparams: { name: 'admin' },
                     hidden: !this.user.admin
                 },
                 {

--- a/frontend/src/pages/account/routes.js
+++ b/frontend/src/pages/account/routes.js
@@ -44,7 +44,7 @@ export default [
         profileMenuIndex: 0,
         path: '/account',
         redirect: '/account/settings',
-        name: 'User Settings',
+        name: 'user-settings',
         meta: {
             title: 'Account - Settings',
             menu: 'user'

--- a/frontend/src/pages/admin/FlowBlueprints/index.vue
+++ b/frontend/src/pages/admin/FlowBlueprints/index.vue
@@ -133,7 +133,7 @@ export default {
         if (this.features?.flowBlueprints) {
             await this.loadItems()
         } else {
-            this.$router.push({ name: 'Admin Settings' })
+            this.$router.push({ name: 'admin' })
         }
     },
     methods: {

--- a/frontend/src/pages/admin/routes.js
+++ b/frontend/src/pages/admin/routes.js
@@ -40,7 +40,7 @@ export default [
         adminOnly: true,
         beforeEnter: ensureAdmin,
         redirect: '/admin/overview',
-        name: 'Admin Settings',
+        name: 'admin',
         icon: AdjustmentsVerticalIcon,
         component: Admin,
         meta: {

--- a/frontend/src/pages/help/routes.js
+++ b/frontend/src/pages/help/routes.js
@@ -7,7 +7,7 @@ export default [
         external: true,
         profileLink: true,
         profileMenuIndex: 60,
-        name: 'Documentation',
+        name: 'help-documentation',
         icon: LifebuoyIcon
     }
 ]


### PR DESCRIPTION
Closes #8086
Part of #8084

## Summary

* Renames 3 route names: `Documentation` -> `help-documentation`, `Admin Settings` -> `admin`, `User Settings` -> `user-settings`
* Updates navigation references in `PageHeader.vue` (dropdown menu) and `FlowBlueprints/index.vue` (feature-unavailable redirect)
* Display labels like `label: 'Admin Settings'` in the dropdown menu and `title: 'User Settings'` in the sidebar are left as-is since those are UI text, not route references

## Test plan

- [ ] User Settings link in the user dropdown menu works
- [ ] Admin Settings link in the user dropdown menu works (as admin user)
- [ ] Documentation link in the dropdown opens external docs
- [ ] Navigating to `/admin/` when flow blueprints feature is disabled redirects correctly