### PR TITLE
docs: drop a stray space on a blank line in the logs page

### DIFF
--- a/docs/user/logs.md
+++ b/docs/user/logs.md
@@ -23,7 +23,7 @@ Node-RED logs can also be output from the Containers/Pods that run Instances on 
 The Audit Log tab on the application and instance views shows key events that have happened.
 
 The events include:
- 
+
  - User logging into the editor
  - Flows being updated
  - Nodes installed


### PR DESCRIPTION
Removes a space from an otherwise blank line, so the documentation workflow has a harmless change to run against. This is a pull request for testing.

https://github.com/FlowFuse/engineering/issues/237
