### PR TITLE
Extend visual and interaction feedback for MCP features

### DIFF
--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -130,8 +130,9 @@ module.exports = function (app) {
                 return false
             }
         },
-        checkUserIsTeamMember: async function (requestParts, usernameParts) {
-            // requestParts = [ fullTopic , <teamHash> [, <userHash> [, <sessionId>]] ]
+        checkTeamUserSession: async function (requestParts, usernameParts) {
+            // requestParts = [ fullTopic , <teamHash> [, <userHash>] ] - v1
+            // requestParts = [ fullTopic , <teamHash>, <userHash>, <sessionId> ] - v2 (MCP)
             // usernameParts = [ 'fe-team', <userHash>, <teamHash>, <sessionId> ]
             const topicTeamHash = requestParts[1]
             const usernameUserHash = usernameParts[1]
@@ -828,9 +829,9 @@ module.exports = function (app) {
         teamFrontend: {
             sub: [
                 // - ff/v1/<team>/t/updated
-                { topic: /^ff\/v1\/([^/]+)\/t\/updated$/, verify: 'checkUserIsTeamMember' },
+                { topic: /^ff\/v1\/([^/]+)\/t\/updated$/, verify: 'checkTeamUserSession' },
                 // - ff/v1/<team>/u/<user>/membership
-                { topic: /^ff\/v1\/([^/]+)\/u\/([^/]+)\/membership$/, verify: 'checkUserIsTeamMember' },
+                { topic: /^ff\/v1\/([^/]+)\/u\/([^/]+)\/membership$/, verify: 'checkTeamUserSession' },
                 // - ff/v1/<team>/p/+/state
                 { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/state$/, verify: 'checkTeamStateSub' },
                 // - ff/v1/<team>/d/+/state
@@ -842,12 +843,12 @@ module.exports = function (app) {
                 // - ff/v1/expert/<user>/<session>/+/+/mcp/inflight/+/request
                 { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/mcp\/inflight\/([^/]+)\/request$/, verify: 'checkMcpInflightTopic', allowWildcard: { entity: true, inflightType: true }, isSub: true },
                 // - ff/v1/<team>/u/<user>/s/<session>/mcp/clients
-                { topic: /^ff\/v1\/([^/]+)\/u\/([^/]+)\/s\/([^/]+)\/mcp\/clients$/, verify: 'checkUserIsTeamMember' }
+                { topic: /^ff\/v1\/([^/]+)\/u\/([^/]+)\/s\/([^/]+)\/mcp\/clients$/, verify: 'checkTeamUserSession' }
             ],
             pub: [
                 // - ff/v1/<team>/u/<user>/s/<session>/<heartbeat|close|disconnected>
                 //   `disconnected` is the last will, published by the broker, not the tab
-                { topic: /^ff\/v1\/([^/]+)\/u\/([^/]+)\/s\/([^/]+)\/(heartbeat|close|disconnected)$/, verify: 'checkUserIsTeamMember' },
+                { topic: /^ff\/v1\/([^/]+)\/u\/([^/]+)\/s\/([^/]+)\/(heartbeat|close|disconnected)$/, verify: 'checkTeamUserSession' },
                 // - ff/v1/expert/<user>/<session>/<a|p|d|t>/<entityId>/mcp/inflight/<type>/response
                 { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([tapd])\/([^/]+)\/mcp\/inflight\/([^/]+)\/response$/, verify: 'checkMcpInflightTopic', isPub: true }
             ]

--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -767,7 +767,10 @@ module.exports = function (app) {
                 { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/platform\/([^/]+)\/response$/, verify: 'checkExpertPlatformTopic', isPlatform: true, isPub: true, agent: 'platform' },
                 // platform can publish third-party MCP requests to the central gateway
                 // - ff/v1/mcp/<platformId>/<userId>/<mcpSessionId>/request
-                { topic: /^ff\/v1\/mcp\/([^/]+)\/([^/]+)\/([^/]+)\/request$/, verify: 'checkMcpTopic', isPlatform: true, isPub: true }
+                { topic: /^ff\/v1\/mcp\/([^/]+)\/([^/]+)\/([^/]+)\/request$/, verify: 'checkMcpTopic', isPlatform: true, isPub: true },
+                // platform can tell one browser tab about its MCP state
+                // - ff/v1/<team>/u/<user>/s/<session>/mcp/<event>
+                { topic: /^ff\/v1\/[^/]+\/u\/[^/]+\/s\/[^/]+\/mcp\/[^/]+$/ }
             ]
         },
         project: {
@@ -837,7 +840,9 @@ module.exports = function (app) {
                 // - ff/v1/<team>/p/+/created|updated|deleted
                 { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/(created|updated|deleted)$/, verify: 'checkTeamStateSub' },
                 // - ff/v1/expert/<user>/<session>/+/+/mcp/inflight/+/request
-                { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/mcp\/inflight\/([^/]+)\/request$/, verify: 'checkMcpInflightTopic', allowWildcard: { entity: true, inflightType: true }, isSub: true }
+                { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/mcp\/inflight\/([^/]+)\/request$/, verify: 'checkMcpInflightTopic', allowWildcard: { entity: true, inflightType: true }, isSub: true },
+                // - ff/v1/<team>/u/<user>/s/<session>/mcp/<event>
+                { topic: /^ff\/v1\/([^/]+)\/u\/([^/]+)\/s\/([^/]+)\/mcp\/([^/]+)$/, verify: 'checkUserIsTeamMember' }
             ],
             pub: [
                 // - ff/v1/<team>/u/<user>/s/<session>/<heartbeat|close|disconnected>

--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -769,8 +769,8 @@ module.exports = function (app) {
                 // - ff/v1/mcp/<platformId>/<userId>/<mcpSessionId>/request
                 { topic: /^ff\/v1\/mcp\/([^/]+)\/([^/]+)\/([^/]+)\/request$/, verify: 'checkMcpTopic', isPlatform: true, isPub: true },
                 // platform can tell one browser tab about its MCP state
-                // - ff/v1/<team>/u/<user>/s/<session>/mcp/<event>
-                { topic: /^ff\/v1\/[^/]+\/u\/[^/]+\/s\/[^/]+\/mcp\/[^/]+$/ }
+                // - ff/v1/<team>/u/<user>/s/<session>/mcp/clients
+                { topic: /^ff\/v1\/[^/]+\/u\/[^/]+\/s\/[^/]+\/mcp\/clients$/ }
             ]
         },
         project: {
@@ -841,8 +841,8 @@ module.exports = function (app) {
                 { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/(created|updated|deleted)$/, verify: 'checkTeamStateSub' },
                 // - ff/v1/expert/<user>/<session>/+/+/mcp/inflight/+/request
                 { topic: /^ff\/v1\/expert\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/mcp\/inflight\/([^/]+)\/request$/, verify: 'checkMcpInflightTopic', allowWildcard: { entity: true, inflightType: true }, isSub: true },
-                // - ff/v1/<team>/u/<user>/s/<session>/mcp/<event>
-                { topic: /^ff\/v1\/([^/]+)\/u\/([^/]+)\/s\/([^/]+)\/mcp\/([^/]+)$/, verify: 'checkUserIsTeamMember' }
+                // - ff/v1/<team>/u/<user>/s/<session>/mcp/clients
+                { topic: /^ff\/v1\/([^/]+)\/u\/([^/]+)\/s\/([^/]+)\/mcp\/clients$/, verify: 'checkUserIsTeamMember' }
             ],
             pub: [
                 // - ff/v1/<team>/u/<user>/s/<session>/<heartbeat|close|disconnected>

--- a/forge/comms/browserSessionLifecycle.js
+++ b/forge/comms/browserSessionLifecycle.js
@@ -7,6 +7,11 @@
  * `disconnected` is the connection's last will. The broker publishes it when a
  * tab goes away without a clean disconnect. New consumers of that signal belong in
  * handleDisconnected - they should not need a topic of their own.
+ *
+ * Traffic also goes the other way: notifyMcp publishes back to a single tab on
+ * ff/v1/<teamHash>/u/<userHash>/s/<sessionId>/mcp/<event>. The broker ACL pins the
+ * session segment to the subscribing connection's own credential, so a tab can only
+ * ever hear about itself.
  */
 class BrowserSessionLifecycleHandler {
     constructor (app, client) {
@@ -23,10 +28,13 @@ class BrowserSessionLifecycleHandler {
         })
     }
 
-    async handleSessionEvent ({ userId, sessionId, event, payload }) {
+    async handleSessionEvent ({ teamId, userId, sessionId, event, payload }) {
         switch (event) {
         case 'heartbeat':
-            await this.app.db.controllers.BrowserSession.recordPresence(userId, sessionId, payload)
+            // teamId is carried so the tab's snapshot knows which topic tree it lives
+            // under, which is what lets the platform publish back to it later from a
+            // context that only has the session id (a pin made over MCP, for instance).
+            await this.app.db.controllers.BrowserSession.recordPresence(userId, sessionId, payload, teamId)
             break
         case 'close':
             // The user opted this tab out. The connection is still alive.
@@ -44,6 +52,22 @@ class BrowserSessionLifecycleHandler {
      */
     async handleDisconnected (userId, sessionId) {
         await this.app.db.controllers.BrowserSession.removeSession(userId, sessionId)
+    }
+
+    /**
+     * Tell one browser tab something about its MCP state.
+     *
+     * Best effort by design: a tab whose snapshot predates teamId being recorded, or
+     * a platform with no broker configured, simply does not get told. Nothing upstream
+     * should fail because a notification could not be delivered - the tab re-learns
+     * the truth on its next heartbeat either way.
+     */
+    notifyMcp (teamId, userId, sessionId, event, payload = {}) {
+        if (!teamId || !userId || !sessionId || !event) {
+            return
+        }
+        const topic = `ff/v1/${teamId}/u/${userId}/s/${sessionId}/mcp/${event}`
+        this.client.publish(topic, JSON.stringify(payload), { qos: 1, retain: false })
     }
 }
 

--- a/forge/comms/browserSessionLifecycle.js
+++ b/forge/comms/browserSessionLifecycle.js
@@ -8,10 +8,9 @@
  * tab goes away without a clean disconnect. New consumers of that signal belong in
  * handleDisconnected - they should not need a topic of their own.
  *
- * Traffic also goes the other way: notifyMcp publishes back to a single tab on
- * ff/v1/<teamHash>/u/<userHash>/s/<sessionId>/mcp/<event>. The broker ACL pins the
- * session segment to the subscribing connection's own credential, so a tab can only
- * ever hear about itself.
+ * Traffic also goes the other way: notifyMcp publishes to one tab on
+ * ff/v1/<teamHash>/u/<userHash>/s/<sessionId>/mcp/<event>. The ACL pins the session
+ * segment to the subscriber's own credential, so a tab only hears about itself.
  */
 class BrowserSessionLifecycleHandler {
     constructor (app, client) {
@@ -31,9 +30,8 @@ class BrowserSessionLifecycleHandler {
     async handleSessionEvent ({ teamId, userId, sessionId, event, payload }) {
         switch (event) {
         case 'heartbeat':
-            // teamId is carried so the tab's snapshot knows which topic tree it lives
-            // under, which is what lets the platform publish back to it later from a
-            // context that only has the session id (a pin made over MCP, for instance).
+            // teamId is stored on the snapshot so the platform can publish back to this
+            // tab from a context that only has the session id (a pin made over MCP)
             await this.app.db.controllers.BrowserSession.recordPresence(userId, sessionId, payload, teamId)
             break
         case 'close':
@@ -55,12 +53,8 @@ class BrowserSessionLifecycleHandler {
     }
 
     /**
-     * Tell one browser tab something about its MCP state.
-     *
-     * Best effort by design: a tab whose snapshot predates teamId being recorded, or
-     * a platform with no broker configured, simply does not get told. Nothing upstream
-     * should fail because a notification could not be delivered - the tab re-learns
-     * the truth on its next heartbeat either way.
+     * Tell one browser tab about its MCP state. Best effort: a tab with no recorded
+     * teamId simply is not told, and re-learns on its next heartbeat.
      */
     notifyMcp (teamId, userId, sessionId, event, payload = {}) {
         if (!teamId || !userId || !sessionId || !event) {

--- a/forge/comms/index.js
+++ b/forge/comms/index.js
@@ -41,7 +41,7 @@ module.exports = fp(async function (app, _opts) {
         const mcpGatewayHandler = McpGatewayHandler(app, client)
         // Owns the browser session topic and dispatches its events. Presence is one
         // consumer of that; anything else needing per-session teardown joins it there.
-        BrowserSessionLifecycleHandler(app, client)
+        const browserSessionHandler = BrowserSessionLifecycleHandler(app, client)
 
         // Not in the current release, but when we handle Launcher status
         // via MQTT, it will arrive here. Compare to the status/device handler in `devices.js`
@@ -58,6 +58,7 @@ module.exports = fp(async function (app, _opts) {
             platformAutomation: platformAutomationHandler,
             expert: expertCommsHandler,
             mcpGateway: mcpGatewayHandler,
+            browserSession: browserSessionHandler,
             platform: {
                 settings: {
                     sync: function (key) {

--- a/forge/db/controllers/BrowserSession.js
+++ b/forge/db/controllers/BrowserSession.js
@@ -9,11 +9,9 @@
  * This owns the cache only. Deciding which broker events feed it lives in
  * forge/comms/browserSessionLifecycle.js.
  *
- * Pins are not exclusive: several MCP clients can target the same tab at once. The
- * tab is told how many currently hold it (see notifyPinnedClients) so the user can
- * see, at a glance, what is driving the page in front of them. That count rides the
- * heartbeat rather than being event-driven, because a pin can also end by simply
- * expiring, and an expiry produces no event for anyone to publish.
+ * Pins are not exclusive: several MCP clients can target one tab, and the tab is told
+ * how many hold it (notifyPinnedClients). That rides the heartbeat rather than events,
+ * because a pin can end by simply expiring, and an expiry produces no event.
  *
  * Scale note: heartbeats only arrive from tabs where the user enabled MCP
  * access, so the scan in refreshActivePins runs rarely and over a small hash.
@@ -21,6 +19,8 @@
  * full hash every 60s (or whatever the freq is). Add a per-tab "has pins" marker
  * entry first, so tabs without pins skip the scan.
  */
+const crypto = require('crypto')
+
 const { escapeGlob } = require('../../caches/util')
 
 const browserSessionCache = 'browserSessions'
@@ -51,30 +51,42 @@ async function touchActiveBrowserSessions (app, userId, browserSessionId) {
 }
 
 /**
- * Tell a tab how many MCP clients currently hold it.
+ * Opaque stand-in for an MCP session id. The tab needs to tell clients apart to report
+ * arrivals and departures, but the id itself keys the PAT cache (forge/ee/routes/mcp/server.js)
+ * and has no business in page memory.
+ */
+function clientRef (mcpSessionId) {
+    return crypto.createHash('sha256').update(String(mcpSessionId)).digest('hex').slice(0, 12)
+}
+
+/**
+ * Tell a tab which MCP clients hold it. `teamId` is its topic tree - passed in by the
+ * heartbeat, read off the snapshot by callers that lack it (a pin made over MCP).
  *
- * `teamId` is the tab's topic tree. Callers that already have it (the heartbeat)
- * pass it in; callers that do not (a pin made over MCP) leave it out and it is read
- * back off the snapshot. A tab whose snapshot predates teamId being recorded gets
- * no notification, and re-learns the count on its next heartbeat.
+ * Best effort: the pin is already written, so a failure here must not fail its caller.
+ * A tab that misses this re-learns the count on its next heartbeat.
  */
 async function notifyPinnedClients (app, userId, browserSessionId, mcpSessionIds, teamId = null) {
-    if (!app.comms?.browserSession) {
-        return
+    try {
+        if (!app.comms?.browserSession) {
+            return
+        }
+        let team = teamId
+        if (!team) {
+            const cache = app.caches.getCache(browserSessionCache)
+            const session = await cache.get(`${userId}:${browserSessionId}`)
+            team = session?.teamId
+        }
+        if (!team) {
+            return
+        }
+        app.comms.browserSession.notifyMcp(team, userId, browserSessionId, 'clients', {
+            count: mcpSessionIds.length,
+            clients: mcpSessionIds.map(clientRef)
+        })
+    } catch (err) {
+        app.log?.warn(`Failed to notify browser session ${browserSessionId} of its MCP clients: ${err.toString()}`)
     }
-    let team = teamId
-    if (!team) {
-        const cache = app.caches.getCache(browserSessionCache)
-        const session = await cache.get(`${userId}:${browserSessionId}`)
-        team = session?.teamId
-    }
-    if (!team) {
-        return
-    }
-    app.comms.browserSession.notifyMcp(team, userId, browserSessionId, 'clients', {
-        count: mcpSessionIds.length,
-        sessionIds: mcpSessionIds
-    })
 }
 
 module.exports = {
@@ -99,8 +111,7 @@ module.exports = {
         await cache.set(`${userId}:${browserSessionId}`, {
             userId,
             sessionId: browserSessionId,
-            // Which topic tree this tab lives under, so the platform can publish back to
-            // it from a context that only knows the session id.
+            // The tab's topic tree, so the platform can publish back to it later
             teamId,
             lastSeen: Date.now(),
             visibility: payload.visibility || 'visible',
@@ -110,9 +121,8 @@ module.exports = {
             capabilities: Array.isArray(payload.capabilities) ? payload.capabilities : [],
             context: payload.context ?? null
         })
-        // the heartbeat is the liveness signal for this tab's pins too, and the pin set it
-        // resolves is the same one the tab wants to know about, so it is answered here
-        // rather than recomputed. This is also what makes an expired pin self-correcting.
+        // The heartbeat keeps this tab's pins alive, and the set it resolves is the one the
+        // tab wants told back to it - which is what makes an expired pin self-correcting.
         const mcpSessionIds = await touchActiveBrowserSessions(app, userId, browserSessionId)
         await notifyPinnedClients(app, userId, browserSessionId, mcpSessionIds, teamId)
     },
@@ -159,12 +169,16 @@ module.exports = {
         await cache.set(`mcp-to-browser::${userId}:${mcpSessionId}`, browserSessionId) // userId:mcpSessionId → browserSessionId
         await cache.set(`browser-to-mcp::${userId}:${browserSessionId}:${mcpSessionId}`, mcpSessionId) // userId:browserSessionId:mcpSessionId → mcpSessionId
 
-        // Tell the tab straight away rather than leaving it to notice on its next
-        // heartbeat. A tab the pin moved away from is told too, so its count drops
-        // at the same moment the new tab's rises.
-        await notifyPinnedClients(app, userId, browserSessionId, await touchActiveBrowserSessions(app, userId, browserSessionId))
-        if (previous && previous !== browserSessionId) {
-            await notifyPinnedClients(app, userId, previous, await touchActiveBrowserSessions(app, userId, previous))
+        // Tell both tabs now rather than at their next heartbeat, so the old tab's count
+        // drops as the new one's rises. Both pins are already written, so nothing here may
+        // fail the call - an agent told its pin failed would retry one that succeeded.
+        try {
+            await notifyPinnedClients(app, userId, browserSessionId, await touchActiveBrowserSessions(app, userId, browserSessionId))
+            if (previous && previous !== browserSessionId) {
+                await notifyPinnedClients(app, userId, previous, await touchActiveBrowserSessions(app, userId, previous))
+            }
+        } catch (err) {
+            app.log?.warn(`Pin for ${browserSessionId} was written but its notification failed: ${err.toString()}`)
         }
     },
 

--- a/forge/db/controllers/BrowserSession.js
+++ b/forge/db/controllers/BrowserSession.js
@@ -9,6 +9,12 @@
  * This owns the cache only. Deciding which broker events feed it lives in
  * forge/comms/browserSessionLifecycle.js.
  *
+ * Pins are not exclusive: several MCP clients can target the same tab at once. The
+ * tab is told how many currently hold it (see notifyPinnedClients) so the user can
+ * see, at a glance, what is driving the page in front of them. That count rides the
+ * heartbeat rather than being event-driven, because a pin can also end by simply
+ * expiring, and an expiry produces no event for anyone to publish.
+ *
  * Scale note: heartbeats only arrive from tabs where the user enabled MCP
  * access, so the scan in refreshActivePins runs rarely and over a small hash.
  * If MCP access ever becomes enabled by default, every open tab will scan the
@@ -44,6 +50,33 @@ async function touchActiveBrowserSessions (app, userId, browserSessionId) {
     return mcpSessionIds
 }
 
+/**
+ * Tell a tab how many MCP clients currently hold it.
+ *
+ * `teamId` is the tab's topic tree. Callers that already have it (the heartbeat)
+ * pass it in; callers that do not (a pin made over MCP) leave it out and it is read
+ * back off the snapshot. A tab whose snapshot predates teamId being recorded gets
+ * no notification, and re-learns the count on its next heartbeat.
+ */
+async function notifyPinnedClients (app, userId, browserSessionId, mcpSessionIds, teamId = null) {
+    if (!app.comms?.browserSession) {
+        return
+    }
+    let team = teamId
+    if (!team) {
+        const cache = app.caches.getCache(browserSessionCache)
+        const session = await cache.get(`${userId}:${browserSessionId}`)
+        team = session?.teamId
+    }
+    if (!team) {
+        return
+    }
+    app.comms.browserSession.notifyMcp(team, userId, browserSessionId, 'clients', {
+        count: mcpSessionIds.length,
+        sessionIds: mcpSessionIds
+    })
+}
+
 module.exports = {
     init (app) {
         // Create a cache for browser session presence. Each entry is a tab snapshot, keyed by userId:sessionId.
@@ -61,11 +94,14 @@ module.exports = {
      * replaced rather than merged. That keeps concurrent messages for the same
      * session from overwriting each other's fields.
      */
-    async recordPresence (app, userId, browserSessionId, payload = {}) {
+    async recordPresence (app, userId, browserSessionId, payload = {}, teamId = null) {
         const cache = app.caches.getCache(browserSessionCache)
         await cache.set(`${userId}:${browserSessionId}`, {
             userId,
             sessionId: browserSessionId,
+            // Which topic tree this tab lives under, so the platform can publish back to
+            // it from a context that only knows the session id.
+            teamId,
             lastSeen: Date.now(),
             visibility: payload.visibility || 'visible',
             focused: payload.focused ?? null,
@@ -74,8 +110,11 @@ module.exports = {
             capabilities: Array.isArray(payload.capabilities) ? payload.capabilities : [],
             context: payload.context ?? null
         })
-        // the heartbeat is the liveness signal for this tab's pins too
-        await touchActiveBrowserSessions(app, userId, browserSessionId)
+        // the heartbeat is the liveness signal for this tab's pins too, and the pin set it
+        // resolves is the same one the tab wants to know about, so it is answered here
+        // rather than recomputed. This is also what makes an expired pin self-correcting.
+        const mcpSessionIds = await touchActiveBrowserSessions(app, userId, browserSessionId)
+        await notifyPinnedClients(app, userId, browserSessionId, mcpSessionIds, teamId)
     },
 
     async removeSession (app, userId, browserSessionId) {
@@ -119,6 +158,14 @@ module.exports = {
         }
         await cache.set(`mcp-to-browser::${userId}:${mcpSessionId}`, browserSessionId) // userId:mcpSessionId → browserSessionId
         await cache.set(`browser-to-mcp::${userId}:${browserSessionId}:${mcpSessionId}`, mcpSessionId) // userId:browserSessionId:mcpSessionId → mcpSessionId
+
+        // Tell the tab straight away rather than leaving it to notice on its next
+        // heartbeat. A tab the pin moved away from is told too, so its count drops
+        // at the same moment the new tab's rises.
+        await notifyPinnedClients(app, userId, browserSessionId, await touchActiveBrowserSessions(app, userId, browserSessionId))
+        if (previous && previous !== browserSessionId) {
+            await notifyPinnedClients(app, userId, previous, await touchActiveBrowserSessions(app, userId, previous))
+        }
     },
 
     async getActiveBrowserSession (app, userId, mcpSessionId) {

--- a/forge/db/controllers/BrowserSession.js
+++ b/forge/db/controllers/BrowserSession.js
@@ -173,9 +173,11 @@ module.exports = {
         // drops as the new one's rises. Both pins are already written, so nothing here may
         // fail the call - an agent told its pin failed would retry one that succeeded.
         try {
-            await notifyPinnedClients(app, userId, browserSessionId, await touchActiveBrowserSessions(app, userId, browserSessionId))
+            const activeBrowserSession = await touchActiveBrowserSessions(app, userId, browserSessionId)
+            await notifyPinnedClients(app, userId, browserSessionId, activeBrowserSession)
             if (previous && previous !== browserSessionId) {
-                await notifyPinnedClients(app, userId, previous, await touchActiveBrowserSessions(app, userId, previous))
+                const previousBrowserSession = await touchActiveBrowserSessions(app, userId, previous)
+                await notifyPinnedClients(app, userId, previous, previousBrowserSession)
             }
         } catch (err) {
             app.log?.warn(`Pin for ${browserSessionId} was written but its notification failed: ${err.toString()}`)

--- a/frontend/src/components/ExpertButton.vue
+++ b/frontend/src/components/ExpertButton.vue
@@ -64,16 +64,14 @@ export default {
         mcpTooltip () {
             switch (this.mcpStatus) {
             case 'connected':
-                // Targeting is not exclusive, so the count is the point: a user glancing at a
-                // green plug should be able to tell one agent from several driving this page.
+                // Targeting is not exclusive, so the count is the point
                 return this.mcpClientCount === 1
                     ? '1 MCP client is targeting this tab. Click to disable'
                     : `${this.mcpClientCount} MCP clients are targeting this tab. Click to disable`
             case 'waiting':
                 return 'Exposed to MCP clients. None are targeting this tab yet. Click to disable'
             case 'interrupted':
-                // Deliberately does not say how many clients were targeting it: that number is
-                // from before the link dropped and there is no way to know if it still holds.
+                // No count: that number predates the drop and may no longer hold
                 return 'Connection to FlowFuse lost. This tab cannot be reached by MCP clients until it reconnects'
             default:
                 return 'Enable MCP'
@@ -86,29 +84,25 @@ export default {
                 return
             }
             // Straight to the store action rather than stopMcp(), which announces the close
-            // itself - that generic notice plus the specific one below is the same event
-            // reported twice. A team switch is the more useful of the two, so it wins.
-            // Only the call that actually closed the session speaks, so the header's second
-            // toggle cannot report the same switch again.
+            // itself - the generic notice plus the specific one below is one event reported
+            // twice. Only the call that actually closed it speaks, so the second toggle
+            // cannot report the same switch again.
             if (await this.disableMcp()) {
                 alerts.emit('MCP session closed due to team switch.', 'info')
             }
         }
     },
     mounted () {
-        // the flag survives a reload, the comms do not - bring them back up
-        if (this.mcpActive && this.team) {
-            this.enableMcp(this.team)
-        }
+        // The flag survives a reload, the comms do not. Counted rather than per instance:
+        // the header mounts two, and only the last to leave should take the comms down.
+        this.retainMcp(this.team)
     },
     beforeUnmount () {
-        if (this.mcpActive) {
-            this.teardownMcp()
-        }
+        this.releaseMcp()
     },
     methods: {
         ...mapActions(useProductExpertStore, ['openAssistantDrawer']),
-        ...mapActions(useProductMcpStore, { enableMcp: 'enable', disableMcp: 'disable', teardownMcp: 'teardown' }),
+        ...mapActions(useProductMcpStore, { enableMcp: 'enable', disableMcp: 'disable', retainMcp: 'retain', releaseMcp: 'release' }),
         onExpertClick () {
             this.openAssistantDrawer({ openPinned: this.rightDrawer.expertState.pinned })
         },
@@ -122,8 +116,7 @@ export default {
         startMcp () {
             if (!this.team) return
             this.enableMcp(this.team)
-            // Deliberately not a confirmation: nothing is targeting the tab yet, and the
-            // toggle turning amber is the honest version of that.
+            // Not a confirmation: nothing is targeting it yet, which is what the amber says
             alerts.emit('MCP session exposed. Third-party agents can now target this tab.', 'info')
         },
         async stopMcp () {
@@ -141,12 +134,6 @@ export default {
     display: none !important;
 }
 
-/*
- * The gradient's angle is animated as a single registered property rather than by
- * redeclaring the whole background at each keyframe. Registering it is what makes it
- * interpolate at all - an unregistered custom property is a string, and animating one
- * snaps between keyframes instead of sweeping.
- */
 @property --ff-expert-border-angle {
     syntax: '<angle>';
     inherits: false;
@@ -156,14 +143,6 @@ export default {
 /* Composite wrapper: animated gradient border around both halves */
 .expert-composite {
     display: inline-flex;
-    /*
-     * Conic rather than linear. A rotating linear gradient sweeps a straight band across
-     * the box, so every pass drags a hard edge over the corners; a conic one radiates from
-     * the centre, which around a 1px border reads as a continuous hue rotation with no
-     * edge to catch. Purple sits between the two brand colours in both directions, because
-     * red to indigo taken directly passes through a muddy midpoint - the extra stops are
-     * what make the ramp gradual instead of a seam that happens to be moving.
-     */
     position: relative;
     background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
                 conic-gradient(from var(--ff-expert-border-angle),
@@ -186,29 +165,6 @@ export default {
         margin: -1px;
     }
 
-    /*
-     * The wave belongs to the whole button, not the MCP half. Tinting only that half put a
-     * hard edge down the divider, which read as two controls rather than one thing in a
-     * state. Living on the composite it runs edge to edge.
-     *
-     * Two independent layers of soft blobs drifting over each other. Deliberately not one
-     * ramp scrolling in a straight line: a single direction at a constant rate reads as a
-     * mechanical wipe, and you can see the beat. These have different durations, different
-     * numbers of waypoints and different paths, so the two layers come back into the same
-     * arrangement only every few minutes. What you notice is colour swelling and receding
-     * in no particular direction, which is the point.
-     *
-     * inset:0 resolves against the padding box, so they fill inside the border without
-     * covering the swirl. Their own border-radius clips them, rather than overflow:hidden,
-     * which would cut the count badge's ring where that oversails the edge.
-     */
-    /*
-     * Interrupted: this tab cannot reach the platform. The conic gradient goes entirely,
-     * replaced by a flat red edge, and the swirl stops with it - a fault that keeps
-     * animating like the healthy states reads as activity, and the whole signal here is
-     * that nothing is flowing. There is no wave either, for the same reason: the states
-     * that move are the ones where something is actually happening.
-     */
     &--mcp-interrupted {
         background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
                     linear-gradient(var(--ff-color-expert-fault-border), var(--ff-color-expert-fault-border)) border-box;
@@ -216,13 +172,6 @@ export default {
     }
 
     &--mcp-connected {
-        /*
-         * The divider goes while the wave is running: a line down the middle cuts the drift
-         * into two halves and gives the eye an edge to stop at, which is the one thing the
-         * whole effect is trying to avoid. Colour rather than width, so the 1px stays in the
-         * layout and nothing shifts as the state flips - and `transition-colors` on the
-         * button means it fades rather than blinks out.
-         */
         .expert-composite__mcp {
             border-left-color: transparent;
         }
@@ -289,15 +238,6 @@ export default {
     }
 }
 
-/*
- * Right half: MCP toggle. Three states, because being exposed to agents and
- * being driven by one are different things:
- *   off       - subtle, nothing running
- *   waiting   - amber and pulsing, exposed but nothing is targeting this tab
- *   connected - steady green, at least one MCP client is driving it
- *
- * Position is for the count badge, which several clients at once makes possible.
- */
 .expert-composite__mcp {
     position: relative;
     border: none;
@@ -321,12 +261,6 @@ export default {
             color: var(--ff-color-status-warning-dot);
         }
 
-        /*
-         * The pulse is on the glyph alone. Breathing the panel as well turns a quiet
-         * status into something that pulls focus off the page behind it, and fading the
-         * whole button would take the divider border with it.
-         * Steady amber is a fine fallback - the colour already carries the state.
-         */
         @media (prefers-reduced-motion: no-preference) {
             svg {
                 animation: mcp-waiting-pulse 1.6s ease-in-out infinite;
@@ -343,15 +277,9 @@ export default {
         }
     }
 
-    /*
-     * Connected is the glyph and the count only. The tint that goes with it lives on the
-     * composite, so it can run the full width instead of stopping at the divider.
-     */
     &--connected {
         color: var(--ff-color-success);
 
-        /* Only the glyph is pinned here. The hover veil is inherited from the base rule so
-           the hovered half still lifts, and the wave still reads through it. */
         &:hover {
             color: var(--ff-color-success);
         }
@@ -375,15 +303,6 @@ export default {
     min-width: 14px;
     padding: 0 3px;
     border-radius: 999px;
-    /*
-     * The tint is translucent in the dark theme, so it needs an opaque fill underneath
-     * or the plug icon reads straight through the badge sitting on top of it. That has
-     * to be a colour plus an image layer: `background: <colour>, <colour>` is invalid
-     * (only the last layer of the shorthand may carry a colour) and drops the whole
-     * declaration, which renders the badge transparent.
-     * The ring is what separates badge from icon - both are green, and without it they
-     * merge into a single shape.
-     */
     background-color: var(--ff-color-bg-app);
     background-image: linear-gradient(var(--ff-color-status-success-bg), var(--ff-color-status-success-bg));
     box-shadow: 0 0 0 1.5px var(--ff-color-bg-app);
@@ -398,14 +317,6 @@ export default {
     z-index: 2;
 }
 
-/*
- * Four waypoints, eased, ending where it began. The eased segments are what stop it
- * reading as a constant drift: each blob slows as it turns and picks up again after.
- *
- * background-position places the image's top-left corner, so these are centre-minus-radius.
- * The button is about 34px tall and the blobs are 56-82px across, so every y is negative:
- * a blob only shows its middle if it hangs well above the box.
- */
 @keyframes expert-splash-a {
     0%, 100% {
         background-position: -46px -34px, 86px -6px;
@@ -421,8 +332,6 @@ export default {
     }
 }
 
-/* Three waypoints against the other layer's four, on a different clock, so the pair does
-   not fall back into step on any short cycle. */
 @keyframes expert-splash-b {
     0%, 100% {
         background-position: 48px -8px, -18px -22px;
@@ -444,14 +353,6 @@ export default {
     }
 }
 
-/*
- * A full turn, stated explicitly at both ends. A `to`-only keyframe takes its start from
- * the property's initial-value, which made this sweep 135deg to 360deg - five eighths of a
- * revolution - and then snap back 135deg every cycle. Ending on 495deg rather than 360deg
- * is what closes the loop: 495 is 135 plus a whole turn, so the last frame renders
- * identically to the first, and the resting angle stays 135deg for anyone who never sees
- * the animation at all.
- */
 @keyframes expert-border-swirl {
     from {
         --ff-expert-border-angle: 135deg;

--- a/frontend/src/components/ExpertButton.vue
+++ b/frontend/src/components/ExpertButton.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="showExpertButton || showMcpToggle" class="expert-button-wrapper flex items-center justify-center h-full px-3" style="height: 60px;">
-        <div class="expert-composite" :class="{ 'expert-composite--mcp-active': mcpActive }">
+        <div class="expert-composite" :class="[`expert-composite--mcp-${mcpStatus}`]">
             <button
                 v-if="showExpertButton"
                 class="expert-composite__expert flex items-center gap-1.5 justify-center px-[9px] py-[6px] font-bold text-[0.85rem] leading-[20px] text-gray-800 whitespace-nowrap transition-colors"
@@ -13,13 +13,15 @@
             </button>
             <button
                 v-if="showMcpToggle"
-                v-ff-tooltip:bottom="mcpActive ? 'Disable MCP' : 'Enable MCP'"
+                v-ff-tooltip:bottom="mcpTooltip"
                 class="expert-composite__mcp flex items-center justify-center py-[6px] px-[7px] transition-colors"
-                :class="{ 'expert-composite__mcp--active': mcpActive }"
+                :class="`expert-composite__mcp--${mcpStatus}`"
+                :data-mcp-status="mcpStatus"
                 data-el="mcp-toggle"
                 @click="onMcpClick"
             >
                 <McpIcon class="w-4 h-4" />
+                <span v-if="mcpStatus === 'connected' && mcpClientCount > 1" class="expert-composite__mcp-count" data-el="mcp-client-count">{{ mcpClientCount }}</span>
             </button>
         </div>
     </div>
@@ -44,7 +46,7 @@ export default {
     },
     computed: {
         ...mapState(useAccountSettingsStore, ['featuresCheck']),
-        ...mapState(useProductMcpStore, { mcpActive: 'active' }),
+        ...mapState(useProductMcpStore, { mcpActive: 'active', mcpStatus: 'status', mcpClientCount: 'clientCount' }),
         ...mapState(useUxDrawersStore, ['rightDrawer']),
         ...mapState(useContextStore, ['team']),
         isExpertDrawerOpen () {
@@ -58,6 +60,24 @@ export default {
         },
         showMcpToggle () {
             return this.isAiEnabled && this.featuresCheck.isMcpThirdPartyFeatureEnabled
+        },
+        mcpTooltip () {
+            switch (this.mcpStatus) {
+            case 'connected':
+                // Targeting is not exclusive, so the count is the point: a user glancing at a
+                // green plug should be able to tell one agent from several driving this page.
+                return this.mcpClientCount === 1
+                    ? '1 MCP client is targeting this tab. Click to disable'
+                    : `${this.mcpClientCount} MCP clients are targeting this tab. Click to disable`
+            case 'waiting':
+                return 'Exposed to MCP clients. None are targeting this tab yet. Click to disable'
+            case 'interrupted':
+                // Deliberately does not say how many clients were targeting it: that number is
+                // from before the link dropped and there is no way to know if it still holds.
+                return 'Connection to FlowFuse lost. This tab cannot be reached by MCP clients until it reconnects'
+            default:
+                return 'Enable MCP'
+            }
         }
     },
     watch: {
@@ -102,7 +122,9 @@ export default {
         startMcp () {
             if (!this.team) return
             this.enableMcp(this.team)
-            alerts.emit('MCP session exposed. Third-party agents can now target this tab.', 'confirmation')
+            // Deliberately not a confirmation: nothing is targeting the tab yet, and the
+            // toggle turning amber is the honest version of that.
+            alerts.emit('MCP session exposed. Third-party agents can now target this tab.', 'info')
         },
         async stopMcp () {
             if (await this.disableMcp()) {
@@ -119,19 +141,140 @@ export default {
     display: none !important;
 }
 
+/*
+ * The gradient's angle is animated as a single registered property rather than by
+ * redeclaring the whole background at each keyframe. Registering it is what makes it
+ * interpolate at all - an unregistered custom property is a string, and animating one
+ * snaps between keyframes instead of sweeping.
+ */
+@property --ff-expert-border-angle {
+    syntax: '<angle>';
+    inherits: false;
+    initial-value: 135deg;
+}
+
 /* Composite wrapper: animated gradient border around both halves */
 .expert-composite {
     display: inline-flex;
+    /*
+     * Conic rather than linear. A rotating linear gradient sweeps a straight band across
+     * the box, so every pass drags a hard edge over the corners; a conic one radiates from
+     * the centre, which around a 1px border reads as a continuous hue rotation with no
+     * edge to catch. Purple sits between the two brand colours in both directions, because
+     * red to indigo taken directly passes through a muddy midpoint - the extra stops are
+     * what make the ramp gradual instead of a seam that happens to be moving.
+     */
+    position: relative;
     background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                linear-gradient(135deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
+                conic-gradient(from var(--ff-expert-border-angle),
+                    var(--ff-palette-red-600),
+                    var(--ff-palette-purple-600),
+                    var(--ff-palette-indigo-600),
+                    var(--ff-palette-purple-600),
+                    var(--ff-palette-red-600)) border-box;
     border: 1px solid transparent;
     border-radius: 6px;
-    animation: gradient-border-rotate 4s linear infinite;
+
+    @media (prefers-reduced-motion: no-preference) {
+        /* Slower than the old sweep: with the edges gone there is nothing to track, so the
+           rotation only has to be perceptible rather than legible. */
+        animation: expert-border-swirl 9s linear infinite;
+    }
 
     &:hover {
         border: 2px solid transparent;
         margin: -1px;
     }
+
+    /*
+     * The wave belongs to the whole button, not the MCP half. Tinting only that half put a
+     * hard edge down the divider, which read as two controls rather than one thing in a
+     * state. Living on the composite it runs edge to edge.
+     *
+     * Two independent layers of soft blobs drifting over each other. Deliberately not one
+     * ramp scrolling in a straight line: a single direction at a constant rate reads as a
+     * mechanical wipe, and you can see the beat. These have different durations, different
+     * numbers of waypoints and different paths, so the two layers come back into the same
+     * arrangement only every few minutes. What you notice is colour swelling and receding
+     * in no particular direction, which is the point.
+     *
+     * inset:0 resolves against the padding box, so they fill inside the border without
+     * covering the swirl. Their own border-radius clips them, rather than overflow:hidden,
+     * which would cut the count badge's ring where that oversails the edge.
+     */
+    /*
+     * Interrupted: this tab cannot reach the platform. The conic gradient goes entirely,
+     * replaced by a flat red edge, and the swirl stops with it - a fault that keeps
+     * animating like the healthy states reads as activity, and the whole signal here is
+     * that nothing is flowing. There is no wave either, for the same reason: the states
+     * that move are the ones where something is actually happening.
+     */
+    &--mcp-interrupted {
+        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
+                    linear-gradient(var(--ff-color-expert-fault-border), var(--ff-color-expert-fault-border)) border-box;
+        animation: none;
+    }
+
+    &--mcp-connected {
+        /*
+         * The divider goes while the wave is running: a line down the middle cuts the drift
+         * into two halves and gives the eye an edge to stop at, which is the one thing the
+         * whole effect is trying to avoid. Colour rather than width, so the 1px stays in the
+         * layout and nothing shifts as the state flips - and `transition-colors` on the
+         * button means it fades rather than blinks out.
+         */
+        .expert-composite__mcp {
+            border-left-color: transparent;
+        }
+
+        &::before,
+        &::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            z-index: 0;
+            border-radius: 5px;
+            pointer-events: none;
+            background-repeat: no-repeat;
+        }
+
+        /* Static fallback: the same hues, held still. Reduced motion should cost the
+           movement, not the signal. */
+        &::after {
+            background-image: linear-gradient(135deg,
+                var(--ff-color-expert-wave-1),
+                var(--ff-color-expert-wave-2),
+                var(--ff-color-expert-wave-3));
+        }
+
+        @media (prefers-reduced-motion: no-preference) {
+            &::before {
+                /* A held core out to 38%, then a long fade. Colour straight to transparent
+                   from the centre peaks at a single point and averages out to nothing over
+                   a blob this size. */
+                background-image:
+                    radial-gradient(closest-side circle, var(--ff-color-expert-wave-1), var(--ff-color-expert-wave-1) 38%, transparent),
+                    radial-gradient(closest-side circle, var(--ff-color-expert-wave-3), var(--ff-color-expert-wave-3) 38%, transparent);
+                background-size: 82px 82px, 64px 64px;
+                animation: expert-splash-a 13s ease-in-out infinite;
+            }
+
+            &::after {
+                background-image:
+                    radial-gradient(closest-side circle, var(--ff-color-expert-wave-2), var(--ff-color-expert-wave-2) 38%, transparent),
+                    radial-gradient(closest-side circle, var(--ff-color-expert-wave-1), var(--ff-color-expert-wave-1) 38%, transparent);
+                background-size: 72px 72px, 56px 56px;
+                animation: expert-splash-b 19s ease-in-out infinite;
+            }
+        }
+    }
+}
+
+/* Both halves sit above the wave: it is a tint behind the button, not over it */
+.expert-composite__expert,
+.expert-composite__mcp {
+    position: relative;
+    z-index: 1;
 }
 
 /* Left half: Expert action */
@@ -142,77 +285,179 @@ export default {
     border-radius: 5px 0 0 5px;
 
     &:hover {
-        background-color: var(--ff-color-bg-surface);
+        background-color: var(--ff-color-expert-hover-veil);
     }
 }
 
-/* Right half: MCP toggle */
+/*
+ * Right half: MCP toggle. Three states, because being exposed to agents and
+ * being driven by one are different things:
+ *   off       - subtle, nothing running
+ *   waiting   - amber and pulsing, exposed but nothing is targeting this tab
+ *   connected - steady green, at least one MCP client is driving it
+ *
+ * Position is for the count badge, which several clients at once makes possible.
+ */
 .expert-composite__mcp {
+    position: relative;
     border: none;
     border-left: 1px solid var(--ff-color-border);
     background: transparent;
     cursor: pointer;
     border-radius: 0 5px 5px 0;
-    color: var(--ff-color-text-subtle);
+    /* Switched off, not merely quiet - it should recede until the user turns it on */
+    color: var(--ff-color-status-idle-dot);
 
     &:hover {
-        background-color: var(--ff-color-bg-surface);
+        background-color: var(--ff-color-expert-hover-veil);
         color: var(--ff-color-text-default);
     }
 
-    &--active {
+    &--waiting {
+        /* The -dot token, not -text: this is a standalone indicator, not text on a tinted pill */
+        color: var(--ff-color-status-warning-dot);
+
+        &:hover {
+            color: var(--ff-color-status-warning-dot);
+        }
+
+        /*
+         * The pulse is on the glyph alone. Breathing the panel as well turns a quiet
+         * status into something that pulls focus off the page behind it, and fading the
+         * whole button would take the divider border with it.
+         * Steady amber is a fine fallback - the colour already carries the state.
+         */
+        @media (prefers-reduced-motion: no-preference) {
+            svg {
+                animation: mcp-waiting-pulse 1.6s ease-in-out infinite;
+            }
+        }
+    }
+
+    /* Interrupted: the glyph goes red with the border, so the two halves agree */
+    &--interrupted {
+        color: var(--ff-color-expert-fault-glyph);
+
+        &:hover {
+            color: var(--ff-color-expert-fault-glyph);
+        }
+    }
+
+    /*
+     * Connected is the glyph and the count only. The tint that goes with it lives on the
+     * composite, so it can run the full width instead of stopping at the divider.
+     */
+    &--connected {
         color: var(--ff-color-success);
 
+        /* Only the glyph is pinned here. The hover veil is inherited from the base rule so
+           the hovered half still lifts, and the wave still reads through it. */
         &:hover {
             color: var(--ff-color-success);
         }
     }
+
+    /* Above the composite's wave, so the tint never washes over the glyph or the count */
+    svg {
+        position: relative;
+        z-index: 1;
+    }
 }
 
-@keyframes gradient-border-rotate {
-    0% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(0deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
+/*
+ * Count badge, shown from two clients upwards. Sits on the icon corner rather than
+ * beside it so the toggle keeps its width as the count changes.
+ */
+.expert-composite__mcp-count {
+    position: absolute;
+    top: 0;
+    right: -1px;
+    min-width: 14px;
+    padding: 0 3px;
+    border-radius: 999px;
+    /*
+     * The tint is translucent in the dark theme, so it needs an opaque fill underneath
+     * or the plug icon reads straight through the badge sitting on top of it. That has
+     * to be a colour plus an image layer: `background: <colour>, <colour>` is invalid
+     * (only the last layer of the shorthand may carry a colour) and drops the whole
+     * declaration, which renders the badge transparent.
+     * The ring is what separates badge from icon - both are green, and without it they
+     * merge into a single shape.
+     */
+    background-color: var(--ff-color-bg-app);
+    background-image: linear-gradient(var(--ff-color-status-success-bg), var(--ff-color-status-success-bg));
+    box-shadow: 0 0 0 1.5px var(--ff-color-bg-app);
+    /* The -text token, not -success: this is text on a tinted pill, and it is small enough
+       that the readable pairing matters more than matching the icon's green exactly. */
+    color: var(--ff-color-status-success-text);
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 14px;
+    text-align: center;
+    pointer-events: none;
+    z-index: 2;
+}
+
+/*
+ * Four waypoints, eased, ending where it began. The eased segments are what stop it
+ * reading as a constant drift: each blob slows as it turns and picks up again after.
+ *
+ * background-position places the image's top-left corner, so these are centre-minus-radius.
+ * The button is about 34px tall and the blobs are 56-82px across, so every y is negative:
+ * a blob only shows its middle if it hangs well above the box.
+ */
+@keyframes expert-splash-a {
+    0%, 100% {
+        background-position: -46px -34px, 86px -6px;
     }
-    10% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(36deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
-    }
-    20% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(72deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
-    }
-    30% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(108deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
-    }
-    40% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(144deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
+    25% {
+        background-position: 10px -12px, 40px -26px;
     }
     50% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(180deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
+        background-position: 62px -30px, -30px -8px;
     }
-    60% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(216deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
+    75% {
+        background-position: 24px -6px, 74px -22px;
     }
-    70% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(252deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
+}
+
+/* Three waypoints against the other layer's four, on a different clock, so the pair does
+   not fall back into step on any short cycle. */
+@keyframes expert-splash-b {
+    0%, 100% {
+        background-position: 48px -8px, -18px -22px;
     }
-    80% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(288deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
+    33% {
+        background-position: -24px -28px, 66px -4px;
     }
-    90% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(324deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
+    66% {
+        background-position: 80px -14px, 26px -20px;
     }
-    100% {
-        background: linear-gradient(var(--ff-color-bg-app), var(--ff-color-bg-app)) padding-box,
-                    linear-gradient(360deg, var(--ff-palette-red-600), var(--ff-palette-indigo-600), var(--ff-palette-red-600)) border-box;
+}
+
+@keyframes mcp-waiting-pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.45;
+    }
+}
+
+/*
+ * A full turn, stated explicitly at both ends. A `to`-only keyframe takes its start from
+ * the property's initial-value, which made this sweep 135deg to 360deg - five eighths of a
+ * revolution - and then snap back 135deg every cycle. Ending on 495deg rather than 360deg
+ * is what closes the loop: 495 is 135 plus a whole turn, so the last frame renders
+ * identically to the first, and the resting angle stays 135deg for anyone who never sees
+ * the animation at all.
+ */
+@keyframes expert-border-swirl {
+    from {
+        --ff-expert-border-angle: 135deg;
+    }
+    to {
+        --ff-expert-border-angle: 495deg;
     }
 }
 </style>

--- a/frontend/src/publishers/tab-presence.publisher.ts
+++ b/frontend/src/publishers/tab-presence.publisher.ts
@@ -49,9 +49,8 @@ class TabPresencePublisher extends TeamPublisher {
     }
 
     /**
-     * This publisher is the tab's link to the platform: it only runs while MCP is exposed,
-     * and it is the thing that is supposed to be beating continuously. So its health is the
-     * tab's health, and it is the honest place to report a broken link from.
+     * This publisher only runs while MCP is exposed and is the thing meant to beat
+     * continuously, so its health is the tab's health.
      */
     protected _onLinkDown (): void {
         useProductMcpStore().markInterrupted()
@@ -61,7 +60,7 @@ class TabPresencePublisher extends TeamPublisher {
         // _onConnect fires again on every broker reconnect, so tear down any timers
         // and listeners from a previous run before registering new ones.
         this._onStopped()
-        // Reached on first connect and on every reconnect, so it is also the all-clear.
+        // Runs on first connect and every reconnect, so it doubles as the all-clear
         useProductMcpStore().markLinkHealthy()
 
         const authStore = useAccountAuthStore()
@@ -143,10 +142,15 @@ class TabPresencePublisher extends TeamPublisher {
             focused: document.hasFocus(),
             capabilities: this._capabilities(context),
             context
+        }).then(() => {
+            // A publish can be rejected while the socket stays up (ACL change, rate limit),
+            // and no reconnect follows to clear that. A heartbeat landing is the all-clear
+            // for exactly the case _onStarted cannot cover.
+            useProductMcpStore().markLinkHealthy()
         }).catch((err) => {
             console.warn('Failed to publish tab presence:', err)
-            // A heartbeat that does not land means the platform's entry for this tab is
-            // going stale even if the socket still looks up, so it counts as interrupted.
+            // A heartbeat that does not land leaves the platform's entry going stale, even
+            // if the socket still looks up
             useProductMcpStore().markInterrupted()
         })
     }
@@ -191,6 +195,15 @@ export function startTabPresence (team: TeamRef): TabPresencePublisher {
             console.warn('Failed to start tab presence:', err)
         })
     return publisher
+}
+
+/**
+ * Heartbeat now, if a publisher is live. For the session subscriber: the platform's answer
+ * is not retained, so one sent before that subscription is up is dropped and the tab waits
+ * out a whole interval. Re-announcing on subscribe closes that window.
+ */
+export function announceTabPresence (): void {
+    activePublisher?.announcePresence()
 }
 
 /**

--- a/frontend/src/publishers/tab-presence.publisher.ts
+++ b/frontend/src/publishers/tab-presence.publisher.ts
@@ -4,6 +4,7 @@ import { TeamPublisher } from './team-publisher.contract'
 import getAppOrchestrator from '@/services/app.orchestrator'
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useContextStore } from '@/stores/context.js'
+import { useProductMcpStore } from '@/stores/product-mcp.js'
 import { createMqttTransport } from '@/transport/mqtt.transport'
 import type { CreatePublisherOptions } from '@/types/publishers/publisher.types'
 import type { TeamRef } from '@/types/subscribers/subscriber.types'
@@ -47,10 +48,21 @@ class TabPresencePublisher extends TeamPublisher {
         this._publishPresence()
     }
 
+    /**
+     * This publisher is the tab's link to the platform: it only runs while MCP is exposed,
+     * and it is the thing that is supposed to be beating continuously. So its health is the
+     * tab's health, and it is the honest place to report a broken link from.
+     */
+    protected _onLinkDown (): void {
+        useProductMcpStore().markInterrupted()
+    }
+
     protected _onStarted (teamId: string, userId: string): void {
         // _onConnect fires again on every broker reconnect, so tear down any timers
         // and listeners from a previous run before registering new ones.
         this._onStopped()
+        // Reached on first connect and on every reconnect, so it is also the all-clear.
+        useProductMcpStore().markLinkHealthy()
 
         const authStore = useAccountAuthStore()
         this.$userId = userId
@@ -133,6 +145,9 @@ class TabPresencePublisher extends TeamPublisher {
             context
         }).catch((err) => {
             console.warn('Failed to publish tab presence:', err)
+            // A heartbeat that does not land means the platform's entry for this tab is
+            // going stale even if the socket still looks up, so it counts as interrupted.
+            useProductMcpStore().markInterrupted()
         })
     }
 

--- a/frontend/src/publishers/team-publisher.contract.ts
+++ b/frontend/src/publishers/team-publisher.contract.ts
@@ -102,10 +102,10 @@ export abstract class TeamPublisher<TTransport extends Transport = Transport> {
                 getCredentials: () => teamApi.getTeamCommsCreds(teamId, sessionId),
                 onMessage: () => {},
                 onConnect: () => this._onConnect(teamId, userId),
-                onClose: () => {},
-                onOffline: () => {},
-                onDisconnect: () => {},
-                onError: () => {}
+                onClose: () => this._onLinkDown(),
+                onOffline: () => this._onLinkDown(),
+                onDisconnect: () => this._onLinkDown(),
+                onError: () => this._onLinkDown()
             })
         } catch (err) {
             console.warn(`[${this.$name}] failed to attach to the team connection:`, err)
@@ -141,6 +141,16 @@ export abstract class TeamPublisher<TTransport extends Transport = Transport> {
     protected _onConnect (teamId: string, userId: string): void {
         this._onStarted(teamId, userId)
     }
+
+    /**
+     * The link to the broker went away. Fires for a clean close, going offline, a server
+     * disconnect and a client error alike, because from a publisher's point of view they
+     * amount to the same thing: nothing it sends from here is reaching the platform.
+     *
+     * A no-op by default. The transport reconnects on its own and _onConnect is what says
+     * the link is back, so a publisher only needs this if it reports its own health.
+     */
+    protected _onLinkDown (): void {}
 
     protected async _publish (topic: string, payload: MqttPayload, options?: Partial<TransportPublishOptions>): Promise<void> {
         const transport = this.$transport

--- a/frontend/src/publishers/team-publisher.contract.ts
+++ b/frontend/src/publishers/team-publisher.contract.ts
@@ -143,12 +143,9 @@ export abstract class TeamPublisher<TTransport extends Transport = Transport> {
     }
 
     /**
-     * The link to the broker went away. Fires for a clean close, going offline, a server
-     * disconnect and a client error alike, because from a publisher's point of view they
-     * amount to the same thing: nothing it sends from here is reaching the platform.
-     *
-     * A no-op by default. The transport reconnects on its own and _onConnect is what says
-     * the link is back, so a publisher only needs this if it reports its own health.
+     * The link to the broker went away - close, offline, disconnect or error alike, since
+     * from here they all mean the same thing. A no-op by default: the transport reconnects
+     * on its own and _onConnect says the link is back.
      */
     protected _onLinkDown (): void {}
 

--- a/frontend/src/services/mqtt.service.ts
+++ b/frontend/src/services/mqtt.service.ts
@@ -169,10 +169,13 @@ class MqttService extends BaseService implements MqttServiceI {
     }
 
     private _buildObserver (options: Partial<MqttConnectionOptions>): ManagedMqttObserver {
-        const { onConnect, onClose, onOffline, onError, onMessage } = options
+        // Only the handlers listed here reach an observer. MqttConnectionHandlers declares
+        // more, and _dispatch fires some of them ('end', 'reconnect'), so any missing here
+        // are silently dropped rather than rejected. Add to both sides when one is needed.
+        const { onConnect, onClose, onDisconnect, onOffline, onError, onMessage } = options
         return {
             id: this.$observerSeq++,
-            handlers: { onConnect, onClose, onOffline, onError, onMessage }
+            handlers: { onConnect, onClose, onDisconnect, onOffline, onError, onMessage }
         }
     }
 

--- a/frontend/src/stores/product-mcp.js
+++ b/frontend/src/stores/product-mcp.js
@@ -1,28 +1,85 @@
 import { defineStore } from 'pinia'
 
 import { startTabPresence, stopTabPresence } from '@/publishers/tab-presence.publisher'
+import alerts from '@/services/alerts.js'
 import { startMcpInflight, stopMcpInflight } from '@/subscribers/mcp-inflight.subscriber'
+import { startMcpSession, stopMcpSession } from '@/subscribers/mcp-session.subscriber'
 
 /**
  * Whether this tab is exposed to third-party MCP agents, and the comms that go with it.
  *
- * Two things run while it is active: the presence publisher, which tells the platform
- * this tab exists and what it is looking at, and the in-flight subscriber, which picks
- * up the requests those agents send back.
+ * Three things run while it is active: the presence publisher, which tells the platform
+ * this tab exists and what it is looking at, the in-flight subscriber, which picks up the
+ * requests those agents send back, and the session subscriber, which hears how many of
+ * them are currently targeting this tab.
  *
- * The flag is persisted per tab so a reload does not silently drop a tab an agent is
- * already targeting.
+ * Being exposed and being targeted are separate things. `active` is the user's choice.
+ * `clients` is the platform's answer, and it is not a boolean: targeting is not exclusive,
+ * so several MCP clients can drive the same tab at once and the user is entitled to see
+ * how many.
+ *
+ * `clients` is never inferred locally. A tab can be dropped by a client that simply goes
+ * quiet and lets its pin expire, which produces no event to listen for, so guessing would
+ * drift. The platform answers with the full set on every presence heartbeat, which makes
+ * the count self-correcting and survives a reload without anything having to ask.
+ *
+ * Only `active` is persisted per tab: whether anything still holds this tab across a
+ * reload is the platform's to say.
  */
 export const useProductMcpStore = defineStore('product-mcp', {
     state: () => ({
-        active: false
+        active: false,
+        // MCP session ids currently targeting this tab, as last reported by the platform.
+        clients: [],
+        /**
+         * The tab's link to the platform is broken: the broker connection dropped, or a
+         * presence heartbeat failed to land. Reported by the presence publisher, which is
+         * the only thing here that talks continuously and so the only thing that can tell.
+         *
+         * This outranks everything else the button can say. While it holds, `clients` is
+         * whatever the platform last managed to tell us and is not to be trusted - which is
+         * the point: we cannot know what is targeting a tab we cannot hear from.
+         */
+        interrupted: false,
+        /**
+         * Whether the platform has answered yet. The first answer is the tab catching up,
+         * not something that just happened, so it sets the count without announcing it -
+         * otherwise every reload of a tab an agent already holds reports a fresh arrival.
+         */
+        synced: false
     }),
+    getters: {
+        clientCount (state) {
+            return state.clients.length
+        },
+        /**
+         * 'off' - not exposed.
+         * 'waiting' - exposed, nothing is targeting it.
+         * 'connected' - at least one MCP client is driving this tab.
+         * 'interrupted' - exposed, but this tab cannot reach the platform.
+         *
+         * Interrupted is checked first: a tab that cannot hear from the platform has no
+         * business claiming either of the other two, because both are things the platform
+         * told it and neither is still being confirmed.
+         */
+        status (state) {
+            if (!state.active) return 'off'
+            if (state.interrupted) return 'interrupted'
+            return state.clients.length > 0 ? 'connected' : 'waiting'
+        }
+    },
     actions: {
         enable (team) {
             if (!team) return
             startTabPresence(team)
             startMcpInflight(team)
+            startMcpSession(team)
             this.active = true
+            // Exposing a tab says nothing about anyone having taken it, and a reload
+            // cannot know what was targeting it. The first heartbeat answers this.
+            this.clients = []
+            this.synced = false
+            this.interrupted = false
         },
         async disable () {
             // The header mounts more than one toggle (a mobile one and a desktop one), so their
@@ -32,6 +89,10 @@ export const useProductMcpStore = defineStore('product-mcp', {
             // is what keeps a single event from being announced once per button.
             if (!this.active) return false
             this.active = false
+            this.clients = []
+            this.synced = false
+            this.interrupted = false
+            await stopMcpSession()
             await stopMcpInflight()
             // A real opt-out: tell the platform to drop this tab's session entry now rather
             // than leaving it listed as targetable until the entry expires.
@@ -48,8 +109,60 @@ export const useProductMcpStore = defineStore('product-mcp', {
          * tab that really is going away is still covered by its connection's last will.
          */
         async teardown () {
+            this.clients = []
+            this.synced = false
+            this.interrupted = false
+            await stopMcpSession()
             await stopMcpInflight()
             await stopTabPresence({ announceClose: false })
+        },
+        /**
+         * The platform's account of who is targeting this tab. Replaces rather than merges:
+         * it is a full set every time, which is what lets a lapsed pin drop off on its own.
+         *
+         * The difference against what we held is the interesting part: an agent picking up
+         * this tab, or letting it go, is worth saying out loud. Comparing sets rather than
+         * counts means a swap (one leaves as another arrives) is reported as both, instead
+         * of passing silently because the total happened not to move.
+         */
+        markInterrupted () {
+            this.interrupted = true
+        },
+        /**
+         * The link is back. `synced` is reset too: the count we were holding is from before
+         * the outage and the platform gets to restate it on the next heartbeat, which should
+         * not be announced as clients arriving or leaving when it is really just us catching
+         * up on what changed while we were deaf.
+         */
+        markLinkHealthy () {
+            if (!this.interrupted) return
+            this.interrupted = false
+            this.clients = []
+            this.synced = false
+        },
+        setClients (sessionIds) {
+            const next = Array.isArray(sessionIds) ? sessionIds : []
+            const previous = this.clients
+            this.clients = next
+
+            if (!this.synced) {
+                this.synced = true
+                return
+            }
+
+            const arrived = next.filter(id => !previous.includes(id)).length
+            const left = previous.filter(id => !next.includes(id)).length
+
+            if (arrived > 0) {
+                alerts.emit(arrived === 1
+                    ? 'An MCP client is now targeting this tab.'
+                    : `${arrived} MCP clients are now targeting this tab.`, 'confirmation')
+            }
+            if (left > 0) {
+                alerts.emit(left === 1
+                    ? 'An MCP client stopped targeting this tab.'
+                    : `${left} MCP clients stopped targeting this tab.`, 'info')
+            }
         }
     },
     persist: {

--- a/frontend/src/stores/product-mcp.js
+++ b/frontend/src/stores/product-mcp.js
@@ -6,45 +6,38 @@ import { startMcpInflight, stopMcpInflight } from '@/subscribers/mcp-inflight.su
 import { startMcpSession, stopMcpSession } from '@/subscribers/mcp-session.subscriber'
 
 /**
- * Whether this tab is exposed to third-party MCP agents, and the comms that go with it.
+ * Whether this tab is exposed to third-party MCP agents, and the comms that go with it:
+ * the presence publisher, the in-flight subscriber, and the session subscriber.
  *
- * Three things run while it is active: the presence publisher, which tells the platform
- * this tab exists and what it is looking at, the in-flight subscriber, which picks up the
- * requests those agents send back, and the session subscriber, which hears how many of
- * them are currently targeting this tab.
+ * Being exposed and being targeted are separate. `active` is the user's choice; `clients`
+ * is the platform's answer, and a set rather than a flag because targeting is not
+ * exclusive. It is never inferred locally - a pin can end by quietly expiring, which
+ * produces no event, so the platform restates the full set on every heartbeat and the
+ * count corrects itself.
  *
- * Being exposed and being targeted are separate things. `active` is the user's choice.
- * `clients` is the platform's answer, and it is not a boolean: targeting is not exclusive,
- * so several MCP clients can drive the same tab at once and the user is entitled to see
- * how many.
- *
- * `clients` is never inferred locally. A tab can be dropped by a client that simply goes
- * quiet and lets its pin expire, which produces no event to listen for, so guessing would
- * drift. The platform answers with the full set on every presence heartbeat, which makes
- * the count self-correcting and survives a reload without anything having to ask.
- *
- * Only `active` is persisted per tab: whether anything still holds this tab across a
- * reload is the platform's to say.
+ * Only `active` is persisted: what holds this tab across a reload is the platform's to say.
  */
 export const useProductMcpStore = defineStore('product-mcp', {
     state: () => ({
         active: false,
-        // MCP session ids currently targeting this tab, as last reported by the platform.
+        // Opaque refs for the clients targeting this tab, as last reported by the platform
         clients: [],
         /**
-         * The tab's link to the platform is broken: the broker connection dropped, or a
-         * presence heartbeat failed to land. Reported by the presence publisher, which is
-         * the only thing here that talks continuously and so the only thing that can tell.
-         *
-         * This outranks everything else the button can say. While it holds, `clients` is
-         * whatever the platform last managed to tell us and is not to be trusted - which is
-         * the point: we cannot know what is targeting a tab we cannot hear from.
+         * The link to the platform is broken - dropped connection, or a heartbeat that did
+         * not land. Reported by the presence publisher, the only thing here talking
+         * continuously. Outranks everything else: `clients` cannot be trusted while it holds.
          */
         interrupted: false,
         /**
-         * Whether the platform has answered yet. The first answer is the tab catching up,
-         * not something that just happened, so it sets the count without announcing it -
-         * otherwise every reload of a tab an agent already holds reports a fresh arrival.
+         * Mounted toggles. The header renders two, and without this the first to unmount
+         * tears down comms the second is still showing as live. Lifecycle, not user intent,
+         * so it is kept apart from `active` and never persisted.
+         */
+        mounts: 0,
+        /**
+         * Whether the platform has answered yet. The first answer is catching up, not an
+         * event, so it sets the count silently - otherwise every reload of a held tab
+         * reports a fresh arrival.
          */
         synced: false
     }),
@@ -58,9 +51,8 @@ export const useProductMcpStore = defineStore('product-mcp', {
          * 'connected' - at least one MCP client is driving this tab.
          * 'interrupted' - exposed, but this tab cannot reach the platform.
          *
-         * Interrupted is checked first: a tab that cannot hear from the platform has no
-         * business claiming either of the other two, because both are things the platform
-         * told it and neither is still being confirmed.
+         * Interrupted wins: the other two are things the platform said, and nothing is
+         * confirming them while we cannot hear it.
          */
         status (state) {
             if (!state.active) return 'off'
@@ -75,18 +67,30 @@ export const useProductMcpStore = defineStore('product-mcp', {
             startMcpInflight(team)
             startMcpSession(team)
             this.active = true
-            // Exposing a tab says nothing about anyone having taken it, and a reload
-            // cannot know what was targeting it. The first heartbeat answers this.
+            // Exposing says nothing about who has taken it - the first heartbeat answers that
             this.clients = []
             this.synced = false
             this.interrupted = false
         },
+        /** A toggle mounted. Comms are singletons, so only the first one starts them. */
+        retain (team) {
+            this.mounts += 1
+            if (this.mounts === 1 && this.active && team) {
+                this.enable(team)
+            }
+        },
+        /** A toggle unmounted. Only the last one leaving takes the comms down. */
+        async release () {
+            this.mounts = Math.max(0, this.mounts - 1)
+            if (this.mounts === 0 && this.active) {
+                await this.teardown()
+            }
+        },
         async disable () {
-            // The header mounts more than one toggle (a mobile one and a desktop one), so their
-            // watchers and lifecycle hooks fire in the same tick. Clearing the flag before the
-            // first await makes every call after the first a no-op, so one opt-out tears the
-            // comms down once - and lets a caller tell whether it was the one that did it, which
-            // is what keeps a single event from being announced once per button.
+            // Both toggles' watchers fire in the same tick. Clearing the flag before the first
+            // await makes every later call a no-op, so one opt-out tears down once - and the
+            // return value tells the caller whether it was the one that did it, which keeps a
+            // single event from being announced per button.
             if (!this.active) return false
             this.active = false
             this.clients = []
@@ -94,19 +98,16 @@ export const useProductMcpStore = defineStore('product-mcp', {
             this.interrupted = false
             await stopMcpSession()
             await stopMcpInflight()
-            // A real opt-out: tell the platform to drop this tab's session entry now rather
-            // than leaving it listed as targetable until the entry expires.
+            // A real opt-out: drop the session entry now rather than leaving it listed
             await stopTabPresence({ announceClose: true })
             return true
         },
         /**
-         * Drops the comms but leaves the flag alone, so a tab that is only unmounting
-         * the button (rather than opting out) comes back up exposed.
+         * Drops the comms but leaves the flag, so an unmounting button comes back exposed.
          *
-         * Deliberately silent: the platform reads the close notice as the user opting out and
-         * deletes the tab's session entry, which would un-list a tab that is still open and
-         * still exposed. Leaving the entry in place lets the remount refresh it instead, and a
-         * tab that really is going away is still covered by its connection's last will.
+         * Silent by design: the platform reads a close notice as opting out and deletes the
+         * session entry, un-listing a tab that is still open. A tab really going away is
+         * covered by its connection's last will.
          */
         async teardown () {
             this.clients = []
@@ -116,30 +117,30 @@ export const useProductMcpStore = defineStore('product-mcp', {
             await stopMcpInflight()
             await stopTabPresence({ announceClose: false })
         },
-        /**
-         * The platform's account of who is targeting this tab. Replaces rather than merges:
-         * it is a full set every time, which is what lets a lapsed pin drop off on its own.
-         *
-         * The difference against what we held is the interesting part: an agent picking up
-         * this tab, or letting it go, is worth saying out loud. Comparing sets rather than
-         * counts means a swap (one leaves as another arrives) is reported as both, instead
-         * of passing silently because the total happened not to move.
-         */
         markInterrupted () {
             this.interrupted = true
         },
         /**
-         * The link is back. `synced` is reset too: the count we were holding is from before
-         * the outage and the platform gets to restate it on the next heartbeat, which should
-         * not be announced as clients arriving or leaving when it is really just us catching
-         * up on what changed while we were deaf.
+         * Evidence the link works: a reconnect, or something we sent landing. Both matter,
+         * because an interruption can start without the socket dropping (a rejected publish)
+         * and the reconnect that would clear it never comes.
+         *
+         * `synced` resets so the restated count reads as catching up, not as arrivals.
+         * `clients` is left alone: blanking it drops the button to amber "nothing is
+         * targeting this tab" until the truth arrives, a worse lie than a slightly stale count.
          */
         markLinkHealthy () {
             if (!this.interrupted) return
             this.interrupted = false
-            this.clients = []
             this.synced = false
         },
+        /**
+         * The platform's account of who is targeting this tab - a full set every time, which
+         * is what lets a lapsed pin drop off on its own.
+         *
+         * Diffed rather than counted so a swap (one leaves as another arrives) is reported as
+         * both, instead of passing silently because the total did not move.
+         */
         setClients (sessionIds) {
             const next = Array.isArray(sessionIds) ? sessionIds : []
             const previous = this.clients

--- a/frontend/src/subscribers/mcp-session.subscriber.ts
+++ b/frontend/src/subscribers/mcp-session.subscriber.ts
@@ -8,10 +8,14 @@ import { useProductMcpStore } from '@/stores/product-mcp.js'
 import { createMqttTransport } from '@/transport/mqtt.transport'
 import type { CreateSubscriberOptions, TeamRef, TeamSubscriberI } from '@/types/subscribers/subscriber.types'
 
-/** Pinned to this tab's session, so an event meant for another tab is ignored. */
-function sessionEventPattern (sessionId: string, event: string): RegExp {
-    const session = sessionId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    return new RegExp(`^ff/v1/[^/]+/u/[^/]+/s/${session}/mcp/${event}$`)
+const escapeForPattern = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/**
+ * Pinned to this tab's user and session, so an event meant for another tab is ignored.
+ * The ACL already makes anything else unreachable; this is the same statement made locally.
+ */
+function sessionEventPattern (userId: string, sessionId: string, event: string): RegExp {
+    return new RegExp(`^ff/v1/[^/]+/u/${escapeForPattern(userId)}/s/${escapeForPattern(sessionId)}/mcp/${event}$`)
 }
 
 /**
@@ -39,8 +43,11 @@ class McpSessionSubscriber extends TeamSubscriber implements TeamSubscriberI {
     protected _topics (teamId: string, userId: string): string[] {
         const authStore = useAccountAuthStore()
 
+        // The exact topic rather than `mcp/+`: the broker ACL matches the subscription filter
+        // literally, so subscribing by wildcard would need a rule permissive enough to admit
+        // any event. There is only one, so name it.
         return [
-            `ff/v1/${teamId}/u/${userId}/s/${authStore.getSessionId()}/mcp/+`
+            `ff/v1/${teamId}/u/${userId}/s/${authStore.getSessionId()}/mcp/clients`
         ]
     }
 
@@ -54,11 +61,11 @@ class McpSessionSubscriber extends TeamSubscriber implements TeamSubscriberI {
     }
 
     protected _routes (): SubscriberRoute[] {
-        const sessionId = useAccountAuthStore().getSessionId()
+        const authStore = useAccountAuthStore()
 
         return [
             {
-                pattern: sessionEventPattern(sessionId, 'clients'),
+                pattern: sessionEventPattern(String(authStore.user?.id ?? ''), authStore.getSessionId(), 'clients'),
                 handle: (payload) => this._onClients(payload)
             }
         ]

--- a/frontend/src/subscribers/mcp-session.subscriber.ts
+++ b/frontend/src/subscribers/mcp-session.subscriber.ts
@@ -1,0 +1,100 @@
+import { defineSubscriberSingleton } from './subscriber.factory'
+import { SubscriberPayload, SubscriberRoute, TeamSubscriber } from './team-subscriber.contract'
+
+import getAppOrchestrator from '@/services/app.orchestrator'
+import { useAccountAuthStore } from '@/stores/account-auth.js'
+import { useProductMcpStore } from '@/stores/product-mcp.js'
+import { createMqttTransport } from '@/transport/mqtt.transport'
+import type { CreateSubscriberOptions, TeamRef, TeamSubscriberI } from '@/types/subscribers/subscriber.types'
+
+/**
+ * Pinned to this tab's own session rather than wildcarding it, so an event meant
+ * for another of the user's tabs is ignored even if one ever reaches this client.
+ */
+function sessionEventPattern (sessionId: string, event: string): RegExp {
+    const session = sessionId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return new RegExp(`^ff/v1/[^/]+/u/[^/]+/s/${session}/mcp/${event}$`)
+}
+
+/**
+ * Listens for what the platform says is targeting this tab over MCP.
+ *
+ * Exposing a tab and an MCP client actually targeting it are two different things:
+ * the toggle only does the first. `clients` is the second, and it carries the whole
+ * set rather than a flag, because targeting is not exclusive - several MCP clients
+ * can drive one tab at once.
+ *
+ * The platform republishes the full set on every presence heartbeat, and again the
+ * moment a pin is made or moved. That means a pin that ends by quietly expiring
+ * still corrects itself, without the tab having to infer anything locally.
+ *
+ * The topic is the tab's own session, and the broker ACL pins that segment to
+ * this connection's credential, so a tab only ever hears about itself. It rides
+ * the team connection because that is the one the toggle already brings up.
+ */
+class McpSessionSubscriber extends TeamSubscriber implements TeamSubscriberI {
+    constructor ({ app, router, transport, subscribers }: CreateSubscriberOptions) {
+        super({
+            name: 'mcpSession',
+            app,
+            router,
+            transport,
+            subscribers
+        })
+    }
+
+    protected _topics (teamId: string, userId: string): string[] {
+        const authStore = useAccountAuthStore()
+
+        return [
+            `ff/v1/${teamId}/u/${userId}/s/${authStore.getSessionId()}/mcp/+`
+        ]
+    }
+
+    protected _routes (): SubscriberRoute[] {
+        const sessionId = useAccountAuthStore().getSessionId()
+
+        return [
+            {
+                pattern: sessionEventPattern(sessionId, 'clients'),
+                handle: (payload) => this._onClients(payload)
+            }
+        ]
+    }
+
+    /**
+     * `sessionIds` is authoritative and complete - an empty array means nothing is
+     * targeting this tab, not that the platform had nothing to say.
+     *
+     * Checked rather than asserted: this arrives off the broker, and a malformed message
+     * should leave the tab reporting nothing rather than throwing inside a message handler.
+     */
+    private _onClients (payload: SubscriberPayload = {}): void {
+        const ids = payload?.sessionIds
+        useProductMcpStore().setClients(
+            Array.isArray(ids) ? ids.filter((id): id is string => typeof id === 'string') : []
+        )
+    }
+}
+
+const { create: createMcpSessionSubscriber, destroy: destroyMcpSessionSubscriber } = defineSubscriberSingleton(McpSessionSubscriber)
+
+export function startMcpSession (team: TeamRef): McpSessionSubscriber {
+    const orchestrator = getAppOrchestrator()
+    const transport = createMqttTransport(orchestrator.$services.mqtt)
+    const subscriber = createMcpSessionSubscriber({
+        app: orchestrator.$app,
+        router: orchestrator.$router,
+        transport
+    })
+    subscriber.connect(team)
+    return subscriber
+}
+
+export async function stopMcpSession (): Promise<void> {
+    await destroyMcpSessionSubscriber()
+}
+
+export { createMcpSessionSubscriber, destroyMcpSessionSubscriber }
+
+export default createMcpSessionSubscriber

--- a/frontend/src/subscribers/mcp-session.subscriber.ts
+++ b/frontend/src/subscribers/mcp-session.subscriber.ts
@@ -1,36 +1,29 @@
 import { defineSubscriberSingleton } from './subscriber.factory'
 import { SubscriberPayload, SubscriberRoute, TeamSubscriber } from './team-subscriber.contract'
 
+import { announceTabPresence } from '@/publishers/tab-presence.publisher'
 import getAppOrchestrator from '@/services/app.orchestrator'
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useProductMcpStore } from '@/stores/product-mcp.js'
 import { createMqttTransport } from '@/transport/mqtt.transport'
 import type { CreateSubscriberOptions, TeamRef, TeamSubscriberI } from '@/types/subscribers/subscriber.types'
 
-/**
- * Pinned to this tab's own session rather than wildcarding it, so an event meant
- * for another of the user's tabs is ignored even if one ever reaches this client.
- */
+/** Pinned to this tab's session, so an event meant for another tab is ignored. */
 function sessionEventPattern (sessionId: string, event: string): RegExp {
     const session = sessionId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     return new RegExp(`^ff/v1/[^/]+/u/[^/]+/s/${session}/mcp/${event}$`)
 }
 
 /**
- * Listens for what the platform says is targeting this tab over MCP.
+ * Listens for what the platform says is targeting this tab over MCP. The toggle only
+ * exposes a tab; `clients` is who actually took it, and a full set rather than a flag
+ * because targeting is not exclusive.
  *
- * Exposing a tab and an MCP client actually targeting it are two different things:
- * the toggle only does the first. `clients` is the second, and it carries the whole
- * set rather than a flag, because targeting is not exclusive - several MCP clients
- * can drive one tab at once.
+ * The platform restates it on every heartbeat and on every pin change, so a pin that
+ * ends by quietly expiring corrects itself without the tab inferring anything.
  *
- * The platform republishes the full set on every presence heartbeat, and again the
- * moment a pin is made or moved. That means a pin that ends by quietly expiring
- * still corrects itself, without the tab having to infer anything locally.
- *
- * The topic is the tab's own session, and the broker ACL pins that segment to
- * this connection's credential, so a tab only ever hears about itself. It rides
- * the team connection because that is the one the toggle already brings up.
+ * The topic is the tab's own session and the ACL pins that segment to this connection's
+ * credential, so a tab only hears about itself. It rides the team connection.
  */
 class McpSessionSubscriber extends TeamSubscriber implements TeamSubscriberI {
     constructor ({ app, router, transport, subscribers }: CreateSubscriberOptions) {
@@ -51,6 +44,15 @@ class McpSessionSubscriber extends TeamSubscriber implements TeamSubscriberI {
         ]
     }
 
+    /**
+     * The platform's answer is not retained, so a heartbeat sent before this subscription
+     * was live goes nowhere and the tab waits out the next interval. Asking for a fresh one
+     * on subscribe closes that window, on first enable and on every reconnect.
+     */
+    protected _onSubscribed (): void {
+        announceTabPresence()
+    }
+
     protected _routes (): SubscriberRoute[] {
         const sessionId = useAccountAuthStore().getSessionId()
 
@@ -63,16 +65,17 @@ class McpSessionSubscriber extends TeamSubscriber implements TeamSubscriberI {
     }
 
     /**
-     * `sessionIds` is authoritative and complete - an empty array means nothing is
-     * targeting this tab, not that the platform had nothing to say.
+     * `clients` is complete - an empty array means nothing is targeting this tab, not that
+     * the platform had nothing to say. They are opaque refs, not MCP session ids (see
+     * clientRef in forge/db/controllers/BrowserSession.js).
      *
-     * Checked rather than asserted: this arrives off the broker, and a malformed message
-     * should leave the tab reporting nothing rather than throwing inside a message handler.
+     * Checked rather than asserted: this is broker data, and a malformed message should
+     * leave the tab reporting nothing rather than throw inside a message handler.
      */
     private _onClients (payload: SubscriberPayload = {}): void {
-        const ids = payload?.sessionIds
+        const refs = payload?.clients
         useProductMcpStore().setClients(
-            Array.isArray(ids) ? ids.filter((id): id is string => typeof id === 'string') : []
+            Array.isArray(refs) ? refs.filter((ref): ref is string => typeof ref === 'string') : []
         )
     }
 }

--- a/frontend/src/subscribers/team-subscriber.contract.ts
+++ b/frontend/src/subscribers/team-subscriber.contract.ts
@@ -11,7 +11,21 @@ export function connectionKey (teamId: string): string {
     return `team:${teamId}`
 }
 
-type SubscriberPayload = { reason?: string, id?: string, meta?: { state?: string } }
+/**
+ * Whatever JSON.parse produced from the message body. The named fields are the ones
+ * current routes happen to read, not a closed set - the index signature is what makes
+ * that honest, and it is load-bearing: without it TypeScript treats this as a weak type
+ * and rejects any handler whose payload shares none of those three names.
+ *
+ * Values are `unknown` deliberately. This is data off a broker, so a route that wants a
+ * shape has to check for it rather than assert it.
+ */
+export type SubscriberPayload = {
+    reason?: string
+    id?: string
+    meta?: { state?: string }
+    [key: string]: unknown
+}
 
 export interface SubscriberRoute {
     pattern: RegExp

--- a/frontend/src/subscribers/team-subscriber.contract.ts
+++ b/frontend/src/subscribers/team-subscriber.contract.ts
@@ -12,13 +12,10 @@ export function connectionKey (teamId: string): string {
 }
 
 /**
- * Whatever JSON.parse produced from the message body. The named fields are the ones
- * current routes happen to read, not a closed set - the index signature is what makes
- * that honest, and it is load-bearing: without it TypeScript treats this as a weak type
- * and rejects any handler whose payload shares none of those three names.
- *
- * Values are `unknown` deliberately. This is data off a broker, so a route that wants a
- * shape has to check for it rather than assert it.
+ * Whatever JSON.parse produced from the message body. The named fields are what current
+ * routes happen to read, not a closed set - the index signature says so, and is
+ * load-bearing: without it this is a weak type and TS rejects any handler sharing none of
+ * those names. Values are `unknown` so a route has to check for a shape, not assert it.
  */
 export type SubscriberPayload = {
     reason?: string

--- a/frontend/src/ui-components/stylesheets/ff-theme-dark.scss
+++ b/frontend/src/ui-components/stylesheets/ff-theme-dark.scss
@@ -65,6 +65,23 @@
     --ff-color-status-success-text:    var(--ff-palette-green-400);
     --ff-color-status-success-dot:     var(--ff-palette-green-400);
 
+    /* The button's own brand hues, faint enough to read as a tint rather than a fill.
+       Same sequence as the swirling border so the two are obviously one motif; the
+       alpha is the whole difference between an accent and a background. */
+    --ff-color-expert-wave-1:          rgba(188, 56, 56, 0.18);
+    --ff-color-expert-wave-2:          rgba(147, 51, 234, 0.18);
+    --ff-color-expert-wave-3:          rgba(79, 70, 229, 0.18);
+
+    /* Hover veil for the split Expert button. Translucent on purpose: the halves sit over
+       an animated background, and an opaque fill would black it out on the hovered side
+       and put back the hard divide the wave exists to avoid. (lifts; bg-surface is identical to bg-app here, so an opaque fill reads as no hover at all) */
+    --ff-color-expert-hover-veil:      rgba(255, 255, 255, 0.07);
+
+    /* The interrupted state. Flat, not a gradient: the swirl and the wave both say the link
+       is alive, so a fault has to be the one thing on this button that does not move. */
+    --ff-color-expert-fault-border:    var(--ff-palette-red-300);
+    --ff-color-expert-fault-glyph:     var(--ff-palette-red-300);
+
     --ff-color-status-progress-bg:     rgba(76, 195, 138, 0.12);
     --ff-color-status-progress-border: rgba(76, 195, 138, 0.35);
 
@@ -75,11 +92,17 @@
     --ff-color-status-warning-bg:      rgba(251, 191, 36, 0.25);
     --ff-color-status-warning-border:  rgba(251, 191, 36, 0.55);
     --ff-color-status-warning-text:    var(--ff-palette-yellow-400);
+    --ff-color-status-warning-dot:     var(--ff-palette-yellow-400);
 
     --ff-color-status-neutral-bg:      var(--ff-color-bg-surface-raised);
     --ff-color-status-neutral-border:  var(--ff-color-border);
     --ff-color-status-neutral-text:    var(--ff-color-text-subtle);
     --ff-color-status-neutral-dot:     var(--ff-color-text-subtle);
+    /* An indicator that is switched off rather than reporting a neutral result. Sits
+       between -neutral-dot (too faint to read as a control) and -text-subtle (dark
+       enough on white to look active). Defined per theme: the dark value is already
+       right at -text-subtle, only light needed softening. */
+    --ff-color-status-idle-dot:        var(--ff-color-text-subtle);
 
     --ff-color-status-info-bg:         var(--ff-color-bg-surface-raised);
     --ff-color-status-info-border:     var(--ff-color-border);

--- a/frontend/src/ui-components/stylesheets/ff-theme-dark.scss
+++ b/frontend/src/ui-components/stylesheets/ff-theme-dark.scss
@@ -65,20 +65,20 @@
     --ff-color-status-success-text:    var(--ff-palette-green-400);
     --ff-color-status-success-dot:     var(--ff-palette-green-400);
 
-    /* The button's own brand hues, faint enough to read as a tint rather than a fill.
-       Same sequence as the swirling border so the two are obviously one motif; the
-       alpha is the whole difference between an accent and a background. */
+    /* The button's brand hues, faint enough to read as a tint rather than a fill. Same
+       sequence as the swirling border, so the two are one motif. */
     --ff-color-expert-wave-1:          rgba(188, 56, 56, 0.18);
     --ff-color-expert-wave-2:          rgba(147, 51, 234, 0.18);
     --ff-color-expert-wave-3:          rgba(79, 70, 229, 0.18);
 
-    /* Hover veil for the split Expert button. Translucent on purpose: the halves sit over
-       an animated background, and an opaque fill would black it out on the hovered side
-       and put back the hard divide the wave exists to avoid. (lifts; bg-surface is identical to bg-app here, so an opaque fill reads as no hover at all) */
+    /* Hover veil for the split Expert button. Translucent because the halves sit over an
+       animated background: an opaque fill blacks it out on the hovered side and puts back
+       the hard divide the wave exists to avoid. Lifts, because bg-surface is identical to
+       bg-app in this theme and an opaque fill reads as no hover at all. */
     --ff-color-expert-hover-veil:      rgba(255, 255, 255, 0.07);
 
-    /* The interrupted state. Flat, not a gradient: the swirl and the wave both say the link
-       is alive, so a fault has to be the one thing on this button that does not move. */
+    /* Interrupted. Flat, not a gradient: the swirl and wave both say the link is alive, so
+       a fault has to be the one thing on this button that does not move. */
     --ff-color-expert-fault-border:    var(--ff-palette-red-300);
     --ff-color-expert-fault-glyph:     var(--ff-palette-red-300);
 
@@ -98,10 +98,9 @@
     --ff-color-status-neutral-border:  var(--ff-color-border);
     --ff-color-status-neutral-text:    var(--ff-color-text-subtle);
     --ff-color-status-neutral-dot:     var(--ff-color-text-subtle);
-    /* An indicator that is switched off rather than reporting a neutral result. Sits
-       between -neutral-dot (too faint to read as a control) and -text-subtle (dark
-       enough on white to look active). Defined per theme: the dark value is already
-       right at -text-subtle, only light needed softening. */
+    /* Switched off, rather than reporting a neutral result. Between -neutral-dot (too faint
+       to read as a control) and -text-subtle (dark enough on white to look active). Per
+       theme: dark was already right, only light needed softening. */
     --ff-color-status-idle-dot:        var(--ff-color-text-subtle);
 
     --ff-color-status-info-bg:         var(--ff-color-bg-surface-raised);

--- a/frontend/src/ui-components/stylesheets/ff-theme-light.scss
+++ b/frontend/src/ui-components/stylesheets/ff-theme-light.scss
@@ -62,20 +62,19 @@
     --ff-color-status-success-text:    var(--ff-palette-green-700);
     --ff-color-status-success-dot:     var(--ff-palette-green-400);
 
-    /* The button's own brand hues, faint enough to read as a tint rather than a fill.
-       Same sequence as the swirling border so the two are obviously one motif; the
-       alpha is the whole difference between an accent and a background. */
+    /* The button's brand hues, faint enough to read as a tint rather than a fill. Same
+       sequence as the swirling border, so the two are one motif. */
     --ff-color-expert-wave-1:          rgba(188, 56, 56, 0.14);
     --ff-color-expert-wave-2:          rgba(147, 51, 234, 0.14);
     --ff-color-expert-wave-3:          rgba(79, 70, 229, 0.14);
 
-    /* Hover veil for the split Expert button. Translucent on purpose: the halves sit over
-       an animated background, and an opaque fill would black it out on the hovered side
-       and put back the hard divide the wave exists to avoid. (darkens, the direction bg-surface already moved in) */
+    /* Hover veil for the split Expert button. Translucent because the halves sit over an
+       animated background: an opaque fill blacks it out on the hovered side and puts back
+       the hard divide the wave exists to avoid. Darkens, matching bg-surface's direction. */
     --ff-color-expert-hover-veil:      rgba(17, 24, 39, 0.04);
 
-    /* The interrupted state. Flat, not a gradient: the swirl and the wave both say the link
-       is alive, so a fault has to be the one thing on this button that does not move. */
+    /* Interrupted. Flat, not a gradient: the swirl and wave both say the link is alive, so
+       a fault has to be the one thing on this button that does not move. */
     --ff-color-expert-fault-border:    var(--ff-palette-red-400);
     --ff-color-expert-fault-glyph:     var(--ff-palette-red-500);
 
@@ -95,10 +94,9 @@
     --ff-color-status-neutral-border:  var(--ff-palette-grey-300);
     --ff-color-status-neutral-text:    var(--ff-palette-grey-600);
     --ff-color-status-neutral-dot:     var(--ff-palette-grey-300);
-    /* An indicator that is switched off rather than reporting a neutral result. Sits
-       between -neutral-dot (too faint to read as a control) and -text-subtle (dark
-       enough on white to look active). Defined per theme: the dark value is already
-       right at -text-subtle, only light needed softening. */
+    /* Switched off, rather than reporting a neutral result. Between -neutral-dot (too faint
+       to read as a control) and -text-subtle (dark enough on white to look active). Per
+       theme: dark was already right, only light needed softening. */
     --ff-color-status-idle-dot:        var(--ff-color-text-disabled);
 
     --ff-color-status-info-bg:         var(--ff-palette-grey-100);

--- a/frontend/src/ui-components/stylesheets/ff-theme-light.scss
+++ b/frontend/src/ui-components/stylesheets/ff-theme-light.scss
@@ -62,6 +62,23 @@
     --ff-color-status-success-text:    var(--ff-palette-green-700);
     --ff-color-status-success-dot:     var(--ff-palette-green-400);
 
+    /* The button's own brand hues, faint enough to read as a tint rather than a fill.
+       Same sequence as the swirling border so the two are obviously one motif; the
+       alpha is the whole difference between an accent and a background. */
+    --ff-color-expert-wave-1:          rgba(188, 56, 56, 0.14);
+    --ff-color-expert-wave-2:          rgba(147, 51, 234, 0.14);
+    --ff-color-expert-wave-3:          rgba(79, 70, 229, 0.14);
+
+    /* Hover veil for the split Expert button. Translucent on purpose: the halves sit over
+       an animated background, and an opaque fill would black it out on the hovered side
+       and put back the hard divide the wave exists to avoid. (darkens, the direction bg-surface already moved in) */
+    --ff-color-expert-hover-veil:      rgba(17, 24, 39, 0.04);
+
+    /* The interrupted state. Flat, not a gradient: the swirl and the wave both say the link
+       is alive, so a fault has to be the one thing on this button that does not move. */
+    --ff-color-expert-fault-border:    var(--ff-palette-red-400);
+    --ff-color-expert-fault-glyph:     var(--ff-palette-red-500);
+
     --ff-color-status-progress-bg:     var(--ff-palette-green-100);
     --ff-color-status-progress-border: var(--ff-palette-green-300);
 
@@ -72,11 +89,17 @@
     --ff-color-status-warning-bg:      var(--ff-palette-yellow-400);
     --ff-color-status-warning-border:  var(--ff-palette-yellow-700);
     --ff-color-status-warning-text:    var(--ff-palette-yellow-900);
+    --ff-color-status-warning-dot:     var(--ff-palette-yellow-500);
 
     --ff-color-status-neutral-bg:      var(--ff-palette-white);
     --ff-color-status-neutral-border:  var(--ff-palette-grey-300);
     --ff-color-status-neutral-text:    var(--ff-palette-grey-600);
     --ff-color-status-neutral-dot:     var(--ff-palette-grey-300);
+    /* An indicator that is switched off rather than reporting a neutral result. Sits
+       between -neutral-dot (too faint to read as a control) and -text-subtle (dark
+       enough on white to look active). Defined per theme: the dark value is already
+       right at -text-subtle, only light needed softening. */
+    --ff-color-status-idle-dot:        var(--ff-color-text-disabled);
 
     --ff-color-status-info-bg:         var(--ff-palette-grey-100);
     --ff-color-status-info-border:     var(--ff-palette-grey-300);

--- a/test/unit/forge/comms/authRoutesV2_spec.js
+++ b/test/unit/forge/comms/authRoutesV2_spec.js
@@ -1671,6 +1671,65 @@ describe('Broker Auth v2 API', async function () {
                     topic: `$share/browser/ff/v1/${TestObjects.ATeam.hashid}/u/${TestObjects.alice.hashid}/s/session-1234567890/heartbeat`
                 })
             })
+
+            // MCP client events, published by the platform to one tab:
+            // ff/v1/<team>/u/<user>/s/<session>/mcp/<event>
+            it('allows fe-team to subscribe to the mcp clients event for its own session', async function () {
+                await allowRead({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/${TestObjects.ATeam.hashid}/u/${TestObjects.alice.hashid}/s/session-1234567890/mcp/clients`
+                })
+            })
+            // The filter is matched literally, so a wildcard needs a rule permissive enough to
+            // admit any event. There is only one event, so it is named and the wildcard denied.
+            it('denies fe-team from wildcarding the mcp event', async function () {
+                await denyRead({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/${TestObjects.ATeam.hashid}/u/${TestObjects.alice.hashid}/s/session-1234567890/mcp/+`
+                })
+            })
+            it('denies fe-team from subscribing to an mcp event that is not published', async function () {
+                await denyRead({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/${TestObjects.ATeam.hashid}/u/${TestObjects.alice.hashid}/s/session-1234567890/mcp/heartbeat`
+                })
+            })
+            it('denies fe-team from subscribing to another tab mcp events', async function () {
+                await denyRead({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/${TestObjects.ATeam.hashid}/u/${TestObjects.alice.hashid}/s/session-abc12345/mcp/clients`
+                })
+            })
+            it('denies fe-team from wildcarding the session on mcp events', async function () {
+                await denyRead({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/${TestObjects.ATeam.hashid}/u/${TestObjects.alice.hashid}/s/+/mcp/clients`
+                })
+            })
+            it('denies fe-team from subscribing to another user mcp events', async function () {
+                await denyRead({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/${TestObjects.ATeam.hashid}/u/${bob.hashid}/s/session-1234567890/mcp/clients`
+                })
+            })
+            it('denies fe-team from subscribing to mcp events on another team', async function () {
+                await denyRead({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/${otherTeam.hashid}/u/${TestObjects.alice.hashid}/s/session-1234567890/mcp/clients`
+                })
+            })
+            it('denies fe-team from publishing mcp events, they come from the platform', async function () {
+                await denyWrite({
+                    username: teamFrontendUsername,
+                    topic: `ff/v1/${TestObjects.ATeam.hashid}/u/${TestObjects.alice.hashid}/s/session-1234567890/mcp/clients`
+                })
+            })
+            it('allows forge_platform to publish an mcp event to a tab', async function () {
+                await allowWrite({
+                    username: 'forge_platform',
+                    topic: `ff/v1/${TestObjects.ATeam.hashid}/u/${TestObjects.alice.hashid}/s/session-1234567890/mcp/clients`
+                })
+            })
         })
 
         describe('MCP In-flight (fe-team)', async function () {

--- a/test/unit/forge/comms/browserSessionLifecycle_spec.js
+++ b/test/unit/forge/comms/browserSessionLifecycle_spec.js
@@ -1,4 +1,4 @@
-const should = require('should') // eslint-disable-line
+const should = require('should')
 
 const setup = require('../routes/setup')
 
@@ -373,6 +373,81 @@ describe('BrowserSessionLifecycleHandler', function () {
         it('returns empty array for unknown user', async function () {
             const sessions = await handler.getSessionsByUser('nonexistent')
             sessions.should.have.length(0)
+        })
+    })
+    describe('teamId propagation', function () {
+        it('carries the teamId from the event onto the tab snapshot', async function () {
+            client.emit('browser-session', {
+                teamId: 'team-abc',
+                userId: 'team-user',
+                sessionId: 'team-session',
+                event: 'heartbeat',
+                payload: { visibility: 'visible' }
+            })
+            await new Promise(resolve => setImmediate(resolve))
+
+            const sessions = await handler.getSessionsByUser('team-user')
+            const session = sessions.find(s => s.sessionId === 'team-session')
+            session.should.have.property('teamId', 'team-abc')
+        })
+
+        it('stores a null teamId rather than failing when the event has none', async function () {
+            client.emit('browser-session', {
+                userId: 'noteam-user',
+                sessionId: 'noteam-session',
+                event: 'heartbeat',
+                payload: {}
+            })
+            await new Promise(resolve => setImmediate(resolve))
+
+            const sessions = await handler.getSessionsByUser('noteam-user')
+            const session = sessions.find(s => s.sessionId === 'noteam-session')
+            should(session).be.an.Object()
+            should(session.teamId).be.null()
+        })
+    })
+
+    describe('notifyMcp', function () {
+        let published
+        let notifier
+
+        beforeEach(function () {
+            published = []
+            const publishingClient = mockClient()
+            publishingClient.publish = (topic, payload, options) => {
+                published.push({ topic, payload, options })
+            }
+            notifier = BrowserSessionLifecycleHandler(app, publishingClient)
+        })
+
+        it('publishes to the tab own session topic', function () {
+            notifier.notifyMcp('team-1', 'user-1', 'session-1', 'clients', { count: 2 })
+
+            published.should.have.length(1)
+            published[0].topic.should.equal('ff/v1/team-1/u/user-1/s/session-1/mcp/clients')
+            JSON.parse(published[0].payload).should.deepEqual({ count: 2 })
+        })
+
+        it('publishes at qos 1 and does not retain', function () {
+            notifier.notifyMcp('team-1', 'user-1', 'session-1', 'clients', {})
+
+            published[0].options.should.have.property('qos', 1)
+            published[0].options.should.have.property('retain', false)
+        })
+
+        it('defaults to an empty payload', function () {
+            notifier.notifyMcp('team-1', 'user-1', 'session-1', 'clients')
+
+            JSON.parse(published[0].payload).should.deepEqual({})
+        })
+
+        it('publishes nothing when any part of the address is missing', function () {
+            notifier.notifyMcp(null, 'user-1', 'session-1', 'clients', {})
+            notifier.notifyMcp('team-1', null, 'session-1', 'clients', {})
+            notifier.notifyMcp('team-1', 'user-1', null, 'clients', {})
+            notifier.notifyMcp('team-1', 'user-1', 'session-1', null, {})
+
+            published.should.have.length(0)
         })
     })
 })

--- a/test/unit/forge/db/controllers/BrowserSession_spec.js
+++ b/test/unit/forge/db/controllers/BrowserSession_spec.js
@@ -181,4 +181,126 @@ describe('BrowserSession controller', function () {
             ;(await controller.getActiveMcpSessions('u40', 'tab-1')).should.deepEqual(['mcp-1'])
         })
     })
+    describe('client notifications', function () {
+        let originalComms
+        let sent
+
+        beforeEach(function () {
+            sent = []
+            originalComms = app.comms
+            app.comms = {
+                browserSession: {
+                    notifyMcp: (teamId, userId, sessionId, event, payload) => {
+                        sent.push({ teamId, userId, sessionId, event, payload })
+                    }
+                }
+            }
+        })
+
+        afterEach(function () {
+            app.comms = originalComms
+        })
+
+        it('records the teamId a tab lives under, so it can be published back to', async function () {
+            await controller.recordPresence('n1', 'tab-1', { visibility: 'visible' }, 'team-1')
+
+            const entry = await app.caches.getCache('browserSessions').get('n1:tab-1')
+            entry.should.have.property('teamId', 'team-1')
+        })
+
+        it('tells a tab its pinned clients on every heartbeat', async function () {
+            await controller.recordPresence('n2', 'tab-1', {}, 'team-1')
+            await controller.setActiveBrowserSession('n2', 'mcp-1', 'tab-1')
+            sent = []
+
+            await controller.recordPresence('n2', 'tab-1', {}, 'team-1')
+
+            sent.should.have.length(1)
+            sent[0].should.have.property('teamId', 'team-1')
+            sent[0].should.have.property('sessionId', 'tab-1')
+            sent[0].should.have.property('event', 'clients')
+            sent[0].payload.should.have.property('count', 1)
+        })
+
+        it('reports an empty set rather than staying silent when nothing is pinned', async function () {
+            await controller.recordPresence('n3', 'tab-1', {}, 'team-1')
+
+            sent.should.have.length(1)
+            sent[0].payload.should.have.property('count', 0)
+            sent[0].payload.clients.should.deepEqual([])
+        })
+
+        it('sends opaque refs, never the MCP session ids themselves', async function () {
+            await controller.recordPresence('n4', 'tab-1', {}, 'team-1')
+            await controller.setActiveBrowserSession('n4', 'super-secret-mcp-session', 'tab-1')
+
+            const payload = sent[sent.length - 1].payload
+            payload.clients.should.have.length(1)
+            payload.clients[0].should.not.equal('super-secret-mcp-session')
+            payload.clients[0].should.match(/^[a-f0-9]{12}$/)
+            JSON.stringify(payload).should.not.match(/super-secret-mcp-session/)
+        })
+
+        it('gives the same client the same ref every time, so arrivals can be told apart', async function () {
+            await controller.recordPresence('n5', 'tab-1', {}, 'team-1')
+            await controller.setActiveBrowserSession('n5', 'mcp-1', 'tab-1')
+            const first = sent[sent.length - 1].payload.clients[0]
+
+            await controller.recordPresence('n5', 'tab-1', {}, 'team-1')
+            const second = sent[sent.length - 1].payload.clients[0]
+
+            second.should.equal(first)
+        })
+
+        it('tells both tabs when a pin moves, so one count rises as the other falls', async function () {
+            await controller.recordPresence('n6', 'tab-1', {}, 'team-1')
+            await controller.recordPresence('n6', 'tab-2', {}, 'team-1')
+            await controller.setActiveBrowserSession('n6', 'mcp-1', 'tab-1')
+            sent = []
+
+            await controller.setActiveBrowserSession('n6', 'mcp-1', 'tab-2')
+
+            const byTab = Object.fromEntries(sent.map(m => [m.sessionId, m.payload.count]))
+            byTab.should.have.property('tab-2', 1)
+            byTab.should.have.property('tab-1', 0)
+        })
+
+        it('stays quiet for a tab whose snapshot predates teamId being recorded', async function () {
+            await controller.recordPresence('n7', 'tab-1', {})
+            sent = []
+
+            await controller.setActiveBrowserSession('n7', 'mcp-1', 'tab-1')
+
+            sent.should.have.length(0)
+        })
+
+        it('still pins when the platform has no comms configured', async function () {
+            app.comms = undefined
+            await controller.recordPresence('n8', 'tab-1', {}, 'team-1')
+
+            await controller.setActiveBrowserSession('n8', 'mcp-1', 'tab-1')
+
+            ;(await controller.getActiveMcpSessions('n8', 'tab-1')).should.deepEqual(['mcp-1'])
+        })
+
+        it('does not fail the pin when the notification throws', async function () {
+            await controller.recordPresence('n9', 'tab-1', {}, 'team-1')
+            app.comms.browserSession.notifyMcp = () => { throw new Error('broker down') }
+
+            await controller.setActiveBrowserSession('n9', 'mcp-1', 'tab-1')
+
+            // the pin is what matters - an agent told this failed would retry one that worked
+            ;(await controller.getActiveMcpSessions('n9', 'tab-1')).should.deepEqual(['mcp-1'])
+            ;(await controller.getActiveBrowserSession('n9', 'mcp-1')).should.have.property('sessionId', 'tab-1')
+        })
+
+        it('does not fail a heartbeat when the notification throws', async function () {
+            app.comms.browserSession.notifyMcp = () => { throw new Error('broker down') }
+
+            await controller.recordPresence('n10', 'tab-1', { visibility: 'visible' }, 'team-1')
+
+            const entry = await app.caches.getCache('browserSessions').get('n10:tab-1')
+            entry.should.have.property('sessionId', 'tab-1')
+        })
+    })
 })

--- a/test/unit/frontend/stores/product-mcp.spec.js
+++ b/test/unit/frontend/stores/product-mcp.spec.js
@@ -1,0 +1,279 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const startTabPresence = vi.fn()
+const stopTabPresence = vi.fn()
+const startMcpInflight = vi.fn()
+const stopMcpInflight = vi.fn()
+const startMcpSession = vi.fn()
+const stopMcpSession = vi.fn()
+const emit = vi.fn()
+
+vi.mock('@/publishers/tab-presence.publisher', () => ({
+    startTabPresence: (...args) => startTabPresence(...args),
+    stopTabPresence: (...args) => stopTabPresence(...args),
+    announceTabPresence: vi.fn()
+}))
+
+vi.mock('@/subscribers/mcp-inflight.subscriber', () => ({
+    startMcpInflight: (...args) => startMcpInflight(...args),
+    stopMcpInflight: (...args) => stopMcpInflight(...args)
+}))
+
+vi.mock('@/subscribers/mcp-session.subscriber', () => ({
+    startMcpSession: (...args) => startMcpSession(...args),
+    stopMcpSession: (...args) => stopMcpSession(...args)
+}))
+
+vi.mock('@/services/alerts.js', () => ({
+    default: { emit: (...args) => emit(...args) }
+}))
+
+// imported after mocks so vi.mock hoisting resolves correctly
+const { useProductMcpStore } = await import('@/stores/product-mcp.js')
+
+const TEAM = { id: 'team-1' }
+
+describe('product-mcp store', () => {
+    let store
+
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        vi.clearAllMocks()
+        store = useProductMcpStore()
+    })
+
+    describe('status', () => {
+        it('is off until the user exposes the tab', () => {
+            expect(store.status).toBe('off')
+        })
+
+        it('is waiting once exposed with nothing targeting it', () => {
+            store.enable(TEAM)
+            expect(store.status).toBe('waiting')
+        })
+
+        it('is connected once something targets it', () => {
+            store.enable(TEAM)
+            store.setClients(['a'])
+            expect(store.status).toBe('connected')
+        })
+
+        it('reports how many clients are targeting the tab', () => {
+            store.enable(TEAM)
+            store.setClients(['a', 'b', 'c'])
+            expect(store.clientCount).toBe(3)
+        })
+
+        it('outranks connected with interrupted, since nothing is confirming the count', () => {
+            store.enable(TEAM)
+            store.setClients(['a'])
+            store.markInterrupted()
+            expect(store.status).toBe('interrupted')
+        })
+
+        it('stays off when interrupted but never exposed', () => {
+            store.markInterrupted()
+            expect(store.status).toBe('off')
+        })
+    })
+
+    describe('enable', () => {
+        it('brings up all three comms', () => {
+            store.enable(TEAM)
+            expect(startTabPresence).toHaveBeenCalledWith(TEAM)
+            expect(startMcpInflight).toHaveBeenCalledWith(TEAM)
+            expect(startMcpSession).toHaveBeenCalledWith(TEAM)
+        })
+
+        it('does nothing without a team', () => {
+            store.enable(null)
+            expect(startTabPresence).not.toHaveBeenCalled()
+            expect(store.active).toBe(false)
+        })
+
+        it('starts from a clean slate, since a reload cannot know what held the tab', () => {
+            store.clients = ['stale']
+            store.interrupted = true
+            store.synced = true
+
+            store.enable(TEAM)
+
+            expect(store.clients).toEqual([])
+            expect(store.interrupted).toBe(false)
+            expect(store.synced).toBe(false)
+        })
+    })
+
+    describe('disable', () => {
+        it('tears the comms down and tells the platform this tab opted out', async () => {
+            store.enable(TEAM)
+            const closed = await store.disable()
+
+            expect(closed).toBe(true)
+            expect(store.active).toBe(false)
+            expect(stopMcpSession).toHaveBeenCalled()
+            expect(stopMcpInflight).toHaveBeenCalled()
+            expect(stopTabPresence).toHaveBeenCalledWith({ announceClose: true })
+        })
+
+        it('reports false on the second call, so one opt-out is announced once', async () => {
+            store.enable(TEAM)
+            const [first, second] = await Promise.all([store.disable(), store.disable()])
+            expect([first, second].filter(Boolean)).toHaveLength(1)
+        })
+    })
+
+    describe('teardown', () => {
+        it('drops the comms silently, leaving the tab exposed for a remount', async () => {
+            store.enable(TEAM)
+            await store.teardown()
+
+            expect(store.active).toBe(true)
+            expect(stopTabPresence).toHaveBeenCalledWith({ announceClose: false })
+        })
+    })
+
+    describe('mount refcount', () => {
+        it('starts the comms only on the first toggle', () => {
+            store.active = true
+            store.retain(TEAM)
+            store.retain(TEAM)
+
+            expect(startTabPresence).toHaveBeenCalledTimes(1)
+            expect(store.mounts).toBe(2)
+        })
+
+        it('keeps the comms up while a second toggle is still mounted', async () => {
+            store.active = true
+            store.retain(TEAM)
+            store.retain(TEAM)
+            vi.clearAllMocks()
+
+            await store.release()
+
+            expect(store.mounts).toBe(1)
+            expect(stopTabPresence).not.toHaveBeenCalled()
+        })
+
+        it('tears down once the last toggle leaves', async () => {
+            store.active = true
+            store.retain(TEAM)
+            store.retain(TEAM)
+            await store.release()
+            await store.release()
+
+            expect(store.mounts).toBe(0)
+            expect(stopTabPresence).toHaveBeenCalledWith({ announceClose: false })
+        })
+
+        it('does not start the comms for a tab that was never exposed', () => {
+            store.retain(TEAM)
+            expect(startTabPresence).not.toHaveBeenCalled()
+        })
+
+        it('never counts below zero', async () => {
+            await store.release()
+            expect(store.mounts).toBe(0)
+        })
+    })
+
+    describe('setClients', () => {
+        beforeEach(() => {
+            store.enable(TEAM)
+        })
+
+        it('replaces rather than merges, so a lapsed pin drops off', () => {
+            store.setClients(['a', 'b'])
+            store.setClients(['b'])
+            expect(store.clients).toEqual(['b'])
+        })
+
+        it('treats a non-array as nothing targeting the tab', () => {
+            store.setClients(['a'])
+            store.setClients(undefined)
+            expect(store.clients).toEqual([])
+        })
+
+        it('says nothing on the first answer, which is catching up rather than an event', () => {
+            store.setClients(['a'])
+            expect(emit).not.toHaveBeenCalled()
+        })
+
+        it('announces an arrival', () => {
+            store.setClients([])
+            store.setClients(['a'])
+            expect(emit).toHaveBeenCalledWith('An MCP client is now targeting this tab.', 'confirmation')
+        })
+
+        it('announces a departure', () => {
+            store.setClients(['a'])
+            store.setClients([])
+            expect(emit).toHaveBeenCalledWith('An MCP client stopped targeting this tab.', 'info')
+        })
+
+        it('pluralises when several arrive at once', () => {
+            store.setClients([])
+            store.setClients(['a', 'b'])
+            expect(emit).toHaveBeenCalledWith('2 MCP clients are now targeting this tab.', 'confirmation')
+        })
+
+        it('reports a swap as both, since the count alone would not move', () => {
+            store.setClients(['a'])
+            emit.mockClear()
+
+            store.setClients(['b'])
+
+            expect(emit).toHaveBeenCalledWith('An MCP client is now targeting this tab.', 'confirmation')
+            expect(emit).toHaveBeenCalledWith('An MCP client stopped targeting this tab.', 'info')
+        })
+
+        it('says nothing when the set has not changed', () => {
+            store.setClients(['a'])
+            emit.mockClear()
+
+            store.setClients(['a'])
+
+            expect(emit).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('link health', () => {
+        beforeEach(() => {
+            store.enable(TEAM)
+        })
+
+        it('clears a fault when the link proves itself, even with no reconnect', () => {
+            store.markInterrupted()
+            store.markLinkHealthy()
+            expect(store.interrupted).toBe(false)
+        })
+
+        it('keeps the last known clients rather than flashing waiting on recovery', () => {
+            store.setClients(['a'])
+            store.markInterrupted()
+
+            store.markLinkHealthy()
+
+            expect(store.clients).toEqual(['a'])
+        })
+
+        it('resyncs, so the restated count is not announced as arrivals', () => {
+            store.setClients(['a'])
+            store.markInterrupted()
+            store.markLinkHealthy()
+            emit.mockClear()
+
+            store.setClients(['x', 'y'])
+
+            expect(emit).not.toHaveBeenCalled()
+        })
+
+        it('is a no-op when the link was never faulted, so a healthy heartbeat costs nothing', () => {
+            store.setClients(['a'])
+            store.markLinkHealthy()
+            expect(store.synced).toBe(true)
+            expect(store.clients).toEqual(['a'])
+        })
+    })
+})

--- a/test/unit/frontend/subscribers/mcp-session.subscriber.spec.js
+++ b/test/unit/frontend/subscribers/mcp-session.subscriber.spec.js
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const getTeamCommsCreds = vi.fn()
+const setClients = vi.fn()
+const announceTabPresence = vi.fn()
+
+const authStore = { user: { id: 'user-hashid-1' }, getSessionId: () => 'browser-session-1' }
+const mcpStore = { setClients }
+
+const useAccountAuthStore = vi.fn(() => authStore)
+const useProductMcpStore = vi.fn(() => mcpStore)
+
+vi.mock('@/api/team.js', () => ({
+    default: { getTeamCommsCreds: (...args) => getTeamCommsCreds(...args) }
+}))
+vi.mock('@/stores/account-auth.js', () => ({ useAccountAuthStore }))
+vi.mock('@/stores/product-mcp.js', () => ({ useProductMcpStore }))
+vi.mock('@/publishers/tab-presence.publisher', () => ({
+    announceTabPresence: (...args) => announceTabPresence(...args)
+}))
+vi.mock('@/services/app.orchestrator', () => ({ default: () => ({ $app: {}, $router: {}, $services: { mqtt: {} } }) }))
+
+function makeTransport () {
+    return {
+        attach: vi.fn().mockImplementation(async (key) => ({ key, id: 1 })),
+        subscribe: vi.fn().mockResolvedValue(undefined),
+        detach: vi.fn().mockResolvedValue(undefined)
+    }
+}
+
+const CLIENTS_TOPIC = 'ff/v1/team-1/u/user-hashid-1/s/browser-session-1/mcp/clients'
+
+describe('McpSessionSubscriber', async () => {
+    const mod = await import('../../../../frontend/src/subscribers/mcp-session.subscriber.ts')
+    const { createMcpSessionSubscriber, destroyMcpSessionSubscriber } = mod
+
+    async function connected () {
+        const transport = makeTransport()
+        const subscriber = createMcpSessionSubscriber({ app: {}, router: { push: vi.fn() }, transport })
+        await subscriber.connect({ id: 'team-1' })
+        // the transport invokes onConnect once the client is up
+        await transport.attach.mock.calls[0][1].onConnect()
+        return { subscriber, transport }
+    }
+
+    function deliver (transport, topic, payload) {
+        const { onMessage } = transport.attach.mock.calls[0][1]
+        return onMessage(topic, JSON.stringify(payload))
+    }
+
+    beforeEach(async () => {
+        getTeamCommsCreds.mockReset()
+        setClients.mockReset()
+        announceTabPresence.mockReset()
+        await destroyMcpSessionSubscriber()
+    })
+
+    afterEach(async () => {
+        await destroyMcpSessionSubscriber()
+    })
+
+    describe('subscription', () => {
+        test('rides the team connection', async () => {
+            const { transport } = await connected()
+            expect(transport.attach.mock.calls[0][0]).toBe('team:team-1')
+            expect(transport.subscribe.mock.calls[0][0]).toBe('team:team-1')
+        })
+
+        test('names the event rather than wildcarding it, so the ACL can be exact', async () => {
+            const { transport } = await connected()
+            const [, topics] = transport.subscribe.mock.calls[0]
+            expect(topics).toEqual([CLIENTS_TOPIC])
+            expect(topics[0]).not.toContain('+')
+        })
+
+        test('asks for a fresh heartbeat once subscribed, so no answer is missed', async () => {
+            await connected()
+            expect(announceTabPresence).toHaveBeenCalled()
+        })
+
+        test('detaches on destroy', async () => {
+            const { transport } = await connected()
+            await destroyMcpSessionSubscriber()
+            expect(transport.detach).toHaveBeenCalledWith(expect.objectContaining({ key: 'team:team-1' }))
+        })
+    })
+
+    describe('clients events', () => {
+        test('passes the reported set to the store', async () => {
+            const { transport } = await connected()
+            deliver(transport, CLIENTS_TOPIC, { count: 2, clients: ['aaa', 'bbb'] })
+            expect(setClients).toHaveBeenCalledWith(['aaa', 'bbb'])
+        })
+
+        test('treats an empty set as nothing targeting the tab', async () => {
+            const { transport } = await connected()
+            deliver(transport, CLIENTS_TOPIC, { count: 0, clients: [] })
+            expect(setClients).toHaveBeenCalledWith([])
+        })
+
+        test('reports nothing rather than throwing when the field is missing', async () => {
+            const { transport } = await connected()
+            deliver(transport, CLIENTS_TOPIC, { count: 3 })
+            expect(setClients).toHaveBeenCalledWith([])
+        })
+
+        test('reports nothing when the field is not an array', async () => {
+            const { transport } = await connected()
+            deliver(transport, CLIENTS_TOPIC, { clients: 'aaa' })
+            expect(setClients).toHaveBeenCalledWith([])
+        })
+
+        test('drops entries that are not strings', async () => {
+            const { transport } = await connected()
+            deliver(transport, CLIENTS_TOPIC, { clients: ['aaa', 42, null, 'bbb'] })
+            expect(setClients).toHaveBeenCalledWith(['aaa', 'bbb'])
+        })
+
+        test('survives a malformed body', async () => {
+            const { transport } = await connected()
+            const { onMessage } = transport.attach.mock.calls[0][1]
+            expect(() => onMessage(CLIENTS_TOPIC, 'not json')).not.toThrow()
+            expect(setClients).toHaveBeenCalledWith([])
+        })
+
+        test('ignores an event addressed to another tab', async () => {
+            const { transport } = await connected()
+            deliver(transport, 'ff/v1/team-1/u/user-hashid-1/s/another-tab/mcp/clients', { clients: ['aaa'] })
+            expect(setClients).not.toHaveBeenCalled()
+        })
+
+        test('ignores an event addressed to another user', async () => {
+            const { transport } = await connected()
+            deliver(transport, 'ff/v1/team-1/u/someone-else/s/browser-session-1/mcp/clients', { clients: ['aaa'] })
+            expect(setClients).not.toHaveBeenCalled()
+        })
+
+        test('ignores an unrelated mcp event', async () => {
+            const { transport } = await connected()
+            deliver(transport, 'ff/v1/team-1/u/user-hashid-1/s/browser-session-1/mcp/something', { clients: ['aaa'] })
+            expect(setClients).not.toHaveBeenCalled()
+        })
+    })
+})


### PR DESCRIPTION
## Description

The MCP toggle now shows whether something is actually driving the tab, not just whether the tab is exposed.

Exposed and targeted are two different things, so the store tracks them separately. Targeting isn't exclusive, so it's a set rather than a flag and the button shows a count when more than one client holds the tab. The tab never works that count out itself: a pin can end by just expiring, which produces no event, so the platform restates the full set
on every heartbeat and pin change.

**Backend**: pins are stored both ways round so we can ask who holds a tab, and there's a new per-session topic (`.../mcp/clients`) for the platform to answer on, with the ACL pinning the session segment to the subscriber's own credential. MCP session ids are hashed to opaque refs before they reach the browser. Cache drivers gained `scan`, with glob matching shared so memory and redis agree.

**Frontend**: new subscriber for that topic, and four button states instead of two (off, waiting, connected, interrupted). Interrupted outranks the rest since nothing is confirming the others while we can't hear the platform. Toggle mounts are counted now, because the header renders two and the first to unmount was tearing down comms the other still showed as live.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/8286

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

