### PR TITLE
Formalize HMR dev setup with hidden webpack dev server

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -158,9 +158,12 @@ module.exports = function (env, argv) {
             new DotenvPlugin(),
             new DefinePlugin({
                 __VUE_OPTIONS_API__: true,
-                __VUE_PROD_DEVTOOLS__: devMode
+                __VUE_PROD_DEVTOOLS__: devMode,
+                __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: devMode,
+                'process.env.hotReloading': devMode && process.env.NODE_RUN_HOT === 'hot'
             })
         ],
+        cache: { type: 'filesystem' },
         optimization: {
             moduleIds: 'deterministic',
             runtimeChunk: 'single',
@@ -182,8 +185,18 @@ module.exports = function (env, argv) {
             }
         },
         devServer: {
-            port: 3000,
-            historyApiFallback: true
+            port: 2880,
+            hot: true,
+            liveReload: false,
+            allowedHosts: 'all',
+            devMiddleware: {
+                writeToDisk: true
+            },
+            client: {
+                webSocketURL: 'ws://localhost:2880/ws',
+                overlay: { errors: true, warnings: false },
+                logging: 'error'
+            }
         },
         watchOptions: {
             poll: 1000,

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -17,6 +17,8 @@ function getPath (file) {
 
 module.exports = function (env, argv) {
     const devMode = argv?.mode === 'development'
+    const hmrEnabled = devMode && process.env.NODE_RUN_HOT === 'hot'
+
     const config = {
         devtool: devMode ? 'source-map' : 'hidden-source-map',
         entry: {
@@ -160,10 +162,10 @@ module.exports = function (env, argv) {
                 __VUE_OPTIONS_API__: true,
                 __VUE_PROD_DEVTOOLS__: devMode,
                 __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: devMode,
-                'process.env.hotReloading': devMode && process.env.NODE_RUN_HOT === 'hot'
+                'process.env.hotReloading': hmrEnabled
             })
         ],
-        cache: { type: 'filesystem' },
+        cache: hmrEnabled ? { type: 'filesystem' } : undefined,
         optimization: {
             moduleIds: 'deterministic',
             runtimeChunk: 'single',

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "start-watch": "cross-env NODE_ENV=development nodemon -w forge -w ee/forge -i forge/containers/localfs_root forge/app.js",
         "start-watch-repl": "cross-env NODE_ENV=development nodemon -w forge -w ee/forge -i forge/containers/localfs_root forge/app.js --repl",
         "build-watch": "webpack --mode=development -c ./config/webpack.config.js --watch",
+        "build-watch-hmr": "cross-env NODE_RUN_HOT=hot webpack serve --mode=development -c ./config/webpack.config.js",
         "lint": "npm-run-all --sequential lint:eslint lint:colors",
         "lint:eslint": "eslint forge frontend test",
         "lint:fix": "eslint forge frontend test --fix",


### PR DESCRIPTION
Closes #8108

## Summary
* Run the webpack dev server on a hidden port (2880) instead of 8080, so devs keep using port 3000 for the app
* Adds `build-watch-hmr` npm script that mirrors `build-watch` but with HMR enabled
* Avoids cross-origin issues with embedded Node-RED editors and port conflicts with other local services

## How it works
The dev server writes built files to disk (`writeToDisk: true`) for the Fastify backend to serve on port 3000. The HMR client in the browser connects to `ws://localhost:2880/ws` for live updates. No proxy rules or CORS needed.

## Usage
```bash
# Terminal 1: start the backend
npm run start-watch

# Terminal 2: start frontend with HMR
npm run build-watch-hmr
```

Or use `npm run serve` with `build-watch-hmr` instead of `build-watch` if you want both in one terminal.

## Test plan
- [ ] Run `npm run build-watch-hmr` and verify it compiles and starts on port 2880
- [ ] Open `http://localhost:3000` and verify the app loads
- [ ] Edit a Vue component and verify HMR applies the change without full reload
- [ ] Open an embedded Node-RED editor and verify the iframe loads without CORS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)