### PR TITLE
Revert stray type column in AuthClients migration

### DIFF
--- a/forge/db/migrations/20260824-01-add-mcp-authclient-fields.js
+++ b/forge/db/migrations/20260824-01-add-mcp-authclient-fields.js
@@ -7,7 +7,6 @@
  * ownerType='mcp' and add a display name and the redirect URIs approved at
  * registration.
  *
- *   type          - 'mcp' for dynamically registered MCP clients, null otherwise
  *   name          - the client_name supplied at registration
  *   redirectURIs  - JSON array of redirect URIs the client may use
  */
@@ -16,11 +15,6 @@ const { DataTypes } = require('sequelize')
 
 module.exports = {
     up: async (context) => {
-        await context.addColumn('AuthClients', 'type', {
-            type: DataTypes.STRING,
-            allowNull: true,
-            defaultValue: null
-        })
         await context.addColumn('AuthClients', 'name', {
             type: DataTypes.STRING,
             allowNull: true,


### PR DESCRIPTION
## Description

A `type` column was added to the already-applied `20260824` AuthClients migration during a merge conflict resolution in #8283. It is not part of the AuthClient model and is not read anywhere (MCP clients are identified by `ownerType`). This restores the migration to its released form so the change is not shipped.