### PR TITLE
feat(mcp): gate third-party MCP tool calls on the per-team AI feature

### DIFF
--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -91,6 +91,23 @@ module.exports = fp(async function (app, opts) {
             throw new Error(`Unrecognised scope requested: '${scope}'`)
         }
         return async (request, reply) => {
+            // Third-party MCP callers may only act on teams with the AI feature
+            // enabled. The team comes from whatever the route already resolved
+            // (directly, or via an application, instance, or device), never from
+            // the tool arguments; a request with no team context is not gated.
+            if (requestContext.get('sourceContext')?.source === 'mcp') {
+                const loadedTeam = request.team || request.application?.Team || request.project?.Team || request.device?.Team
+                const teamId = loadedTeam?.id ?? request.teamMembership?.TeamId
+                if (teamId !== undefined && teamId !== null) {
+                    // getFeatureProperty falls back to the team type, so ensure the
+                    // type is loaded, re-fetching only when it isn't already.
+                    const team = loadedTeam?.TeamType ? loadedTeam : await app.db.models.Team.byId(teamId)
+                    if (team && !team.getFeatureProperty('ai', true)) {
+                        reply.code(403).send({ code: 'unauthorized', error: 'AI features are disabled for this team' })
+                        throw new Error()
+                    }
+                }
+            }
             if (!request.session.scope && request.session.User && request.session.User.admin) {
                 // Admins get to have all the fun - as long as they are logged in and not
                 // using an access-token which has a reduced scope.

--- a/test/unit/forge/ee/routes/mcp/teamAiGate_spec.js
+++ b/test/unit/forge/ee/routes/mcp/teamAiGate_spec.js
@@ -1,0 +1,96 @@
+require('should')
+
+const setup = require('../../setup')
+
+const LICENSE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImZkNDFmNmRjLTBmM2QtNGFmNy1hNzk0LWIyNWFhNGJmYTliZCIsInZlciI6IjIwMjQtMDMtMDQiLCJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGdXNlIERldmVsb3BtZW50IiwibmJmIjoxNzMwNjc4NDAwLCJleHAiOjIwNzc3NDcyMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxMCwidGVhbXMiOjEwLCJpbnN0YW5jZXMiOjEwLCJtcXR0Q2xpZW50cyI6NiwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTczMDcyMTEyNH0.02KMRf5kogkpH3HXHVSGprUm0QQFLn21-3QIORhxFgRE9N5DIE8YnTH_f8W_21T6TlYbDUmf4PtWyj120HTM2w'
+
+// The third-party MCP door forwards the caller's raw PAT and Forge enforces the
+// PAT's own team scopes; the AI gate rides alongside that enforcement in
+// needsPermission. These tests drive real team-scoped routes with a Bearer PAT
+// and the source nonce the tool-exec layer stamps, so the source context reads
+// as a third-party MCP call and the gate on the resolved team is exercised.
+describe('MCP third-party per-team AI gate', function () {
+    let app
+    const TestObjects = {}
+
+    before(async function () {
+        app = await setup({
+            license: LICENSE,
+            ai: { enabled: true },
+            expert: { enabled: true }
+        })
+        // An all-teams PAT: no team scopes, so Forge grants every team the user
+        // belongs to. This is the case the door could not itself narrow.
+        TestObjects.pat = await app.db.controllers.AccessToken.createPersonalAccessToken(app.user, '', null, 'ai-gate-pat')
+        // An application in the same team, to exercise a route that resolves the
+        // team via the application rather than setting request.team directly.
+        TestObjects.application = await app.factory.createApplication({ name: 'AI Gate App' }, app.team)
+    })
+
+    after(async function () {
+        await app.close()
+    })
+
+    async function setTeamAi (enabled) {
+        const properties = { ...(app.team.properties || {}) }
+        properties.features = { ...(properties.features || {}), ai: enabled }
+        app.team.properties = properties
+        await app.team.save()
+    }
+
+    // Fresh nonce per call: nonces are single-use. Omit source to send a plain
+    // PAT request, which the auth layer classifies as source 'api'.
+    function mcpHeaders (source) {
+        const headers = { authorization: `Bearer ${TestObjects.pat.token}` }
+        if (source) {
+            headers['x-ff-source-nonce'] = app.nonceStore.createSourceNonce({ source, toolName: 'test-tool' })
+        }
+        return headers
+    }
+
+    function listTeamDevices (source) {
+        return app.inject({ method: 'GET', url: `/api/v1/teams/${app.team.hashid}/devices`, headers: mcpHeaders(source) })
+    }
+
+    function listApplicationDevices (source) {
+        return app.inject({ method: 'GET', url: `/api/v1/applications/${TestObjects.application.hashid}/devices`, headers: mcpHeaders(source) })
+    }
+
+    it('blocks a third-party MCP call to a team with AI disabled', async function () {
+        await setTeamAi(false)
+        const response = await listTeamDevices('mcp')
+        response.statusCode.should.equal(403)
+        response.json().should.have.property('code', 'unauthorized')
+        response.json().should.have.property('error', 'AI features are disabled for this team')
+    })
+
+    it('allows a third-party MCP call to a team with AI enabled', async function () {
+        await setTeamAi(true)
+        const response = await listTeamDevices('mcp')
+        response.statusCode.should.equal(200)
+    })
+
+    it('does not gate a normal API PAT call to a team with AI disabled', async function () {
+        await setTeamAi(false)
+        const response = await listTeamDevices()
+        response.statusCode.should.equal(200)
+    })
+
+    it('does not gate a first-party Expert call to a team with AI disabled', async function () {
+        await setTeamAi(false)
+        const response = await listTeamDevices('mcp:expert')
+        response.statusCode.should.equal(200)
+    })
+
+    it('blocks a third-party MCP call whose team is resolved via an application, not a team id', async function () {
+        await setTeamAi(false)
+        const response = await listApplicationDevices('mcp')
+        response.statusCode.should.equal(403)
+    })
+
+    it('allows the same application-scoped call once AI is enabled', async function () {
+        await setTeamAi(true)
+        const response = await listApplicationDevices('mcp')
+        response.statusCode.should.equal(200)
+    })
+})


### PR DESCRIPTION
## Summary

Third-party MCP tool calls now require the target team to have the AI feature enabled, not just the platform-level AI flag. A team that has opted out of AI is no longer reachable through the third-party MCP surface.

- The check runs in `needsPermission`, alongside the existing personal access token team-scope enforcement, so it applies to every team-scoped tool.
- It reads the team the route has already resolved (directly, or via an application, instance, or device), never the tool arguments, so a tool that takes an application, instance, or device id is covered the same way as one that takes a team id.
- Only third-party MCP requests are affected. The platform REST API, the UI, and the first-party paths are unchanged.
- A blocked call returns 403 with a clear message: `AI features are disabled for this team`.

## Testing

- New unit tests drive real team-scoped routes with a personal access token and the third-party MCP source context, covering a blocked team, an allowed team, an application-scoped call whose team is resolved without a team id, and the unaffected REST API and first-party paths.
