### PR TITLE
ci: Do not send telemetry anonymously on pre-staging

### DIFF
--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -42,6 +42,9 @@ forge:
           port: 5432
           database: postgres
           ssl: false
+  telemetry:
+    enabled: true
+    anonymize: false
 
 broker:
   replicas: 1


### PR DESCRIPTION
## Description

This pull request updates the values file used for creating pre-staging environments and disables anonymization of telemetry data.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/1560

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

