### PR TITLE
feat(expert): fetch flow-building tool catalog over MQTT

### DIFF
--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -697,6 +697,40 @@ module.exports = function (app) {
                 }
             }
             return false
+        },
+        /**
+         * First-party flow-building catalog channel - the platform fetching the global,
+         * session-less tool catalog from the central gateway.
+         *
+         *   ff/v1/mcp/catalog/<platformId>/request   platform -> gateway
+         *   ff/v1/mcp/catalog/<platformId>/response  gateway -> platform
+         *
+         * Distinct from checkMcpTopic: no user or session (the catalog is global) and no
+         * mcpThirdParty gate (this is a first-party read). Only the platform client uses it,
+         * and the platformId is concrete per replica, so only its UUID shape is validated.
+         */
+        checkMcpCatalogTopic: async function (topicParts, usernameParts, acl) {
+            // topicParts = [ fullTopic, <platformId> ]
+            const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+            const [, platformId] = topicParts
+            const [clientType] = usernameParts
+
+            if (topicParts.length !== 2 || !platformId) {
+                app.log.warn('ACL validation error for MCP catalog topic: invalid topic format')
+                return false
+            }
+            if (!acl.isPlatform || clientType !== 'forge_platform') {
+                app.log.warn('ACL validation error for MCP catalog topic: expected the platform client')
+                return false
+            }
+            if (platformId === '+') {
+                return !!acl.allowWildcard?.platformId
+            }
+            if (!UUID_RE.test(platformId)) {
+                app.log.warn('ACL validation error for MCP catalog topic: invalid platform id')
+                return false
+            }
+            return true
         }
     }
 
