### PR TITLE
Hide yearly billing toggle if there are no yearly billing deets to show

### DIFF
--- a/frontend/src/api/teamTypes.js
+++ b/frontend/src/api/teamTypes.js
@@ -37,7 +37,7 @@ const getTeamTypes = async (cursor, limit, filter) => {
                     teamType.annualBillingInterval = annualInterval
                 }
             } else {
-                teamType.billingPrice = 'free'
+                teamType.billingPrice = ''
                 teamType.billingInterval = ''
             }
             return teamType

--- a/frontend/src/components/TeamTypeSelection.vue
+++ b/frontend/src/components/TeamTypeSelection.vue
@@ -46,6 +46,8 @@ export default {
     async created () {
         const { types } = await teamTypesApi.getTeamTypes()
         this.types = types.sort((a, b) => a.order - b.order)
+        // If any of the available types has an annualBillingPrice, show the annual billing toggle
+        this.annualBillingAvailable = this.types.some(type => !!type.annualBillingPrice)
     }
 }
 </script>

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -309,12 +309,8 @@ export default {
         }).sort((a, b) => a.order - b.order)
         this.input.teamTypeId = this.team.type.id
 
-        this.teamTypes.forEach(tt => {
-            // Check if *any* team type has annual billing available
-            if (tt.annualBillingPrice) {
-                this.annualBillingAvailable = true
-            }
-        })
+        // If any of the available types has an annualBillingPrice, show the annual billing toggle
+        this.annualBillingAvailable = this.teamTypes.some(type => !!type.annualBillingPrice)
 
         const instanceTypes = (await instanceTypesApi.getInstanceTypes()).types
         instanceTypes.forEach(instanceType => {

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -211,6 +211,8 @@ export default {
 
         this.teamTypes = (await teamTypesPromise).types.sort((a, b) => a.order - b.order)
         this.input.teamTypeId = this.teamTypes[0].id
+        // If any of the available types has an annualBillingPrice, show the annual billing toggle
+        this.annualBillingAvailable = this.teamTypes.some(type => !!type.annualBillingPrice)
 
         if (this.$route.query.teamType) {
             this.input.teamTypeId = this.$route.query.teamType


### PR DESCRIPTION
Alternative fix for #8218  - replaces #8221 

Rather than rip out the toggle, this fixes up the conditional logic for whether it is shown or not. They already had a `v-if` conditional on, but the value wasn't being set consistently.

I have also updated the code that mapped a blank pricing detail to display 'free' so that it no longer does that. We don't have a free tier - and it only saved having to type the word 'free' into the pricing description box.