### PR TITLE
Fix MCP gateway ACL check for multi-replica deployments

### DIFF
--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -592,7 +592,9 @@ module.exports = function (app) {
          * The platformId is the id of the replica that owns the exchange (see
          * commsClient.platformId). The replica that emits a request is the one that must
          * receive its response, so the platformId is always concrete: there is no wildcard
-         * for it on either side of the channel.
+         * for it on either side of the channel. In a multi-replica deployment the ACL
+         * callback may be served by a different replica than the one that owns the id,
+         * so only the id's shape (a UUID) is validated here, not its identity.
          *
          * Direction is not checked here. It is already fixed by which list a rule sits in
          * (verify() picks sub[] or pub[] from the access level) and by the request/response
@@ -608,6 +610,11 @@ module.exports = function (app) {
             // that routes one to the mcpGateway acls, so keep this in step with whatever
             // identity lands there and with the gateway service's own broker config.
             const MCP_GATEWAY_CLIENT_TYPE = 'ff-mcp-gateway'
+
+            // Replica platformIds are minted per-process (commsClient.platformId), and this
+            // check may run on a different replica than the topic's owner, so the id can
+            // only be validated by shape.
+            const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
             const ValidationError = function (message) {
                 const error = new Error(message)
@@ -659,7 +666,7 @@ module.exports = function (app) {
                     if (!acl.allowWildcard?.platformId) {
                         throw ValidationError('invalid platform id wildcard')
                     }
-                } else if (platformId !== app.comms.id) {
+                } else if (!UUID_RE.test(platformId)) {
                     throw ValidationError('invalid platform id')
                 }
 

--- a/test/unit/forge/comms/authRoutesV2_spec.js
+++ b/test/unit/forge/comms/authRoutesV2_spec.js
@@ -1760,5 +1760,84 @@ describe('Broker Auth v2 API', async function () {
                 }
             })
         })
+
+        describe('MCP gateway channel (forge_platform)', async function () {
+            // checkMcpTopic verifier coverage - the platform proxying third-party MCP
+            // requests to the central gateway over ff/v1/mcp/... topics
+            const MCP_SESSION = '7d292be0-d561-41c7-afc9-280a3c914284'
+            // A valid replica id that is not this instance's own app.comms.id - in a
+            // multi-replica deployment the ACL check can be served by any replica
+            const OTHER_PLATFORM_ID = '3d7e858c-259f-4d17-b9c0-0d046509cc42'
+
+            before(async function () {
+                await setupEE()
+                app.config.features.register('ai', true, true)
+                app.config.features.register('mcpThirdParty', true, true)
+            })
+
+            after(async function () {
+                await app.close()
+            })
+
+            it('allows forge_platform to publish an mcp request for another replica\'s platformId', async function () {
+                await allowWrite({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/${OTHER_PLATFORM_ID}/${TestObjects.alice.hashid}/${MCP_SESSION}/request`
+                })
+            })
+            it('allows forge_platform to publish an mcp request for its own platformId', async function () {
+                await allowWrite({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/${app.comms.id}/${TestObjects.alice.hashid}/${MCP_SESSION}/request`
+                })
+            })
+            it('allows forge_platform to subscribe to mcp responses for a platformId', async function () {
+                await allowRead({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/${OTHER_PLATFORM_ID}/+/+/response`
+                })
+            })
+            it('denies an mcp request with a non-uuid platformId', async function () {
+                await denyWrite({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/not-a-uuid/${TestObjects.alice.hashid}/${MCP_SESSION}/request`
+                })
+            })
+            it('denies an mcp request with a wildcard platformId', async function () {
+                await denyWrite({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/+/${TestObjects.alice.hashid}/${MCP_SESSION}/request`
+                })
+            })
+            it('denies an mcp response subscription with a wildcard platformId', async function () {
+                await denyRead({
+                    username: 'forge_platform',
+                    topic: 'ff/v1/mcp/+/+/+/response'
+                })
+            })
+            it('denies an mcp request with a short mcp session id', async function () {
+                await denyWrite({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/${OTHER_PLATFORM_ID}/${TestObjects.alice.hashid}/short/request`
+                })
+            })
+            it('denies an mcp request for an unknown user', async function () {
+                await denyWrite({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/${OTHER_PLATFORM_ID}/nonExistentUser/${MCP_SESSION}/request`
+                })
+            })
+            it('denies an mcp request when mcpThirdParty is disabled', async function () {
+                app.config.features.register('mcpThirdParty', false, true)
+                try {
+                    await denyWrite({
+                        username: 'forge_platform',
+                        topic: `ff/v1/mcp/${OTHER_PLATFORM_ID}/${TestObjects.alice.hashid}/${MCP_SESSION}/request`
+                    })
+                } finally {
+                    app.config.features.register('mcpThirdParty', true, true)
+                }
+            })
+        })
     })
 })


### PR DESCRIPTION


## Description

The EMQX authz callback is load-balanced across forge replicas, but checkMcpTopic compared the topic's platformId against the answering replica's own randomly-minted id. With more than one replica this denied ff/v1/mcp/... request publishes and response subscriptions whenever the callback landed on a different replica, surfacing as intermittent 504s from /mcp.

The platformId is a routing address, not an identity claim - the client is already authenticated as forge_platform - so validate its shape (UUID) instead of its identity.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

