### PR TITLE
Add browser session gating for tool execution and metadata support

### DIFF
--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -18,7 +18,14 @@ module.exports = function (app) {
         const toolAccessPermission = {
             'automation:select-nodes': 'project:flows:view',
             'automation:get-nodes': 'project:flows:view',
-            'automation:get-flows': 'project:flows:view'
+            'automation:get-flows': 'project:flows:view',
+            // Platform-UI automation rides the same inflight channel but never touches flows.
+            // Discovery returns static tool definitions, and the tools themselves (ui_get_context,
+            // ui_list_routes, ui_navigate) are all readOnlyHint - so they only need view access.
+            // Without these entries both fall through to the project:flows:edit default below,
+            // which locks read-only navigation out for anyone who cannot edit flows.
+            'automation-ui:mcp-get-features': 'project:flows:view',
+            'automation-ui:mcp-call-tool': 'project:flows:view'
         }
         const requiredPermission = toolAccessPermission[toolName] || 'project:flows:edit' // default to highest level of access if tool isn't in the list, to be safe
 

--- a/forge/db/controllers/BrowserSession.js
+++ b/forge/db/controllers/BrowserSession.js
@@ -36,6 +36,9 @@ module.exports = {
             lastSeen: Date.now(),
             visibility: payload.visibility || 'visible',
             focused: payload.focused ?? null,
+            // Tool groups this tab can answer for, so a consumer can pick a tab by the group it
+            // needs to dispatch without reinterpreting the context's supports* flags.
+            capabilities: Array.isArray(payload.capabilities) ? payload.capabilities : [],
             context: payload.context ?? null
         })
     },

--- a/forge/ee/lib/mcp/sessionGatedTools.js
+++ b/forge/ee/lib/mcp/sessionGatedTools.js
@@ -1,0 +1,42 @@
+/**
+ * Tool groups that can only run against a live browser tab.
+ *
+ * `platform` tools execute inside the platform, so they work for any MCP caller. The
+ * `platform_ui` and `flow_building` groups are dispatched to a browser tab over MQTT, so
+ * they need a tab pinned with platform_set_active_browser_session before they can run.
+ *
+ * Discovery is deliberately NOT gated on a tab being present: definitions are static per
+ * platform version and identical for every tab, so a caller must be able to see these tools
+ * (and be told they need a tab) without one already being open. Callers typically fetch the
+ * tool list once, before any tab is pinned, and never refetch - so a group that only appears
+ * after pinning is a group the caller never learns about.
+ *
+ * The names below mirror frontend/src/mcp/tools/. Keep them in step: the browser owns the
+ * handlers, this list only exists so the platform can name what a pinned tab unlocks.
+ */
+
+const PLATFORM_UI_TOOL_NAMES = [
+    'ui_get_context',
+    'ui_list_routes',
+    'ui_navigate'
+]
+
+const SESSION_GATED_GROUPS = ['platform_ui', 'flow_building']
+
+/**
+ * Guidance for a caller that tried a browser-bound tool with no tab pinned.
+ * Names the recovery steps rather than just reporting the failure.
+ */
+function noBrowserSessionGuidance (baseUrl = '') {
+    return 'This tool runs inside the user\'s browser tab, and no tab is currently pinned for this MCP session. ' +
+        'To fix: call platform_list_browser_sessions, then pass a sessionId from it to platform_set_active_browser_session. ' +
+        'If platform_list_browser_sessions returns no sessions, the user has no tab exposed - ask them to ' +
+        `open the FlowFuse platform${baseUrl ? ` (${baseUrl})` : ''} and click the MCP toggle ` +
+        '(the plug icon next to the Expert button in the header), then retry.'
+}
+
+module.exports = {
+    PLATFORM_UI_TOOL_NAMES,
+    SESSION_GATED_GROUPS,
+    noBrowserSessionGuidance
+}

