### PR TITLE
Add PostHog flag handling and team-dependent re-evaluation logic

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -86,6 +86,7 @@ import PasswordExpired from './pages/PasswordExpired.vue'
 import TermsAndConditions from './pages/TermsAndConditions.vue'
 import UnverifiedEmail from './pages/UnverifiedEmail.vue'
 
+import product from '@/services/product.js'
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useContextStore } from '@/stores/context.js'
@@ -118,7 +119,7 @@ export default {
         ...mapState(useAccountAuthStore, ['user']),
         ...mapState(useUxLoadingStore, ['appLoader', 'offline']),
         ...mapState(useAccountSettingsStore, ['settings']),
-        ...mapState(useContextStore, ['instance', 'device']),
+        ...mapState(useContextStore, ['instance', 'device', 'team']),
         pageTitleSignal () {
             return [this.instance?.id, this.instance?.name, this.device?.id, this.device?.name, this.$route.name]
         },
@@ -167,6 +168,21 @@ export default {
                 if (isEditorRoute(this.$route)) return
                 const title = computePageTitle(this.$route, { instance: this.instance, device: this.device })
                 if (title) document.title = title
+            }
+        },
+        'team.id': {
+            immediate: true,
+            handler (teamId, oldTeamId) {
+                // PostHog evaluates its flags as soon as it initialises, before we know
+                // which team the user is in - so anything targeting the team group comes
+                // back false. On a hard refresh the team is rehydrated from sessionStorage
+                // and account.setTeam early-returns, so nothing ever tells PostHog about
+                // it. Registering the group here triggers a re-evaluation. First team of
+                // this page load only: real team switches already go through
+                // product.setTeam.
+                if (!oldTeamId && teamId) {
+                    product.setTeam(this.team)
+                }
             }
         }
     },

--- a/test/unit/frontend/stores/account-settings.spec.js
+++ b/test/unit/frontend/stores/account-settings.spec.js
@@ -43,6 +43,7 @@ describe('account-settings store', () => {
     beforeEach(() => {
         setActivePinia(createPinia())
         vi.clearAllMocks()
+        delete window.posthog
         mockAuth()
         mockTeam()
     })
@@ -81,6 +82,26 @@ describe('account-settings store', () => {
                 expect(settingsApi.getSettings).toHaveBeenCalledOnce()
                 expect(store.settings).toEqual(settings)
                 expect(store.features).toEqual({ billing: true })
+            })
+        })
+
+        describe('loadPosthogFlags', () => {
+            it('stores the flag values PostHog reports', () => {
+                const onFeatureFlags = vi.fn((cb) => cb(['MCP_THIRD_PARTY'], { MCP_THIRD_PARTY: true }))
+                window.posthog = { onFeatureFlags }
+
+                const store = useAccountSettingsStore()
+                store.loadPosthogFlags()
+
+                expect(store.posthogFlags).toEqual({ MCP_THIRD_PARTY: true })
+            })
+
+            it('does not throw when PostHog is unavailable', () => {
+                delete window.posthog
+
+                const store = useAccountSettingsStore()
+                expect(() => store.loadPosthogFlags()).not.toThrow()
+                expect(store.posthogFlags).toEqual({})
             })
         })
     })


### PR DESCRIPTION
## Description

Fix PostHog stale cache on hard reload when loading feature flags, caused by PostHog being initialized before the team was loaded.

## Related Issue(s)

n/a

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

