### PR TITLE
Persist session ID in sessionStorage for tab identity

### DIFF
--- a/frontend/src/stores/account-auth.js
+++ b/frontend/src/stores/account-auth.js
@@ -38,7 +38,6 @@ export const useAccountAuthStore = defineStore('account-auth', {
         isAdminUser: (state) => !!state.user?.admin
     },
     actions: {
-        // In-memory, per page-load — duplicate tabs each mint their own
         getSessionId () {
             if (!this.sessionId) this.sessionId = uuidv4()
             return this.sessionId
@@ -245,8 +244,14 @@ export const useAccountAuthStore = defineStore('account-auth', {
             useProductExpertStore().$reset()
         }
     },
-    persist: {
-        pick: ['redirectUrlAfterLogin'],
-        storage: localStorage
-    }
+    persist: [
+        {
+            pick: ['redirectUrlAfterLogin'],
+            storage: localStorage
+        },
+        {
+            pick: ['sessionId'],
+            storage: sessionStorage
+        }
+    ]
 })

--- a/frontend/src/stores/context.js
+++ b/frontend/src/stores/context.js
@@ -16,8 +16,7 @@ export const useContextStore = defineStore('context', {
         route: null,
         application: null,
         instance: null,
-        device: null,
-        tabSessionId: null
+        device: null
     }),
     getters: {
         team () {
@@ -181,15 +180,6 @@ export const useContextStore = defineStore('context', {
                 return
             }
             await this.refreshTeamMembership()
-        }
-    },
-    persist: {
-        pick: ['tabSessionId'],
-        storage: sessionStorage,
-        afterHydrate ({ store }) {
-            if (!store.tabSessionId) {
-                store.tabSessionId = uuidv4()
-            }
         }
     }
 })

--- a/frontend/src/stores/context.js
+++ b/frontend/src/stores/context.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { v4 as uuidv4 } from 'uuid'
 
 import { hasAMinimumTeamRoleOf } from '../composables/Permissions.js'
 import product from '../services/product.js'
@@ -15,7 +16,8 @@ export const useContextStore = defineStore('context', {
         route: null,
         application: null,
         instance: null,
-        device: null
+        device: null,
+        tabSessionId: null
     }),
     getters: {
         team () {
@@ -179,6 +181,15 @@ export const useContextStore = defineStore('context', {
                 return
             }
             await this.refreshTeamMembership()
+        }
+    },
+    persist: {
+        pick: ['tabSessionId'],
+        storage: sessionStorage,
+        afterHydrate ({ store }) {
+            if (!store.tabSessionId) {
+                store.tabSessionId = uuidv4()
+            }
         }
     }
 })

--- a/frontend/src/stores/context.js
+++ b/frontend/src/stores/context.js
@@ -1,5 +1,4 @@
 import { defineStore } from 'pinia'
-import { v4 as uuidv4 } from 'uuid'
 
 import { hasAMinimumTeamRoleOf } from '../composables/Permissions.js'
 import product from '../services/product.js'


### PR DESCRIPTION
## Description

  - tabSessionId added to state (separate from the agent stores' chat sessionId)                                                                                                                                                                                                                                              
  - Persisted to sessionStorage so it survives page refreshes within the same tab
  - Auto-generated on first hydration if not present                                                                                                                                                                                                                                                                          
  - Not consumed by anything yet. The MCP button (#8159) will be the first consumer.                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                              
  The agent stores, expert store, and post-message service are all untouched. Chat session IDs remain as they are. 

### Addendum: reuse `account-auth` session ID instead of a new `tabSessionId`

The original approach added a new `tabSessionId` to the context store. After further discussion, we realized the `account-auth.js` store already has a per-tab `sessionId` (generated via `getSessionId()`, used by the `fe-team` MQTT connection for broker client uniqueness). The only problem was that it was stored in-memory, so it died on page refresh.

By persisting it to `sessionStorage`, it becomes exactly what `tabSessionId` was supposed to be: per-tab, stable across refreshes, unique across tabs. This also means we can reuse the existing `fe-team` MQTT connection for presence topics on the backend, so there's no need for a separate MQTT connection or a new client identity for MCP presence. The `tabSessionId` addition to the context store was reverted.

The change simplifies to: persist the existing `account-auth` session ID in `sessionStorage` (split the `persist` config into an array with `localStorage` for `redirectUrlAfterLogin` and `sessionStorage` for `sessionId`).

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/8157

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label