--- a/forge/ee/lib/mcp/tools/platform.js
+++ b/forge/ee/lib/mcp/tools/platform.js
@@ -1,5 +1,7 @@
 const { z } = require('zod')
 
+const { PLATFORM_UI_TOOL_NAMES, SESSION_GATED_GROUPS, noBrowserSessionGuidance } = require('../sessionGatedTools')
+
 function getProperty (properties, key) {
     let value = properties
     for (const part of key.split('.')) {
@@ -141,6 +143,7 @@ module.exports = [
                     userId: session.userId,
                     lastSeen: session.lastSeen,
                     visibility: session.visibility || 'unknown',
+                    capabilities: session.capabilities || [],
                     context: session.context || null
                 }))
             }
@@ -171,17 +174,47 @@ module.exports = [
                 return {
                     success: false,
                     message: `No live browser session with sessionId '${args.session_id}' was found for this user. ` +
-                        'Call platform_list_browser_sessions to see the current live tabs and pick one from there.'
+                        'A tab that was listed earlier may have been closed, had its MCP toggle turned off, or stopped ' +
+                        'sending presence heartbeats. ' + noBrowserSessionGuidance(app.config.base_url || '')
                 }
             }
 
             await app.db.controllers.BrowserSession.setActiveBrowserSession(user.hashid, mcpSessionId, args.session_id)
 
+            // Callers list the tool surface once, up front - usually before any tab is pinned - and
+            // rarely list it again. Naming what this pin just unlocked means the caller learns about
+            // the browser-bound groups from this response, without having to re-run list_tools.
+            // Report only the groups THIS tab can actually answer for: a plain platform page carries
+            // platform_ui but not flow_building (that needs the Node-RED editor), so announcing both
+            // unconditionally would send the caller after tools this tab cannot serve.
+            const tabCapabilities = Array.isArray(match.capabilities) ? match.capabilities : []
+            const unlockedToolGroups = SESSION_GATED_GROUPS.filter(group => tabCapabilities.includes(group))
+            const unlockedTools = {}
+            if (unlockedToolGroups.includes('platform_ui')) {
+                unlockedTools.platform_ui = PLATFORM_UI_TOOL_NAMES
+            }
+            if (unlockedToolGroups.includes('flow_building')) {
+                unlockedTools.flow_building = 'All flow_building_* tools - call list_tools or search_tools for the current set.'
+            }
+
+            let message = 'Active browser session set. Subsequent platform_ui and flow_building tool calls will target this tab. '
+            if (unlockedToolGroups.length) {
+                message += `This tab can serve the ${unlockedToolGroups.join(' and ')} ` +
+                    `${unlockedToolGroups.length === 1 ? 'group' : 'groups'}` +
+                    `${unlockedTools.platform_ui ? `, including ${PLATFORM_UI_TOOL_NAMES.join(', ')}` : ''}. ` +
+                    'If you listed the available tools before this pin, that list was missing these groups - re-read them from unlockedTools above rather than assuming they are unavailable.'
+            } else {
+                message += 'Note this tab reports no browser-bound capabilities yet, so platform_ui and flow_building calls against it may fail. ' +
+                    'flow_building needs a tab open on a Node-RED editor; if the tab was only just opened, retry after its next presence heartbeat.'
+            }
+
             return {
                 success: true,
                 activeSessionId: args.session_id,
                 context: match.context || null,
-                message: 'Active browser session set. Subsequent platform_ui and flow_building tool calls will target this tab.'
+                unlockedToolGroups,
+                unlockedTools,
+                message
             }
         }
     },
