### PR TITLE
feat(mcp): gate the third-party MCP surface per team on the AI feature

### DIFF
--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -1,6 +1,64 @@
 const { Roles, RoleNames } = require('../../lib/roles')
 
+// Per-team AI gate caches for the MCP door, keyed by hashid. The TTL backstops
+// the memory driver, whose del only clears the process that handled the write.
+const TEAM_AI_CACHE = 'mcp-team-ai-enabled'
+const USER_TEAMS_CACHE = 'mcp-user-teams'
+const AI_CACHE_TTL = 1000 * 60 * 5 // 5 minutes
+const AI_CACHE_MAX = 10000
+
 module.exports = {
+
+    init (app) {
+        app.caches.createCache(TEAM_AI_CACHE, { ttl: AI_CACHE_TTL, max: AI_CACHE_MAX })
+        app.caches.createCache(USER_TEAMS_CACHE, { ttl: AI_CACHE_TTL, max: AI_CACHE_MAX })
+    },
+
+    // Cached per-team AI feature value for the door's gate; a missing team
+    // resolves to false (fail closed).
+    isTeamAiEnabled: async function (app, teamHashId) {
+        const cache = app.caches.getCache(TEAM_AI_CACHE)
+        const cached = await cache.get(teamHashId)
+        if (cached !== undefined) {
+            return cached
+        }
+        const team = await app.db.models.Team.byId(teamHashId)
+        const enabled = team ? !!team.getFeatureProperty('ai', true) : false
+        await cache.set(teamHashId, enabled)
+        return enabled
+    },
+
+    // Cached team memberships for the door's all-teams path. Staleness is fail
+    // closed: downstream RBAC re-checks live membership on every call.
+    getUserTeamHashIds: async function (app, user) {
+        const cache = app.caches.getCache(USER_TEAMS_CACHE)
+        const key = '' + user.id
+        const cached = await cache.get(key)
+        if (cached !== undefined) {
+            return cached
+        }
+        const memberships = await user.getTeamMemberships(true)
+        const hashids = memberships.map(m => m.Team.hashid)
+        await cache.set(key, hashids)
+        return hashids
+    },
+
+    clearTeamAiCache: async function (app, teamHashId) {
+        await app.caches.getCache(TEAM_AI_CACHE).del(teamHashId)
+    },
+
+    // Dropped wholesale on a team-type change, which shifts AI for every team of
+    // that type without a per-team override.
+    clearAllTeamAiCache: async function (app) {
+        const cache = app.caches.getCache(TEAM_AI_CACHE)
+        for (const key of await cache.keys()) {
+            await cache.del(key)
+        }
+    },
+
+    clearUserTeamsCache: async function (app, userId) {
+        await app.caches.getCache(USER_TEAMS_CACHE).del('' + userId)
+    },
 
     createTeamForUser: async function (app, teamDetails, user) {
         const newTeam = await app.db.models.Team.create(teamDetails)
@@ -109,6 +167,7 @@ module.exports = {
         }
 
         await team.addUser(user, { through: { role: userRole } })
+        await app.db.controllers.Team.clearUserTeamsCache(user.id)
     },
     /**
      * Remove a user from a team
@@ -166,6 +225,7 @@ module.exports = {
             }
 
             await app.db.controllers.StorageSession.removeUserFromTeamSessions(user, team)
+            await app.db.controllers.Team.clearUserTeamsCache(user.id)
 
             return true
         }

--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -2,22 +2,22 @@ const { Roles, RoleNames } = require('../../lib/roles')
 
 // Per-team AI gate caches for the MCP door, keyed by hashid. The TTL backstops
 // the memory driver, whose del only clears the process that handled the write.
-const TEAM_AI_CACHE = 'mcp-team-ai-enabled'
-const USER_TEAMS_CACHE = 'mcp-user-teams'
+const AI_TEAM_CACHE = 'ai-mcp-team-enabled'
+const AI_USER_TEAMS_CACHE = 'ai-mcp-user-teams'
 const AI_CACHE_TTL = 1000 * 60 * 5 // 5 minutes
 const AI_CACHE_MAX = 10000
 
 module.exports = {
 
     init (app) {
-        app.caches.createCache(TEAM_AI_CACHE, { ttl: AI_CACHE_TTL, max: AI_CACHE_MAX })
-        app.caches.createCache(USER_TEAMS_CACHE, { ttl: AI_CACHE_TTL, max: AI_CACHE_MAX })
+        app.caches.createCache(AI_TEAM_CACHE, { ttl: AI_CACHE_TTL, max: AI_CACHE_MAX })
+        app.caches.createCache(AI_USER_TEAMS_CACHE, { ttl: AI_CACHE_TTL, max: AI_CACHE_MAX })
     },
 
     // Cached per-team AI feature value for the door's gate; a missing team
     // resolves to false (fail closed).
     isTeamAiEnabled: async function (app, teamHashId) {
-        const cache = app.caches.getCache(TEAM_AI_CACHE)
+        const cache = app.caches.getCache(AI_TEAM_CACHE)
         const cached = await cache.get(teamHashId)
         if (cached !== undefined) {
             return cached
@@ -31,7 +31,7 @@ module.exports = {
     // Cached team memberships for the door's all-teams path. Staleness is fail
     // closed: downstream RBAC re-checks live membership on every call.
     getUserTeamHashIds: async function (app, user) {
-        const cache = app.caches.getCache(USER_TEAMS_CACHE)
+        const cache = app.caches.getCache(AI_USER_TEAMS_CACHE)
         const key = '' + user.id
         const cached = await cache.get(key)
         if (cached !== undefined) {
@@ -44,20 +44,20 @@ module.exports = {
     },
 
     clearTeamAiCache: async function (app, teamHashId) {
-        await app.caches.getCache(TEAM_AI_CACHE).del(teamHashId)
+        await app.caches.getCache(AI_TEAM_CACHE).del(teamHashId)
     },
 
     // Dropped wholesale on a team-type change, which shifts AI for every team of
     // that type without a per-team override.
     clearAllTeamAiCache: async function (app) {
-        const cache = app.caches.getCache(TEAM_AI_CACHE)
+        const cache = app.caches.getCache(AI_TEAM_CACHE)
         for (const key of await cache.keys()) {
             await cache.del(key)
         }
     },
 
     clearUserTeamsCache: async function (app, userId) {
-        await app.caches.getCache(USER_TEAMS_CACHE).del('' + userId)
+        await app.caches.getCache(AI_USER_TEAMS_CACHE).del('' + userId)
     },
 
     createTeamForUser: async function (app, teamDetails, user) {

--- a/forge/ee/routes/mcp/server.js
+++ b/forge/ee/routes/mcp/server.js
@@ -40,6 +40,7 @@ module.exports = async function (app) {
     // Narrows a token's team reach (teamScopes, empty means all-teams) to the teams
     // with AI enabled, substituting the deny sentinel when none survive.
     async function resolveAiTeams (user, teamScopes) {
+        // Team-scoped token: keep only the named teams that have AI enabled.
         if (teamScopes.length > 0) {
             const enabled = []
             for (const teamHashId of teamScopes) {
@@ -49,6 +50,7 @@ module.exports = async function (app) {
             }
             return enabled.length > 0 ? enabled : [AI_DISABLED_SENTINEL]
         }
+        // All-teams token: filter the AI gate over the user's actual memberships.
         const memberTeams = await app.db.controllers.Team.getUserTeamHashIds(user)
         if (memberTeams.length === 0) {
             return [AI_DISABLED_SENTINEL]

--- a/forge/ee/routes/mcp/server.js
+++ b/forge/ee/routes/mcp/server.js
@@ -4,6 +4,11 @@ const { randomUUID } = require('node:crypto')
 const MCP_SESSION_TOKEN_CACHE = 'mcp-session-token'
 const MCP_SESSION_TOKEN_CACHE_TTL = 1000 * 60 * 60 // 1 hour
 
+// Deny stand-in for when no team survives AI filtering. An empty team list means
+// "all teams", so we substitute a value that matches no team rather than let a
+// filtered-to-empty list read as all-teams.
+const AI_DISABLED_SENTINEL = '__ff_no_ai_team__'
+
 /**
  * MCP Platform Tools Server
  *
@@ -32,6 +37,38 @@ module.exports = async function (app) {
         return 'read'
     }
 
+    // Narrows a token's team reach (teamScopes, empty means all-teams) to the teams
+    // with AI enabled, substituting the deny sentinel when none survive.
+    async function resolveAiTeams (user, teamScopes) {
+        if (teamScopes.length > 0) {
+            const enabled = []
+            for (const teamHashId of teamScopes) {
+                if (await app.db.controllers.Team.isTeamAiEnabled(teamHashId)) {
+                    enabled.push(teamHashId)
+                }
+            }
+            return enabled.length > 0 ? enabled : [AI_DISABLED_SENTINEL]
+        }
+        const memberTeams = await app.db.controllers.Team.getUserTeamHashIds(user)
+        if (memberTeams.length === 0) {
+            return [AI_DISABLED_SENTINEL]
+        }
+        const enabled = []
+        for (const teamHashId of memberTeams) {
+            if (await app.db.controllers.Team.isTeamAiEnabled(teamHashId)) {
+                enabled.push(teamHashId)
+            }
+        }
+        if (enabled.length === 0) {
+            return [AI_DISABLED_SENTINEL]
+        }
+        // Keep an all-teams token unrestricted only when every team qualifies.
+        if (enabled.length === memberTeams.length) {
+            return []
+        }
+        return enabled
+    }
+
     // Resolves the caller's identity and scope, or sends an error reply and returns null.
     async function resolveCaller (request, reply) {
         if (!request.session?.User) {
@@ -40,18 +77,17 @@ module.exports = async function (app) {
             reply.code(401).send({ code: 'unauthorized', error: 'Unauthorized' })
             return null
         }
-        const pat = request.session.pat
-        const readOnly = !!pat?.readOnly
-        const teams = Array.isArray(pat?.teamScopes)
-            ? pat.teamScopes.map(entry => Object.keys(entry)[0])
-            : []
-        // Gate the third-party MCP surface on the platform having AI enabled. An empty
-        // allow-list is an all-teams PAT, so no single team is pinned here; per-team
-        // access is enforced downstream by the scope-capped token at invoke.
+        // Gate the third-party MCP surface on the platform having AI enabled.
         if (!app.config.features.enabled('ai')) {
             reply.code(404).send({ code: 'not_found', error: 'Not Found' })
             return null
         }
+        const pat = request.session.pat
+        const readOnly = !!pat?.readOnly
+        const teamScopes = Array.isArray(pat?.teamScopes)
+            ? pat.teamScopes.map(entry => Object.keys(entry)[0])
+            : []
+        const teams = await resolveAiTeams(request.session.User, teamScopes)
         return {
             userId: request.session.User.hashid,
             scope: { readOnly, teams }
@@ -141,7 +177,7 @@ module.exports = async function (app) {
         }
 
         // A single-team PAT pins the action there when no tab named a team; multi-team tokens stay unattributed.
-        if (!userProperties.teamId && caller.scope.teams.length === 1) {
+        if (!userProperties.teamId && caller.scope.teams.length === 1 && caller.scope.teams[0] !== AI_DISABLED_SENTINEL) {
             userProperties.teamId = caller.scope.teams[0]
         }
 

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -930,6 +930,8 @@ module.exports = async function (app) {
                 auditLogFunc(request.session.User, null, request.team, updates)
                 app.comms?.team?.notify(request.team.hashid, 'updated')
             }
+            // Every AI-affecting update (feature, properties, team-type) reaches here.
+            await app.db.controllers.Team.clearTeamAiCache(request.team.hashid)
             reply.send(app.db.views.Team.team(request.team))
         } catch (err) {
             auditLogFunc(request.session.User, err, request.team, updates)

--- a/forge/routes/api/teamType.js
+++ b/forge/routes/api/teamType.js
@@ -217,6 +217,8 @@ module.exports = async function (app) {
                 teamType.properties = request.body.properties
             }
             await teamType.save()
+            // A feature change here shifts AI for every team of this type without an override.
+            await app.db.controllers.Team.clearAllTeamAiCache()
             // TODO: audit log
             // await app.auditLog.Platform.platform.projectType.updated(request.session.User, null, projectType, updates)
             reply.send(app.db.views.TeamType.teamType(teamType, request.session.User.admin))

--- a/test/unit/forge/ee/routes/mcp/server_spec.js
+++ b/test/unit/forge/ee/routes/mcp/server_spec.js
@@ -3,6 +3,21 @@ const sinon = require('sinon')
 
 const setup = require('../../setup')
 
+const FF_UTIL = require('flowforge-test-utils')
+
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+const ENTERPRISE_LICENSE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZkNDFmNmRjLTBmM2QtNGFmNy1hNzk0LWIyNWFhNGJmYTliZCIsInZlciI6IjIwMjQtMDMtMDQiLCJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGdXNlIERldmVsb3BtZW50IiwibmJmIjoxNzMwNjc4NDAwLCJleHAiOjIwNzc3NDcyMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxMCwidGVhbXMiOjEwLCJpbnN0YW5jZXMiOjEwLCJtcXR0Q2xpZW50cyI6NiwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTczMDcyMTEyNH0.02KMRf5kogkpH3HXHVSGprUm0QQFLn21-3QIORhxFgRE9N5DIE8YnTH_f8W_21T6TlYbDUmf4PtWyj120HTM2w'
+
+// Set (and invalidate the cache for) a team's per-team AI feature override.
+async function setTeamAi (app, team, enabled) {
+    const properties = team.properties || {}
+    properties.features = { ...(properties.features || {}), ai: enabled }
+    team.properties = properties
+    await team.save()
+    await app.db.controllers.Team.clearTeamAiCache(team.hashid)
+}
+
 describe('MCP Platform Tools Server', function () {
     describe('Feature flag enabled (default)', function () {
         let app
@@ -401,12 +416,14 @@ describe('MCP Platform Tools Server', function () {
 
     describe('Feature flag disabled', function () {
         let app
+        let disabledPAT
 
         before(async function () {
             app = await setup({
                 license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZkNDFmNmRjLTBmM2QtNGFmNy1hNzk0LWIyNWFhNGJmYTliZCIsInZlciI6IjIwMjQtMDMtMDQiLCJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGdXNlIERldmVsb3BtZW50IiwibmJmIjoxNzMwNjc4NDAwLCJleHAiOjIwNzc3NDcyMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxMCwidGVhbXMiOjEwLCJpbnN0YW5jZXMiOjEwLCJtcXR0Q2xpZW50cyI6NiwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTczMDcyMTEyNH0.02KMRf5kogkpH3HXHVSGprUm0QQFLn21-3QIORhxFgRE9N5DIE8YnTH_f8W_21T6TlYbDUmf4PtWyj120HTM2w',
                 ai: { enabled: false }
             })
+            disabledPAT = await app.db.controllers.AccessToken.createPersonalAccessToken(app.user, '', null, 'ai-disabled-pat')
         })
 
         after(async function () {
@@ -415,6 +432,272 @@ describe('MCP Platform Tools Server', function () {
 
         it('should not register the expertPlatformAutomation feature flag when AI is disabled', async function () {
             should(app.config.features.enabled('expertPlatformAutomation')).not.equal(true)
+        })
+
+        it('returns 404 from the MCP door when the platform AI feature is off', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/mcp',
+                headers: { authorization: `Bearer ${disabledPAT.token}` },
+                payload: { jsonrpc: '2.0', method: 'tools/list', id: 1 }
+            })
+            response.statusCode.should.equal(404)
+        })
+    })
+
+    describe('Per-team AI gating', function () {
+        let app
+        let proxyRequest
+        const T = {}
+
+        before(async function () {
+            app = await setup({
+                license: ENTERPRISE_LICENSE,
+                ai: { enabled: true },
+                expert: { enabled: true }
+            })
+            // app.user (alice) is already an owner of app.team; give her two more teams
+            // so the all-teams token has a mix to gate.
+            T.ateam = app.team
+            T.bteam = await app.factory.createTeam({ name: 'BTeam' })
+            await T.bteam.addUser(app.user, { through: { role: Roles.Owner } })
+            T.cteam = await app.factory.createTeam({ name: 'CTeam' })
+            await T.cteam.addUser(app.user, { through: { role: Roles.Owner } })
+
+            T.globalPAT = await app.db.controllers.AccessToken.createPersonalAccessToken(app.user, '', null, 'ai-global')
+            T.bTeamPAT = await app.db.controllers.AccessToken.createPersonalAccessToken(app.user, '', null, 'ai-bteam', { teamIds: [T.bteam.hashid] })
+            T.abTeamPAT = await app.db.controllers.AccessToken.createPersonalAccessToken(app.user, '', null, 'ai-abteam', { teamIds: [T.ateam.hashid, T.bteam.hashid] })
+
+            // Edge-case fixtures on their own users, so alice's all-teams baseline stays "every team on".
+            T.noTeamsUser = await app.factory.createUser({ username: 'bob', name: 'Bob', email: 'bob@example.com', password: 'bbPassword' })
+            T.noTeamsPAT = await app.db.controllers.AccessToken.createPersonalAccessToken(T.noTeamsUser, '', null, 'ai-no-teams')
+
+            T.carol = await app.factory.createUser({ username: 'carol', name: 'Carol', email: 'carol@example.com', password: 'ccPassword' })
+            const aiOffType = await app.factory.createTeamType({ name: 'ai-off-type', properties: { features: { ai: false } } })
+            const aiOnType = await app.factory.createTeamType({ name: 'ai-on-type', properties: { features: { ai: true } } })
+            T.inheritOffTeam = await app.factory.createTeam({ name: 'InheritOff' }, aiOffType)
+            await T.inheritOffTeam.addUser(T.carol, { through: { role: Roles.Owner } })
+            T.inheritOnTeam = await app.factory.createTeam({ name: 'InheritOn' }, aiOnType)
+            await T.inheritOnTeam.addUser(T.carol, { through: { role: Roles.Owner } })
+            T.inheritOffPAT = await app.db.controllers.AccessToken.createPersonalAccessToken(T.carol, '', null, 'ai-inherit-off', { teamIds: [T.inheritOffTeam.hashid] })
+            T.inheritOnPAT = await app.db.controllers.AccessToken.createPersonalAccessToken(T.carol, '', null, 'ai-inherit-on', { teamIds: [T.inheritOnTeam.hashid] })
+
+            T.flipType = await app.factory.createTeamType({ name: 'ai-flip-type', properties: { features: { ai: true } } })
+            T.flipTeam = await app.factory.createTeam({ name: 'FlipTeam' }, T.flipType)
+            await T.flipTeam.addUser(T.carol, { through: { role: Roles.Owner } })
+            T.flipPAT = await app.db.controllers.AccessToken.createPersonalAccessToken(T.carol, '', null, 'ai-flip', { teamIds: [T.flipTeam.hashid] })
+        })
+
+        after(async function () {
+            await app.close()
+        })
+
+        beforeEach(async function () {
+            proxyRequest = sinon.stub(app.comms.mcpGateway, 'proxyRequest')
+                .resolves({ jsonrpc: '2.0', id: 1, result: { tools: [] } })
+            // Reset every team to AI-enabled before each case.
+            await setTeamAi(app, T.ateam, true)
+            await setTeamAi(app, T.bteam, true)
+            await setTeamAi(app, T.cteam, true)
+        })
+
+        afterEach(function () {
+            proxyRequest.restore()
+        })
+
+        async function callWith (pat) {
+            proxyRequest.resetHistory()
+            return app.inject({
+                method: 'POST',
+                url: '/mcp',
+                headers: { authorization: `Bearer ${pat.token}` },
+                payload: { jsonrpc: '2.0', method: 'tools/list', id: 1 }
+            })
+        }
+
+        function forwardedTeams () {
+            return proxyRequest.firstCall.args[1].scope.teams
+        }
+
+        it('leaves an all-teams token unrestricted when every team has AI enabled', async function () {
+            const response = await callWith(T.globalPAT)
+            response.statusCode.should.equal(200)
+            forwardedTeams().should.deepEqual([])
+        })
+
+        it('narrows an all-teams token to the AI-enabled subset when some teams are disabled', async function () {
+            await setTeamAi(app, T.cteam, false)
+            const response = await callWith(T.globalPAT)
+            response.statusCode.should.equal(200)
+            const teams = forwardedTeams()
+            teams.should.have.length(2)
+            teams.should.containEql(T.ateam.hashid)
+            teams.should.containEql(T.bteam.hashid)
+            teams.should.not.containEql(T.cteam.hashid)
+        })
+
+        it('denies an all-teams token via a sentinel when every team has AI disabled', async function () {
+            await setTeamAi(app, T.ateam, false)
+            await setTeamAi(app, T.bteam, false)
+            await setTeamAi(app, T.cteam, false)
+            const response = await callWith(T.globalPAT)
+            response.statusCode.should.equal(200)
+            const teams = forwardedTeams()
+            // Non-empty (never collapses to all-teams) and matches no real team.
+            teams.should.have.length(1)
+            teams[0].should.not.equal(T.ateam.hashid)
+            teams[0].should.not.equal(T.bteam.hashid)
+            teams[0].should.not.equal(T.cteam.hashid)
+        })
+
+        it('does not attribute the sentinel as a team on a denied all-teams token', async function () {
+            await setTeamAi(app, T.ateam, false)
+            await setTeamAi(app, T.bteam, false)
+            await setTeamAi(app, T.cteam, false)
+            const response = await callWith(T.globalPAT)
+            response.statusCode.should.equal(200)
+            proxyRequest.firstCall.args[3].should.not.have.property('teamId')
+        })
+
+        it('keeps a team-scoped token when its team has AI enabled', async function () {
+            const response = await callWith(T.bTeamPAT)
+            response.statusCode.should.equal(200)
+            forwardedTeams().should.deepEqual([T.bteam.hashid])
+        })
+
+        it('denies a team-scoped token via a sentinel when its only team has AI disabled', async function () {
+            await setTeamAi(app, T.bteam, false)
+            const response = await callWith(T.bTeamPAT)
+            response.statusCode.should.equal(200)
+            const teams = forwardedTeams()
+            teams.should.have.length(1)
+            teams[0].should.not.equal(T.bteam.hashid)
+        })
+
+        it('filters a multi-team scoped token down to its AI-enabled teams', async function () {
+            await setTeamAi(app, T.bteam, false)
+            const response = await callWith(T.abTeamPAT)
+            response.statusCode.should.equal(200)
+            forwardedTeams().should.deepEqual([T.ateam.hashid])
+        })
+
+        it('caches the team AI value until it is invalidated', async function () {
+            const first = await app.db.controllers.Team.isTeamAiEnabled(T.cteam.hashid)
+            first.should.be.true()
+            // Flip the value in the database without clearing the cache.
+            const properties = T.cteam.properties
+            properties.features = { ...(properties.features || {}), ai: false }
+            T.cteam.properties = properties
+            await T.cteam.save()
+            const cached = await app.db.controllers.Team.isTeamAiEnabled(T.cteam.hashid)
+            cached.should.be.true()
+            await app.db.controllers.Team.clearTeamAiCache(T.cteam.hashid)
+            const fresh = await app.db.controllers.Team.isTeamAiEnabled(T.cteam.hashid)
+            fresh.should.be.false()
+        })
+
+        it('reflects an AI toggle made through the team API on the next call', async function () {
+            const loginResponse = await app.inject({
+                method: 'POST',
+                url: '/account/login',
+                payload: { username: 'alice', password: 'aaPassword', remember: false }
+            })
+            const sid = loginResponse.cookies[0].value
+            const putResponse = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${T.cteam.hashid}`,
+                cookies: { sid },
+                payload: { features: { ai: false } }
+            })
+            putResponse.statusCode.should.equal(200)
+
+            const response = await callWith(T.globalPAT)
+            response.statusCode.should.equal(200)
+            const teams = forwardedTeams()
+            teams.should.not.containEql(T.cteam.hashid)
+            teams.should.containEql(T.ateam.hashid)
+            teams.should.containEql(T.bteam.hashid)
+        })
+
+        it('denies an all-teams token for a user who belongs to no teams', async function () {
+            const response = await callWith(T.noTeamsPAT)
+            response.statusCode.should.equal(200)
+            const teams = forwardedTeams()
+            teams.should.have.length(1)
+            teams[0].should.not.equal(T.ateam.hashid)
+        })
+
+        it('keeps every team of a multi-team scoped token when all have AI enabled', async function () {
+            const response = await callWith(T.abTeamPAT)
+            response.statusCode.should.equal(200)
+            const teams = forwardedTeams()
+            teams.should.have.length(2)
+            teams.should.containEql(T.ateam.hashid)
+            teams.should.containEql(T.bteam.hashid)
+        })
+
+        it('denies a multi-team scoped token when all its teams have AI disabled', async function () {
+            await setTeamAi(app, T.ateam, false)
+            await setTeamAi(app, T.bteam, false)
+            const response = await callWith(T.abTeamPAT)
+            response.statusCode.should.equal(200)
+            const teams = forwardedTeams()
+            teams.should.have.length(1)
+            teams[0].should.not.equal(T.ateam.hashid)
+            teams[0].should.not.equal(T.bteam.hashid)
+        })
+
+        it('gates on the team-type value when a team has no per-team override', async function () {
+            const off = await callWith(T.inheritOffPAT)
+            off.statusCode.should.equal(200)
+            const offTeams = forwardedTeams()
+            offTeams.should.have.length(1)
+            offTeams.should.not.containEql(T.inheritOffTeam.hashid)
+
+            const on = await callWith(T.inheritOnPAT)
+            on.statusCode.should.equal(200)
+            forwardedTeams().should.deepEqual([T.inheritOnTeam.hashid])
+        })
+
+        it('reflects a new team membership on the next call', async function () {
+            await setTeamAi(app, T.cteam, false)
+            const before = await callWith(T.globalPAT)
+            before.statusCode.should.equal(200)
+            forwardedTeams().should.not.containEql(T.cteam.hashid)
+
+            const dteam = await app.factory.createTeam({ name: 'DTeam' })
+            // Through the controller, so the user-teams cache is invalidated (the path real membership changes take).
+            await app.db.controllers.Team.addUser(dteam, app.user, Roles.Owner)
+            try {
+                const after = await callWith(T.globalPAT)
+                after.statusCode.should.equal(200)
+                forwardedTeams().should.containEql(dteam.hashid)
+            } finally {
+                await dteam.destroy()
+                await app.db.controllers.Team.clearUserTeamsCache(app.user.id)
+            }
+        })
+
+        it('flushes cached team values on a team-type feature change', async function () {
+            const warm = await callWith(T.flipPAT)
+            warm.statusCode.should.equal(200)
+            forwardedTeams().should.deepEqual([T.flipTeam.hashid])
+
+            const login = await app.inject({ method: 'POST', url: '/account/login', payload: { username: 'alice', password: 'aaPassword', remember: false } })
+            const sid = login.cookies[0].value
+            const put = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/team-types/${T.flipType.hashid}`,
+                cookies: { sid },
+                payload: { properties: { instances: {}, devices: {}, users: {}, features: { ai: false } } }
+            })
+            put.statusCode.should.equal(200)
+
+            const after = await callWith(T.flipPAT)
+            after.statusCode.should.equal(200)
+            const teams = forwardedTeams()
+            teams.should.have.length(1)
+            teams[0].should.not.equal(T.flipTeam.hashid)
         })
     })
 })


### PR DESCRIPTION
## Summary

Gates the third-party MCP surface on the per-team AI feature, not just the platform-level flag, so a token can no longer reach platform tools for a team that has opted out of AI.

- The front door narrows a token's forwarded team reach to the teams with AI enabled, resolved per request in `resolveCaller`.
- An empty team list already means all teams, so when filtering leaves no teams a sentinel that matches no team is substituted (deny) rather than collapsing back to all teams.
- The gate is backed by two hashid-keyed caches, the team AI value and the user's team memberships, which cache inputs rather than the filtered result so each is invalidated with a single delete. Invalidation is wired to the routes that change the effective AI value: per-team and admin properties edits, team-type feature changes, and team membership changes. A five minute TTL is the backstop, and the shared cache driver propagates deletes across instances.
- The user-teams cache is fail closed: downstream RBAC re-checks live membership on every call, so a stale list can only make an all-teams token temporarily more restrictive, never grant a team the user has left.
- Tests cover the resolution cases (all-teams, team-scoped, multi-team, team-type inherited, no-teams user), the caches, and invalidation through the team and team-type APIs.
