### PR TITLE
[8196] Support popup-window context on the sign-up page (/account/create)

### DIFF
--- a/frontend/src/components/GoogleLoginButton.vue
+++ b/frontend/src/components/GoogleLoginButton.vue
@@ -24,11 +24,13 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import { GoogleLogin } from 'vue3-google-login'
 
 import SSOApi from '@/api/sso.js'
 import SpinnerIcon from '@/components/icons/Spinner.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
+import { handoffFromPopup, isPopupContext } from '@/utils/popupContext.js'
 
 withDefaults(defineProps<{
     label?: string
@@ -38,6 +40,7 @@ withDefaults(defineProps<{
     disabled: false
 })
 
+const route = useRoute()
 const { settings } = storeToRefs(useAccountSettingsStore())
 
 const error = ref('')
@@ -52,7 +55,11 @@ async function ggCallback (response: { access_token: string }) {
     error.value = ''
     const result = await SSOApi.googleSSOCallback(response.access_token)
     if (result.url) {
-        window.location = result.url
+        if (isPopupContext(route.query)) {
+            handoffFromPopup(result.url)
+        } else {
+            window.location = result.url
+        }
     } else if (result.error) {
         error.value = result.error
         busy.value = false

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -2,7 +2,7 @@
 
 <template>
     <ff-layout-box class="ff-signup ff--center-box">
-        <template v-if="splash" #splash-content>
+        <template v-if="splash && !isPopup" #splash-content>
             <div data-el="splash" v-html="splash" />
         </template>
         <form v-if="!ssoCreated" id="ff-sign-up" class="max-w-md m-auto" @submit.prevent="registerUser()">
@@ -74,6 +74,7 @@ import userApi from '../../api/user.js'
 import GoogleLoginButton from '../../components/GoogleLoginButton.vue'
 import SpinnerIcon from '../../components/icons/Spinner.js'
 import FFLayoutBox from '../../layouts/Box.vue'
+import { handoffFromPopup, isPopupContext } from '../../utils/popupContext.js'
 
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
@@ -130,6 +131,9 @@ export default {
         ...mapState(useAccountSettingsStore, ['settings']),
         splash () {
             return this.settings['branding:account:signUpLeftBanner']
+        },
+        isPopup () {
+            return isPopupContext(this.$route.query)
         },
         formValid () {
             return (this.input.email && !this.errors.email) &&
@@ -258,6 +262,10 @@ export default {
                 this.busy = false
                 if (window.gtag && this.settings.adwords?.events?.conversion) {
                     window.gtag('event', 'conversion', this.settings.adwords.events.conversion)
+                }
+                if (this.isPopup) {
+                    handoffFromPopup()
+                    return
                 }
                 if (!result.sso_enabled) {
                     useAccountAuthStore().setUser(result)

--- a/frontend/src/stores/account-auth.js
+++ b/frontend/src/stores/account-auth.js
@@ -5,6 +5,7 @@ import { nextTick } from 'vue'
 import settingsApi from '../api/settings.js'
 import teamApi from '../api/team.js'
 import userApi from '../api/user.js'
+import { handoffFromPopup, isPopupContext } from '../utils/popupContext.js'
 
 import getAppOrchestrator from '@/services/app.orchestrator'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
@@ -89,6 +90,10 @@ export const useAccountAuthStore = defineStore('account-auth', {
                 // User is logged in
                 if (router.currentRoute.value.meta.requiresLogin === false) {
                     // This is only for logged-out users
+                    if (isPopupContext(router.currentRoute.value.query)) {
+                        handoffFromPopup('/')
+                        return
+                    }
                     window.location = '/'
                     return
                 } else if (user.email_verified === false || user.password_expired) {

--- a/frontend/src/utils/popupContext.ts
+++ b/frontend/src/utils/popupContext.ts
@@ -1,0 +1,14 @@
+export function isPopupContext (query: Record<string, unknown> = {}): boolean {
+    return query.context === 'popup'
+}
+
+export function handoffFromPopup (path = '/'): void {
+    const target = new URL(path, window.location.origin).href
+    if (window.opener && !window.opener.closed) {
+        window.opener.location.href = target
+        window.opener.focus()
+        window.close()
+    } else {
+        window.location.href = target
+    }
+}

--- a/test/e2e/frontend/cypress/tests/registration.spec.js
+++ b/test/e2e/frontend/cypress/tests/registration.spec.js
@@ -344,4 +344,32 @@ describe('FlowFuse - Sign Up Page', () => {
         cy.get('[data-form="signup-join-reason"] span.checkbox').first().click()
         cy.get('[data-action="sign-up"]').should('not.be.disabled')
     })
+
+    it('shows the left marketing column when a left banner is configured', () => {
+        cy.intercept('GET', '/api/*/settings', (req) => {
+            req.continue((res) => {
+                res.body['branding:account:signUpLeftBanner'] = '<p>Marketing copy</p>'
+            })
+        }).as('getUserSettings')
+        cy.visit('/account/create')
+        cy.wait('@getUserSettings')
+
+        cy.get('[data-el="splash"]').should('be.visible')
+        cy.get('[data-form="signup-username"]').should('be.visible')
+    })
+
+    it('hides the left marketing column in popup context but keeps the form and top banner', () => {
+        cy.intercept('GET', '/api/*/settings', (req) => {
+            req.continue((res) => {
+                res.body['branding:account:signUpLeftBanner'] = '<p>Marketing copy</p>'
+                res.body['branding:account:signUpTopBanner'] = '<span>Start building today</span>'
+            })
+        }).as('getUserSettings')
+        cy.visit('/account/create?context=popup')
+        cy.wait('@getUserSettings')
+
+        cy.get('[data-el="splash"]').should('not.exist')
+        cy.get('[data-form="signup-username"]').should('be.visible')
+        cy.get('[data-el="banner-text"]').should('be.visible')
+    })
 })


### PR DESCRIPTION
## Description

When opened with `?context=popup` (set by the marketing site), the sign-up page now hides the left marketing column and hands off to a full browser tab once past the form — on successful registration, an already-authenticated load, and Google/SSO — instead of cramming verification or the platform into the ~420px popup. 

Per Nick's callout, the "above the form" one-liner is left untouched: it still shows whenever an admin has configured it, so no self-hosted install loses its banner.

### Test plan 

<details><summary> ✅ All tests passed! </summary>

## Popup mode (`/account/create?context=popup`)

- [x] Left marketing column is hidden; form renders in a single centered column, logo above the form.
- [x] Above-form banner shows when `branding:account:signUpTopBanner` is set (unchanged from normal mode).
- [x] Complete a valid registration → opener tab navigates to `/`, popup closes.
- [x] Register a user whose email requires verification → opener tab lands on `/` and shows the unverified-email screen; popup closes (no verification screen inside the popup).
- [x] Load the URL while already logged in → opener tab navigates to `/`, popup closes (platform never renders in the popup).
- [x] Open the URL directly (no opener, e.g. paste into a tab) → registration/auth handoff navigates the same tab to `/` in place (no new tab, no `window.close` warning).
- [x] `?email=` prefill and `?code=` invite code still work alongside `context=popup`.
- [x] Google/SSO sign-up: after success the flow leaves the popup rather than rendering the post-form state inside it.

## Normal mode (`/account/create`, no param) — regression

- [x] Left column shows when `signUpLeftBanner` is set; single column when it isn't.
- [x] Above-form banner shows when `signUpTopBanner` is set — self-hosted with a configured banner still sees it.
- [x] Successful registration logs in and routes to `/` in the same tab — unverified user lands on the verification screen (no popup handoff, no new tab).
- [x] Already-logged-in user hitting the URL is redirected to `/` in the same tab.

</details>

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/8196


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

