### PR TITLE
[8110] Carried-over status search term breaks pagination on Devices and Application instance/device lists

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -222,7 +222,7 @@ module.exports = {
         const filters = Object.fromEntries(filterString.split(',').map((filterString) => filterString.split(':')))
 
         return {
-            ...(filters.status ? { state: filters.status } : null),
+            ...(filters.status ? { state: filters.status.includes('|') ? filters.status.split('|') : filters.status } : null),
             ...(filters.lastseen ? { lastseen: filters.lastseen } : null),
             ...(filters.mode ? { mode: filters.mode } : null)
         }

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -515,7 +515,11 @@ module.exports = {
                     // Filtering
                     if (pagination.filters?.state) {
                         // Unknown is the blank state
-                        where.state = pagination.filters.state === 'unknown' ? '' : pagination.filters.state
+                        if (Array.isArray(pagination.filters.state)) {
+                            where.state = { [Op.in]: pagination.filters.state.map(state => state === 'unknown' ? '' : state) }
+                        } else {
+                            where.state = pagination.filters.state === 'unknown' ? '' : pagination.filters.state
+                        }
                     }
 
                     // Filtering

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -30,28 +30,48 @@
                 @update:page-size="onPageSizeChange"
             >
                 <template #actions>
-                    <ff-popover button-text="Filters" button-kind="secondary">
-                        <template #panel="{ close }">
-                            <section>
+                    <ff-popover
+                        :button-text="activeFilterCount ? `Filters (${activeFilterCount})` : 'Filters'"
+                        button-kind="secondary"
+                        data-el="device-filters"
+                    >
+                        <template #panel>
+                            <section class="device-filters-panel">
+                                <label class="device-filters-heading">Mode</label>
                                 <popover-item
                                     title="Fleet Mode"
-                                    @click="onFilterClick('fleetMode', close)"
+                                    @click="onFilterClick('fleetMode')"
                                 >
                                     <template #icon>
                                         <ff-checkbox
                                             v-model="deviceModeFilters.fleetMode" style="top: -8px;"
-                                            @click.stop.prevent="onFilterClick('fleetMode', close)"
+                                            @click.stop.prevent="onFilterClick('fleetMode')"
                                         />
                                     </template>
                                 </popover-item>
                                 <popover-item
                                     title="Developer Mode"
-                                    @click="onFilterClick('developerMode', close)"
+                                    @click="onFilterClick('developerMode')"
                                 >
                                     <template #icon>
                                         <ff-checkbox
                                             v-model="deviceModeFilters.developerMode" style="top: -8px;"
-                                            @click.stop.prevent="onFilterClick('developerMode', close)"
+                                            @click.stop.prevent="onFilterClick('developerMode')"
+                                        />
+                                    </template>
+                                </popover-item>
+                                <label class="device-filters-heading">Status</label>
+                                <popover-item
+                                    v-for="statusFilter in statusFilters" :key="statusFilter.key"
+                                    :title="statusFilter.label"
+                                    :data-action="'filter-' + statusFilter.key"
+                                    @click="toggleStatusGroup(statusFilter.key)"
+                                >
+                                    <template #icon>
+                                        <ff-checkbox
+                                            :model-value="selectedStatusGroups.includes(statusFilter.key)"
+                                            style="top: -8px;"
+                                            @click.stop.prevent="toggleStatusGroup(statusFilter.key)"
                                         />
                                     </template>
                                 </popover-item>
@@ -353,6 +373,7 @@ import { markRaw } from 'vue'
 import deviceApi from '../api/devices.js'
 import teamApi from '../api/team.js'
 import DropdownMenu from '../components/DropdownMenu.vue'
+import { useInstanceStates } from '../composables/InstanceStates.js'
 import usePermissions from '../composables/Permissions.js'
 import { getTeamProperty } from '../composables/TeamProperties.js'
 import deviceActionsMixin from '../mixins/DeviceActions.js'
@@ -431,8 +452,9 @@ export default {
     emits: ['instance-updated'],
     setup () {
         const { hasPermission } = usePermissions()
+        const { statesMap } = useInstanceStates()
 
-        return { hasPermission }
+        return { hasPermission, statesMap }
     },
     data () {
         return {
@@ -452,6 +474,12 @@ export default {
             pageSize: 25,
             totalRows: 0,
             searchTerm: '',
+            selectedStatusGroups: [],
+            statusFilters: [
+                { key: 'running', label: 'Running' },
+                { key: 'error', label: 'Error' },
+                { key: 'stopped', label: 'Not Running' }
+            ],
 
             sort: {
                 key: null,
@@ -546,6 +574,14 @@ export default {
                 total: this.totalRows
             }
         },
+        statusStateFilter () {
+            if (this.selectedStatusGroups.length === 0) return null
+            return this.selectedStatusGroups.flatMap(group => this.statesMap[group] || [])
+        },
+        activeFilterCount () {
+            const modeCount = (this.deviceModeFilters.fleetMode ? 1 : 0) + (this.deviceModeFilters.developerMode ? 1 : 0)
+            return modeCount + this.selectedStatusGroups.length
+        },
         teamRuntimeLimitReached () {
             let teamTypeRuntimeLimit = getTeamProperty(this.team, 'runtimes.limit')
             // Uses this.teamDeviceCount as that tracks live updates made in the page
@@ -616,6 +652,11 @@ export default {
         }
     },
     mounted () {
+        const statusParam = this.$route.query.status
+        if (statusParam) {
+            const groups = Array.isArray(statusParam) ? statusParam : [statusParam]
+            this.selectedStatusGroups = groups.filter(group => this.statusFilters.some(f => f.key === group))
+        }
         this.fullReloadOfData()
         this.pollTimer = createPollTimer(this.pollTimerElapsed, POLL_TIME, !this.statusChannelLive)
     },
@@ -659,17 +700,36 @@ export default {
          *  - property: which filter row is being applied, e.g. status or lastseen
          *  - bucket: which value of this property are we filtering on from the buckets in the status bar
          */
-        applyFilter (filter, shouldClearDeviceModeFilters = true) {
+        applyFilter (filter) {
             this.filter = filter
             this.page = 1
-            this.doFilterServerSide()
-
-            if (shouldClearDeviceModeFilters) {
-                this.deviceModeFilters = {
-                    fleetMode: false,
-                    developerMode: false
-                }
+            this.deviceModeFilters = {
+                fleetMode: false,
+                developerMode: false
             }
+            if (this.selectedStatusGroups.length) {
+                this.selectedStatusGroups = []
+                this.$router.replace({ query: { ...this.$route.query, status: undefined } })
+            }
+            this.doFilterServerSide()
+        },
+
+        toggleStatusGroup (key) {
+            const index = this.selectedStatusGroups.indexOf(key)
+            if (index === -1) {
+                this.selectedStatusGroups.push(key)
+            } else {
+                this.selectedStatusGroups.splice(index, 1)
+            }
+            this.$router.replace({
+                query: {
+                    ...this.$route.query,
+                    status: this.selectedStatusGroups.length ? this.selectedStatusGroups : undefined
+                }
+            })
+            this.filter = null
+            this.page = 1
+            this.doFilterServerSide()
         },
 
         updateSearch (searchTerm) {
@@ -905,8 +965,21 @@ export default {
             }
 
             // Specific filtering
+            const filterParts = []
             if (this.filter?.property && this.filter?.bucket) {
-                extraParams.filters = `${this.filter.property}:${this.filter.bucket}`
+                filterParts.push(`${this.filter.property}:${this.filter.bucket}`)
+            }
+            if (this.statusStateFilter) {
+                filterParts.push(`status:${this.statusStateFilter.join('|')}`)
+            }
+            const modeFilter = this.deviceModeFilters.fleetMode
+                ? 'autonomous'
+                : (this.deviceModeFilters.developerMode ? 'developer' : null)
+            if (modeFilter) {
+                filterParts.push(`mode:${modeFilter}`)
+            }
+            if (filterParts.length) {
+                extraParams.filters = filterParts.join(',')
             }
 
             // Search and sort
@@ -950,28 +1023,16 @@ export default {
             return 'Unassigned'
         },
 
-        onFilterClick (filter, closeCallback) {
-            const compare = filter === 'fleetMode' ? 'autonomous' : 'developer'
-            this.deviceModeFilters[filter] = !this.deviceModeFilters[filter]
-
-            this.applyFilter(
-                {
-                    devices: Array.from(this.devices.values())
-                        .filter((device) => !this.deviceModeFilters[filter] ? true : device.mode === compare)
-                        .map(device => device.id),
-                    property: 'mode',
-                    bucket: compare
-                },
-                false
-            )
-
-            // resetting filters because we can't have multiple filters applied at once
-            const filters = {
-                fleetMode: false,
-                developerMode: false
+        onFilterClick (filter) {
+            const enabled = !this.deviceModeFilters[filter]
+            // Fleet and developer mode remain mutually exclusive
+            this.deviceModeFilters = {
+                fleetMode: filter === 'fleetMode' ? enabled : false,
+                developerMode: filter === 'developerMode' ? enabled : false
             }
-            filters[filter] = this.deviceModeFilters[filter]
-            this.deviceModeFilters = filters
+            this.filter = null
+            this.page = 1
+            this.doFilterServerSide()
         },
 
         removeFromSelection (device) {
@@ -982,6 +1043,18 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.device-filters-panel {
+    white-space: nowrap;
+
+    .device-filters-heading {
+        display: block;
+        padding: 10px 20px 4px;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: var(--ff-color-text-subtle);
+    }
+}
 .ff-dialog-content .ff-devices-ul {
     list-style-type: disc;
     list-style-position: inside;

--- a/frontend/src/mixins/Application.js
+++ b/frontend/src/mixins/Application.js
@@ -11,6 +11,7 @@ export default {
         return {
             application: {},
             applicationInstances: new Map(),
+            loadingInstanceStatuses: false,
             loading: {
                 deleting: false,
                 suspend: false
@@ -62,6 +63,7 @@ export default {
                 })
 
                 // Not waited for, as loading status is slightly slower
+                this.loadingInstanceStatuses = true
                 ApplicationApi
                     .getApplicationInstancesStatuses(applicationId)
                     .then((instanceStatuses) => {
@@ -74,6 +76,9 @@ export default {
                     })
                     .catch((err) => {
                         console.error(err)
+                    })
+                    .finally(() => {
+                        this.loadingInstanceStatuses = false
                     })
             } catch (err) {
                 this.$router.push({

--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -33,6 +33,8 @@
                 :search="searchTerm"
                 search-placeholder="Search Instances"
                 :rows-selectable="true"
+                :loading="tableLoading"
+                loading-type="skeleton"
                 @row-selected="selectedCloudRow"
             >
                 <template #actions>
@@ -177,6 +179,10 @@ export default {
         instances: {
             type: Array,
             required: true
+        },
+        loadingInstanceStatuses: {
+            type: Boolean,
+            default: false
         }
     },
     emits: ['instance-delete', 'instance-suspend', 'instance-restart', 'instance-start'],
@@ -230,6 +236,9 @@ export default {
         filteredInstances () {
             if (!this.statusFilter) return this.instances
             return this.instances.filter(instance => this.statusFilter.has(instance.meta?.state))
+        },
+        tableLoading () {
+            return this.loadingInstanceStatuses && !!this.statusFilter
         },
         cloudRows () {
             return this.filteredInstances.map((instance) => {

--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -35,6 +35,32 @@
                 :rows-selectable="true"
                 @row-selected="selectedCloudRow"
             >
+                <template #actions>
+                    <ff-popover
+                        :button-text="selectedStatusGroups.length ? `Status (${selectedStatusGroups.length})` : 'Status'"
+                        button-kind="secondary"
+                        data-el="status-filter"
+                    >
+                        <template #panel>
+                            <section class="status-filter-panel">
+                                <popover-item
+                                    v-for="filter in statusFilters" :key="filter.key"
+                                    :title="filter.label"
+                                    :data-action="'filter-' + filter.key"
+                                    @click="toggleStatusGroup(filter.key)"
+                                >
+                                    <template #icon>
+                                        <ff-checkbox
+                                            :model-value="selectedStatusGroups.includes(filter.key)"
+                                            style="top: -8px;"
+                                            @click.stop.prevent="toggleStatusGroup(filter.key)"
+                                        />
+                                    </template>
+                                </popover-item>
+                            </section>
+                        </template>
+                    </ff-popover>
+                </template>
                 <template
                     v-if="hasPermission('project:change-status', { application })"
                     #context-menu="{row}"
@@ -119,6 +145,7 @@ import { markRaw } from 'vue'
 import EmptyState from '../../components/EmptyState.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import FeatureUnavailableToTeam from '../../components/banners/FeatureUnavailableToTeam.vue'
+import { useInstanceStates } from '../../composables/InstanceStates.js'
 import { useNavigationHelper } from '../../composables/NavigationHelper.js'
 import usePermissions from '../../composables/Permissions.js'
 
@@ -130,6 +157,7 @@ import DeploymentName from './components/cells/DeploymentName.vue'
 import LastSeen from './components/cells/LastSeen.vue'
 
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
+import PopoverItem from '@/ui-components/components/PopoverItem.vue'
 
 export default {
     name: 'ProjectOverview',
@@ -137,7 +165,8 @@ export default {
         PlusSmallIcon,
         SectionTopMenu,
         EmptyState,
-        FeatureUnavailableToTeam
+        FeatureUnavailableToTeam,
+        PopoverItem
     },
     inheritAttrs: false,
     props: {
@@ -154,16 +183,24 @@ export default {
     setup () {
         const { navigateTo } = useNavigationHelper()
         const { hasPermission, isVisitingAdmin } = usePermissions()
+        const { statesMap } = useInstanceStates()
 
         return {
             hasPermission,
             isVisitingAdmin,
-            navigateTo
+            navigateTo,
+            statesMap
         }
     },
     data () {
         return {
-            searchTerm: ''
+            searchTerm: '',
+            selectedStatusGroups: [],
+            statusFilters: [
+                { key: 'running', label: 'Running' },
+                { key: 'error', label: 'Error' },
+                { key: 'stopped', label: 'Not Running' }
+            ]
         }
     },
     computed: {
@@ -186,8 +223,16 @@ export default {
                 { label: '', component: { is: markRaw(InstanceEditorLinkCell), map: { instance: '_self' } } }
             ]
         },
+        statusFilter () {
+            if (this.selectedStatusGroups.length === 0) return null
+            return new Set(this.selectedStatusGroups.flatMap(group => this.statesMap[group] || []))
+        },
+        filteredInstances () {
+            if (!this.statusFilter) return this.instances
+            return this.instances.filter(instance => this.statusFilter.has(instance.meta?.state))
+        },
         cloudRows () {
-            return this.instances.map((instance) => {
+            return this.filteredInstances.map((instance) => {
                 instance.running = instance.meta?.state === 'running'
                 instance.notSuspended = instance.meta?.state !== 'suspended'
                 instance.isHA = instance.ha?.replicas !== undefined
@@ -202,11 +247,30 @@ export default {
         }
     },
     mounted () {
+        const statusParam = this.$route.query.status
+        if (statusParam) {
+            const groups = Array.isArray(statusParam) ? statusParam : [statusParam]
+            this.selectedStatusGroups = groups.filter(group => this.statusFilters.some(f => f.key === group))
+        }
         if (this.$route?.query?.searchQuery) {
             this.searchTerm = this.$route.query.searchQuery
         }
     },
     methods: {
+        toggleStatusGroup (key) {
+            const index = this.selectedStatusGroups.indexOf(key)
+            if (index === -1) {
+                this.selectedStatusGroups.push(key)
+            } else {
+                this.selectedStatusGroups.splice(index, 1)
+            }
+            this.$router.replace({
+                query: {
+                    ...this.$route.query,
+                    status: this.selectedStatusGroups.length ? this.selectedStatusGroups : undefined
+                }
+            })
+        },
         selectedCloudRow (cloudInstance, event) {
             this.navigateTo({
                 name: 'Instance',
@@ -218,3 +282,9 @@ export default {
     }
 }
 </script>
+
+<style lang="scss" scoped>
+.status-filter-panel {
+    white-space: nowrap;
+}
+</style>

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -16,6 +16,7 @@
             <router-view
                 :application="application"
                 :instances="instancesArray"
+                :loading-instance-statuses="loadingInstanceStatuses"
                 :is-visiting-admin="isVisitingAdmin"
                 @application-updated="updateApplication"
                 @application-delete="showConfirmDeleteApplicationDialog"

--- a/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/DevicesWrapper.vue
@@ -42,11 +42,10 @@ export default {
         }
     },
     setup () {
-        const { groupBySimplifiedStates, statesMap: instanceStatesMap } = useInstanceStates()
+        const { groupBySimplifiedStates } = useInstanceStates()
 
         return {
-            groupBySimplifiedStates,
-            instanceStatesMap
+            groupBySimplifiedStates
         }
     },
     data () {
@@ -76,14 +75,10 @@ export default {
     },
     methods: {
         onCounterClick (state) {
-            const searchQuery = Object.prototype.hasOwnProperty.call(this.instanceStatesMap, state)
-                ? this.instanceStatesMap[state].join(' | ')
-                : ''
-
             this.$router.push({
                 name: 'ApplicationDevices',
                 params: { team_slug: this.team.slug, id: this.application.id },
-                query: { searchQuery }
+                query: { status: state }
             })
         }
     }

--- a/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
+++ b/frontend/src/pages/team/Applications/components/compact/InstancesWrapper.vue
@@ -42,11 +42,10 @@ export default {
         }
     },
     setup () {
-        const { groupBySimplifiedStates, statesMap: instanceStatesMap } = useInstanceStates()
+        const { groupBySimplifiedStates } = useInstanceStates()
 
         return {
-            groupBySimplifiedStates,
-            instanceStatesMap
+            groupBySimplifiedStates
         }
     },
     data () {
@@ -74,14 +73,10 @@ export default {
     },
     methods: {
         onCounterClick (state) {
-            const searchQuery = Object.prototype.hasOwnProperty.call(this.instanceStatesMap, state)
-                ? this.instanceStatesMap[state].join(' | ')
-                : ''
-
             this.$router.push({
                 name: 'ApplicationInstances',
                 params: { team_slug: this.team.slug, id: this.application.id },
-                query: { searchQuery }
+                query: { status: state }
             })
         }
     }

--- a/frontend/src/pages/team/Home/index.vue
+++ b/frontend/src/pages/team/Home/index.vue
@@ -170,12 +170,11 @@ export default {
         TeamDeviceCreateDialog
     },
     setup () {
-        const { groupBySimplifiedStates, statesMap: instanceStatesMap } = useInstanceStates()
+        const { groupBySimplifiedStates } = useInstanceStates()
 
         const { hasPermission } = usePermissions()
         return {
             groupBySimplifiedStates,
-            instanceStatesMap,
             hasPermission
         }
     },
@@ -242,14 +241,8 @@ export default {
                 })
         },
         onStatClick (payload) {
-            if (payload.type === 'hosted') {
-                this.$router.push({ name: 'Instances', query: { status: payload.state } })
-            } else {
-                const states = Object.prototype.hasOwnProperty.call(this.instanceStatesMap, payload.state)
-                    ? this.instanceStatesMap[payload.state]
-                    : []
-                this.$router.push({ name: 'TeamDevices', query: { searchQuery: states.join(' | ') } })
-            }
+            const name = payload.type === 'hosted' ? 'Instances' : 'TeamDevices'
+            this.$router.push({ name, query: { status: payload.state } })
         },
         getInstanceStateCounts () {
             return TeamAPI.getTeamInstanceCounts(this.team.id, [], 'hosted')

--- a/test/e2e/frontend/cypress/tests/applications/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications/overview.spec.js
@@ -90,42 +90,42 @@ describe('FlowFuse - Applications', () => {
             })
         })
 
-        it('should have interactive counter tiles which carry on the search terms to their respective targets', () => {
+        it('should have interactive counter tiles which apply a status filter on their respective targets', () => {
             cy.visit('team/bteam/applications')
             cy.get('[data-el="application-instances"] [data-state="running"]').click()
             cy.get('[data-hero="Node-RED Instances"]').should('exist')
-            cy.get('[data-form="search"]').should('exist')
-            cy.get('[data-form="search"] input').should('have.value', 'importing | connected | info | success | pushing | pulling | loading | updating | installing | safe | protected | running | warning | starting')
+            cy.url().should('include', 'status=running')
+            cy.get('[data-el="status-filter"]').should('contain', 'Status (1)')
 
             cy.visit('team/bteam/applications')
             cy.get('[data-el="application-instances"] [data-state="error"]').click()
             cy.get('[data-hero="Node-RED Instances"]').should('exist')
-            cy.get('[data-form="search"]').should('exist')
-            cy.get('[data-form="search"] input').should('have.value', 'error | crashed')
+            cy.url().should('include', 'status=error')
+            cy.get('[data-el="status-filter"]').should('contain', 'Status (1)')
 
             cy.visit('team/bteam/applications')
             cy.get('[data-el="application-instances"] [data-state="stopped"]').click()
             cy.get('[data-hero="Node-RED Instances"]').should('exist')
-            cy.get('[data-form="search"]').should('exist')
-            cy.get('[data-form="search"] input').should('have.value', 'stopping | restarting | suspending | rollback | stopped | suspended | offline | unknown')
+            cy.url().should('include', 'status=stopped')
+            cy.get('[data-el="status-filter"]').should('contain', 'Status (1)')
 
             cy.visit('team/bteam/applications')
             cy.get('[data-el="application-devices"] [data-state="running"]').click()
             cy.get('[data-hero="Remote Instances"]').should('exist')
-            cy.get('[data-form="search"]').should('exist')
-            cy.get('[data-form="search"] input').should('have.value', 'importing | connected | info | success | pushing | pulling | loading | updating | installing | safe | protected | running | warning | starting')
+            cy.url().should('include', 'status=running')
+            cy.get('[data-el="device-filters"]').should('contain', 'Filters (1)')
 
             cy.visit('team/bteam/applications')
             cy.get('[data-el="application-devices"] [data-state="error"]').click()
             cy.get('[data-hero="Remote Instances"]').should('exist')
-            cy.get('[data-form="search"]').should('exist')
-            cy.get('[data-form="search"] input').should('have.value', 'error | crashed')
+            cy.url().should('include', 'status=error')
+            cy.get('[data-el="device-filters"]').should('contain', 'Filters (1)')
 
             cy.visit('team/bteam/applications')
             cy.get('[data-el="application-devices"] [data-state="stopped"]').click()
             cy.get('[data-hero="Remote Instances"]').should('exist')
-            cy.get('[data-form="search"]').should('exist')
-            cy.get('[data-form="search"] input').should('have.value', 'stopping | restarting | suspending | rollback | stopped | suspended | offline | unknown')
+            cy.url().should('include', 'status=stopped')
+            cy.get('[data-el="device-filters"]').should('contain', 'Filters (1)')
         })
 
         it('should allow users to navigate using the application summary header shortcuts', () => {

--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -412,6 +412,16 @@ describe('Team Devices API', function () {
                 unknownDevices.map((device) => device.name).should.match(['device 1'])
             })
 
+            it('by a group of states', async function () {
+                const devices = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?filters=status:running|offline`)
+                devices.map((device) => device.name).should.match(['device 2', 'device 4', 'device 5'])
+            })
+
+            it('by a group of states including unknown', async function () {
+                const devices = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?filters=status:stopped|unknown`)
+                devices.map((device) => device.name).should.match(['device 1', 'device 3'])
+            })
+
             it('by last seen', async function () {
                 // Running
                 const runningDevices = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?filters=lastseen:never`)


### PR DESCRIPTION
## Description

See test plan: https://github.com/FlowFuse/flowfuse/issues/8110#issuecomment-5208482101

- Status tiles/counters now deep-link with `?status=<group>` instead of the pipe search term that broke filtering + pagination.
- Devices: status filter added to the Filters dropdown (combines with mode, shared count); backend accepts a state group.
- App hosted instances: status filter + skeleton while statuses load.

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/8110

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