@@ -204,8 +237,8 @@ module.exports = [
             const activeSession = await app.db.controllers.BrowserSession.getActiveBrowserSession(user.hashid, mcpSessionId)
             if (!activeSession) {
                 return {
-                    message: 'No active browser session is set. Call platform_list_browser_sessions to see available tabs, ' +
-                        'then platform_set_active_browser_session to pick one.'
+                    activeSessionId: null,
+                    message: 'No active browser session is set. ' + noBrowserSessionGuidance(app.config.base_url || '')
                 }
             }
 

--- a/frontend/src/components/ExpertButton.vue
+++ b/frontend/src/components/ExpertButton.vue
@@ -61,9 +61,16 @@ export default {
         }
     },
     watch: {
-        team () {
-            if (this.mcpActive) {
-                this.stopMcp()
+        async team () {
+            if (!this.mcpActive) {
+                return
+            }
+            // Straight to the store action rather than stopMcp(), which announces the close
+            // itself - that generic notice plus the specific one below is the same event
+            // reported twice. A team switch is the more useful of the two, so it wins.
+            // Only the call that actually closed the session speaks, so the header's second
+            // toggle cannot report the same switch again.
+            if (await this.disableMcp()) {
                 alerts.emit('MCP session closed due to team switch.', 'info')
             }
         }
@@ -97,9 +104,10 @@ export default {
             this.enableMcp(this.team)
             alerts.emit('MCP session exposed. Third-party agents can now target this tab.', 'confirmation')
         },
-        stopMcp () {
-            this.disableMcp()
-            alerts.emit('MCP session closed.', 'info')
+        async stopMcp () {
+            if (await this.disableMcp()) {
+                alerts.emit('MCP session closed.', 'info')
+            }
         }
     }
 }

--- a/frontend/src/mcp/tools/context.ts
+++ b/frontend/src/mcp/tools/context.ts
@@ -14,6 +14,7 @@ const tools: McpToolDefinition[] = [
             application the user is talking about without them having to spell it out.
             If there are still things you are not sure about after reading the response, ask the user to clarify.`,
         annotations: { readOnlyHint: true, destructiveHint: false },
+        _meta: { requiresBrowserSession: true },
         inputSchema: {
             type: 'object',
             properties: {}

--- a/frontend/src/mcp/tools/navigation.ts
+++ b/frontend/src/mcp/tools/navigation.ts
@@ -15,6 +15,7 @@ const tools: McpToolDefinition[] = [
             If the navigation failed, it might be because a newly created entity has not finished setting up yet. Wait a few seconds and try the navigation again.
             If it still does not work after retrying, navigate the user back to the page they were on before and let them know what happened.`,
         annotations: { readOnlyHint: true, destructiveHint: false },
+        _meta: { requiresBrowserSession: true },
         inputSchema: {
             type: 'object',
             properties: {

--- a/frontend/src/mcp/tools/routes.ts
+++ b/frontend/src/mcp/tools/routes.ts
@@ -28,6 +28,7 @@ const tools: McpToolDefinition[] = [
             (like "/device/:id/overview" means you need to pass { id: "..." }), and metadata like the page title.
             You do not need to call this every time. If you already know the route name from a tool description (e.g. platform_create_hosted_instance tells you to use "instance-overview"), just use it directly.`,
         annotations: { readOnlyHint: true, destructiveHint: false },
+        _meta: { requiresBrowserSession: true },
         inputSchema: {
             type: 'object',
             properties: {}

--- a/frontend/src/publishers/tab-presence.publisher.ts
+++ b/frontend/src/publishers/tab-presence.publisher.ts
@@ -99,13 +99,30 @@ class TabPresencePublisher extends TeamPublisher {
         const topic = this._sessionTopic('heartbeat')
         if (!topic) return
         const contextStore = useContextStore()
+        const context = contextStore.expert
         this._publish(topic, {
             visibility: document.visibilityState,
             focused: document.hasFocus(),
-            context: contextStore.expert
+            capabilities: this._capabilities(context),
+            context
         }).catch((err) => {
             console.warn('Failed to publish tab presence:', err)
         })
+    }
+
+    /**
+     * The tool groups this tab can answer for, named the same way the served tool catalog
+     * groups them. Consumers pick a tab by the group they need to dispatch, so this is a flat
+     * list of group names rather than the several `supports*` booleans it is derived from.
+     */
+    private _capabilities (context: { supportsPlatformAutomation?: boolean, supportsPlatformUIAutomation?: boolean, scope?: string, assistantVersion?: string | null }): string[] {
+        const capabilities: string[] = []
+        if (context?.supportsPlatformAutomation) capabilities.push('platform')
+        if (context?.supportsPlatformUIAutomation) capabilities.push('platform_ui')
+        // flow_building dispatches into the Node-RED editor, so it needs the assistant present
+        // in an immersive tab - a plain platform page cannot answer for it.
+        if (context?.scope === 'immersive' && context?.assistantVersion) capabilities.push('flow_building')
+        return capabilities
     }
 }
 

--- a/frontend/src/publishers/tab-presence.publisher.ts
+++ b/frontend/src/publishers/tab-presence.publisher.ts
@@ -18,9 +18,33 @@ class TabPresencePublisher extends TeamPublisher {
     private $userId: string | null = null
     private $sessionId: string | null = null
     private $teamId: string | null = null
+    private $announceClose = true
 
     constructor (options: CreatePublisherOptions<Transport>) {
         super({ name: 'tabPresence', ...options })
+    }
+
+    /**
+     * Go quiet for this shutdown: skip the `close` notice on the way out.
+     *
+     * The platform reads `close` as the user opting this tab out and drops its session
+     * entry, so it must only be sent when that is what actually happened. A tab that is
+     * merely unmounting the toggle (a layout change, say) has to stay listed, and the
+     * entry it leaves behind is refreshed the moment the tab announces itself again.
+     */
+    silenceCloseNotice (): void {
+        this.$announceClose = false
+    }
+
+    /**
+     * Publishes presence immediately, whether or not this call also (re)connected.
+     *
+     * The transport is shared per team and _connect short-circuits when it is already
+     * attached, so a caller that re-enables presence over a live connection would
+     * otherwise get no heartbeat and stay unlisted until the interval came round.
+     */
+    announcePresence (): void {
+        this._publishPresence()
     }
 
     protected _onStarted (teamId: string, userId: string): void {
@@ -32,6 +56,7 @@ class TabPresencePublisher extends TeamPublisher {
         this.$userId = userId
         this.$sessionId = authStore.getSessionId()
         this.$teamId = teamId
+        this.$announceClose = true
 
         this._publishPresence()
 
@@ -75,6 +100,7 @@ class TabPresencePublisher extends TeamPublisher {
      * for a couple of minutes after the user opted out.
      */
     protected async _onStopping (): Promise<void> {
+        if (!this.$announceClose) return
         const topic = this._sessionTopic('close')
         if (!topic) return
         await this._publish(topic, {}).catch((err) => {
@@ -128,6 +154,10 @@ class TabPresencePublisher extends TeamPublisher {
 
 const { create: createTabPresencePublisher, destroy: destroyTabPresencePublisher } = definePublisherSingleton(TabPresencePublisher)
 
+// Tracked alongside the singleton so a caller can reach the live publisher to adjust how it
+// shuts down, which the factory's argument-less destroy() cannot express on its own.
+let activePublisher: TabPresencePublisher | null = null
+
 export function startTabPresence (team: TeamRef): TabPresencePublisher {
     const orchestrator = getAppOrchestrator()
     const transport = createMqttTransport(orchestrator.$services.mqtt)
@@ -136,10 +166,27 @@ export function startTabPresence (team: TeamRef): TabPresencePublisher {
         router: orchestrator.$router,
         transport
     })
+    activePublisher = publisher
+    // connect() resolves to an already-attached transport without starting the publisher
+    // again, so announce presence either way rather than assuming this call produced a
+    // heartbeat. Re-enabling over a live connection has to leave the tab listed.
     publisher.connect(team)
+        .then(() => publisher.announcePresence())
+        .catch((err) => {
+            console.warn('Failed to start tab presence:', err)
+        })
     return publisher
 }
 
-export async function stopTabPresence (): Promise<void> {
+/**
+ * @param announceClose - whether to tell the platform this tab is opting out. Pass false when
+ *   presence is only being dismantled (an unmounting toggle, say) and the tab should stay
+ *   listed; the platform treats the notice as a deliberate opt-out and drops the tab's entry.
+ */
+export async function stopTabPresence ({ announceClose = true } = {}): Promise<void> {
+    if (!announceClose) {
+        activePublisher?.silenceCloseNotice()
+    }
+    activePublisher = null
     await destroyTabPresencePublisher()
 }

--- a/frontend/src/services/automations.service.ts
+++ b/frontend/src/services/automations.service.ts
@@ -31,7 +31,8 @@ class AutomationsService extends BaseService implements AutomationsServiceI {
             title: tool.title,
             description: tool.description,
             annotations: tool.annotations,
-            inputSchema: tool.inputSchema
+            inputSchema: tool.inputSchema,
+            _meta: tool._meta
         }))
     }
 

--- a/frontend/src/stores/product-mcp.js
+++ b/frontend/src/stores/product-mcp.js
@@ -25,16 +25,31 @@ export const useProductMcpStore = defineStore('product-mcp', {
             this.active = true
         },
         async disable () {
-            await this.teardown()
+            // The header mounts more than one toggle (a mobile one and a desktop one), so their
+            // watchers and lifecycle hooks fire in the same tick. Clearing the flag before the
+            // first await makes every call after the first a no-op, so one opt-out tears the
+            // comms down once - and lets a caller tell whether it was the one that did it, which
+            // is what keeps a single event from being announced once per button.
+            if (!this.active) return false
             this.active = false
+            await stopMcpInflight()
+            // A real opt-out: tell the platform to drop this tab's session entry now rather
+            // than leaving it listed as targetable until the entry expires.
+            await stopTabPresence({ announceClose: true })
+            return true
         },
         /**
          * Drops the comms but leaves the flag alone, so a tab that is only unmounting
          * the button (rather than opting out) comes back up exposed.
+         *
+         * Deliberately silent: the platform reads the close notice as the user opting out and
+         * deletes the tab's session entry, which would un-list a tab that is still open and
+         * still exposed. Leaving the entry in place lets the remount refresh it instead, and a
+         * tab that really is going away is still covered by its connection's last will.
          */
         async teardown () {
             await stopMcpInflight()
-            await stopTabPresence()
+            await stopTabPresence({ announceClose: false })
         }
     },
     persist: {

--- a/frontend/src/types/mcp/mcp.types.ts
+++ b/frontend/src/types/mcp/mcp.types.ts
@@ -17,12 +17,27 @@ export interface McpToolHandlerContext {
     router: Router
 }
 
+/**
+ * Out-of-band facts about a tool, carried alongside the definition rather than buried in
+ * the description so a caller can reason about it without parsing prose. Mirrors how the
+ * flow-building catalog already ships `assistantMinVersion`.
+ */
+export interface McpToolMeta {
+    /**
+     * The tool executes in a browser tab, so it needs one pinned with
+     * platform_set_active_browser_session before it can run. Discovery is not gated on this.
+     */
+    requiresBrowserSession?: boolean,
+    requiresImmersiveEditor?: boolean
+}
+
 export interface McpToolDefinition {
     name: string
     title: string
     description: string
     annotations: McpToolAnnotations
     inputSchema: McpToolInputSchema
+    _meta?: McpToolMeta
     handler: (args: unknown, context: McpToolHandlerContext) => unknown | Promise<unknown>
 }
 
@@ -32,4 +47,5 @@ export interface McpToolWireDefinition {
     description: string
     annotations: McpToolAnnotations
     inputSchema: McpToolInputSchema
+    _meta?: McpToolMeta
 }


### PR DESCRIPTION
## Description

Add browser session gating for tool execution and metadata support

## Related Issue(s)

part of https://github.com/FlowFuse/flowfuse/issues/7424

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

