### PR TITLE
fix(auth): enforce PAT team scope on user-scoped list routes

### DIFF
--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -41,6 +41,10 @@ module.exports = async function (app) {
         if (app.license.active() && app.billing && app.db.controllers.Subscription.freeTrialCreditEnabled()) {
             response.free_trial_available = await app.db.controllers.Subscription.userEligibleForFreeTrialCredit(user)
         }
+        const allowTeam = app.patTeamScopeFilter(request)
+        if (allowTeam && response.defaultTeam && !allowTeam(response.defaultTeam)) {
+            delete response.defaultTeam
+        }
 
         reply.send(response)
     })
@@ -128,7 +132,11 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const teams = await app.db.models.Team.forUser(request.session.User)
-        const result = await app.db.views.Team.userTeamList(teams)
+        let result = await app.db.views.Team.userTeamList(teams)
+        const allowTeam = app.patTeamScopeFilter(request)
+        if (allowTeam) {
+            result = result.filter(team => allowTeam(team.id))
+        }
         reply.send({
             meta: {}, // For future pagination
             count: result.length,

--- a/forge/routes/api/userInvitations.js
+++ b/forge/routes/api/userInvitations.js
@@ -31,7 +31,11 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const invitations = await app.db.models.Invitation.forUser(request.session.User)
-        const result = app.db.views.Invitation.invitationList(invitations)
+        let result = app.db.views.Invitation.invitationList(invitations)
+        const allowTeam = app.patTeamScopeFilter(request)
+        if (allowTeam) {
+            result = result.filter(invite => allowTeam(invite.team.id))
+        }
         reply.send({
             meta: {}, // For future pagination
             count: result.length,

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -32,6 +32,22 @@ function patAllowsWrite (pat, scope) {
 }
 
 /**
+ * Build a predicate that drops out-of-scope teams from user-scoped list
+ * responses, where there is no single team for the preHandler PAT check to
+ * gate on.
+ * @param {object} request - The Fastify request
+ * @returns {((teamHashId: string) => boolean)|null} a predicate returning true
+ *   for in-scope teams, or null when the caller is not a team-scoped PAT
+ */
+function patTeamScopeFilter (request) {
+    const pat = request.session.pat
+    if (!pat || !pat.teamScopes) {
+        return null
+    }
+    return (teamHashId) => patAllowsTeam(pat, teamHashId)
+}
+
+/**
  * Resolve the team hashid a request is acting on.
  *
  * PATs are team-scoped, but entity-addressed routes set the entity, not
@@ -237,4 +253,5 @@ module.exports = fp(async function (app, opts) {
 
     app.decorate('hasPermission', hasPermission)
     app.decorate('needsPermission', needsPermission)
+    app.decorate('patTeamScopeFilter', patTeamScopeFilter)
 }, { name: 'app.routes.auth.permissions' })

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -1447,6 +1447,95 @@ describe('User API', async function () {
                 response.statusCode.should.equal(403)
             })
 
+            it('team-scoped PAT sees only in-scope teams from /user/teams', async function () {
+                // bob belongs to ATeam and BTeam; scope the PAT to ATeam only
+                await login('bob', 'bbPassword')
+                const createResponse = await app.inject({
+                    method: 'POST',
+                    url: '/api/v1/user/tokens',
+                    cookies: { sid: TestObjects.tokens.bob },
+                    payload: { name: 'ATeam Only (teams)', scope: '', teamIds: [TestObjects.ATeam.hashid] }
+                })
+                createResponse.statusCode.should.equal(200)
+                const patToken = createResponse.json().token
+
+                const response = await app.inject({
+                    method: 'GET',
+                    url: '/api/v1/user/teams',
+                    headers: { authorization: `Bearer ${patToken}` }
+                })
+                response.statusCode.should.equal(200)
+                response.json().teams.map(team => team.id).should.deepEqual([TestObjects.ATeam.hashid])
+            })
+
+            it('team-scoped PAT drops out-of-scope invitations from /user/invitations', async function () {
+                // grace is a member of BTeam only; invite her to ATeam
+                await login('grace', 'ggPassword')
+                await app.db.controllers.Invitation.createInvitations(TestObjects.alice, TestObjects.ATeam, ['grace'])
+                const createResponse = await app.inject({
+                    method: 'POST',
+                    url: '/api/v1/user/tokens',
+                    cookies: { sid: TestObjects.tokens.grace },
+                    payload: { name: 'BTeam Only (invites)', scope: '', teamIds: [TestObjects.BTeam.hashid] }
+                })
+                createResponse.statusCode.should.equal(200)
+                const patToken = createResponse.json().token
+
+                // The cookie session sees the ATeam invite; the BTeam-scoped PAT does not
+                const cookieResponse = await app.inject({
+                    method: 'GET',
+                    url: '/api/v1/user/invitations',
+                    cookies: { sid: TestObjects.tokens.grace }
+                })
+                cookieResponse.json().invitations.should.have.length(1)
+
+                const response = await app.inject({
+                    method: 'GET',
+                    url: '/api/v1/user/invitations',
+                    headers: { authorization: `Bearer ${patToken}` }
+                })
+                response.statusCode.should.equal(200)
+                response.json().invitations.should.have.length(0)
+            })
+
+            it('team-scoped PAT hides an out-of-scope defaultTeam on /user', async function () {
+                await login('bob', 'bbPassword')
+                const originalDefault = TestObjects.bob.defaultTeamId
+                TestObjects.bob.defaultTeamId = TestObjects.BTeam.id
+                await TestObjects.bob.save()
+                try {
+                    const outOfScope = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/user/tokens',
+                        cookies: { sid: TestObjects.tokens.bob },
+                        payload: { name: 'ATeam Only (profile)', scope: '', teamIds: [TestObjects.ATeam.hashid] }
+                    })
+                    const outResponse = await app.inject({
+                        method: 'GET',
+                        url: '/api/v1/user',
+                        headers: { authorization: `Bearer ${outOfScope.json().token}` }
+                    })
+                    outResponse.statusCode.should.equal(200)
+                    outResponse.json().should.not.have.property('defaultTeam')
+
+                    const inScope = await app.inject({
+                        method: 'POST',
+                        url: '/api/v1/user/tokens',
+                        cookies: { sid: TestObjects.tokens.bob },
+                        payload: { name: 'BTeam Only (profile)', scope: '', teamIds: [TestObjects.BTeam.hashid] }
+                    })
+                    const inResponse = await app.inject({
+                        method: 'GET',
+                        url: '/api/v1/user',
+                        headers: { authorization: `Bearer ${inScope.json().token}` }
+                    })
+                    inResponse.json().should.have.property('defaultTeam', TestObjects.BTeam.hashid)
+                } finally {
+                    TestObjects.bob.defaultTeamId = originalDefault
+                    await TestObjects.bob.save()
+                }
+            })
+
             it('team-agnostic PAT (no teamScopes) can access any team the user belongs to', async function () {
                 await login('bob', 'bbPassword')
                 const createResponse = await app.inject({


### PR DESCRIPTION
## Summary

Team-scoped personal access tokens are enforced on team- and entity-addressed routes, but the user-scoped routes return data spanning every team the user belongs to, with no single team for the `needsPermission` check to gate on. A token scoped to one team could therefore read teams, invitations, and a default team outside its scope.

- `GET /user/teams` now returns only the teams in the token's scope.
- `GET /user/invitations` drops invitations to out-of-scope teams.
- `GET /user` omits `defaultTeam` when it is out of scope.
- A new `patTeamScopeFilter(request)` helper returns a predicate for the token's team scope, or null for callers that are not team-scoped PATs, so cookie sessions and all-teams tokens are unaffected.
- Out-of-scope entries are omitted rather than flagged, so a response never discloses the existence of a team the token cannot see.

## Testing

- New unit tests drive the routes with a team-scoped personal access token: only in-scope teams are returned from `/user/teams`, an out-of-scope invitation is dropped from `/user/invitations` (the cookie session still sees it), and an out-of-scope `defaultTeam` is omitted from `/user`.
- Validated live against a running instance with a token scoped to a single team (see the testing comment).
