### PR TITLE
feat: rename team action route names to kebab-case

### DIFF
--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -59,7 +59,7 @@
                     v-if="canCreateTeam"
                     label="Create New Team" :icon="plusIcon"
                     class="create"
-                    @click="mobileTeamSelectionOpen = false; $router.push({name: 'CreateTeam'})"
+                    @click="mobileTeamSelectionOpen = false; $router.push({name: 'team-create'})"
                 />
             </ul>
         </div>

--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -118,7 +118,7 @@ export default {
         },
         createTeam () {
             return this.$router.push({
-                name: 'CreateTeam'
+                name: 'team-create'
             })
         },
         inviteMembers () {

--- a/frontend/src/components/TeamTypeTile.vue
+++ b/frontend/src/components/TeamTypeTile.vue
@@ -73,7 +73,7 @@ export default {
         },
         toCreateTeam () {
             return {
-                name: 'CreateTeam',
+                name: 'team-create',
                 query: {
                     teamType: this.teamType.id,
                     interval: this.billingInterval

--- a/frontend/src/components/banners/FeatureUnavailableToTeam.vue
+++ b/frontend/src/components/banners/FeatureUnavailableToTeam.vue
@@ -53,7 +53,7 @@ export default {
     computed: {
         ...mapState(useContextStore, ['team']),
         upgradePath () {
-            return { name: 'TeamChangeType', params: { team_slug: this.team.slug } }
+            return { name: 'team-change-type', params: { team_slug: this.team.slug } }
         }
     }
 }

--- a/frontend/src/components/multi-step-forms/instance/steps/flows-step/BlueprintsSection.vue
+++ b/frontend/src/components/multi-step-forms/instance/steps/flows-step/BlueprintsSection.vue
@@ -141,7 +141,7 @@ export default {
         },
         preSelectBlueprint () {
             return new Promise(resolve => {
-                if ((this.$route?.query && this.$route?.query?.blueprintId) || this.$route.name === 'DeployBlueprint') {
+                if ((this.$route?.query && this.$route?.query?.blueprintId) || this.$route.name === 'deploy-blueprint') {
                     // we can safely assume we got to this point either by selecting a blueprint from the Team Library or
                     // through a website deployment, so we really want a blueprint
                     let blueprint = this.blueprints.find(bp => bp.id === this.$route.query.blueprintId)

--- a/frontend/src/pages/account/components/CreateTeamButton.vue
+++ b/frontend/src/pages/account/components/CreateTeamButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <router-link :to="{name: 'CreateTeam'}" class="forge-button">
+    <router-link :to="{name: 'team-create'}" class="forge-button">
         <PlusSmallIcon class="w-5 h-5 my-1 -ml-1 mr-1" /><span>Create Team</span>
     </router-link>
 </template>

--- a/frontend/src/pages/team/Applications/index.vue
+++ b/frontend/src/pages/team/Applications/index.vue
@@ -21,7 +21,7 @@
                         v-if="hasPermission('project:create')"
                         data-action="create-application"
                         kind="primary"
-                        :to="{name: 'CreateTeamApplication'}"
+                        :to="{name: 'team-application-create'}"
                         type="anchor"
                     >
                         <template #icon-left>
@@ -79,7 +79,7 @@
                         data-action="create-application"
                         kind="primary"
                         type="anchor"
-                        :to="{name: 'CreateTeamApplication'}"
+                        :to="{name: 'team-application-create'}"
                     >
                         <template #icon-left>
                             <PlusSmallIcon />

--- a/frontend/src/pages/team/Billing/index.vue
+++ b/frontend/src/pages/team/Billing/index.vue
@@ -22,7 +22,7 @@
                     </template>
                     <template #tools>
                         <div class="flex flex-row gap-x-4">
-                            <ff-button v-if="!isUnmanaged" data-action="change-team-type" :to="{name: 'TeamChangeType'}">
+                            <ff-button v-if="!isUnmanaged" data-action="change-team-type" :to="{name: 'team-change-type'}">
                                 <span v-if="trialMode || trialHasEnded">Click here to setup billing</span>
                                 <span v-else>Upgrade Team</span>
                             </ff-button>
@@ -104,7 +104,7 @@
                     </template>
                 </template>
                 <template #actions>
-                    <ff-button v-if="hasPermission('team:edit')" data-action="change-team-type" :to="{name: 'TeamChangeType'}">Start Billing</ff-button>
+                    <ff-button v-if="hasPermission('team:edit')" data-action="change-team-type" :to="{name: 'team-change-type'}">Start Billing</ff-button>
                 </template>
             </EmptyState>
         </ff-page>

--- a/frontend/src/pages/team/Brokers/Clients/index.vue
+++ b/frontend/src/pages/team/Brokers/Clients/index.vue
@@ -3,7 +3,7 @@
         <feature-unavailable-to-team v-if="reachedClientLimit" class="-mt-2">
             <div>
                 You’ve hit your current broker clients limit.
-                <router-link class="ff-link" :to="{ name: 'TeamChangeType', params: { team_slug: team.slug } }">Upgrade</router-link>
+                <router-link class="ff-link" :to="{ name: 'team-change-type', params: { team_slug: team.slug } }">Upgrade</router-link>
                 your team for more capacity or get in touch with sales for assistance.
             </div>
         </feature-unavailable-to-team>

--- a/frontend/src/pages/team/Home/components/RecentlyModifiedInstances.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedInstances.vue
@@ -17,7 +17,7 @@
         <div v-else class="no-instances flex flex-col flex-1 justify-center text-gray-500 italic">
             <p class="text-center self-center">
                 It's looking a little empty.
-                <team-link :to="{name: 'CreateInstance'}" class="text-indigo-500">Create a Hosted Instance</team-link>
+                <team-link :to="{name: 'team-instance-create'}" class="text-indigo-500">Create a Hosted Instance</team-link>
                 to get started.
             </p>
         </div>

--- a/frontend/src/pages/team/Home/index.vue
+++ b/frontend/src/pages/team/Home/index.vue
@@ -39,7 +39,7 @@
                                     v-ff-tooltip:left="!hasPermission('project:create') && 'Your role does not allow creating new instances. Contact a team admin to change your role.'"
                                     data-action="create-project"
                                     kind="secondary"
-                                    :to="{name: 'CreateInstance'}"
+                                    :to="{name: 'team-instance-create'}"
                                     :disabled="!hasPermission('project:create')"
                                 >
                                     <template #icon-left>

--- a/frontend/src/pages/team/Instances.vue
+++ b/frontend/src/pages/team/Instances.vue
@@ -77,7 +77,7 @@
                             v-ff-tooltip:left="!hasPermission('project:create') && 'Your role does not allow creating new instances. Contact a team admin to change your role.'"
                             data-action="create-project"
                             kind="primary"
-                            :to="{name: 'CreateInstance'}"
+                            :to="{name: 'team-instance-create'}"
                             :disabled="!hasPermission('project:create')"
                         >
                             <template #icon-left>
@@ -150,7 +150,7 @@
                         <ff-button
                             v-ff-tooltip:bottom="!hasPermission('project:create') && 'Your role does not allow creating new instances. Contact a team admin to change your role.'"
                             kind="primary"
-                            :to="{name: 'CreateInstance'}"
+                            :to="{name: 'team-instance-create'}"
                             :disabled="!hasPermission('project:create')"
                         >
                             <template #icon-left>

--- a/frontend/src/pages/team/Library/Blueprints.vue
+++ b/frontend/src/pages/team/Library/Blueprints.vue
@@ -93,7 +93,7 @@ export default {
             }
         },
         onBlueprintSelect (blueprint) {
-            this.$router.push({ name: 'CreateInstance', query: { blueprintId: blueprint.id } })
+            this.$router.push({ name: 'team-instance-create', query: { blueprintId: blueprint.id } })
         }
     }
 }

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -7,7 +7,7 @@
                     <div class="max-w-sm pr-2">Change to a different team type</div>
                 </div>
                 <div class="min-w-fit shrink-0">
-                    <ff-button data-action="change-team-type" :to="{name: 'TeamChangeType'}">Change Team Type</ff-button>
+                    <ff-button data-action="change-team-type" :to="{name: 'team-change-type'}">Change Team Type</ff-button>
                 </div>
             </div>
         </template>

--- a/frontend/src/pages/team/Settings/General.vue
+++ b/frontend/src/pages/team/Settings/General.vue
@@ -21,7 +21,7 @@
                             <td class="w-40 font-medium">Type</td>
                             <td class="flex flex-row items-center">
                                 <span class="grow">{{ input.teamType }} </span>
-                                <ff-button v-if="!team.suspended" kind="secondary" size="small" :to="{name: 'TeamChangeType'}">Change Team Type</ff-button>
+                                <ff-button v-if="!team.suspended" kind="secondary" size="small" :to="{name: 'team-change-type'}">Change Team Type</ff-button>
                             </td>
                         </tr>
                         <tr class="border-b">

--- a/frontend/src/pages/team/components/ProjectSummaryList.vue
+++ b/frontend/src/pages/team/components/ProjectSummaryList.vue
@@ -20,7 +20,7 @@
         </template>
         <template v-else>
             <div class="forge-button-tertiary text-xs border-dashed">
-                <router-link :to="{name: 'CreateTeamApplication'}" class="px-1 py-4 flex w-full">
+                <router-link :to="{name: 'team-application-create'}" class="px-1 py-4 flex w-full">
                     <div class="grow">
                         <div class="text-base flex items-center"><PlusSmallIcon class="w-5 h-5 -ml-1 mr-1" /> Create Application</div>
                     </div>

--- a/frontend/src/pages/team/createInstance.vue
+++ b/frontend/src/pages/team/createInstance.vue
@@ -35,8 +35,8 @@
             v-else
             ref="multiStepForm"
             :applications="applications"
-            :has-team-step="$route.name === 'DeployBlueprint'"
-            :deploying-blueprint="$route.name === 'DeployBlueprint'"
+            :has-team-step="$route.name === 'deploy-blueprint'"
+            :deploying-blueprint="$route.name === 'deploy-blueprint'"
             @form-success="onInstanceCreated"
             @previous-step-state-changed="form.previousButtonState = $event"
             @next-step-state-changed="form.nextButtonState = $event"
@@ -62,14 +62,14 @@ export default {
         MultiStepApplicationsInstanceForm
     },
     beforeRouteEnter (to, from, next) {
-        if (from.name === 'CreateTeamApplication') {
+        if (from.name === 'team-application-create') {
             // we've got a user pressing "back" from the Create Application page,
             // but this page will very likely just bounce them back as they have
             // no applications. This breaks the cycle and redirects them back to Team > Applications
             return next('/')
         }
 
-        if (to.name === 'DeployBlueprint') {
+        if (to.name === 'deploy-blueprint') {
             if (!useAccountAuthStore().user && !LocalStorageService.getItem('redirectUrlAfterLogin')) {
                 useAccountAuthStore().setRedirectUrl(to.fullPath)
             }
@@ -93,7 +93,7 @@ export default {
     computed: {
         ...mapState(useContextStore, ['team']),
         isLandingFromExternalLink () {
-            return this.$route.name === 'DeployBlueprint'
+            return this.$route.name === 'deploy-blueprint'
         },
         pageTitle () {
             return this.isLandingFromExternalLink ? 'Deploy Blueprint' : 'Instances'
@@ -112,7 +112,7 @@ export default {
         if (!this.applications.length && !this.isLandingFromExternalLink) {
             // need to also create an Application
             this.$router.push({
-                name: 'CreateTeamApplication',
+                name: 'team-application-create',
                 params: {
                     team_slug: this.team.slug
                 }

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -75,7 +75,7 @@ export default [
                                 }
                             },
                             {
-                                name: 'CreateTeamApplication',
+                                name: 'team-application-create',
                                 path: 'create',
                                 component: CreateApplication,
                                 meta: {
@@ -98,7 +98,7 @@ export default [
                                 }
                             },
                             {
-                                name: 'CreateInstance',
+                                name: 'team-instance-create',
                                 path: 'create',
                                 component: CreateInstance,
                                 meta: {
@@ -175,7 +175,7 @@ export default [
                                 ]
                             },
                             {
-                                name: 'TeamChangeType',
+                                name: 'team-change-type',
                                 path: 'change-type',
                                 component: ChangeTeamType,
                                 meta: {
@@ -227,7 +227,7 @@ export default [
                 ]
             },
             {
-                name: 'CreateTeam',
+                name: 'team-create',
                 path: 'create',
                 beforeEnter: ensurePermission('team:create'),
                 component: CreateTeam,
@@ -278,7 +278,7 @@ export default [
     {
         path: '/deploy/blueprint',
         component: CreateInstance,
-        name: 'DeployBlueprint',
+        name: 'deploy-blueprint',
         meta: {
             title: 'Deploy Blueprint',
             menu: {


### PR DESCRIPTION
Closes #8089
Part of #8084

## Summary

* Renames 5 team action/creation route names: `CreateTeam` -> `team-create`, `CreateTeamApplication` -> `team-application-create`, `CreateInstance` -> `team-instance-create`, `TeamChangeType` -> `team-change-type`, `DeployBlueprint` -> `deploy-blueprint`
* Updates all navigation references across 18 files
* Includes `$route.name === 'DeployBlueprint'` conditional checks in `createInstance.vue` (4 places) and `BlueprintsSection.vue` (1 place)
* Includes `from.name === 'CreateTeamApplication'` route guard check in `createInstance.vue`
* Component `name:` properties left as-is

## Test plan

- [ ] Create Team flow from header, team selection, and team type tile
- [ ] Create Application flow from Applications page and project summary
- [ ] Create Instance flow from Home, Instances page, and blueprint selection
- [ ] Change Team Type flow from Settings, Billing, and Broker Clients upgrade link
- [ ] Deploy Blueprint flow works with blueprint pre-selection and team step
- [ ] Feature unavailable banner shows correct upgrade link