### PR TITLE
feat: rename Team and Applications route names to kebab-case

### DIFF
--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -29,7 +29,7 @@ const getTeams = async (): Promise<{ teams: TeamListItem[] }> => {
     const res = await client.get<{ teams: UserTeamList }>('/api/v1/user/teams')
     const teams = res.data.teams.map((r): TeamListItem => ({
         ...r,
-        link: { name: 'Team', params: { team_slug: r.slug } },
+        link: { name: 'team', params: { team_slug: r.slug } },
         roleName: RoleNames[r.role]
     }))
     return { ...res.data, teams }

--- a/frontend/src/api/teams.js
+++ b/frontend/src/api/teams.js
@@ -6,7 +6,7 @@ const getTeams = async (cursor, limit, query, filter) => {
     const url = paginateUrl('/api/v1/teams', cursor, limit, query, filter)
     return client.get(url).then(res => {
         res.data.teams = res.data.teams.map(r => {
-            r.link = { name: 'Team', params: { team_slug: r.slug } }
+            r.link = { name: 'team', params: { team_slug: r.slug } }
             return r
         })
         return res.data

--- a/frontend/src/api/users.js
+++ b/frontend/src/api/users.js
@@ -34,7 +34,7 @@ const getUserTeams = async (userId, cursor, limit, query) => {
     const url = paginateUrl(`/api/v1/users/${userId}/teams`, cursor, limit, query)
     return client.get(url).then(res => {
         res.data.teams = res.data.teams.map(r => {
-            r.link = { name: 'Team', params: { team_slug: r.slug } }
+            r.link = { name: 'team', params: { team_slug: r.slug } }
             return r
         })
         return res.data

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -53,7 +53,7 @@
                 <nav-item
                     v-for="team in teams" :key="team.name"
                     :label="team.name" :avatar="team.avatar"
-                    @click="mobileTeamSelectionOpen = false; $router.push({name: 'Team', params: {team_slug: team.slug}})"
+                    @click="mobileTeamSelectionOpen = false; $router.push({name: 'team', params: {team_slug: team.slug}})"
                 />
                 <nav-item
                     v-if="canCreateTeam"

--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -108,7 +108,7 @@ export default {
             if (team) {
                 useAccountStore().setTeam(team.slug)
                     .then(() => this.$router.push({
-                        name: 'Team',
+                        name: 'team',
                         params: {
                             team_slug: team.slug
                         }

--- a/frontend/src/components/drawers/navigation/MainNav.vue
+++ b/frontend/src/components/drawers/navigation/MainNav.vue
@@ -77,7 +77,7 @@ export default {
         backToButton () {
             const defaultBackToRoute = {
                 label: 'Back to Dashboard',
-                to: { name: 'Applications', params: { team_slug: this.team?.slug } },
+                to: { name: 'team-applications', params: { team_slug: this.team?.slug } },
                 tag: 'back',
                 icon: ChevronLeftIcon
             }

--- a/frontend/src/components/global-search/components/ResultSection.vue
+++ b/frontend/src/components/global-search/components/ResultSection.vue
@@ -113,7 +113,7 @@ export default {
         sectionRoute () {
             switch (this.resultType) {
             case 'application':
-                return { name: 'Applications', query: { searchQuery: this.query }, params: { team_slug: this.team.slug } }
+                return { name: 'team-applications', query: { searchQuery: this.query }, params: { team_slug: this.team.slug } }
             case 'instance':
                 return { name: 'Instances', query: { searchQuery: this.query }, params: { team_slug: this.team.slug } }
             case 'device':

--- a/frontend/src/components/tables/cells/TeamCell.vue
+++ b/frontend/src/components/tables/cells/TeamCell.vue
@@ -18,7 +18,7 @@ export default {
             if (this.slug) {
                 useAccountStore().setTeam(this.slug)
                     .then(() => this.$router.push({
-                        name: 'Team',
+                        name: 'team',
                         params: {
                             team_slug: this.slug
                         }

--- a/frontend/src/mixins/Application.js
+++ b/frontend/src/mixins/Application.js
@@ -91,7 +91,7 @@ export default {
             try {
                 await this.deleteApplicationEntity(this.application.id, this.team.id)
                 await useContextStore().refreshTeam()
-                this.$router.push({ name: 'Applications' })
+                this.$router.push({ name: 'team-applications' })
                 alerts.emit('Application successfully deleted.', 'confirmation')
             } catch (err) {
                 if (err.response.data.error) {

--- a/frontend/src/mixins/Navigation.js
+++ b/frontend/src/mixins/Navigation.js
@@ -9,9 +9,9 @@ export default {
         ...mapState(useAccountStore, ['defaultUserTeam']),
         homeLink () {
             if (this.team?.slug) {
-                return { name: 'Team', params: { team_slug: this.team.slug } }
+                return { name: 'team', params: { team_slug: this.team.slug } }
             } else if (this.defaultUserTeam?.slug) {
-                return { name: 'Team', params: { team_slug: this.defaultUserTeam?.slug } }
+                return { name: 'team', params: { team_slug: this.defaultUserTeam?.slug } }
             } else {
                 return { name: 'Home' }
             }

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -91,7 +91,7 @@ export default {
             if (this.user.email_verified) {
                 if (this.team || this.defaultUserTeam) {
                     this.$router.push({
-                        name: 'Team',
+                        name: 'team',
                         params: {
                             team_slug: this.team?.slug || this.defaultUserTeam?.slug
                         }

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -352,7 +352,7 @@ export default {
         selectTeam (team) {
             useAccountStore().setTeam(team.slug)
                 .then(() => this.$router.push({
-                    name: 'Team',
+                    name: 'team',
                     params: {
                         team_slug: team.slug
                     }

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -56,7 +56,7 @@ export default {
             // navigate to team dashboad once invite accepted
             useAccountStore().setTeam(invite.team.slug)
                 .then(() => this.$router.push({
-                    name: 'Team',
+                    name: 'team',
                     params: {
                         team_slug: invite.team.slug
                     }

--- a/frontend/src/pages/account/Teams/Teams.vue
+++ b/frontend/src/pages/account/Teams/Teams.vue
@@ -48,7 +48,7 @@ export default {
     },
     methods: {
         teamSelected (team) {
-            this.$router.push({ name: 'Team', params: { team_slug: team.slug } })
+            this.$router.push({ name: 'team', params: { team_slug: team.slug } })
         },
         removeUserDialog (row) {
             if (row.memberCount === 1) {

--- a/frontend/src/pages/admin/Teams.vue
+++ b/frontend/src/pages/admin/Teams.vue
@@ -228,7 +228,7 @@ export default {
         viewTeam (row) {
             useAccountStore().setTeam(row.slug)
                 .then(() => this.$router.push({
-                    name: 'Team',
+                    name: 'team',
                     params: {
                         team_slug: row.slug
                     }

--- a/frontend/src/pages/application/DeviceGroup/index.vue
+++ b/frontend/src/pages/application/DeviceGroup/index.vue
@@ -12,7 +12,7 @@
         </Teleport>
         <ff-page-header :title="deviceGroup?.name" :tabs="navigation">
             <template #breadcrumbs>
-                <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'Applications', params: {team_slug: team.slug}}">
+                <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'team-applications', params: {team_slug: team.slug}}">
                     Applications
                 </ff-nav-breadcrumb>
                 <ff-nav-breadcrumb class="whitespace-nowrap" :to="{name: 'Application', params: {team_slug: team.slug, id: application.id}}">

--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -3,7 +3,7 @@
         <template #header>
             <ff-page-header title="Instances">
                 <template #custom-breadcrumbs>
-                    <ff-nav-breadcrumb v-if="team" :to="{name: 'Applications', params: {team_slug: team.slug}}">Applications</ff-nav-breadcrumb>
+                    <ff-nav-breadcrumb v-if="team" :to="{name: 'team-applications', params: {team_slug: team.slug}}">Applications</ff-nav-breadcrumb>
                     <ff-nav-breadcrumb v-if="team" :to="{name: 'Application', params: {id: application.id}}">
                         {{ application.name }}
                     </ff-nav-breadcrumb>

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -9,7 +9,7 @@
         <ConfirmInstanceDeleteDialog ref="confirmInstanceDeleteDialog" @confirm="onInstanceDeleted" />
         <ff-page-header :title="application.name" :tabs="navigation">
             <template #breadcrumbs>
-                <ff-nav-breadcrumb v-if="team" :to="{name: 'Applications', params: {team_slug: team.slug}}">Applications</ff-nav-breadcrumb>
+                <ff-nav-breadcrumb v-if="team" :to="{name: 'team-applications', params: {team_slug: team.slug}}">Applications</ff-nav-breadcrumb>
             </template>
         </ff-page-header>
         <div class="px-3 py-3 md:px-6 md:py-6 flex-1 flex flex-col h-full overflow-auto">

--- a/frontend/src/pages/team/Instances.vue
+++ b/frontend/src/pages/team/Instances.vue
@@ -137,7 +137,7 @@
                         <p>
                             Instances are managed in FlowFuse via <ff-team-link
                                 class="ff-link"
-                                :to="{name:'Applications', params: {team_slug: team.slug}}"
+                                :to="{name:'team-applications', params: {team_slug: team.slug}}"
                             >
                                 Applications
                             </ff-team-link>.

--- a/frontend/src/pages/team/Pipelines/index.vue
+++ b/frontend/src/pages/team/Pipelines/index.vue
@@ -20,7 +20,7 @@
                     </p>
                     <p>
                         Get started by choosing an
-                        <router-link :to="{name: 'Team'}">Application</router-link>
+                        <router-link :to="{name: 'team'}">Application</router-link>
                         to build your first DevOps Pipeline in.
                     </p>
                 </template>
@@ -77,7 +77,7 @@
                         <template #message>
                             <p>DevOps Pipelines are used to link multiple Node-RED instances together in a deployment pipeline.</p>
                             <p>This is normally used to define "Development" instances, where you can test your new flows without fear or breaking "Production" environments, and then, when you're ready, deploy your changes with a single click</p>
-                            <p>Get started by choosing an <router-link :to="{name: 'Team'}" class="text-blue-600 hover:text-blue-800 hover:underline">Application</router-link> to build your first DevOps Pipeline in.</p>
+                            <p>Get started by choosing an <router-link :to="{name: 'team'}" class="text-blue-600 hover:text-blue-800 hover:underline">Application</router-link> to build your first DevOps Pipeline in.</p>
                         </template>
                     </EmptyState>
                 </template>
@@ -138,7 +138,7 @@ export default {
     mounted () {
         if (!this.hasPermission('application:pipeline:list')) {
             return this.$router.push({
-                name: 'Applications',
+                name: 'team-applications',
                 params: this.$route.params
             })
         }

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -350,7 +350,7 @@ export default {
                 }, {
                     team: this.team.id
                 })
-                this.$router.push({ name: 'Team', params: { team_slug: result.slug } })
+                this.$router.push({ name: 'team', params: { team_slug: result.slug } })
             }).catch(err => {
                 Alerts.emit('Unable to change team type: ' + err.response.data.error, 'warning', 15000)
             }).finally(() => {

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -262,7 +262,7 @@ export default {
                     this.redirecting = true
                     window.open(result.billingURL, '_self')
                 } else {
-                    this.$router.push({ name: 'Team', params: { team_slug: result.slug } })
+                    this.$router.push({ name: 'team', params: { team_slug: result.slug } })
                 }
             }).catch(err => {
                 if (err.response.data) {

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -42,7 +42,7 @@ export default [
             {
                 path: ':team_slug',
                 redirect: { name: 'team-home' },
-                name: 'Team',
+                name: 'team',
                 component: Team,
                 meta: {
                     title: 'Team - Overview'
@@ -67,7 +67,7 @@ export default [
                         path: 'applications',
                         children: [
                             {
-                                name: 'Applications',
+                                name: 'team-applications',
                                 path: '',
                                 component: TeamApplications,
                                 meta: {
@@ -238,7 +238,7 @@ export default [
                         backTo: ({ team }) => {
                             return {
                                 label: 'Back to Dashboard',
-                                to: { name: 'Team', params: { team_slug: team?.slug } }
+                                to: { name: 'team', params: { team_slug: team?.slug } }
                             }
                         }
                     }
@@ -286,7 +286,7 @@ export default [
                 backTo: ({ team }) => {
                     return {
                         label: 'Back to Dashboard',
-                        to: { name: 'Team', params: { team_slug: team?.slug } }
+                        to: { name: 'team', params: { team_slug: team?.slug } }
                     }
                 }
             }

--- a/frontend/src/stores/ux-navigation.js
+++ b/frontend/src/stores/ux-navigation.js
@@ -236,7 +236,7 @@ export const useUxNavigationStore = defineStore('ux-navigation', {
                             {
                                 label: 'Applications',
                                 to: {
-                                    name: 'Applications',
+                                    name: 'team-applications',
                                     params: { team_slug: team.slug }
                                 },
                                 tag: 'team-applications',

--- a/test/unit/frontend/api/team.spec.js
+++ b/test/unit/frontend/api/team.spec.js
@@ -98,7 +98,7 @@ describe('Team API', async () => {
         }))
         const response = await TeamAPI.default.getTeams()
         expect(response.teams[0].link).toEqual({
-            name: 'Team',
+            name: 'team',
             params: {
                 team_slug: 'team_slug'
             }


### PR DESCRIPTION
Closes #8091
Part of #8084

## Summary

* Renames 2 broadly referenced route names: `Team` -> `team`, `Applications` -> `team-applications`
* Updates ~31 references across 25 files including API response mappers (`api/team.ts`, `api/teams.js`, `api/users.js`), navigation mixin, page header, team selection, global search, breadcrumbs, admin teams page, account pages, and route `backTo` callbacks
* Updates 1 unit test that asserts on the `Team` link in API responses
* Audit log scope labels (`{ name: 'Team', id: 'team' }` and `{ name: 'Applications', id: 'application' }`) are display text, not route references, and are left as-is
* Component `name:` properties left as-is

## Test plan

- [ ] Team selection dropdown navigates to selected team
- [ ] Mobile team list in header navigates correctly
- [ ] Accepting a team invitation redirects to the team
- [ ] Creating a team redirects to the new team
- [ ] Changing team type redirects back to the team
- [ ] Admin teams list clicking a team navigates correctly
- [ ] Applications breadcrumb on application/instance pages works
- [ ] Global search "View all" for applications works
- [ ] Back button in nav drawer works (defaults to team-applications)
- [ ] Deleting an application redirects to team-applications
- [ ] `npm run test:unit:frontend` passes