### PR TITLE
feat: rename Home and team navigation route names to kebab-case

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -185,7 +185,7 @@
                             <p>
                                 A full list of your Team's Devices are available <ff-team-link
                                     class="ff-link"
-                                    :to="{name: 'TeamDevices', params: {team_slug: team.slug}}"
+                                    :to="{name: 'team-remote-instances', params: {team_slug: team.slug}}"
                                 >
                                     here
                                 </ff-team-link>.
@@ -224,7 +224,7 @@
                             <p>
                                 A full list of your Team's Devices are available <ff-team-link
                                     class="ff-link"
-                                    :to="{name: 'TeamDevices', params: {team_slug: team.slug}}"
+                                    :to="{name: 'team-remote-instances', params: {team_slug: team.slug}}"
                                 >
                                     here
                                 </ff-team-link>.

--- a/frontend/src/components/global-search/components/ResultSection.vue
+++ b/frontend/src/components/global-search/components/ResultSection.vue
@@ -115,9 +115,9 @@ export default {
             case 'application':
                 return { name: 'Applications', query: { searchQuery: this.query }, params: { team_slug: this.team.slug } }
             case 'instance':
-                return { name: 'Instances', query: { searchQuery: this.query }, params: { team_slug: this.team.slug } }
+                return { name: 'team-hosted-instances', query: { searchQuery: this.query }, params: { team_slug: this.team.slug } }
             case 'device':
-                return { name: 'TeamDevices', query: { searchQuery: this.query }, params: { team_slug: this.team.slug } }
+                return { name: 'team-remote-instances', query: { searchQuery: this.query }, params: { team_slug: this.team.slug } }
             default:
                 return ''
             }

--- a/frontend/src/components/router-links/TeamLink.vue
+++ b/frontend/src/components/router-links/TeamLink.vue
@@ -26,7 +26,7 @@ export default {
             if (!this.team) {
                 // rewrite the url to point home where the user will either get redirected to his default team or to the
                 // team creation page
-                props.to.name = 'Home'
+                props.to.name = 'home'
             }
 
             if (!props.to.params?.team_slug) {

--- a/frontend/src/composables/DeviceHelper.js
+++ b/frontend/src/composables/DeviceHelper.js
@@ -143,7 +143,7 @@ export function useDeviceHelper () {
                 Alerts.emit('Successfully deleted the device', 'confirmation')
                 // Trigger a refresh of team info to resync following device changes
                 await useContextStore().refreshTeam()
-                await $router.push({ name: 'TeamDevices', params: { team_slug: useContextStore().team.slug } })
+                await $router.push({ name: 'team-remote-instances', params: { team_slug: useContextStore().team.slug } })
             } catch (err) {
                 Alerts.emit('Failed to delete device: ' + err.toString(), 'warning', 7500)
             }

--- a/frontend/src/mixins/Navigation.js
+++ b/frontend/src/mixins/Navigation.js
@@ -13,7 +13,7 @@ export default {
             } else if (this.defaultUserTeam?.slug) {
                 return { name: 'Team', params: { team_slug: this.defaultUserTeam?.slug } }
             } else {
-                return { name: 'Home' }
+                return { name: 'home' }
             }
         }
     },

--- a/frontend/src/pages/PageNotFound.vue
+++ b/frontend/src/pages/PageNotFound.vue
@@ -12,7 +12,7 @@
             </div>
             <div class="actions">
                 <ff-button @click="$router.back()">Go Back</ff-button>
-                <router-link :to="{name: 'Home'}" class="ff-btn ff-btn--primary">Go to Homepage</router-link>
+                <router-link :to="{name: 'home'}" class="ff-btn ff-btn--primary">Go to Homepage</router-link>
             </div>
         </div>
     </main>

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -59,7 +59,7 @@
         </form>
         <div v-else-if="ssoCreated">
             <p>You can now login using your SSO Provider.</p>
-            <ff-button :to="{ name: 'Home' }" data-action="login">Login</ff-button>
+            <ff-button :to="{ name: 'home' }" data-action="login">Login</ff-button>
         </div>
     </ff-layout-box>
 </template>

