### PR TITLE
feat: rename low-ref team route names to kebab-case

### DIFF
--- a/frontend/src/components/notifications/Generic.vue
+++ b/frontend/src/components/notifications/Generic.vue
@@ -96,7 +96,7 @@ export default {
                 return { url: this.notification.data.url }
 
             case this.notification.type === 'team-trial-suspended':
-                return { name: 'Billing', params: { team_slug: this.notification.data.team.slug } }
+                return { name: 'team-billing', params: { team_slug: this.notification.data.team.slug } }
 
             default:
                 return null // no link

--- a/frontend/src/pages/application/CreateInstanceMultiStep.vue
+++ b/frontend/src/pages/application/CreateInstanceMultiStep.vue
@@ -100,7 +100,7 @@ export default {
             )
         ) {
             this.$router.push({
-                name: 'Billing',
+                name: 'team-billing',
                 params: {
                     team_slug: this.team.slug
                 }

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -125,7 +125,7 @@ export default [
                         }
                     },
                     {
-                        name: 'TeamLibrary',
+                        name: 'team-library',
                         path: 'library',
                         component: Library,
                         meta: {
@@ -148,7 +148,7 @@ export default [
                         ]
                     },
                     {
-                        name: 'AuditLog',
+                        name: 'team-audit-log',
                         path: 'audit-log',
                         component: TeamAuditLog,
                         meta: {
@@ -159,7 +159,7 @@ export default [
                         path: 'settings',
                         children: [
                             {
-                                name: 'TeamSettings',
+                                name: 'team-settings',
                                 path: '',
                                 component: TeamSettings,
                                 meta: {
@@ -168,7 +168,7 @@ export default [
                                 redirect: { name: 'team-settings-general' },
                                 children: [
                                     { name: 'team-settings-general', path: 'general', component: TeamSettingsGeneral },
-                                    { name: 'TeamSettingsDevices', path: 'devices', component: TeamSettingsDevices },
+                                    { name: 'team-settings-devices', path: 'devices', component: TeamSettingsDevices },
                                     { name: 'team-settings-integrations', path: 'integrations', component: TeamSettingsIntegrations },
                                     { name: 'team-settings-danger', path: 'danger', component: TeamSettingsDanger }
 
@@ -185,7 +185,7 @@ export default [
                         ]
                     },
                     {
-                        name: 'Billing',
+                        name: 'team-billing',
                         path: 'billing',
                         component: TeamBilling,
                         meta: {
@@ -249,7 +249,7 @@ export default [
     {
         path: '/register/remote-instance/:sessionToken',
         component: RegisterDevice,
-        name: 'RegisterDevice',
+        name: 'register-device',
         meta: {
             title: 'Register Remote Instance',
             layout: 'plain'

--- a/frontend/src/stores/ux-navigation.js
+++ b/frontend/src/stores/ux-navigation.js
@@ -325,7 +325,7 @@ export const useUxNavigationStore = defineStore('ux-navigation', {
                             {
                                 label: 'Library',
                                 to: {
-                                    name: 'TeamLibrary',
+                                    name: 'team-library',
                                     params: { team_slug: team.slug }
                                 },
                                 tag: 'shared-library',
@@ -368,7 +368,7 @@ export const useUxNavigationStore = defineStore('ux-navigation', {
                             {
                                 label: 'Audit Log',
                                 to: {
-                                    name: 'AuditLog',
+                                    name: 'team-audit-log',
                                     params: { team_slug: team.slug }
                                 },
                                 tag: 'team-audit',
@@ -379,7 +379,7 @@ export const useUxNavigationStore = defineStore('ux-navigation', {
                             {
                                 label: 'Billing',
                                 to: {
-                                    name: 'Billing',
+                                    name: 'team-billing',
                                     params: { team_slug: team.slug }
                                 },
                                 tag: 'team-billing',
@@ -398,7 +398,7 @@ export const useUxNavigationStore = defineStore('ux-navigation', {
                             {
                                 label: 'Team Settings',
                                 to: {
-                                    name: 'TeamSettings',
+                                    name: 'team-settings',
                                     params: { team_slug: team.slug }
                                 },
                                 tag: 'team-settings',


### PR DESCRIPTION
Closes #8088
Part of #8084

## Summary

* Renames 6 team route names with low reference counts: `TeamSettingsDevices` -> `team-settings-devices`, `RegisterDevice` -> `register-device`, `TeamLibrary` -> `team-library`, `AuditLog` -> `team-audit-log`, `TeamSettings` -> `team-settings`, `Billing` -> `team-billing`
* Updates sidebar nav entries in `ux-navigation.js`
* Updates billing redirect references in `notifications/Generic.vue` and `CreateInstanceMultiStep.vue`
* Component `name:` properties left as-is

## Test plan

- [ ] Team sidebar navigation works for Library, Audit Log, Billing, and Settings entries
- [ ] Team Settings page loads and tabs work
- [ ] Billing page accessible from sidebar and from trial-suspended notification
- [ ] Creating an instance when over quota redirects to billing
- [ ] Remote instance registration page loads