### PR TITLE
[8218] Remove monthly/yearly toggle + pricing from Team Types page

### DIFF
--- a/frontend/src/components/TeamTypeSelection.vue
+++ b/frontend/src/components/TeamTypeSelection.vue
@@ -4,29 +4,16 @@
             <team-type-tile
                 v-for="type in types" :key="type.id"
                 :team-type="type"
-                :billingInterval="isAnnualBilling ? 'year' : 'month'"
-                :enableCTA="!isBillingEnabled || !isAnnualBilling || !!type.annualBillingPrice"
             />
-        </div>
-        <div class="flex gap-6 justify-center relative z-10 flex-wrap mt-4">
-            <div v-if="isBillingEnabled && annualBillingAvailable" class="text-sm font-medium text-gray-400 flex items-center gap-2">
-                <span :class="{'text-gray-800': !isAnnualBilling }">Monthly</span>
-                <ff-toggle-switch v-model="isAnnualBilling" />
-                <span :class="{'text-gray-800': isAnnualBilling }">Yearly</span>
-            </div>
         </div>
     </div>
 </template>
 
 <script>
 
-import { mapState } from 'pinia'
-
 import teamTypesApi from '../api/teamTypes.js'
 
 import TeamTypeTile from './TeamTypeTile.vue'
-
-import { useAccountSettingsStore } from '@/stores/account-settings.js'
 
 export default {
     name: 'TeamTypeSelection',
@@ -35,13 +22,8 @@ export default {
     },
     data () {
         return {
-            isAnnualBilling: false,
-            annualBillingAvailable: true,
             types: []
         }
-    },
-    computed: {
-        ...mapState(useAccountSettingsStore, ['isBillingEnabled'])
     },
     async created () {
         const { types } = await teamTypesApi.getTeamTypes()

--- a/frontend/src/components/TeamTypeTile.vue
+++ b/frontend/src/components/TeamTypeTile.vue
@@ -8,9 +8,6 @@
             <div class="flex flex-col gap-5">
                 <div class="flex justify-between items-center text-2xl">
                     <label class="font-medium">{{ teamType.name }}</label>
-                    <span v-if="pricing?.value && pricing.value.trim() !== ''">
-                        {{ pricing.value }} <span class="text-xs">/{{ pricing.interval }}</span>
-                    </span>
                 </div>
                 <ff-markdown-viewer :content="teamType.description" />
             </div>
@@ -61,16 +58,6 @@ export default {
     computed: {
         ...mapState(useDataFarmTeamsStore, { teams: 'teamList' }),
         ...mapState(useAccountAuthStore, ['user']),
-        pricing: function () {
-            const billingDescriptionKey = this.billingInterval === 'year' ? 'yrDescription' : 'description'
-            const billing = this.teamType.properties?.billing?.[billingDescriptionKey]?.split('/')
-            const price = {}
-            if (typeof billing !== 'undefined') {
-                price.value = billing[0]
-                price.interval = billing[1]
-            }
-            return price
-        },
         toCreateTeam () {
             return {
                 name: 'team-create',


### PR DESCRIPTION
## Description

Removes the Monthly/Yearly billing toggle and per-tier pricing from the Choose Team Type onboarding page, since pricing is no longer shown there. Also drops the now-unused pricing computed and billing-interval/CTA wiring from `TeamTypeSelection`/`TeamTypeTile`.

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/8218

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

