### PR TITLE
feat: rename team library route names to kebab-case

### DIFF
--- a/frontend/src/pages/team/Library/TeamLibrary.vue
+++ b/frontend/src/pages/team/Library/TeamLibrary.vue
@@ -130,7 +130,7 @@ export default {
     methods: {
         entrySelected (entry) {
             this.$router.push({
-                name: 'LibraryTeamLibrary',
+                name: 'team-library-files',
                 params: {
                     entryPath: entry.path.split('/')
                 }

--- a/frontend/src/pages/team/Library/index.vue
+++ b/frontend/src/pages/team/Library/index.vue
@@ -34,13 +34,13 @@ export default {
                 {
                     label: 'Team Library',
                     to: {
-                        name: 'LibraryTeamLibrary'
+                        name: 'team-library-files'
                     }
                 },
                 {
                     label: 'Blueprints',
                     to: {
-                        name: 'LibraryBlueprints'
+                        name: 'team-library-blueprints'
                     }
                 }
             ]
@@ -49,7 +49,7 @@ export default {
                     label: 'Custom Nodes',
                     featureUnavailable: !this.featuresCheck?.isPrivateRegistryFeatureEnabledForPlatform || !this.featuresCheck?.isPrivateRegistryFeatureEnabledForTeam,
                     to: {
-                        name: 'LibraryRegistry'
+                        name: 'team-library-registry'
                     }
                 })
             }

--- a/frontend/src/pages/team/Library/routes.js
+++ b/frontend/src/pages/team/Library/routes.js
@@ -3,7 +3,7 @@ import Registry from './Registry/Index.vue'
 import TeamLibrary from './TeamLibrary.vue'
 
 export default [
-    { name: 'LibraryBlueprints', path: 'blueprints', component: Blueprints },
-    { name: 'LibraryRegistry', path: 'team-library/registry', component: Registry },
-    { name: 'LibraryTeamLibrary', path: 'team-library/:entryPath*', component: TeamLibrary }
+    { name: 'team-library-blueprints', path: 'blueprints', component: Blueprints },
+    { name: 'team-library-registry', path: 'team-library/registry', component: Registry },
+    { name: 'team-library-files', path: 'team-library/:entryPath*', component: TeamLibrary }
 ]

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -131,7 +131,7 @@ export default [
                         meta: {
                             title: 'Team - Library'
                         },
-                        redirect: { name: 'LibraryTeamLibrary' },
+                        redirect: { name: 'team-library-files' },
                         children: [...LibraryRoutes]
                     },
                     {


### PR DESCRIPTION
Closes #8087
Part of #8084

## Summary

* Renames 3 library route names: `LibraryBlueprints` -> `team-library-blueprints`, `LibraryRegistry` -> `team-library-registry`, `LibraryTeamLibrary` -> `team-library-files`
* Updates tab navigation config in `Library/index.vue`, dynamic navigation in `TeamLibrary.vue`, and redirect in `team/routes.js`
* Zero remaining references to old names in the codebase

## Test plan

- [ ] Team Library page loads with correct tab selected
- [ ] Clicking between Team Library / Blueprints / Custom Nodes tabs navigates correctly
- [ ] Navigating into a library entry and clicking breadcrumbs/entries works (dynamic `entryPath` params)
- [ ] Navigating to the library parent route redirects to the Team Library tab