@@ -728,6 +762,9 @@ module.exports = function (app) {
                 // platform can listen for third-party MCP responses from the central gateway
                 // - ff/v1/mcp/<platformId>/+/+/response
                 { topic: /^ff\/v1\/mcp\/([^/]+)\/([^/]+)\/([^/]+)\/response$/, verify: 'checkMcpTopic', allowWildcard: { user: true, session: true }, isPlatform: true, isSub: true },
+                // platform can listen for first-party flow-building catalog responses
+                // - ff/v1/mcp/catalog/<platformId>/response
+                { topic: /^ff\/v1\/mcp\/catalog\/([^/]+)\/response$/, verify: 'checkMcpCatalogTopic', isPlatform: true, isSub: true },
                 // - ff/v1/<team>/u/<user>/s/<session>/<event> (shared subscription)
                 //   [^/]+ on the event segment: the subscription wildcard (+) is matched
                 //   literally, and teamFrontend's pub rule already restricts the events
@@ -767,7 +804,10 @@ module.exports = function (app) {
                 { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/platform\/([^/]+)\/response$/, verify: 'checkExpertPlatformTopic', isPlatform: true, isPub: true, agent: 'platform' },
                 // platform can publish third-party MCP requests to the central gateway
                 // - ff/v1/mcp/<platformId>/<userId>/<mcpSessionId>/request
-                { topic: /^ff\/v1\/mcp\/([^/]+)\/([^/]+)\/([^/]+)\/request$/, verify: 'checkMcpTopic', isPlatform: true, isPub: true }
+                { topic: /^ff\/v1\/mcp\/([^/]+)\/([^/]+)\/([^/]+)\/request$/, verify: 'checkMcpTopic', isPlatform: true, isPub: true },
+                // platform can publish first-party flow-building catalog requests to the central gateway
+                // - ff/v1/mcp/catalog/<platformId>/request
+                { topic: /^ff\/v1\/mcp\/catalog\/([^/]+)\/request$/, verify: 'checkMcpCatalogTopic', isPlatform: true, isPub: true }
             ]
         },
         project: {

--- a/forge/comms/commsClient.js
+++ b/forge/comms/commsClient.js
@@ -56,6 +56,18 @@ class CommsClient extends EventEmitter {
                  * 3rd Party Mcp events
                  */
                 if (topicParts[2] === 'mcp') {
+                    // ff/v1/mcp/catalog/<platformId>/response (first-party, session-less)
+                    if (topicParts[3] === 'catalog' && topicParts[5] === 'response') {
+                        let payload
+                        try {
+                            payload = JSON.parse(message.toString())
+                        } catch (err) {
+                            this.app.log.warn(`Ignoring malformed MCP catalog response on ${topic}: ${err.message}`)
+                            return
+                        }
+                        this.emit('response/mcp-gateway', packet.properties?.correlationData, payload)
+                        return
+                    }
                     // ff/v1/mcp/<platformId>/<userId>/<mcpSessionId>/response/
                     if (topicParts[6] === 'response') {
                         let payload
@@ -293,7 +305,9 @@ class CommsClient extends EventEmitter {
                 // Browser session events - shared subscription
                 '$share/browser/ff/v1/+/u/+/s/+/+',
                 // MCP gateway responses - per-replica (not shared), same as device responses
-                `ff/v1/mcp/${this.platformId}/+/+/response`
+                `ff/v1/mcp/${this.platformId}/+/+/response`,
+                // First-party flow-building catalog responses - per-replica
+                `ff/v1/mcp/catalog/${this.platformId}/response`
             ])
         }
     }

--- a/forge/comms/mcpGateway.js
+++ b/forge/comms/mcpGateway.js
@@ -57,6 +57,31 @@ class McpGatewayHandler {
         const response = await promise
         return response.mcp || response
     }
+
+    /**
+     * Fetch the global flow-building tool catalog from the gateway over MQTT.
+     * First-party and session-less: no userId/mcpSessionId/scope, its own topic.
+     *
+     * @param {object} payload Request payload (mcp body, toolGroups)
+     * @param {number} [timeoutMs] Override default timeout
+     * @returns {Promise<object>} The MCP response body
+     */
+    async proxyCatalogRequest (payload, timeoutMs) {
+        const requestTopic = `ff/v1/mcp/catalog/${this.client.platformId}/request`
+
+        const { correlationData, mqttOptions, promise } = this.awaitReply.create({
+            timeout: timeoutMs || DEFAULT_TIMEOUT
+        })
+
+        this.client.publish(
+            requestTopic,
+            JSON.stringify({ ...payload, correlationData }),
+            mqttOptions
+        )
+
+        const response = await promise
+        return response.mcp || response
+    }
 }
 
 module.exports = {

--- a/forge/ee/lib/expert/emxq-bridge/setup.js
+++ b/forge/ee/lib/expert/emxq-bridge/setup.js
@@ -14,7 +14,7 @@ const axios = require('axios')
 const httpAgent = new http.Agent({ keepAlive: false })
 const httpsAgent = new https.Agent({ keepAlive: false })
 
-const { connector, actionOut, sourceChat, sourceInflight, sourcePlatform, sourceMcpRes, ruleIn, ruleOut } = require('./templates.js')
+const { connector, actionOut, sourceChat, sourceInflight, sourcePlatform, sourceMcpRes, sourceMcpCatalogRes, ruleIn, ruleOut } = require('./templates.js')
 
 // EMQX v5 IDs for connector/action/source resources are `<type>:<name>`.
 // Rule IDs are the rule's own `id` field.
@@ -190,7 +190,8 @@ async function validateBridge (app, { cfg, client } = {}) {
         const hasSourceInflight = sources.some(s => s.name === sourceInflight.name && s.type === 'mqtt')
         const hasSourcePlatform = sources.some(s => s.name === sourcePlatform.name && s.type === 'mqtt')
         const hasSourceMcpRes = sources.some(s => s.name === sourceMcpRes.name && s.type === 'mqtt')
-        if (!hasSourceChat || !hasSourceInflight || !hasSourcePlatform || !hasSourceMcpRes) {
+        const hasSourceMcpCatalogRes = sources.some(s => s.name === sourceMcpCatalogRes.name && s.type === 'mqtt')
+        if (!hasSourceChat || !hasSourceInflight || !hasSourcePlatform || !hasSourceMcpRes || !hasSourceMcpCatalogRes) {
             app.log.info('Expert bridge sources not found')
             return false
         }
@@ -331,6 +332,8 @@ async function addBridge (app, { cfg, client } = {}) {
     await post(client, '/sources', sourcePlatform)
     app.log.info(`creating EMQX source ${sourceMcpRes.name}`)
     await post(client, '/sources', sourceMcpRes)
+    app.log.info(`creating EMQX source ${sourceMcpCatalogRes.name}`)
+    await post(client, '/sources', sourceMcpCatalogRes)
     app.log.info(`creating EMQX rule ${ruleOut.id}`)
     await post(client, '/rules', ruleOut)
     app.log.info(`creating EMQX rule ${ruleIn.id}`)

--- a/forge/ee/lib/expert/emxq-bridge/templates.js
+++ b/forge/ee/lib/expert/emxq-bridge/templates.js
@@ -104,9 +104,26 @@ const sourceMcpRes = {
     }
 }
 
+// Expert Broker → FF App Instance Broker. First-party flow-building catalog responses.
+const sourceMcpCatalogRes = {
+    name: 'ff-expert-to-app-mcp-catalog-res-source',
+    type: 'mqtt',
+    connector: 'ff-expert-broker',
+    description: 'Subscribe to first-party flow-building catalog responses on the Expert Broker',
+    enable: true,
+    parameters: {
+        qos: 1,
+        topic: 'ff/v1/mcp/catalog/+/response'
+    },
+    resource_opts: {
+        health_check_interval: '15s'
+    }
+}
+
 // Republish inbound bridge messages onto the FF App Instance Broker.
 // `topic` is already mountpoint-stripped by the Expert Broker, so no rewrite needed.
-// This covers chat responses, inflight requests, platform requests, and third-party MCP responses.
+// This covers chat responses, inflight requests, platform requests, third-party MCP responses,
+// and first-party flow-building catalog responses.
 //
 // v5 property forwarding via the inline republish action is fiddly on EMQX:
 //   - `user_properties` is a template scalar, so `${pub_props.'User-Property'}` works.
@@ -119,7 +136,7 @@ const ruleIn = {
     name: 'ff-expert-to-app-rule',
     description: 'Republish chat responses, inflight requests and platform requests on the FF App Instance Broker',
     enable: true,
-    sql: 'SELECT\n  *,\n  pub_props.\'Correlation-Data\' as correlation_data,\n  pub_props.\'Response-Topic\' as response_topic,\n  pub_props.\'Content-Type\' as content_type,\n  pub_props.\'Payload-Format-Indicator\' as payload_format_indicator,\n  pub_props.\'Message-Expiry-Interval\' as message_expiry_interval\nFROM\n  "$bridges/mqtt:ff-expert-to-app-chat-source",\n  "$bridges/mqtt:ff-expert-to-app-inflight-source",\n  "$bridges/mqtt:ff-expert-to-app-platform-source",\n  "$bridges/mqtt:ff-expert-to-app-mcp-res-source"',
+    sql: 'SELECT\n  *,\n  pub_props.\'Correlation-Data\' as correlation_data,\n  pub_props.\'Response-Topic\' as response_topic,\n  pub_props.\'Content-Type\' as content_type,\n  pub_props.\'Payload-Format-Indicator\' as payload_format_indicator,\n  pub_props.\'Message-Expiry-Interval\' as message_expiry_interval\nFROM\n  "$bridges/mqtt:ff-expert-to-app-chat-source",\n  "$bridges/mqtt:ff-expert-to-app-inflight-source",\n  "$bridges/mqtt:ff-expert-to-app-platform-source",\n  "$bridges/mqtt:ff-expert-to-app-mcp-res-source",\n  "$bridges/mqtt:ff-expert-to-app-mcp-catalog-res-source"',
     actions: [
         {
             args: {
@@ -147,16 +164,17 @@ const ruleIn = {
 //   - ../<channel>/inflight/+/response  (channel wildcarded: `support` and `mcp`)
 //   - ../support/platform/+/response
 //   - ff/v1/mcp/+/+/+/request  (third-party MCP requests to the central gateway)
+//   - ff/v1/mcp/catalog/+/request  (first-party flow-building catalog requests)
 // The Expert Broker's mountpoint applies the `<licenceId>/` namespace prefix on receipt.
 const ruleOut = {
     id: 'ff-app-to-expert-rule',
     name: 'ff-app-to-expert-rule',
     description: 'Forward chat requests, inflight responses, platform responses, third-party MCP requests and browser-tab presence to the Expert Broker',
     enable: true,
-    sql: 'SELECT\n  *\nFROM\n  "ff/v1/expert/+/+/+/+/support/chat/request",\n  "ff/v1/expert/+/+/+/+/+/inflight/+/response",\n  "ff/v1/expert/+/+/platform/+/response",\n  "ff/v1/mcp/+/+/+/request"',
+    sql: 'SELECT\n  *\nFROM\n  "ff/v1/expert/+/+/+/+/support/chat/request",\n  "ff/v1/expert/+/+/+/+/+/inflight/+/response",\n  "ff/v1/expert/+/+/platform/+/response",\n  "ff/v1/mcp/+/+/+/request",\n  "ff/v1/mcp/catalog/+/request"',
     actions: [
         'mqtt:ff-app-to-expert-action'
     ]
 }
 
-module.exports = { connector, actionOut, sourceChat, sourceInflight, sourcePlatform, sourceMcpRes, ruleIn, ruleOut }
+module.exports = { connector, actionOut, sourceChat, sourceInflight, sourcePlatform, sourceMcpRes, sourceMcpCatalogRes, ruleIn, ruleOut }

--- a/forge/ee/routes/expert/index.js
+++ b/forge/ee/routes/expert/index.js
@@ -57,8 +57,7 @@ const curatePlatformTool = (def) => {
     }
 }
 
-// Unwraps list_flow_catalog's CallToolResult: nr-mcp-server-nodes wraps the payload as JSON
-// in content[0].text, matching the Expert gateway-client's parseToolResult.
+// Unwraps a CallToolResult: the payload is JSON in content[0].text.
 const parseFlowCatalogResult = (mcpResponse) => {
     const result = mcpResponse?.result
     const text = result?.content?.[0]?.text
@@ -72,8 +71,7 @@ const parseFlowCatalogResult = (mcpResponse) => {
     return result?.structuredContent ?? null
 }
 
-// Maps a gateway flow-building descriptor to the permissions-UI entry, identical to the
-// Expert gateway-client's toUiCatalogEntry so the shape matches the old HTTP path.
+// Maps a flow-building tool descriptor to the permissions-UI entry shape.
 const toUiCatalogEntry = (d) => {
     const ann = d.annotations || {}
     const meta = d._meta || {}
@@ -731,9 +729,9 @@ module.exports = async function (app) {
             return reply.status(404).send({ code: 'not_found', error: 'Not Found' })
         }
 
-        // Fetch the flow-building catalog from the gateway's list_flow_catalog meta-tool over
-        // the MQTT bridge (no Expert service token). It is session-less, so no team/scope is
-        // sent; failure degrades to the platform tools alone.
+        // Flow-building catalog, over MQTT:
+        // - no service token, no team/scope (catalog is global)
+        // - failure degrades to platform tools alone
         let catalog = []
         let hash = null
         const mcpGateway = app.comms?.mcpGateway
@@ -761,8 +759,6 @@ module.exports = async function (app) {
             }
         }
 
-        // Merge in the global platform tools, reusing the app.comms singleton (constructing
-        // one re-registers its MQTT listener).
         const platformHandler = app.comms?.platformAutomation
         if (platformHandler) {
             const platformDefs = platformHandler.getToolDefinitions() || []

--- a/forge/ee/routes/expert/index.js
+++ b/forge/ee/routes/expert/index.js
@@ -57,6 +57,36 @@ const curatePlatformTool = (def) => {
     }
 }
 
+// Unwraps list_flow_catalog's CallToolResult: nr-mcp-server-nodes wraps the payload as JSON
+// in content[0].text, matching the Expert gateway-client's parseToolResult.
+const parseFlowCatalogResult = (mcpResponse) => {
+    const result = mcpResponse?.result
+    const text = result?.content?.[0]?.text
+    if (typeof text === 'string') {
+        try {
+            return JSON.parse(text)
+        } catch (e) {
+            return null
+        }
+    }
+    return result?.structuredContent ?? null
+}
+
+// Maps a gateway flow-building descriptor to the permissions-UI entry, identical to the
+// Expert gateway-client's toUiCatalogEntry so the shape matches the old HTTP path.
+const toUiCatalogEntry = (d) => {
+    const ann = d.annotations || {}
+    const meta = d._meta || {}
+    return {
+        key: d.key || d.name,
+        name: ann.title || d.title || d.name,
+        toolClass: d.toolClass,
+        destructive: d.toolClass === 'delete',
+        minVersion: meta.assistantMinVersion || null,
+        maxVersion: meta.assistantMaxVersion || null
+    }
+}
+
 /**
  * @param {import('../../forge.js').ForgeApplication} app
  */
@@ -700,40 +730,46 @@ module.exports = async function (app) {
         if (!request.isExpertAssistantEnabled) {
             return reply.status(404).send({ code: 'not_found', error: 'Not Found' })
         }
-        try {
-            const toolsUrl = `${app.expert.expertUrl.split('/').slice(0, -1).join('/')}/mcp/flow-tools`
-            const response = await axios.get(toolsUrl, {
-                headers: {
-                    Origin: request.headers.origin,
-                    ...(app.expert.serviceToken ? { Authorization: `Bearer ${app.expert.serviceToken}` } : {})
-                },
-                timeout: app.expert.requestTimeout
-            })
-            const catalog = response.data?.catalog || []
 
-            // Merge in the FlowFuse platform tools. They are global (no per-team filtering)
-            // and served from the handler singleton already constructed on app.comms, so we
-            // reuse it rather than newing one up — constructing re-registers its MQTT event
-            // listener. getToolDefinitions() is synchronous and takes no args.
-            const platformHandler = app.comms?.platformAutomation
-            if (platformHandler) {
-                const platformDefs = platformHandler.getToolDefinitions() || []
-                catalog.push(...platformDefs.map(curatePlatformTool))
+        // Fetch the flow-building catalog from the gateway's list_flow_catalog meta-tool over
+        // the MQTT bridge (no Expert service token). It is session-less, so no team/scope is
+        // sent; failure degrades to the platform tools alone.
+        let catalog = []
+        let hash = null
+        const mcpGateway = app.comms?.mcpGateway
+        if (mcpGateway) {
+            try {
+                const mcpResponse = await mcpGateway.proxyRequest(
+                    { userId: request.user.hashid, mcpSessionId: uuidv4() },
+                    {
+                        mcp: {
+                            jsonrpc: '2.0',
+                            id: 1,
+                            method: 'tools/call',
+                            params: { name: 'list_flow_catalog', arguments: {} }
+                        },
+                        toolGroups: ['flow_building']
+                    },
+                    app.expert.requestTimeout
+                )
+                const parsed = parseFlowCatalogResult(mcpResponse)
+                const tools = Array.isArray(parsed?.tools) ? parsed.tools : []
+                catalog = tools.map(toUiCatalogEntry)
+                hash = parsed?.hash || null
+            } catch (error) {
+                app.log.warn(`[expert/mcp/tools] gateway flow-catalog fetch failed: ${error.message}`)
             }
-
-            reply.send({ catalog, hash: response.data?.hash || null })
-        } catch (error) {
-            // The tool catalog is a non-fatal enhancement (the client swallows failures and
-            // gates safely with defaults). Never forward an upstream auth failure as our own
-            // 401. The SPA's axios interceptor treats any 401 as session-expiry and logs the
-            // user out, which an unrelated expert-service token rejection must not trigger.
-            const upstreamStatus = error.response?.status
-            app.log.warn(`[expert/mcp/tools] upstream tool-catalog fetch failed: status=${upstreamStatus} msg=${error.message}`)
-            if (upstreamStatus === 401 || upstreamStatus === 403) {
-                return reply.send({ catalog: [], hash: null })
-            }
-            reply.code(upstreamStatus || 500).send({ code: error.response?.data?.code || 'unexpected_error', error: error.response?.data?.error || error.message })
         }
+
+        // Merge in the global platform tools, reusing the app.comms singleton (constructing
+        // one re-registers its MQTT listener).
+        const platformHandler = app.comms?.platformAutomation
+        if (platformHandler) {
+            const platformDefs = platformHandler.getToolDefinitions() || []
+            catalog.push(...platformDefs.map(curatePlatformTool))
+        }
+
+        reply.send({ catalog, hash })
     })
 }
 

--- a/forge/ee/routes/expert/index.js
+++ b/forge/ee/routes/expert/index.js
@@ -688,8 +688,8 @@ module.exports = async function (app) {
 
     /**
      * Returns the merged tool catalog for the Expert permissions UI: flow-building tools
-     * proxied from the agent's /mcp/flow-tools endpoint, plus curated platform tools. A
-     * `hash` of the flow-building catalog rides along so the browser refetches only when
+     * fetched from the gateway's list_flow_catalog over MQTT, plus curated platform tools.
+     * A `hash` of the flow-building catalog rides along so the browser refetches only when
      * it changes. Team access and feature gating are enforced by the shared preHandler.
      */
     app.get('/mcp/tools', {
@@ -737,8 +737,7 @@ module.exports = async function (app) {
         const mcpGateway = app.comms?.mcpGateway
         if (mcpGateway) {
             try {
-                const mcpResponse = await mcpGateway.proxyRequest(
-                    { userId: request.user.hashid, mcpSessionId: uuidv4() },
+                const mcpResponse = await mcpGateway.proxyCatalogRequest(
                     {
                         mcp: {
                             jsonrpc: '2.0',

--- a/test/unit/forge/comms/authRoutesV2_spec.js
+++ b/test/unit/forge/comms/authRoutesV2_spec.js
@@ -1839,5 +1839,62 @@ describe('Broker Auth v2 API', async function () {
                 }
             })
         })
+
+        describe('MCP catalog channel (forge_platform)', async function () {
+            // checkMcpCatalogTopic verifier coverage - the platform fetching the global,
+            // session-less flow-building catalog over ff/v1/mcp/catalog/... topics
+            const OTHER_PLATFORM_ID = '3d7e858c-259f-4d17-b9c0-0d046509cc42'
+
+            before(async function () {
+                await setupEE()
+                app.config.features.register('ai', true, true)
+            })
+
+            after(async function () {
+                await app.close()
+            })
+
+            it('allows forge_platform to publish a catalog request for its own platformId', async function () {
+                await allowWrite({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/catalog/${app.comms.id}/request`
+                })
+            })
+            it('allows forge_platform to publish a catalog request for another replica\'s platformId', async function () {
+                await allowWrite({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/catalog/${OTHER_PLATFORM_ID}/request`
+                })
+            })
+            it('allows forge_platform to subscribe to a catalog response for a platformId', async function () {
+                await allowRead({
+                    username: 'forge_platform',
+                    topic: `ff/v1/mcp/catalog/${OTHER_PLATFORM_ID}/response`
+                })
+            })
+            it('allows a catalog request when mcpThirdParty is disabled (first-party, not gated)', async function () {
+                app.config.features.register('mcpThirdParty', false, true)
+                try {
+                    await allowWrite({
+                        username: 'forge_platform',
+                        topic: `ff/v1/mcp/catalog/${OTHER_PLATFORM_ID}/request`
+                    })
+                } finally {
+                    app.config.features.register('mcpThirdParty', true, true)
+                }
+            })
+            it('denies a catalog request with a non-uuid platformId', async function () {
+                await denyWrite({
+                    username: 'forge_platform',
+                    topic: 'ff/v1/mcp/catalog/not-a-uuid/request'
+                })
+            })
+            it('denies a catalog request with a wildcard platformId', async function () {
+                await denyWrite({
+                    username: 'forge_platform',
+                    topic: 'ff/v1/mcp/catalog/+/request'
+                })
+            })
+        })
     })
 })

--- a/test/unit/forge/ee/lib/expert/tasks/emqx-bridge/setup_spec.js
+++ b/test/unit/forge/ee/lib/expert/tasks/emqx-bridge/setup_spec.js
@@ -10,7 +10,7 @@ const {
     getConfig, getList, makeClient, del, post
 } = bridge._internal
 
-const { connector, actionOut, sourceChat, sourceInflight, sourcePlatform, sourceMcpRes, ruleIn, ruleOut } = templates
+const { connector, actionOut, sourceChat, sourceInflight, sourcePlatform, sourceMcpRes, sourceMcpCatalogRes, ruleIn, ruleOut } = templates
 
 // #region helpers
 
@@ -100,7 +100,8 @@ function passingValidate (client, { licenceId = 'test-licence-id', server = 'exp
             { name: sourceChat.name, type: 'mqtt' },
             { name: sourceInflight.name, type: 'mqtt' },
             { name: sourcePlatform.name, type: 'mqtt' },
-            { name: sourceMcpRes.name, type: 'mqtt' }
+            { name: sourceMcpRes.name, type: 'mqtt' },
+            { name: sourceMcpCatalogRes.name, type: 'mqtt' }
         ]
     })
     client.get.withArgs('/rules?limit=100').resolves({
@@ -404,15 +405,16 @@ describe('EMQX bridge-setup', function () {
 
             await addBridge(app, { cfg, client })
 
-            client.post.callCount.should.equal(8) // 1 connector + 1 action + 4 sources + 2 rules
+            client.post.callCount.should.equal(9) // 1 connector + 1 action + 5 sources + 2 rules
             client.post.getCall(0).args[0].should.equal('/connectors')
             client.post.getCall(1).args[0].should.equal('/actions')
             client.post.getCall(2).args[0].should.equal('/sources')
             client.post.getCall(3).args[0].should.equal('/sources')
             client.post.getCall(4).args[0].should.equal('/sources')
             client.post.getCall(5).args[0].should.equal('/sources')
-            client.post.getCall(6).args[0].should.equal('/rules')
+            client.post.getCall(6).args[0].should.equal('/sources')
             client.post.getCall(7).args[0].should.equal('/rules')
+            client.post.getCall(8).args[0].should.equal('/rules')
 
             const connectorPayload = client.post.getCall(0).args[1]
             connectorPayload.server.should.equal('expert.test:1884')
@@ -559,9 +561,9 @@ describe('EMQX bridge-setup', function () {
 
             const result = await syncBridge(app, { force: true, client })
             result.should.be.true()
-            // 1 connector delete + 8 creates (1 connector + 1 action + 4 sources + 2 rules)
+            // 1 connector delete + 9 creates (1 connector + 1 action + 5 sources + 2 rules)
             client.delete.callCount.should.equal(1)
-            client.post.callCount.should.equal(8)
+            client.post.callCount.should.equal(9)
             // didn't bother validating
             client.get.calledWith('/connectors').should.be.false()
         })
@@ -591,7 +593,7 @@ describe('EMQX bridge-setup', function () {
             const result = await syncBridge(app, { client })
             result.should.be.true()
             client.delete.called.should.be.true()
-            client.post.callCount.should.equal(8) // 1 connector + 1 action + 4 sources + 2 rules
+            client.post.callCount.should.equal(9) // 1 connector + 1 action + 5 sources + 2 rules
         })
 
         it('returns false when an underlying call throws. (force=true) (logs error)', async function () {

--- a/test/unit/forge/ee/routes/expert/index_spec.js
+++ b/test/unit/forge/ee/routes/expert/index_spec.js
@@ -2030,8 +2030,8 @@ describe('Expert API', function () {
             })
 
             it('should return 404 for a non-team member', async function () {
-                const proxyRequest = sinon.stub()
-                app.comms = { mcpGateway: { proxyRequest } }
+                const proxyCatalogRequest = sinon.stub()
+                app.comms = { mcpGateway: { proxyCatalogRequest } }
                 try {
                     const response = await app.inject({
                         method: 'GET',
@@ -2039,7 +2039,7 @@ describe('Expert API', function () {
                         cookies: { sid: chrisToken }
                     })
                     response.statusCode.should.equal(404)
-                    proxyRequest.called.should.be.false()
+                    proxyCatalogRequest.called.should.be.false()
                 } finally {
                     app.comms = null
                 }
@@ -2057,11 +2057,11 @@ describe('Expert API', function () {
             })
 
             it('should fetch the flow-building catalog and hash from the gateway over MQTT', async function () {
-                const proxyRequest = sinon.stub().resolves(mcpToolResponse({
+                const proxyCatalogRequest = sinon.stub().resolves(mcpToolResponse({
                     tools: [{ name: 'create-flow', title: 'Create Flow', toolClass: 'write' }],
                     hash: 'abc123'
                 }))
-                app.comms = { mcpGateway: { proxyRequest } }
+                app.comms = { mcpGateway: { proxyCatalogRequest } }
                 try {
                     const response = await app.inject({
                         method: 'GET',
@@ -2074,8 +2074,8 @@ describe('Expert API', function () {
                     json.should.have.property('catalog').which.is.an.Array().and.have.length(1)
                     json.catalog[0].should.have.property('key', 'create-flow')
                     json.catalog[0].should.have.property('name', 'Create Flow')
-                    proxyRequest.calledOnce.should.be.true()
-                    const [, payload] = proxyRequest.firstCall.args
+                    proxyCatalogRequest.calledOnce.should.be.true()
+                    const [payload] = proxyCatalogRequest.firstCall.args
                     payload.mcp.params.should.have.property('name', 'list_flow_catalog')
                     payload.toolGroups.should.deepEqual(['flow_building'])
                 } finally {
@@ -2084,8 +2084,8 @@ describe('Expert API', function () {
             })
 
             it('should default catalog to [] and hash to null when the gateway omits them', async function () {
-                const proxyRequest = sinon.stub().resolves(mcpToolResponse({}))
-                app.comms = { mcpGateway: { proxyRequest } }
+                const proxyCatalogRequest = sinon.stub().resolves(mcpToolResponse({}))
+                app.comms = { mcpGateway: { proxyCatalogRequest } }
                 try {
                     const response = await app.inject({
                         method: 'GET',
@@ -2100,8 +2100,8 @@ describe('Expert API', function () {
             })
 
             it('should degrade to an empty flow catalog when the gateway does not respond', async function () {
-                const proxyRequest = sinon.stub().rejects(new Error('Request timed out'))
-                app.comms = { mcpGateway: { proxyRequest } }
+                const proxyCatalogRequest = sinon.stub().rejects(new Error('Request timed out'))
+                app.comms = { mcpGateway: { proxyCatalogRequest } }
                 try {
                     const response = await app.inject({
                         method: 'GET',
@@ -2116,7 +2116,7 @@ describe('Expert API', function () {
             })
 
             it('should merge platform tools into the catalog, curated with a platform group and class', async function () {
-                const proxyRequest = sinon.stub().resolves(mcpToolResponse({
+                const proxyCatalogRequest = sinon.stub().resolves(mcpToolResponse({
                     tools: [{ name: 'create-flow', title: 'Create Flow', toolClass: 'write' }],
                     hash: 'abc123'
                 }))
@@ -2125,7 +2125,7 @@ describe('Expert API', function () {
                     { name: 'platform_delete_instance', description: 'Delete an instance', annotations: { readOnlyHint: false, destructiveHint: true } },
                     { name: 'platform_create_instance', description: 'Create an instance', annotations: { readOnlyHint: false, destructiveHint: false } }
                 ])
-                app.comms = { mcpGateway: { proxyRequest }, platformAutomation: { getToolDefinitions } }
+                app.comms = { mcpGateway: { proxyCatalogRequest }, platformAutomation: { getToolDefinitions } }
                 try {
                     const response = await app.inject({
                         method: 'GET',

--- a/test/unit/forge/ee/routes/expert/index_spec.js
+++ b/test/unit/forge/ee/routes/expert/index_spec.js
@@ -2008,8 +2008,7 @@ describe('Expert API', function () {
             })
         })
 
-        describe('MCP tools Endpoint (tool permissions catalog #421)', function () {
-            // Mimic the gateway's list_flow_catalog CallToolResult (payload JSON in content[0].text).
+        describe('MCP tools Endpoint (tool permissions catalog)', function () {
             const mcpToolResponse = (payload) => ({ result: { content: [{ type: 'text', text: JSON.stringify(payload) }] } })
 
             it('should return 401 for instance token', async function () {

--- a/test/unit/forge/ee/routes/expert/index_spec.js
+++ b/test/unit/forge/ee/routes/expert/index_spec.js
@@ -2009,6 +2009,9 @@ describe('Expert API', function () {
         })
 
         describe('MCP tools Endpoint (tool permissions catalog #421)', function () {
+            // Mimic the gateway's list_flow_catalog CallToolResult (payload JSON in content[0].text).
+            const mcpToolResponse = (payload) => ({ result: { content: [{ type: 'text', text: JSON.stringify(payload) }] } })
+
             it('should return 401 for instance token', async function () {
                 const response = await app.inject({
                     method: 'GET',
@@ -2028,90 +2031,102 @@ describe('Expert API', function () {
             })
 
             it('should return 404 for a non-team member', async function () {
-                const get = sinon.stub(axios, 'get') // must not proxy for a caller with no team access
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/expert/mcp/tools?teamId=${team.hashid}`,
-                    cookies: { sid: chrisToken }
-                })
-                response.statusCode.should.equal(404)
-                get.called.should.be.false()
+                const proxyRequest = sinon.stub()
+                app.comms = { mcpGateway: { proxyRequest } }
+                try {
+                    const response = await app.inject({
+                        method: 'GET',
+                        url: `/api/v1/expert/mcp/tools?teamId=${team.hashid}`,
+                        cookies: { sid: chrisToken }
+                    })
+                    response.statusCode.should.equal(404)
+                    proxyRequest.called.should.be.false()
+                } finally {
+                    app.comms = null
+                }
             })
 
             // teamId is validated by the querystring schema (required, minLength 10),
             // which runs before the preHandler — so a missing teamId is a 400, not a 404.
             it('should return 400 when the teamId query param is missing', async function () {
-                const get = sinon.stub(axios, 'get') // should not be called
                 const response = await app.inject({
                     method: 'GET',
                     url: '/api/v1/expert/mcp/tools',
                     cookies: { sid: bobToken }
                 })
                 response.statusCode.should.equal(400)
-                get.called.should.be.false()
             })
 
-            it('should proxy the flow-tools catalog and hash for a team member', async function () {
-                const get = sinon.stub(axios, 'get').resolves({
-                    data: {
-                        catalog: [{ key: 'create-flow', name: 'Create Flow', toolClass: 'write' }],
-                        hash: 'abc123'
-                    }
-                })
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/expert/mcp/tools?teamId=${team.hashid}`,
-                    cookies: { sid: bobToken }
-                })
-                response.statusCode.should.equal(200)
-                const json = response.json()
-                json.should.have.property('hash', 'abc123')
-                json.should.have.property('catalog').which.is.an.Array().and.have.length(1)
-                json.catalog[0].should.have.property('key', 'create-flow')
-                // the upstream request goes to the agent's /mcp/flow-tools with the service token
-                get.calledOnce.should.be.true()
-                const [calledUrl, calledOpts] = get.firstCall.args
-                calledUrl.should.endWith('/mcp/flow-tools')
-                calledOpts.headers.should.have.property('Authorization', 'Bearer test-token')
+            it('should fetch the flow-building catalog and hash from the gateway over MQTT', async function () {
+                const proxyRequest = sinon.stub().resolves(mcpToolResponse({
+                    tools: [{ name: 'create-flow', title: 'Create Flow', toolClass: 'write' }],
+                    hash: 'abc123'
+                }))
+                app.comms = { mcpGateway: { proxyRequest } }
+                try {
+                    const response = await app.inject({
+                        method: 'GET',
+                        url: `/api/v1/expert/mcp/tools?teamId=${team.hashid}`,
+                        cookies: { sid: bobToken }
+                    })
+                    response.statusCode.should.equal(200)
+                    const json = response.json()
+                    json.should.have.property('hash', 'abc123')
+                    json.should.have.property('catalog').which.is.an.Array().and.have.length(1)
+                    json.catalog[0].should.have.property('key', 'create-flow')
+                    json.catalog[0].should.have.property('name', 'Create Flow')
+                    proxyRequest.calledOnce.should.be.true()
+                    const [, payload] = proxyRequest.firstCall.args
+                    payload.mcp.params.should.have.property('name', 'list_flow_catalog')
+                    payload.toolGroups.should.deepEqual(['flow_building'])
+                } finally {
+                    app.comms = null
+                }
             })
 
-            it('should default catalog to [] and hash to null when the agent omits them', async function () {
-                sinon.stub(axios, 'get').resolves({ data: {} })
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/expert/mcp/tools?teamId=${team.hashid}`,
-                    cookies: { sid: bobToken }
-                })
-                response.statusCode.should.equal(200)
-                response.json().should.deepEqual({ catalog: [], hash: null })
+            it('should default catalog to [] and hash to null when the gateway omits them', async function () {
+                const proxyRequest = sinon.stub().resolves(mcpToolResponse({}))
+                app.comms = { mcpGateway: { proxyRequest } }
+                try {
+                    const response = await app.inject({
+                        method: 'GET',
+                        url: `/api/v1/expert/mcp/tools?teamId=${team.hashid}`,
+                        cookies: { sid: bobToken }
+                    })
+                    response.statusCode.should.equal(200)
+                    response.json().should.deepEqual({ catalog: [], hash: null })
+                } finally {
+                    app.comms = null
+                }
             })
 
-            it('should propagate the upstream status code when the agent errors', async function () {
-                sinon.stub(axios, 'get').rejects({
-                    response: { status: 502, data: { code: 'bad_gateway', error: 'upstream down' } }
-                })
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/expert/mcp/tools?teamId=${team.hashid}`,
-                    cookies: { sid: bobToken }
-                })
-                response.statusCode.should.equal(502)
-                response.json().should.have.property('code', 'bad_gateway')
+            it('should degrade to an empty flow catalog when the gateway does not respond', async function () {
+                const proxyRequest = sinon.stub().rejects(new Error('Request timed out'))
+                app.comms = { mcpGateway: { proxyRequest } }
+                try {
+                    const response = await app.inject({
+                        method: 'GET',
+                        url: `/api/v1/expert/mcp/tools?teamId=${team.hashid}`,
+                        cookies: { sid: bobToken }
+                    })
+                    response.statusCode.should.equal(200)
+                    response.json().should.deepEqual({ catalog: [], hash: null })
+                } finally {
+                    app.comms = null
+                }
             })
 
             it('should merge platform tools into the catalog, curated with a platform group and class', async function () {
-                sinon.stub(axios, 'get').resolves({
-                    data: {
-                        catalog: [{ key: 'create-flow', name: 'Create Flow', toolClass: 'write', group: 'flow-building' }],
-                        hash: 'abc123'
-                    }
-                })
+                const proxyRequest = sinon.stub().resolves(mcpToolResponse({
+                    tools: [{ name: 'create-flow', title: 'Create Flow', toolClass: 'write' }],
+                    hash: 'abc123'
+                }))
                 const getToolDefinitions = sinon.stub().returns([
                     { name: 'platform_list_stacks', description: 'List stacks', annotations: { readOnlyHint: true, destructiveHint: false } },
                     { name: 'platform_delete_instance', description: 'Delete an instance', annotations: { readOnlyHint: false, destructiveHint: true } },
                     { name: 'platform_create_instance', description: 'Create an instance', annotations: { readOnlyHint: false, destructiveHint: false } }
                 ])
-                app.comms = { platformAutomation: { getToolDefinitions } }
+                app.comms = { mcpGateway: { proxyRequest }, platformAutomation: { getToolDefinitions } }
                 try {
                     const response = await app.inject({
                         method: 'GET',


### PR DESCRIPTION
Closes #8611

## Description

The `/api/v4/expert/mcp/tools` route (tool-permissions catalog, added in #7639) builds the list of tools shown in the permissions UI. It previously fetched the flow-building tools with a direct `axios.get` to the Expert instance's `/mcp/flow-tools` endpoint, authenticated with the `expert.service.token`.

This replaces that HTTP fetch with a request over MQTT to the gateway's `list_flow_catalog` tool, reusing the existing third-party MCP request/response channel:

- request: `ff/v1/mcp/<platformId>/flow-building-tool-catalog/<uuid>/request`
- response: `ff/v1/mcp/<platformId>/flow-building-tool-catalog/<uuid>/response`

The `flow-building-tool-catalog` sentinel sits in the `userId` topic level to mark the fetch as the first-party, session-less catalog read.

Design points:

- **No service token** is needed on this path.
- **No new topic.** The catalog rides the channel the bridge and the central gateway already carry (`ff/v1/mcp/+/+/+/request` / `.../response`), so no new bridge source, rule, or gateway handler is required. `list_flow_catalog` is already a registered tool on the gateway's MCP server, so the request is served by the same dispatch as any other MCP call.
- **Not gated on `mcpThirdParty`.** The ACL recognises the sentinel `userId` and treats it as a first-party read: exempt from the third-party feature gate and from the user lookup. Every other check (platform client, platformId shape, topic-safe session id) still applies, so the sentinel can only perform the designed request/response exchange. Deployments that have not enabled third-party MCP still get the permissions-UI catalog.
- If the gateway is unreachable or errors, the route degrades to the platform tools alone and still returns 200, rather than forwarding an upstream failure to the browser.

## Backward compatibility

Forge no longer sends the service token on this path. The Expert instance keeps its HTTP `/mcp/flow-tools` endpoint for older Forge deployments; new Forge uses MQTT only, with no HTTP fallback.

## Testing

Unit tests cover the sentinel ACL path (including that the catalog channel works with `mcpThirdParty` disabled and without a real user, while the topic-shape checks still apply) and the route fetching the catalog over MQTT. Validated live on a self-hosted deployment with the central broker.