--- a/frontend/src/pages/device/Settings/Danger.vue
+++ b/frontend/src/pages/device/Settings/Danger.vue
@@ -82,7 +82,7 @@ export default {
         deleteDevice () {
             this.loading.deleting = true
             deviceApi.deleteDevice(this.device.id, this.team.id).then(() => {
-                this.$router.push({ name: 'TeamDevices', params: { team_slug: this.team.slug } })
+                this.$router.push({ name: 'team-remote-instances', params: { team_slug: this.team.slug } })
             }).catch(err => {
                 console.warn(err)
             }).finally(() => {

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -6,7 +6,7 @@
         </Teleport>
         <SectionNavigationHeader :tabs="navigation">
             <template #breadcrumbs>
-                <ff-nav-breadcrumb :to="{name: 'TeamDevices', params: {team_slug: team.slug}}">Remote Instances</ff-nav-breadcrumb>
+                <ff-nav-breadcrumb :to="{name: 'team-remote-instances', params: {team_slug: team.slug}}">Remote Instances</ff-nav-breadcrumb>
                 <ff-nav-breadcrumb>{{ device.name }}</ff-nav-breadcrumb>
             </template>
             <template #status>
@@ -419,7 +419,7 @@ export default {
                 if (err.status === 403) {
                     this.pollTimer?.stop()
                     clearTimeout(this.openTunnelTimeout)
-                    return this.$router.push({ name: 'Home' })
+                    return this.$router.push({ name: 'home' })
                 }
             }
             if (!this.pollTimer && !this.statusChannelLive) {
@@ -598,7 +598,7 @@ export default {
                     Alerts.emit('Successfully deleted the device', 'confirmation')
                     // Trigger a refresh of team info to resync following device changes
                     await useContextStore().refreshTeam()
-                    this.$router.push({ name: 'TeamDevices', params: { team_slug: this.team.slug } })
+                    this.$router.push({ name: 'team-remote-instances', params: { team_slug: this.team.slug } })
                 } catch (err) {
                     Alerts.emit('Failed to delete device: ' + err.toString(), 'warning', 7500)
                 }

--- a/frontend/src/pages/instance/DuplicateInstance.vue
+++ b/frontend/src/pages/instance/DuplicateInstance.vue
@@ -3,7 +3,7 @@
         <template #header>
             <ff-page-header>
                 <template #breadcrumbs>
-                    <ff-nav-breadcrumb v-if="team" class="whitespace-nowrap" :to="{name: 'Instances', params: {team_slug: team.slug}}">
+                    <ff-nav-breadcrumb v-if="team" class="whitespace-nowrap" :to="{name: 'team-hosted-instances', params: {team_slug: team.slug}}">
                         Instances
                     </ff-nav-breadcrumb>
                     <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'instance-settings', params: {team_slug: team.slug, id: instance.id}}">

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -7,7 +7,7 @@
         <template #header>
             <ff-page-header :title="instance.name" :tabs="navigation">
                 <template #breadcrumbs>
-                    <ff-nav-breadcrumb :to="{name: 'Instances', params: {team_slug: team.slug}}">Instances</ff-nav-breadcrumb>
+                    <ff-nav-breadcrumb :to="{name: 'team-hosted-instances', params: {team_slug: team.slug}}">Instances</ff-nav-breadcrumb>
                 </template>
                 <template #status>
                     <InstanceStatusBadge

--- a/frontend/src/pages/team/BOM/index.vue
+++ b/frontend/src/pages/team/BOM/index.vue
@@ -128,7 +128,7 @@ export default {
     },
     mounted () {
         if (!this.hasPermission('team:bom')) {
-            this.$router.push({ name: 'Home' })
+            this.$router.push({ name: 'home' })
         }
         if (this.featuresCheck.isBOMFeatureEnabled) {
             this.getTeamDependencies()

--- a/frontend/src/pages/team/Brokers/index.vue
+++ b/frontend/src/pages/team/Brokers/index.vue
@@ -284,7 +284,7 @@ export default {
 
         // redirect if no minimum role
         if (!this.hasAMinimumTeamRoleOf(Roles.Member)) {
-            return this.$router.push({ name: 'Home' })
+            return this.$router.push({ name: 'home' })
         }
 
         this.fetchData()

--- a/frontend/src/pages/team/DeviceGroups/index.vue
+++ b/frontend/src/pages/team/DeviceGroups/index.vue
@@ -206,7 +206,7 @@ export default {
         if (this.hasPermission('team:device-group:list')) {
             this.loadTeamDeviceGroups()
         } else {
-            this.$router.replace({ name: 'Home' })
+            this.$router.replace({ name: 'home' })
         }
     },
     methods: {

--- a/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
@@ -11,7 +11,7 @@
                 />
             </li>
             <li v-if="hasMore" class="device-wrapper flex" data-el="has-more">
-                <team-link :to="{name: 'TeamDevices'}" class="device-tile has-more hover:text-indigo-700">
+                <team-link :to="{name: 'team-remote-instances'}" class="device-tile has-more hover:text-indigo-700">
                     <span>{{ instancesLeft }} More</span>
                     <span>
                         <ChevronRightIcon class="ff-icon ff-icon-sm" />

--- a/frontend/src/pages/team/Home/components/RecentlyModifiedInstances.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedInstances.vue
@@ -6,7 +6,7 @@
                 <InstanceTile :instance="instance" :minimal-view="true" @delete-instance="$emit('delete-instance', $event)" />
             </li>
             <li v-if="hasMore" class="instance-wrapper flex">
-                <team-link :to="{name: 'Instances'}" class="instance-tile has-more hover:text-indigo-700" data-el="has-more">
+                <team-link :to="{name: 'team-hosted-instances'}" class="instance-tile has-more hover:text-indigo-700" data-el="has-more">
                     <span>{{ instancesLeft }} More</span>
                     <span>
                         <ChevronRightIcon class="ff-icon ff-icon-sm" />

--- a/frontend/src/pages/team/Home/index.vue
+++ b/frontend/src/pages/team/Home/index.vue
@@ -243,12 +243,12 @@ export default {
         },
         onStatClick (payload) {
             if (payload.type === 'hosted') {
-                this.$router.push({ name: 'Instances', query: { status: payload.state } })
+                this.$router.push({ name: 'team-hosted-instances', query: { status: payload.state } })
             } else {
                 const states = Object.prototype.hasOwnProperty.call(this.instanceStatesMap, payload.state)
                     ? this.instanceStatesMap[payload.state]
                     : []
-                this.$router.push({ name: 'TeamDevices', query: { searchQuery: states.join(' | ') } })
+                this.$router.push({ name: 'team-remote-instances', query: { searchQuery: states.join(' | ') } })
             }
         },
         getInstanceStateCounts () {

--- a/frontend/src/pages/team/Library/TeamLibrary.vue
+++ b/frontend/src/pages/team/Library/TeamLibrary.vue
@@ -39,8 +39,8 @@
                 </p>
             </template>
             <template #actions>
-                <ff-button v-if="featuresCheck.isSharedLibraryFeatureEnabled" :to="{name: 'Instances'}" data-el="go-to-instances">Go To Instances</ff-button>
-                <ff-button v-else :to="{name: 'Instances'}" :disabled="true">
+                <ff-button v-if="featuresCheck.isSharedLibraryFeatureEnabled" :to="{name: 'team-hosted-instances'}" data-el="go-to-instances">Go To Instances</ff-button>
+                <ff-button v-else :to="{name: 'team-hosted-instances'}" :disabled="true">
                     Add To Library
                     <template #icon-right><PlusIcon /></template>
                 </ff-button>

--- a/frontend/src/pages/team/Tables/index.vue
+++ b/frontend/src/pages/team/Tables/index.vue
@@ -97,7 +97,7 @@ export default defineComponent({
         }
 
         if (!this.featuresCheck.isTablesFeatureEnabledForPlatform) {
-            return this.$router.push({ name: 'Home' })
+            return this.$router.push({ name: 'home' })
         }
 
         if (this.featuresCheck.isTablesFeatureEnabledForTeam) {

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -90,7 +90,7 @@ export default [
                         path: 'instances',
                         children: [
                             {
-                                name: 'Instances',
+                                name: 'team-hosted-instances',
                                 path: '',
                                 component: TeamInstances,
                                 meta: {
@@ -108,7 +108,7 @@ export default [
                                         backTo: (params) => {
                                             return {
                                                 label: 'Back to Instances',
-                                                to: { name: 'Instances', params }
+                                                to: { name: 'team-hosted-instances', params }
                                             }
                                         }
                                     }
@@ -117,7 +117,7 @@ export default [
                         ]
                     },
                     {
-                        name: 'TeamDevices',
+                        name: 'team-remote-instances',
                         path: 'devices',
                         component: TeamDevices,
                         meta: {

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -20,7 +20,7 @@ const routes = [
     {
         navigationLink: true,
         path: '/',
-        name: 'Home',
+        name: 'home',
         component: Home,
         icon: 'HomeIcon',
         meta: {

--- a/frontend/src/stores/account-auth.js
+++ b/frontend/src/stores/account-auth.js
@@ -92,7 +92,7 @@ export const useAccountAuthStore = defineStore('account-auth', {
                     return
                 } else if (user.email_verified === false || user.password_expired) {
                     useUxLoadingStore().clearAppLoader()
-                    router.push({ name: 'Home' })
+                    router.push({ name: 'home' })
                     return
                 }
 
@@ -108,7 +108,7 @@ export const useAccountAuthStore = defineStore('account-auth', {
                     useUxLoadingStore().clearAppLoader()
                     useAccountStore().setTeam(null)
                     if (/^\/team\//.test(router.currentRoute.value.path)) {
-                        router.push({ name: 'Home' })
+                        router.push({ name: 'home' })
                     }
                     return
                 }
@@ -185,7 +185,7 @@ export const useAccountAuthStore = defineStore('account-auth', {
                     //     // Only remember the url if it isn't the default / path
                     //     this.setRedirectUrl(router.currentRoute.value.fullPath)
                     // }
-                    router.push({ name: 'Home' })
+                    router.push({ name: 'home' })
                 }
             }
         },

--- a/frontend/src/stores/ux-navigation.js
+++ b/frontend/src/stores/ux-navigation.js
@@ -45,7 +45,7 @@ export const useUxNavigationStore = defineStore('ux-navigation', {
                     entries: [
                         {
                             label: 'Back to Dashboard',
-                            to: { name: 'Home' },
+                            to: { name: 'home' },
                             tag: 'back',
                             icon: ChevronLeftIcon
                         }
@@ -147,7 +147,7 @@ export const useUxNavigationStore = defineStore('ux-navigation', {
                     entries: [
                         {
                             label: 'Back to Dashboard',
-                            to: { name: 'Home' },
+                            to: { name: 'home' },
                             tag: 'back',
                             icon: ChevronLeftIcon
                         }
@@ -203,7 +203,7 @@ export const useUxNavigationStore = defineStore('ux-navigation', {
                             {
                                 label: 'Hosted Instances',
                                 to: {
-                                    name: 'Instances',
+                                    name: 'team-hosted-instances',
                                     params: { team_slug: team.slug }
                                 },
                                 tag: 'team-instances',
@@ -214,7 +214,7 @@ export const useUxNavigationStore = defineStore('ux-navigation', {
                             {
                                 label: 'Remote Instances',
                                 to: {
-                                    name: 'TeamDevices',
+                                    name: 'team-remote-instances',
                                     params: { team_slug: team.slug }
                                 },
                                 tag: 'team-devices',

--- a/test/unit/frontend/stores/ux-navigation.spec.js
+++ b/test/unit/frontend/stores/ux-navigation.spec.js
@@ -85,7 +85,7 @@ describe('ux-navigation store', () => {
 
     it('setMainNavBackButton stores the button object', () => {
         const store = useUxNavigationStore()
-        const button = { label: 'Back', to: { name: 'Home' } }
+        const button = { label: 'Back', to: { name: 'home' } }
         store.setMainNavBackButton(button)
         expect(store.mainNav.backToButton).toEqual(button)
     })

--- a/test/unit/frontend/utils/page-title.spec.js
+++ b/test/unit/frontend/utils/page-title.spec.js
@@ -20,7 +20,7 @@ describe('isEditorRoute', () => {
     test('returns false for non-editor and null routes', () => {
         expect(isEditorRoute({ name: 'instance-overview' })).toBe(false)
         expect(isEditorRoute({ name: 'device-overview' })).toBe(false)
-        expect(isEditorRoute({ name: 'Home' })).toBe(false)
+        expect(isEditorRoute({ name: 'home' })).toBe(false)
         expect(isEditorRoute(null)).toBe(false)
         expect(isEditorRoute(undefined)).toBe(false)
         expect(isEditorRoute({})).toBe(false)
@@ -35,7 +35,7 @@ describe('computePageTitle', () => {
     })
 
     test('falls through to static title with FlowFuse suffix when no context match', () => {
-        const route = makeRoute({ name: 'Home', title: 'Home' })
+        const route = makeRoute({ name: 'home', title: 'Home' })
         expect(computePageTitle(route, {})).toBe('Home - FlowFuse')
     })
 


### PR DESCRIPTION
Closes #8090
Part of #8084

## Summary

* Renames 3 high-traffic navigation route names: `Home` -> `home`, `Instances` -> `team-hosted-instances`, `TeamDevices` -> `team-remote-instances`
* The Instances/TeamDevices renames reflect the actual nav labels ("Hosted Instances" and "Remote Instances")
* Updates ~39 references across 25 files including auth store, navigation mixin, ux-navigation store, global search, breadcrumbs, device pages, and team home page
* Updates 2 unit test files that referenced the old `Home` route name
* Component `name:` properties and audit log scope labels left as-is

## Test plan

- [ ] Login redirects to home correctly
- [ ] 404 page "Go to Homepage" link works
- [ ] Sidebar navigation for Hosted Instances and Remote Instances works
- [ ] Breadcrumbs on instance and device pages navigate correctly
- [ ] Global search "View all" links for instances and devices work
- [ ] Home page stat click handlers navigate correctly
- [ ] Device deletion redirects to Remote Instances
- [ ] Team pages redirect to home when feature is unavailable (Brokers, BOM, DeviceGroups, Tables)
- [ ] `npm run test:unit:frontend` passes