### PR TITLE
[8220] A trial team with 'contact sales' enabled is directed to stripe to setup billing

### DIFF
--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -104,6 +104,7 @@ import { useHubspotHelper } from '../../composables/Hubspot.js'
 
 import Alerts from '../../services/alerts.js'
 import Product from '../../services/product.js'
+import { contactRequiredToChangeTeamType } from '../../utils/teamType.js'
 
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
@@ -185,11 +186,14 @@ export default {
             return this.team.billing?.unmanaged
         },
         isContactRequired () {
-            return this.billingEnabled &&
-                   !this.user.admin &&
-                   this.input.teamType &&
-                   this.input.teamTypeId !== this.team.type.id &&
-                   this.input.teamType.properties?.billing?.requireContact
+            return contactRequiredToChangeTeamType({
+                billingEnabled: this.billingEnabled,
+                isAdmin: this.user.admin,
+                selectedTeamType: this.input.teamType,
+                selectedTeamTypeId: this.input.teamTypeId,
+                currentTeamTypeId: this.team.type.id,
+                trialMode: this.trialMode
+            })
         },
         isSelectionAvailable () {
             if (this.input.teamTypeId) {

--- a/frontend/src/utils/teamType.ts
+++ b/frontend/src/utils/teamType.ts
@@ -1,0 +1,22 @@
+interface ContactRequiredParams {
+    billingEnabled: boolean
+    isAdmin: boolean
+    selectedTeamType: { properties?: { billing?: { requireContact?: boolean } } } | null | undefined
+    selectedTeamTypeId: string
+    currentTeamTypeId: string
+    trialMode: boolean
+}
+
+export function contactRequiredToChangeTeamType ({
+    billingEnabled,
+    isAdmin,
+    selectedTeamType,
+    selectedTeamTypeId,
+    currentTeamTypeId,
+    trialMode
+}: ContactRequiredParams): boolean {
+    if (!billingEnabled || isAdmin || !selectedTeamType?.properties?.billing?.requireContact) {
+        return false
+    }
+    return selectedTeamTypeId !== currentTeamTypeId || trialMode
+}

--- a/test/unit/frontend/utils/teamType.spec.js
+++ b/test/unit/frontend/utils/teamType.spec.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { contactRequiredToChangeTeamType } from '../../../../frontend/src/utils/teamType.ts'
+
+const contactType = { properties: { billing: { requireContact: true } } }
+const selfServeType = { properties: { billing: { requireContact: false } } }
+
+const base = {
+    billingEnabled: true,
+    isAdmin: false,
+    selectedTeamType: contactType,
+    selectedTeamTypeId: 'current',
+    currentTeamTypeId: 'current',
+    trialMode: false
+}
+
+describe('contactRequiredToChangeTeamType', () => {
+    it('requires contact for a trial converting on its current contact-required type', () => {
+        expect(contactRequiredToChangeTeamType({ ...base, trialMode: true })).toBe(true)
+    })
+
+    it('does not require contact for a trial when the current type is self-serve', () => {
+        expect(contactRequiredToChangeTeamType({ ...base, selectedTeamType: selfServeType, trialMode: true })).toBe(false)
+    })
+
+    it('requires contact when switching to a different contact-required type', () => {
+        expect(contactRequiredToChangeTeamType({ ...base, selectedTeamTypeId: 'target' })).toBe(true)
+    })
+
+    it('does not require contact for a non-trial team staying on its current contact-required type', () => {
+        expect(contactRequiredToChangeTeamType(base)).toBe(false)
+    })
+
+    it('lets admins self-serve even in a trial on a contact-required type', () => {
+        expect(contactRequiredToChangeTeamType({ ...base, isAdmin: true, trialMode: true })).toBe(false)
+    })
+
+    it('never requires contact when billing is disabled', () => {
+        expect(contactRequiredToChangeTeamType({ ...base, billingEnabled: false, selectedTeamTypeId: 'target', trialMode: true })).toBe(false)
+    })
+
+    it('does not require contact when the selected team type is missing', () => {
+        expect(contactRequiredToChangeTeamType({ ...base, selectedTeamType: null, selectedTeamTypeId: 'target' })).toBe(false)
+    })
+})


### PR DESCRIPTION
## Description

Fixes trial teams with "contact sales" enabled on their current type seeing "Setup Payment Details" instead of "Talk to sales". Extracted the `isContactRequired` check into a util + spec covering all cases. 

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/8220

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

