### PR TITLE
docs: name the file each config snippet belongs in

### DIFF
--- a/docs/device-agent/register.md
+++ b/docs/device-agent/register.md
@@ -304,7 +304,7 @@ The values should be set to the contents of the certificate/key.
 Alternatively, the properties `caPath`, `keyPath` and `certPath` can be used instead
 to provide absolute paths to files containing the certificates/keys.
 
-```yml
+```yml [device.yml]
 https:
    keyPath: /opt/flowfuse-device/certs/key.pem
    certPath: /opt/flowfuse-device/certs/cert.pem
@@ -319,14 +319,14 @@ This option can be used to serve content from a local directory.
 
 If set to a path, the files in that directory will be served relative to `/`.
 
-```yml
+```yml [device.yml]
 httpStatic: /opt/flowfuse-device/static-content
 ```
 
 It is also possible to configure it with a list of directories and the corresponding
 path they should be served from.
 
-```yml
+```yml [device.yml]
 httpStatic:
   - path: /opt/flowfuse-device/static-content/images
     root: /images
@@ -347,7 +347,7 @@ _Local Auth settings for Remote Instance_
 
 Or by adding the following to the `device.yml` file
 
-```yml
+```yml [device.yml]
 localAuth:
     enabled: true
     user: user-name

--- a/docs/device-agent/running.md
+++ b/docs/device-agent/running.md
@@ -125,7 +125,7 @@ flowfuse-device-agent --node-options='--max-old-space-size=256' --node-options='
 
 Add a `nodeOptions` array to the `device.yml` configuration file:
 
-```yaml
+```yaml [device.yml]
 nodeOptions:
   - "--max-old-space-size=256"
   - "--use-openssl-ca"

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -173,7 +173,7 @@ kubectl label node <projects-node-name> role=projects
 
 To override this behavior, you can remove the node selectors with the following entry in the `customization.yml` file which will mean that all pods can run on any nodes.
 
-```yaml
+```yaml [customization.yml]
 forge:
   projectSelector:
   managementSelector:
@@ -212,7 +212,7 @@ However, if you want to use SSL termination on the Kubernetes Ingress Controller
 
 Once you have Cert-Manager installed, you can enable TLS support in the `customization.yml` file by specifying the [ClusterIssuer](https://cert-manager.io/docs/configuration/#cluster-resource-namespace) name:
 
-```yaml
+```yaml [customization.yml]{2}
 ingress:
   clusterIssuer: <your-cluster-issuer>
 ```
@@ -223,7 +223,7 @@ Apply changes with [platform startup command](#start-flowfuse-platform).
 
 If you are issuing your own HTTPS certificates (rather than using a Public Certificate Authority) you will need to tell the Hosted Node-RED Instances to trust this CA. To do this you need to pass base64 encoded CA certificate chain to the helm chart in the `customization.yml`. Details are in the Helm chart [README.md](https://github.com/FlowFuse/helm/blob/main/helm/flowfuse/README.md#private-certificate-authority).
 
-```yaml
+```yaml [customization.yml]{3}
 forge:
   privateCA:
     certs: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk...
@@ -263,7 +263,7 @@ FlowFuse platform uses PostgreSQL database to store its data. By default, the He
 
 If you want to use an external database server, you need to edit `customization.yml` file and provide the database connection details:
 
-```yaml
+```yaml [customization.yml]{2}
 forge:
   localPostgresql: false # Disable internal database
 postgresql:
@@ -345,7 +345,7 @@ Check [FlowFuse Helm chart documentation](https://github.com/FlowFuse/helm/tree/
 
 If you use AWS EKS (Elastic Kubernetes Service) and want to use AWS SES (Simple Email Service) for sending e-mails, you need to provide the IAM role with the required permissions to use SES.
 
-```yaml
+```yaml [customization.yml]{6}
 forge:
   entryPoint: forge.example.com
   domain: example.com
@@ -367,7 +367,7 @@ The FlowFuse Helm chart provides the MQTT broker service.
 
 To enable the MQTT broker you need to add the following to the `customization.yml` file:
 
-```yaml
+```yaml [customization.yml]
 forge:
   broker:
     enabled: true
@@ -386,7 +386,7 @@ These files will persist for the lifetime of the Instance including across Suspe
 
 To enable this feature the following configuration needs to be added to the `customization.yml` file (replace '<storage-class-name>' with the name of the StorageClass you have in the cluster):
 
-```yaml
+```yaml [customization.yml]{5}
 forge:
   persistentStorage:
     enabled: true
@@ -400,7 +400,7 @@ Apply changes with [platform startup command](#start-flowfuse-platform).
 
 To enable the FlowFuse File Storage component add the following to the `customization.yml` file:
 
-```yaml
+```yaml [customization.yml]
 forge:
   fileStore:
     enabled: true


### PR DESCRIPTION
## TL;DR

Config snippets in docs now say which file they are, and point at the line you have to change. A reader landing on the Kubernetes install guide from search sees `customization.yml` on the block instead of having to scroll back through the prose to work it out.

Depends on FlowFuse/website#5627. Until that merges the website drops both the file name and the highlights, so this changes nothing on flowfuse.com and breaks nothing either.

## What changed

- **Kubernetes install guide**: every `customization.yml` snippet is labelled. Where the prose tells you to edit a value, that line is highlighted: the cluster issuer, the private CA certs, the external database switch, the SES IAM role, the storage class.
- **Device agent**: the `https`, `httpStatic` and `localAuth` snippets in `register.md`, and `nodeOptions` in `running.md`, are labelled `device.yml`.

Only fence info strings changed. No prose, no snippet contents, no new files.

## Checked

The website's docs sync passes fence info strings through untouched, so the label and line numbers survive into the built site. The rendering itself was verified on the website side in FlowFuse/website#5627, against blocks using this exact syntax.