### PR TITLE
Make closing the welcome tour actually close it

### DIFF
--- a/frontend/src/stores/ux-tours.js
+++ b/frontend/src/stores/ux-tours.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { markRaw } from 'vue'
 
 import Tours from '../tours/Tours.js'
-import TourWelcome, { id as WelcomeTourId } from '../tours/tour-welcome.js'
+import TourWelcome, { id as WelcomeTourId, onCancel as onWelcomeTourCancel } from '../tours/tour-welcome.js'
 
 export const useUxToursStore = defineStore('ux-tours', {
     state: () => ({
@@ -54,7 +54,7 @@ export const useUxToursStore = defineStore('ux-tours', {
             this.modals[modal] = false
         },
         setWelcomeTour (callback = () => {}) {
-            this.setActiveTour(Tours.create(WelcomeTourId, TourWelcome, callback))
+            this.setActiveTour(Tours.create(WelcomeTourId, TourWelcome, callback, onWelcomeTourCancel))
             this.startTour()
         },
         startTour () {

--- a/frontend/src/tours/Tours.js
+++ b/frontend/src/tours/Tours.js
@@ -7,7 +7,7 @@ import 'shepherd.js/dist/css/shepherd.css'
 
 import { useUxToursStore } from '@/stores/ux-tours.js'
 
-function create (id, tourJson, onCloseHook) {
+function create (id, tourJson, onCloseHook, onCancelHook) {
     // Load tour styles at point-of-use
     // NOTE: Due to sass loader settings, a static import does not work since there are no explicit
     //       references to the styles in the codebase.  This dynamic import ensures the styles are
@@ -35,45 +35,35 @@ function create (id, tourJson, onCloseHook) {
         }
     })
 
-    const cancelTour = tour.cancel
-    tour.cancel = function () {
-        const currentStep = tour.getCurrentStep()
+    function closeTour () {
+        useUxToursStore().deactivateTour(id)
+        useUxToursStore().clearActiveTour()
+        useUxToursStore().withdrawTour()
+        if (onCloseHook) {
+            onCloseHook()
+        }
+    }
 
-        const index = tour.steps.indexOf(currentStep)
-        const finalExitStepIndexExists = tour.steps.findIndex(step => step.options.id?.includes('final-step')) !== -1
-        const allSteps = tour.steps
-        const isLastStep = index === allSteps.length || !!currentStep.options.id?.includes('final-step')
-
-        // highlight the newly created instance only if quitting start- / mid-tour
-        // highlight the newly created instance only for the welcome tour
-        if (tour.options.id === 'welcome' && finalExitStepIndexExists && !isLastStep) {
-            return tour.show('final-step-with-hosted-instance')
-        } else {
-            useUxToursStore().deactivateTour(id)
-            useUxToursStore().clearActiveTour()
-            useUxToursStore().withdrawTour()
-
-            Product.capture('ff-tour-cancel', {
-                tour_id: id,
-                tour_step: index
-            })
-            if (onCloseHook) {
-                onCloseHook()
-            }
-            cancelTour()
+    // Shepherd hands us the index of the step that was on screen when the tour
+    // ended, read before it tears the steps down.
+    function onCancel ({ index } = {}) {
+        Product.capture('ff-tour-cancel', {
+            tour_id: id,
+            tour_step: index
+        })
+        closeTour()
+        // Leaving early skips whatever the tour was going to point at last, so
+        // give the tour a chance to flag it once the overlay is out of the way.
+        if (onCancelHook) {
+            onCancelHook()
         }
     }
 
     function onComplete () {
-        useUxToursStore().deactivateTour(id)
-        useUxToursStore().clearActiveTour()
-        useUxToursStore().withdrawTour()
         Product.capture('ff-tour-complete', {
             tour_id: id
         })
-        if (onCloseHook) {
-            onCloseHook()
-        }
+        closeTour()
     }
 
     function onBack () {
@@ -94,6 +84,7 @@ function create (id, tourJson, onCloseHook) {
         })
     }
 
+    tour.on('cancel', onCancel)
     tour.on('complete', onComplete)
 
     // loop over steps and add them to the tour

--- a/frontend/src/tours/tour-welcome.js
+++ b/frontend/src/tours/tour-welcome.js
@@ -1,6 +1,24 @@
 import { highlightElement } from '../composables/Ux.js'
 
 export const id = 'welcome'
+
+const EDITOR_BUTTON_SELECTOR = '[data-el="dashboard-section-hosted"] .instance-tile:first-of-type .actions .ff-btn'
+
+function highlightEditorButton () {
+    const editorButton = document.querySelector(EDITOR_BUTTON_SELECTOR)
+
+    if (editorButton) {
+        highlightElement(editorButton, { count: 3, duration: 2000, animation: 'pulse' })
+    }
+}
+
+// Users who leave the tour early open the editor less often than those who
+// finish it, so point them at it on the way out rather than holding them in
+// the tour they just closed.
+export function onCancel () {
+    highlightEditorButton()
+}
+
 export default [
     {
         title: 'Welcome to FlowFuse!',
@@ -102,8 +120,7 @@ export default [
                     })
                 }
 
-                const editorButton = document.querySelector('[data-el="dashboard-section-hosted"] .instance-tile:first-of-type .actions .ff-btn')
-                highlightElement(editorButton, { count: 3, duration: 2000, animation: 'pulse' })
+                highlightEditorButton()
             }
         },
         modalOverlayOpeningPadding: 6,

--- a/test/unit/frontend/tours/Tours.spec.js
+++ b/test/unit/frontend/tours/Tours.spec.js
@@ -1,0 +1,189 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Product from '../../../../frontend/src/services/product.js'
+import { useUxToursStore } from '../../../../frontend/src/stores/ux-tours.js'
+import Tours from '../../../../frontend/src/tours/Tours.js'
+
+vi.mock('../../../../frontend/src/services/product.js', () => ({
+    default: { capture: vi.fn() }
+}))
+
+// shepherd positions its steps with floating-ui, which watches the target for
+// resizes. jsdom has no ResizeObserver.
+global.ResizeObserver = class {
+    observe () {}
+    unobserve () {}
+    disconnect () {}
+}
+
+const STEPS = [
+    { title: 'First', text: 'one' },
+    { title: 'Second', text: 'two' },
+    { id: 'final-step-with-hosted-instance', title: 'You are all set', text: 'three' }
+]
+
+// shepherd renders its steps asynchronously
+const rendered = () => new Promise(resolve => setTimeout(resolve, 50))
+
+// shepherd leaves the previous step in the DOM, marked hidden, so every query
+// has to be scoped to the step that is actually on screen
+function visibleStep () {
+    return document.querySelector('.shepherd-element:not([hidden])')
+}
+
+function currentTitle () {
+    return visibleStep()?.querySelector('.shepherd-title')?.textContent
+}
+
+function clickCloseIcon () {
+    visibleStep().querySelector('.shepherd-cancel-icon').click()
+}
+
+function clickButton (text) {
+    const button = [...visibleStep().querySelectorAll('.shepherd-button')]
+        .find(candidate => candidate.textContent.trim() === text)
+    button.click()
+}
+
+function pressEscape () {
+    visibleStep().dispatchEvent(
+        new KeyboardEvent('keydown', { keyCode: 27, key: 'Escape', bubbles: true })
+    )
+}
+
+function captureOf (event) {
+    return Product.capture.mock.calls.find(call => call[0] === event)?.[1]
+}
+
+describe('Tours.create', () => {
+    let tour
+
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        Product.capture.mockClear()
+    })
+
+    afterEach(() => {
+        if (tour?.isActive()) {
+            tour.complete()
+        }
+        tour = undefined
+        document.body.innerHTML = ''
+    })
+
+    describe('leaving the tour', () => {
+        it('closes the tour when the close icon is used on the first step', async () => {
+            tour = Tours.create('welcome', STEPS, vi.fn())
+            tour.start()
+            await rendered()
+            expect(currentTitle()).toBe('First')
+
+            clickCloseIcon()
+            await rendered()
+
+            expect(tour.isActive()).toBe(false)
+            expect(document.querySelectorAll('.shepherd-element')).toHaveLength(0)
+            expect(document.querySelectorAll('.shepherd-modal-overlay-container')).toHaveLength(0)
+        })
+
+        it('closes the tour when the close icon is used part way through', async () => {
+            tour = Tours.create('welcome', STEPS, vi.fn())
+            tour.start()
+            await rendered()
+            tour.next()
+            await rendered()
+            expect(currentTitle()).toBe('Second')
+
+            clickCloseIcon()
+            await rendered()
+
+            expect(tour.isActive()).toBe(false)
+            expect(document.querySelectorAll('.shepherd-element')).toHaveLength(0)
+        })
+
+        it('closes the tour when the Exit button on the first step is pressed', async () => {
+            tour = Tours.create('welcome', STEPS, vi.fn())
+            tour.start()
+            await rendered()
+
+            clickButton('Exit')
+            await rendered()
+
+            expect(tour.isActive()).toBe(false)
+            expect(document.querySelectorAll('.shepherd-element')).toHaveLength(0)
+        })
+
+        it('closes the tour when escape is pressed', async () => {
+            tour = Tours.create('welcome', STEPS, vi.fn())
+            tour.start()
+            await rendered()
+
+            pressEscape()
+            await rendered()
+
+            expect(tour.isActive()).toBe(false)
+            expect(document.querySelectorAll('.shepherd-element')).toHaveLength(0)
+        })
+    })
+
+    describe('on cancel', () => {
+        it('reports the step the user actually left on', async () => {
+            tour = Tours.create('welcome', STEPS, vi.fn())
+            tour.start()
+            await rendered()
+            tour.next()
+            await rendered()
+
+            clickCloseIcon()
+            await rendered()
+
+            expect(captureOf('ff-tour-cancel')).toEqual({ tour_id: 'welcome', tour_step: 1 })
+        })
+
+        it('clears tour state and runs the close hook once', async () => {
+            const onClose = vi.fn()
+            tour = Tours.create('welcome', STEPS, onClose)
+            const store = useUxToursStore()
+            tour.start()
+            await rendered()
+
+            clickCloseIcon()
+            await rendered()
+
+            expect(onClose).toHaveBeenCalledTimes(1)
+            expect(store.tours.welcome).toBe(false)
+            expect(store.activeTour).toBeNull()
+            expect(store.shouldPresentTour).toBe(false)
+        })
+
+        it('runs the cancel hook so the tour can still flag a next step', async () => {
+            const onCancel = vi.fn()
+            tour = Tours.create('welcome', STEPS, vi.fn(), onCancel)
+            tour.start()
+            await rendered()
+
+            clickCloseIcon()
+            await rendered()
+
+            expect(onCancel).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('on complete', () => {
+        it('runs the close hook but not the cancel hook', async () => {
+            const onClose = vi.fn()
+            const onCancel = vi.fn()
+            tour = Tours.create('welcome', STEPS, onClose, onCancel)
+            tour.start()
+            await rendered()
+
+            tour.complete()
+            await rendered()
+
+            expect(captureOf('ff-tour-complete')).toEqual({ tour_id: 'welcome' })
+            expect(onClose).toHaveBeenCalledTimes(1)
+            expect(onCancel).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/test/unit/frontend/tours/tour-welcome.spec.js
+++ b/test/unit/frontend/tours/tour-welcome.spec.js
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { onCancel } from '../../../../frontend/src/tours/tour-welcome.js'
+
+function renderHostedInstanceTile () {
+    document.body.innerHTML = `
+        <div data-el="dashboard-section-hosted">
+            <div class="instance-tile">
+                <div class="actions"><a class="ff-btn">Open Editor</a></div>
+            </div>
+        </div>
+    `
+
+    return document.querySelector('.ff-btn')
+}
+
+describe('welcome tour onCancel', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        document.body.innerHTML = ''
+    })
+
+    it('pulses the open editor button of the first hosted instance', () => {
+        const editorButton = renderHostedInstanceTile()
+
+        onCancel()
+        vi.advanceTimersByTime(1000)
+
+        expect(editorButton.classList.contains('pulse')).toBe(true)
+    })
+
+    it('does nothing when the team has no hosted instance to point at', () => {
+        document.body.innerHTML = '<div data-el="dashboard-section-hosted"><div class="no-instances"><a>Create Instance</a></div></div>'
+
+        expect(() => {
+            onCancel()
+            vi.advanceTimersByTime(1000)
+        }).not.toThrow()
+    })
+})


### PR DESCRIPTION
## Summary

The close icon, the escape key and the first step's Exit button all route through `tour.cancel`. https://github.com/FlowFuse/flowfuse/pull/6511 overrode that method to jump to the final step, so none of them ended the tour on the first press and a button labelled Exit did not exit.

It also reported `ff-tour-cancel` against the final step rather than the step the user left on, so the drop-off funnel behind https://github.com/FlowFuse/flowfuse/issues/5580 shows everyone abandoning at the end.

Back to listening for the `cancel` event, with an optional cancel hook on `Tours.create`. The welcome tour uses it to pulse the Open Editor button once the overlay is gone, so the nudge survives without holding the user in a tour they closed.

## Test plan

* [ ] `npx vitest run --config ./config/vitest.config.ts test/unit/frontend/tours/` (drives the real shepherd.js in jsdom and clicks the rendered close icon; fails on `main`)
* [ ] `npx vitest run --config ./config/vitest.config.ts` (no regressions)