### PR TITLE
Add tab presence support to track user activity across sessions

### DIFF
--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -492,7 +492,7 @@ module.exports = function (app) {
                 // Uses [^/]+ for the message-type segment because the subscription wildcard (+)
                 // is matched as a literal character. The publish-side ACL on teamFrontend
                 // already restricts to heartbeat|context.
-                { topic: /^ff\/v1\/browser\/tab-presence\/[^/]+\/[^/]+\/[^/]+$/ }
+                { topic: /^ff\/v1\/browser\/tab-presence\/[^/]+\/[^/]+\/[^/]+$/, shared: true }
             ],
             pub: [
                 // Send commands to project launchers

--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -489,7 +489,10 @@ module.exports = function (app) {
                 { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/platform\/([^/]+)\/request$/, verify: 'checkExpertPlatformTopic', allowWildcard: { user: true, session: true, command: true }, isPlatform: true, isSub: true, agent: 'platform' },
                 // platform can listen for browser tab presence (shared subscription)
                 // - ff/v1/tab-presence/<userId>/<sessionId>/<heartbeat|context>
-                { topic: /^ff\/v1\/tab-presence\/[^/]+\/[^/]+\/(heartbeat|context)$/, shared: true }
+                // Uses [^/]+ for the message-type segment because the subscription wildcard (+)
+                // is matched as a literal character. The publish-side ACL on teamFrontend
+                // already restricts to heartbeat|context.
+                { topic: /^ff\/v1\/tab-presence\/[^/]+\/[^/]+\/[^/]+$/, shared: true }
             ],
             pub: [
                 // Send commands to project launchers

--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -488,11 +488,11 @@ module.exports = function (app) {
                 // platform can listen for Expert Agent requests
                 { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/platform\/([^/]+)\/request$/, verify: 'checkExpertPlatformTopic', allowWildcard: { user: true, session: true, command: true }, isPlatform: true, isSub: true, agent: 'platform' },
                 // platform can listen for browser tab presence (shared subscription)
-                // - ff/v1/tab-presence/<userId>/<sessionId>/<heartbeat|context>
+                // - ff/v1/browser/tab-presence/<userId>/<sessionId>/<heartbeat|context>
                 // Uses [^/]+ for the message-type segment because the subscription wildcard (+)
                 // is matched as a literal character. The publish-side ACL on teamFrontend
                 // already restricts to heartbeat|context.
-                { topic: /^ff\/v1\/tab-presence\/[^/]+\/[^/]+\/[^/]+$/, shared: true }
+                { topic: /^ff\/v1\/browser\/tab-presence\/[^/]+\/[^/]+\/[^/]+$/, shared: true }
             ],
             pub: [
                 // Send commands to project launchers
@@ -592,8 +592,8 @@ module.exports = function (app) {
                 { topic: /^ff\/v1\/([^/]+)\/a\/([^/]+)\/(created|updated|deleted)$/, verify: 'checkTeamStateSub' }
             ],
             pub: [
-                // ff/v1/tab-presence/<userId>/<sessionId>/<heartbeat|context>
-                { topic: /^ff\/v1\/tab-presence\/([^/]+)\/([^/]+)\/(heartbeat|context)$/, verify: 'checkPresenceTopic' }
+                // ff/v1/browser/tab-presence/<userId>/<sessionId>/<heartbeat|context>
+                { topic: /^ff\/v1\/browser\/tab-presence\/([^/]+)\/([^/]+)\/(heartbeat|context)$/, verify: 'checkPresenceTopic' }
             ]
         },
         // frontend client (user)
@@ -675,7 +675,7 @@ module.exports = function (app) {
                         isSharedSub = true
                         // This is a shared sub - validate the share group name
                         const shareGroup = sharedSubParts[1]
-                        if (shareGroup !== 'platform' && shareGroup !== usernameParts[2]) {
+                        if (shareGroup !== 'platform' && shareGroup !== 'browser' && shareGroup !== usernameParts[2]) {
                             return false
                         }
                         topic = sharedSubParts[2]

--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -171,6 +171,25 @@ module.exports = function (app) {
                 return false
             }
         },
+        checkPresenceTopic: async function (requestParts, usernameParts) {
+            // requestParts = [ fullTopic, <userId>, <sessionId>, <messageType> ]
+            // usernameParts = [ 'fe-team', <userHash>, <teamHash>, <sessionId> ]
+            const topicUserId = requestParts[1]
+            const usernameUserHash = usernameParts[1]
+            if (topicUserId !== usernameUserHash) {
+                return false
+            }
+            try {
+                const user = await app.db.models.User.byId(usernameUserHash)
+                if (!user || user.suspended) {
+                    return false
+                }
+                return true
+            } catch (error) {
+                app.log.error('Unexpected error during presence topic ACL check', { requestParts, usernameParts, error })
+                return false
+            }
+        },
         checkExpertPlatformTopic: async function (topicParts, usernameParts, acl) {
             // topicParts = [ fullTopic , <userid>, <sessionid>, <command> ]
             // usernameParts = [ 'forge_platform' | 'expert-agent', <userid> [, <sessionid>] ]
@@ -467,7 +486,10 @@ module.exports = function (app) {
                 // ff/v1/platform/leader
                 { topic: /^ff\/v1\/platform\/leader$/ },
                 // platform can listen for Expert Agent requests
-                { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/platform\/([^/]+)\/request$/, verify: 'checkExpertPlatformTopic', allowWildcard: { user: true, session: true, command: true }, isPlatform: true, isSub: true, agent: 'platform' }
+                { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/platform\/([^/]+)\/request$/, verify: 'checkExpertPlatformTopic', allowWildcard: { user: true, session: true, command: true }, isPlatform: true, isSub: true, agent: 'platform' },
+                // platform can listen for browser tab presence (shared subscription)
+                // - ff/v1/tab-presence/<userId>/<sessionId>/<heartbeat|context>
+                { topic: /^ff\/v1\/tab-presence\/[^/]+\/[^/]+\/(heartbeat|context)$/, shared: true }
             ],
             pub: [
                 // Send commands to project launchers
@@ -566,7 +588,10 @@ module.exports = function (app) {
                 // - ff/v1/<team>/a/+/created|updated|deleted
                 { topic: /^ff\/v1\/([^/]+)\/a\/([^/]+)\/(created|updated|deleted)$/, verify: 'checkTeamStateSub' }
             ],
-            pub: []
+            pub: [
+                // ff/v1/tab-presence/<userId>/<sessionId>/<heartbeat|context>
+                { topic: /^ff\/v1\/tab-presence\/([^/]+)\/([^/]+)\/(heartbeat|context)$/, verify: 'checkPresenceTopic' }
+            ]
         },
         // frontend client (user)
         expertClient: {

--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -492,7 +492,7 @@ module.exports = function (app) {
                 // Uses [^/]+ for the message-type segment because the subscription wildcard (+)
                 // is matched as a literal character. The publish-side ACL on teamFrontend
                 // already restricts to heartbeat|context.
-                { topic: /^ff\/v1\/browser\/tab-presence\/[^/]+\/[^/]+\/[^/]+$/, shared: true }
+                { topic: /^ff\/v1\/browser\/tab-presence\/[^/]+\/[^/]+\/[^/]+$/ }
             ],
             pub: [
                 // Send commands to project launchers

--- a/forge/comms/browserSessionPresence.js
+++ b/forge/comms/browserSessionPresence.js
@@ -1,0 +1,56 @@
+const CACHE_NAME = 'browserSessions'
+const CACHE_TTL = 135_000 // ~3x the 45s heartbeat interval
+const CACHE_MAX = 10_000
+
+class BrowserSessionPresenceHandler {
+    constructor (app, client) {
+        this.app = app
+        this.client = client
+        this.cache = app.caches.createCache(CACHE_NAME, { max: CACHE_MAX, ttl: CACHE_TTL })
+        this.setupEventHandlers()
+    }
+
+    setupEventHandlers () {
+        this.client.on('tab-presence', (msg) => this.handlePresence(msg))
+    }
+
+    async handlePresence ({ userId, sessionId, messageType, payload }) {
+        const cacheKey = `${userId}:${sessionId}`
+
+        if (messageType === 'heartbeat') {
+            const existing = await this.cache.get(cacheKey) || {}
+            await this.cache.set(cacheKey, {
+                ...existing,
+                userId,
+                sessionId,
+                lastSeen: Date.now(),
+                visibility: payload.visibility || 'visible'
+            })
+        } else if (messageType === 'context') {
+            const existing = await this.cache.get(cacheKey) || {}
+            await this.cache.set(cacheKey, {
+                ...existing,
+                userId,
+                sessionId,
+                lastSeen: Date.now(),
+                context: payload
+            })
+        }
+    }
+
+    async getSessionsByUser (userId) {
+        const allEntries = await this.cache.all()
+        const prefix = `${userId}:`
+        const sessions = []
+        for (const [key, value] of Object.entries(allEntries)) {
+            if (key.startsWith(prefix)) {
+                sessions.push(value)
+            }
+        }
+        return sessions
+    }
+}
+
+module.exports = {
+    BrowserSessionPresenceHandler: (app, client) => new BrowserSessionPresenceHandler(app, client)
+}

--- a/forge/comms/commsClient.js
+++ b/forge/comms/commsClient.js
@@ -52,6 +52,22 @@ class CommsClient extends EventEmitter {
                 const ownerId = topicParts[4]
                 const messageType = topicParts[5]
 
+                if (topicParts[2] === 'tab-presence') {
+                    // ff/v1/tab-presence/<userId>/<sessionId>/<messageType>
+                    const userId = topicParts[3]
+                    const sessionId = topicParts[4]
+                    const messageType = topicParts[5]
+                    let payload
+                    try {
+                        payload = JSON.parse(message.toString())
+                    } catch (err) {
+                        this.app.log.warn(`Ignoring malformed tab-presence payload on ${topic}: ${err.message}`)
+                        return
+                    }
+                    this.emit('tab-presence', { userId, sessionId, messageType, payload })
+                    return
+                }
+
                 if (topicParts[2] === 'expert') {
                     const userId = topicParts[3]
                     const sessionId = topicParts[4]
@@ -249,7 +265,9 @@ class CommsClient extends EventEmitter {
                 // of consumers that share the workload, so keeping Expert separate from the
                 // "platform" group prevents unrelated features from sharing a consumer pool and
                 // allows them to scale independently.
-                '$share/expert/ff/v1/expert/+/+/platform/+/request'
+                '$share/expert/ff/v1/expert/+/+/platform/+/request',
+                // Browser tab presence - shared subscription
+                '$share/platform/ff/v1/tab-presence/+/+/+'
             ])
         }
     }

--- a/forge/comms/commsClient.js
+++ b/forge/comms/commsClient.js
@@ -52,16 +52,16 @@ class CommsClient extends EventEmitter {
                 const ownerId = topicParts[4]
                 const messageType = topicParts[5]
 
-                if (topicParts[2] === 'tab-presence') {
-                    // ff/v1/tab-presence/<userId>/<sessionId>/<messageType>
-                    const userId = topicParts[3]
-                    const sessionId = topicParts[4]
-                    const messageType = topicParts[5]
+                if (topicParts[2] === 'browser') {
+                    // ff/v1/browser/tab-presence/<userId>/<sessionId>/<messageType>
+                    const userId = topicParts[4]
+                    const sessionId = topicParts[5]
+                    const messageType = topicParts[6]
                     let payload
                     try {
                         payload = JSON.parse(message.toString())
                     } catch (err) {
-                        this.app.log.warn(`Ignoring malformed tab-presence payload on ${topic}: ${err.message}`)
+                        this.app.log.warn(`Ignoring malformed browser payload on ${topic}: ${err.message}`)
                         return
                     }
                     this.emit('tab-presence', { userId, sessionId, messageType, payload })
@@ -267,7 +267,7 @@ class CommsClient extends EventEmitter {
                 // allows them to scale independently.
                 '$share/expert/ff/v1/expert/+/+/platform/+/request',
                 // Browser tab presence - shared subscription
-                '$share/platform/ff/v1/tab-presence/+/+/+'
+                '$share/browser/ff/v1/browser/tab-presence/+/+/+'
             ])
         }
     }

--- a/forge/comms/index.js
+++ b/forge/comms/index.js
@@ -1,6 +1,7 @@
 const fp = require('fastify-plugin')
 
 const ACLManager = require('./aclManager')
+const { BrowserSessionPresenceHandler } = require('./browserSessionPresence')
 const { CommsClient } = require('./commsClient')
 const { DeviceCommsHandler } = require('./devices')
 const { ExpertCommsHandler } = require('./expert')
@@ -36,6 +37,7 @@ module.exports = fp(async function (app, _opts) {
         const instanceCommsHandler = InstanceCommsHandler(app, client)
         const platformAutomationHandler = PlatformAutomationHandler(app, client)
         const expertCommsHandler = new ExpertCommsHandler(app, client)
+        const browserSessionPresenceHandler = BrowserSessionPresenceHandler(app, client)
 
         // Not in the current release, but when we handle Launcher status
         // via MQTT, it will arrive here. Compare to the status/device handler in `devices.js`
@@ -50,6 +52,7 @@ module.exports = fp(async function (app, _opts) {
             aclManager: ACLManager(app),
             platformAutomation: platformAutomationHandler,
             expert: expertCommsHandler,
+            browserSessions: browserSessionPresenceHandler,
             platform: {
                 settings: {
                     sync: function (key) {

--- a/test/unit/forge/comms/authRoutesV2_spec.js
+++ b/test/unit/forge/comms/authRoutesV2_spec.js
@@ -1580,31 +1580,31 @@ describe('Broker Auth v2 API', async function () {
             it('allows fe-team to publish heartbeat to own presence topic', async function () {
                 await allowWrite({
                     username: teamFrontendUsername,
-                    topic: `ff/v1/tab-presence/${TestObjects.alice.hashid}/session-abc12345/heartbeat`
+                    topic: `ff/v1/browser/tab-presence/${TestObjects.alice.hashid}/session-abc12345/heartbeat`
                 })
             })
             it('allows fe-team to publish context to own presence topic', async function () {
                 await allowWrite({
                     username: teamFrontendUsername,
-                    topic: `ff/v1/tab-presence/${TestObjects.alice.hashid}/session-abc12345/context`
+                    topic: `ff/v1/browser/tab-presence/${TestObjects.alice.hashid}/session-abc12345/context`
                 })
             })
             it('denies fe-team from publishing to another user\'s presence topic', async function () {
                 await denyWrite({
                     username: teamFrontendUsername,
-                    topic: `ff/v1/tab-presence/${bob.hashid}/session-abc12345/heartbeat`
+                    topic: `ff/v1/browser/tab-presence/${bob.hashid}/session-abc12345/heartbeat`
                 })
             })
             it('denies fe-team from publishing to an invalid presence message type', async function () {
                 await denyWrite({
                     username: teamFrontendUsername,
-                    topic: `ff/v1/tab-presence/${TestObjects.alice.hashid}/session-abc12345/invalid`
+                    topic: `ff/v1/browser/tab-presence/${TestObjects.alice.hashid}/session-abc12345/invalid`
                 })
             })
             it('allows forge_platform to subscribe to presence topics via shared subscription', async function () {
                 await allowRead({
                     username: 'forge_platform',
-                    topic: `$share/platform/ff/v1/tab-presence/${TestObjects.alice.hashid}/session-abc12345/heartbeat`
+                    topic: `$share/browser/ff/v1/browser/tab-presence/${TestObjects.alice.hashid}/session-abc12345/heartbeat`
                 })
             })
         })

--- a/test/unit/forge/comms/authRoutesV2_spec.js
+++ b/test/unit/forge/comms/authRoutesV2_spec.js
@@ -1575,6 +1575,38 @@ describe('Broker Auth v2 API', async function () {
                     teamLookupStub.restore()
                 }
             })
+
+            // Browser session presence topics
+            it('allows fe-team to publish heartbeat to own presence topic', async function () {
+                await allowWrite({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/tab-presence/${TestObjects.alice.hashid}/session-abc12345/heartbeat`
+                })
+            })
+            it('allows fe-team to publish context to own presence topic', async function () {
+                await allowWrite({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/tab-presence/${TestObjects.alice.hashid}/session-abc12345/context`
+                })
+            })
+            it('denies fe-team from publishing to another user\'s presence topic', async function () {
+                await denyWrite({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/tab-presence/${bob.hashid}/session-abc12345/heartbeat`
+                })
+            })
+            it('denies fe-team from publishing to an invalid presence message type', async function () {
+                await denyWrite({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/tab-presence/${TestObjects.alice.hashid}/session-abc12345/invalid`
+                })
+            })
+            it('allows forge_platform to subscribe to presence topics via shared subscription', async function () {
+                await allowRead({
+                    username: 'forge_platform',
+                    topic: `$share/platform/ff/v1/tab-presence/${TestObjects.alice.hashid}/session-abc12345/heartbeat`
+                })
+            })
         })
     })
 })

--- a/test/unit/forge/comms/browserSessionPresence_spec.js
+++ b/test/unit/forge/comms/browserSessionPresence_spec.js
@@ -1,0 +1,214 @@
+const should = require('should') // eslint-disable-line
+
+const setup = require('../routes/setup')
+
+const FF_UTIL = require('flowforge-test-utils')
+const { BrowserSessionPresenceHandler } = FF_UTIL.require('forge/comms/browserSessionPresence')
+
+describe('BrowserSessionPresenceHandler', function () {
+    function mockClient () {
+        const handlers = {}
+        return {
+            on: (event, callback) => {
+                handlers[event] = callback
+            },
+            emit: function () {
+                const evt = arguments[0]
+                const args = Array.prototype.slice.call(arguments, 1)
+                if (handlers[evt]) {
+                    handlers[evt].apply(null, args)
+                }
+            }
+        }
+    }
+
+    let app
+    let client
+    let handler
+
+    before(async function () {
+        app = await setup()
+    })
+
+    after(async function () {
+        await app.close()
+    })
+
+    beforeEach(function () {
+        client = mockClient()
+        handler = BrowserSessionPresenceHandler(app, client)
+    })
+
+    describe('event handler registration', function () {
+        it('registers a tab-presence listener on the client', function () {
+            const testClient = mockClient()
+            const listeners = []
+            testClient.on = (event) => { listeners.push(event) }
+            BrowserSessionPresenceHandler(app, testClient)
+            listeners.should.containEql('tab-presence')
+        })
+    })
+
+    describe('heartbeat handling', function () {
+        it('creates a cache entry with lastSeen and visibility', async function () {
+            client.emit('tab-presence', {
+                userId: 'user1',
+                sessionId: 'session1',
+                messageType: 'heartbeat',
+                payload: { visibility: 'visible' }
+            })
+
+            // Allow async handler to complete
+            await new Promise(resolve => setImmediate(resolve))
+
+            const sessions = await handler.getSessionsByUser('user1')
+            sessions.should.have.length(1)
+            sessions[0].should.have.property('userId', 'user1')
+            sessions[0].should.have.property('sessionId', 'session1')
+            sessions[0].should.have.property('visibility', 'visible')
+            sessions[0].should.have.property('lastSeen').which.is.a.Number()
+        })
+
+        it('defaults visibility to visible when not provided', async function () {
+            client.emit('tab-presence', {
+                userId: 'user1',
+                sessionId: 'session2',
+                messageType: 'heartbeat',
+                payload: {}
+            })
+
+            await new Promise(resolve => setImmediate(resolve))
+
+            const sessions = await handler.getSessionsByUser('user1')
+            const session = sessions.find(s => s.sessionId === 'session2')
+            session.should.have.property('visibility', 'visible')
+        })
+
+        it('preserves existing context when updating with heartbeat', async function () {
+            // First set context
+            client.emit('tab-presence', {
+                userId: 'user2',
+                sessionId: 'session1',
+                messageType: 'context',
+                payload: { teamId: 'team1', pageName: 'instances' }
+            })
+            await new Promise(resolve => setImmediate(resolve))
+
+            // Then send heartbeat
+            client.emit('tab-presence', {
+                userId: 'user2',
+                sessionId: 'session1',
+                messageType: 'heartbeat',
+                payload: { visibility: 'hidden' }
+            })
+            await new Promise(resolve => setImmediate(resolve))
+
+            const sessions = await handler.getSessionsByUser('user2')
+            sessions.should.have.length(1)
+            sessions[0].should.have.property('visibility', 'hidden')
+            sessions[0].should.have.property('context').which.deepEqual({ teamId: 'team1', pageName: 'instances' })
+        })
+    })
+
+    describe('context handling', function () {
+        it('creates a cache entry with context payload', async function () {
+            client.emit('tab-presence', {
+                userId: 'user3',
+                sessionId: 'session1',
+                messageType: 'context',
+                payload: { teamId: 'team1', instanceId: 'inst1', pageName: 'editor' }
+            })
+
+            await new Promise(resolve => setImmediate(resolve))
+
+            const sessions = await handler.getSessionsByUser('user3')
+            sessions.should.have.length(1)
+            sessions[0].should.have.property('context').which.deepEqual({
+                teamId: 'team1',
+                instanceId: 'inst1',
+                pageName: 'editor'
+            })
+            sessions[0].should.have.property('lastSeen').which.is.a.Number()
+        })
+
+        it('updates lastSeen on context update', async function () {
+            client.emit('tab-presence', {
+                userId: 'user4',
+                sessionId: 'session1',
+                messageType: 'heartbeat',
+                payload: { visibility: 'visible' }
+            })
+            await new Promise(resolve => setImmediate(resolve))
+
+            const before = (await handler.getSessionsByUser('user4'))[0].lastSeen
+
+            // Small delay to ensure different timestamp
+            await new Promise(resolve => setTimeout(resolve, 10))
+
+            client.emit('tab-presence', {
+                userId: 'user4',
+                sessionId: 'session1',
+                messageType: 'context',
+                payload: { teamId: 'team2' }
+            })
+            await new Promise(resolve => setImmediate(resolve))
+
+            const after = (await handler.getSessionsByUser('user4'))[0].lastSeen
+            after.should.be.greaterThanOrEqual(before)
+        })
+    })
+
+    describe('unknown messageType', function () {
+        it('ignores unknown message types', async function () {
+            client.emit('tab-presence', {
+                userId: 'user5',
+                sessionId: 'session1',
+                messageType: 'invalid',
+                payload: { some: 'data' }
+            })
+
+            await new Promise(resolve => setImmediate(resolve))
+
+            const sessions = await handler.getSessionsByUser('user5')
+            sessions.should.have.length(0)
+        })
+    })
+
+    describe('getSessionsByUser', function () {
+        it('returns only sessions for the requested user', async function () {
+            client.emit('tab-presence', {
+                userId: 'userA',
+                sessionId: 'sessionA1',
+                messageType: 'heartbeat',
+                payload: { visibility: 'visible' }
+            })
+            client.emit('tab-presence', {
+                userId: 'userA',
+                sessionId: 'sessionA2',
+                messageType: 'heartbeat',
+                payload: { visibility: 'hidden' }
+            })
+            client.emit('tab-presence', {
+                userId: 'userB',
+                sessionId: 'sessionB1',
+                messageType: 'heartbeat',
+                payload: { visibility: 'visible' }
+            })
+
+            await new Promise(resolve => setImmediate(resolve))
+
+            const sessionsA = await handler.getSessionsByUser('userA')
+            sessionsA.should.have.length(2)
+            sessionsA.every(s => s.userId === 'userA').should.be.true()
+
+            const sessionsB = await handler.getSessionsByUser('userB')
+            sessionsB.should.have.length(1)
+            sessionsB[0].should.have.property('userId', 'userB')
+        })
+
+        it('returns empty array for unknown user', async function () {
+            const sessions = await handler.getSessionsByUser('nonexistent')
+            sessions.should.have.length(0)
+        })
+    })
+})


### PR DESCRIPTION
## Description

 - Add MQTT-based browser session presence so third-party MCP agents can discover which tabs a user has exposed                                                                                                                                                                                                              
 - Forge stores presence in a Redis cache bucket (browserSessions) with a 135s TTL, auto-expired when heartbeats stop                                                                                                                                                                                                        
 - Browser tabs publish on ff/v1/tab-presence/<userId>/<sessionId>/heartbeat and .../context using the existing fe-team MQTT connection                                                                                                                                                                                      
 - Forge subscribes via a shared subscription ($share/platform/...) so only one replica handles each message, avoiding redundant Redis writes

 The browser sends two types of messages over MQTT:                                                                                                                                                                                                                                                                          
 - Heartbeat (periodic, ~45s): extends TTL, carries visibility/focus state                                                                                                                                                                                                                                                 
 - Context (on route change): carries the full contextStore.expert payload so the gateway can reconstitute in-flight MQTT topics with the correct entity info                                                                                                                                                                
                                                                                                                                                              
 Both message types call cache.set() which resets the TTL. If heartbeats stop (browser crash, tab close), the entry auto-expires after ~135s.                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                              
` app.comms.browserSessions.getSessionsByUser(userId)` retrieves all active sessions for a user, for the future list_browser_sessions MCP tool (#8161).    

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/8158

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

