### PR TITLE
Fix README logo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-<div align="center"> <a href="https://flowfuse.com/">
-    <img
-      src="https://github.com/FlowFuse/website/blob/main/src/handbook/images/logos/ff-logo--wordmark--light.png"
-      width="300"
-      height="auto"
-    />
+<div align="center">
+  <a href="https://flowfuse.com/">
+    <img src="frontend/public/ff-logo--wordmark--light.svg" width="300" alt="FlowFuse" />
   </a>
 </div>
 


### PR DESCRIPTION
## Description

Nuxt migration nuked the file path for the logo - using a local copy of the image instead. 

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

