### PR TITLE
[8288] If a team has no dashboard-serving instances, clicking on dashboard tab shows error  

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -507,7 +507,10 @@ module.exports = async function (app) {
                 projects: result
             })
         } else {
-            return reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+            return reply.send({
+                count: 0,
+                projects: []
+            })
         }
     })
 

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -1053,7 +1053,7 @@ describe('Team API', function () {
             })
             response.statusCode.should.equal(401)
         })
-        it('Returns a 404 response when no instances are found', async () => {
+        it('Returns a 200 empty response when no instances are found', async () => {
             // GET /api/v1/team/:teamId/dashboard-instances
             const team = await app.db.models.Team.create({ name: 'mock-team-1', TeamTypeId: app.defaultTeamType.id })
             await app.factory.createApplication({ name: 'application-1' }, team)
@@ -1063,7 +1063,12 @@ describe('Team API', function () {
                 url: `/api/v1/teams/${team.hashid}/dashboard-instances`,
                 cookies: { sid: TestObjects.tokens.alice }
             })
-            response.statusCode.should.equal(404)
+            response.statusCode.should.equal(200)
+            const reply = response.json()
+            should(reply).be.an.Object()
+            reply.should.have.property('count', 0)
+            reply.should.have.property('projects').and.be.Array()
+            reply.projects.should.have.property('length', 0)
         })
         it('Returns a 200 empty response when no dashboards are found', async () => {
             // GET /api/v1/team/:teamId/dashboard-instances


### PR DESCRIPTION
## Description

Returns an empty array and 200 for team dashboard instances instead of 400.

## Related Issue(s)

Resolves https://github.com/FlowFuse/flowfuse/issues/8288

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

