### PR TITLE
Move MCP comms lifecycle out of the Expert button and into the orchestrator

### DIFF
--- a/frontend/src/components/ExpertButton.vue
+++ b/frontend/src/components/ExpertButton.vue
@@ -79,8 +79,13 @@ export default {
         }
     },
     watch: {
-        async team () {
+        async team (team, previousTeam) {
             if (!this.mcpActive) {
+                return
+            }
+            // The first team resolving is not a switch.
+            if (!previousTeam?.id) {
+                this.resumeMcp(team)
                 return
             }
             // Straight to the store action rather than stopMcp(), which announces the close
@@ -93,16 +98,11 @@ export default {
         }
     },
     mounted () {
-        // The flag survives a reload, the comms do not. Counted rather than per instance:
-        // the header mounts two, and only the last to leave should take the comms down.
-        this.retainMcp(this.team)
-    },
-    beforeUnmount () {
-        this.releaseMcp()
+        this.resumeMcp(this.team)
     },
     methods: {
         ...mapActions(useProductExpertStore, ['openAssistantDrawer']),
-        ...mapActions(useProductMcpStore, { enableMcp: 'enable', disableMcp: 'disable', retainMcp: 'retain', releaseMcp: 'release' }),
+        ...mapActions(useProductMcpStore, { enableMcp: 'enable', disableMcp: 'disable', resumeMcp: 'resume' }),
         onExpertClick () {
             this.openAssistantDrawer({ openPinned: this.rightDrawer.expertState.pinned })
         },

--- a/frontend/src/publishers/publisher.registry.ts
+++ b/frontend/src/publishers/publisher.registry.ts
@@ -1,1 +1,12 @@
-export default []
+import { createTabPresencePublisher } from './tab-presence.publisher'
+
+/**
+ * Publishers follow the same rule as subscribers: created once at boot, disposed with
+ * the app, never owned by a component.
+ *
+ * Tab presence is `autoConnect: false` because it announces this tab to MCP clients,
+ * which only happens once the user has asked for it.
+ */
+export default [
+    { key: 'tabPresence' as const, create: createTabPresencePublisher, requiredLifecycle: ['destroy'] as const, autoConnect: false }
+]

--- a/frontend/src/publishers/tab-presence.publisher.ts
+++ b/frontend/src/publishers/tab-presence.publisher.ts
@@ -1,13 +1,10 @@
 import { definePublisherSingleton } from './publisher.factory'
 import { TeamPublisher } from './team-publisher.contract'
 
-import getAppOrchestrator from '@/services/app.orchestrator'
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useContextStore } from '@/stores/context.js'
 import { useProductMcpStore } from '@/stores/product-mcp.js'
-import { createMqttTransport } from '@/transport/mqtt.transport'
 import type { CreatePublisherOptions } from '@/types/publishers/publisher.types'
-import type { TeamRef } from '@/types/subscribers/subscriber.types'
 import type { Transport } from '@/types/transport/transport.types'
 
 const HEARTBEAT_INTERVAL = 45_000
@@ -19,22 +16,9 @@ class TabPresencePublisher extends TeamPublisher {
     private $userId: string | null = null
     private $sessionId: string | null = null
     private $teamId: string | null = null
-    private $announceClose = true
 
     constructor (options: CreatePublisherOptions<Transport>) {
         super({ name: 'tabPresence', ...options })
-    }
-
-    /**
-     * Go quiet for this shutdown: skip the `close` notice on the way out.
-     *
-     * The platform reads `close` as the user opting this tab out and drops its session
-     * entry, so it must only be sent when that is what actually happened. A tab that is
-     * merely unmounting the toggle (a layout change, say) has to stay listed, and the
-     * entry it leaves behind is refreshed the moment the tab announces itself again.
-     */
-    silenceCloseNotice (): void {
-        this.$announceClose = false
     }
 
     /**
@@ -67,7 +51,6 @@ class TabPresencePublisher extends TeamPublisher {
         this.$userId = userId
         this.$sessionId = authStore.getSessionId()
         this.$teamId = teamId
-        this.$announceClose = true
 
         this._publishPresence()
 
@@ -111,7 +94,6 @@ class TabPresencePublisher extends TeamPublisher {
      * for a couple of minutes after the user opted out.
      */
     protected async _onStopping (): Promise<void> {
-        if (!this.$announceClose) return
         const topic = this._sessionTopic('close')
         if (!topic) return
         await this._publish(topic, {}).catch((err) => {
@@ -173,48 +155,6 @@ class TabPresencePublisher extends TeamPublisher {
 
 const { create: createTabPresencePublisher, destroy: destroyTabPresencePublisher } = definePublisherSingleton(TabPresencePublisher)
 
-// Tracked alongside the singleton so a caller can reach the live publisher to adjust how it
-// shuts down, which the factory's argument-less destroy() cannot express on its own.
-let activePublisher: TabPresencePublisher | null = null
+export { createTabPresencePublisher, destroyTabPresencePublisher }
 
-export function startTabPresence (team: TeamRef): TabPresencePublisher {
-    const orchestrator = getAppOrchestrator()
-    const transport = createMqttTransport(orchestrator.$services.mqtt)
-    const publisher = createTabPresencePublisher({
-        app: orchestrator.$app,
-        router: orchestrator.$router,
-        transport
-    })
-    activePublisher = publisher
-    // connect() resolves to an already-attached transport without starting the publisher
-    // again, so announce presence either way rather than assuming this call produced a
-    // heartbeat. Re-enabling over a live connection has to leave the tab listed.
-    publisher.connect(team)
-        .then(() => publisher.announcePresence())
-        .catch((err) => {
-            console.warn('Failed to start tab presence:', err)
-        })
-    return publisher
-}
-
-/**
- * Heartbeat now, if a publisher is live. For the session subscriber: the platform's answer
- * is not retained, so one sent before that subscription is up is dropped and the tab waits
- * out a whole interval. Re-announcing on subscribe closes that window.
- */
-export function announceTabPresence (): void {
-    activePublisher?.announcePresence()
-}
-
-/**
- * @param announceClose - whether to tell the platform this tab is opting out. Pass false when
- *   presence is only being dismantled (an unmounting toggle, say) and the tab should stay
- *   listed; the platform treats the notice as a deliberate opt-out and drops the tab's entry.
- */
-export async function stopTabPresence ({ announceClose = true } = {}): Promise<void> {
-    if (!announceClose) {
-        activePublisher?.silenceCloseNotice()
-    }
-    activePublisher = null
-    await destroyTabPresencePublisher()
-}
+export default createTabPresencePublisher

--- a/frontend/src/stores/account.js
+++ b/frontend/src/stores/account.js
@@ -9,11 +9,19 @@ import { useDataFarmApplicationsStore } from '@/stores/data-farm-applications'
 import { useDataFarmHostedInstancesStore } from '@/stores/data-farm-hosted-instances'
 import { useDataFarmTeamsStore } from '@/stores/data-farm-teams'
 import { useProductTablesStore } from '@/stores/product-tables.js'
+import SUBSCRIBER_REGISTRY from '@/subscribers/subscriber.registry'
+
+function isOptInSubscriber (key) {
+    return SUBSCRIBER_REGISTRY.some(subscriber => subscriber.key === key && subscriber.autoConnect === false)
+}
 
 function ensureTeamChannelConnected (team) {
     if (!team?.id) return
     const subscribers = getAppOrchestrator().$subscribers
-    Object.values(subscribers).forEach(subscriber => subscriber?.connect(team).catch(() => {}))
+    Object.entries(subscribers).forEach(([key, subscriber]) => {
+        if (isOptInSubscriber(key)) return
+        subscriber?.connect(team).catch(() => {})
+    })
 }
 
 function disconnectTeamSubscribers () {

--- a/frontend/src/stores/product-mcp.js
+++ b/frontend/src/stores/product-mcp.js
@@ -1,9 +1,21 @@
 import { defineStore } from 'pinia'
 
-import { startTabPresence, stopTabPresence } from '@/publishers/tab-presence.publisher'
 import alerts from '@/services/alerts.js'
-import { startMcpInflight, stopMcpInflight } from '@/subscribers/mcp-inflight.subscriber'
-import { startMcpSession, stopMcpSession } from '@/subscribers/mcp-session.subscriber'
+import getAppOrchestrator from '@/services/app.orchestrator'
+
+/**
+ * The three comms this store drives. They are created once by the orchestrator and live
+ * as long as the app does, so this only ever connects and disconnects them - it never
+ * creates or destroys one.
+ */
+function comms () {
+    const orchestrator = getAppOrchestrator()
+    return {
+        presence: orchestrator.$publishers.tabPresence,
+        inflight: orchestrator.$subscribers.mcpInflight,
+        session: orchestrator.$subscribers.mcpSession
+    }
+}
 
 /**
  * Whether this tab is exposed to third-party MCP agents, and the comms that go with it:
@@ -28,12 +40,6 @@ export const useProductMcpStore = defineStore('product-mcp', {
          * continuously. Outranks everything else: `clients` cannot be trusted while it holds.
          */
         interrupted: false,
-        /**
-         * Mounted toggles. The header renders two, and without this the first to unmount
-         * tears down comms the second is still showing as live. Lifecycle, not user intent,
-         * so it is kept apart from `active` and never persisted.
-         */
-        mounts: 0,
         /**
          * Whether the platform has answered yet. The first answer is catching up, not an
          * event, so it sets the count silently - otherwise every reload of a held tab
@@ -63,28 +69,16 @@ export const useProductMcpStore = defineStore('product-mcp', {
     actions: {
         enable (team) {
             if (!team) return
-            startTabPresence(team)
-            startMcpInflight(team)
-            startMcpSession(team)
             this.active = true
             // Exposing says nothing about who has taken it - the first heartbeat answers that
             this.clients = []
             this.synced = false
             this.interrupted = false
+            this._connect(team)
         },
-        /** A toggle mounted. Comms are singletons, so only the first one starts them. */
-        retain (team) {
-            this.mounts += 1
-            if (this.mounts === 1 && this.active && team) {
-                this.enable(team)
-            }
-        },
-        /** A toggle unmounted. Only the last one leaving takes the comms down. */
-        async release () {
-            this.mounts = Math.max(0, this.mounts - 1)
-            if (this.mounts === 0 && this.active) {
-                await this.teardown()
-            }
+        resume (team) {
+            if (!this.active || !team) return
+            this._connect(team)
         },
         async disable () {
             // Both toggles' watchers fire in the same tick. Clearing the flag before the first
@@ -96,26 +90,23 @@ export const useProductMcpStore = defineStore('product-mcp', {
             this.clients = []
             this.synced = false
             this.interrupted = false
-            await stopMcpSession()
-            await stopMcpInflight()
-            // A real opt-out: drop the session entry now rather than leaving it listed
-            await stopTabPresence({ announceClose: true })
+            const { presence, inflight, session } = comms()
+            await session?.disconnect()
+            await inflight?.disconnect()
+            await presence?.disconnect()
             return true
         },
-        /**
-         * Drops the comms but leaves the flag, so an unmounting button comes back exposed.
-         *
-         * Silent by design: the platform reads a close notice as opting out and deletes the
-         * session entry, un-listing a tab that is still open. A tab really going away is
-         * covered by its connection's last will.
-         */
-        async teardown () {
-            this.clients = []
-            this.synced = false
-            this.interrupted = false
-            await stopMcpSession()
-            await stopMcpInflight()
-            await stopTabPresence({ announceClose: false })
+        announcePresence () {
+            comms().presence?.announcePresence()
+        },
+        _connect (team) {
+            const { presence, inflight, session } = comms()
+            const warn = (err) => console.warn('Failed to bring up MCP comms:', err)
+            inflight?.connect(team).catch(warn)
+            session?.connect(team).catch(warn)
+            presence?.connect(team)
+                .then(() => presence.announcePresence())
+                .catch(warn)
         },
         markInterrupted () {
             this.interrupted = true

--- a/frontend/src/subscribers/mcp-inflight.subscriber.ts
+++ b/frontend/src/subscribers/mcp-inflight.subscriber.ts
@@ -2,11 +2,9 @@ import { defineSubscriberSingleton } from './subscriber.factory'
 import { SubscriberRoute, TeamSubscriber } from './team-subscriber.contract'
 
 import { useMqttExpertTopicHelper } from '@/composables/services/MqttExpertTopicHelper'
-import getAppOrchestrator from '@/services/app.orchestrator'
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useProductExpertStore } from '@/stores/product-expert.js'
-import { createMqttTransport } from '@/transport/mqtt.transport'
-import type { CreateSubscriberOptions, TeamRef, TeamSubscriberI } from '@/types/subscribers/subscriber.types'
+import type { CreateSubscriberOptions, TeamSubscriberI } from '@/types/subscribers/subscriber.types'
 import type { TransportMessagePacket, TransportSubscribeOptions } from '@/types/transport/transport.types'
 
 const INFLIGHT_CHANNEL = 'mcp'
@@ -92,22 +90,6 @@ class McpInflightSubscriber extends TeamSubscriber implements TeamSubscriberI {
 }
 
 const { create: createMcpInflightSubscriber, destroy: destroyMcpInflightSubscriber } = defineSubscriberSingleton(McpInflightSubscriber)
-
-export function startMcpInflight (team: TeamRef): McpInflightSubscriber {
-    const orchestrator = getAppOrchestrator()
-    const transport = createMqttTransport(orchestrator.$services.mqtt)
-    const subscriber = createMcpInflightSubscriber({
-        app: orchestrator.$app,
-        router: orchestrator.$router,
-        transport
-    })
-    subscriber.connect(team)
-    return subscriber
-}
-
-export async function stopMcpInflight (): Promise<void> {
-    await destroyMcpInflightSubscriber()
-}
 
 export { createMcpInflightSubscriber, destroyMcpInflightSubscriber }
 

--- a/frontend/src/subscribers/mcp-session.subscriber.ts
+++ b/frontend/src/subscribers/mcp-session.subscriber.ts
@@ -1,12 +1,9 @@
 import { defineSubscriberSingleton } from './subscriber.factory'
 import { SubscriberPayload, SubscriberRoute, TeamSubscriber } from './team-subscriber.contract'
 
-import { announceTabPresence } from '@/publishers/tab-presence.publisher'
-import getAppOrchestrator from '@/services/app.orchestrator'
 import { useAccountAuthStore } from '@/stores/account-auth.js'
 import { useProductMcpStore } from '@/stores/product-mcp.js'
-import { createMqttTransport } from '@/transport/mqtt.transport'
-import type { CreateSubscriberOptions, TeamRef, TeamSubscriberI } from '@/types/subscribers/subscriber.types'
+import type { CreateSubscriberOptions, TeamSubscriberI } from '@/types/subscribers/subscriber.types'
 
 const escapeForPattern = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
@@ -57,7 +54,7 @@ class McpSessionSubscriber extends TeamSubscriber implements TeamSubscriberI {
      * on subscribe closes that window, on first enable and on every reconnect.
      */
     protected _onSubscribed (): void {
-        announceTabPresence()
+        useProductMcpStore().announcePresence()
     }
 
     protected _routes (): SubscriberRoute[] {
@@ -88,22 +85,6 @@ class McpSessionSubscriber extends TeamSubscriber implements TeamSubscriberI {
 }
 
 const { create: createMcpSessionSubscriber, destroy: destroyMcpSessionSubscriber } = defineSubscriberSingleton(McpSessionSubscriber)
-
-export function startMcpSession (team: TeamRef): McpSessionSubscriber {
-    const orchestrator = getAppOrchestrator()
-    const transport = createMqttTransport(orchestrator.$services.mqtt)
-    const subscriber = createMcpSessionSubscriber({
-        app: orchestrator.$app,
-        router: orchestrator.$router,
-        transport
-    })
-    subscriber.connect(team)
-    return subscriber
-}
-
-export async function stopMcpSession (): Promise<void> {
-    await destroyMcpSessionSubscriber()
-}
 
 export { createMcpSessionSubscriber, destroyMcpSessionSubscriber }
 

--- a/frontend/src/subscribers/subscriber.registry.ts
+++ b/frontend/src/subscribers/subscriber.registry.ts
@@ -1,11 +1,26 @@
 import { createApplicationsSubscriber } from './applications.subscriber'
 import { createHostedInstancesSubscriber } from './hosted-instances.subscriber'
 import { createLiveStatusSubscriber } from './live-status.subscriber'
+import { createMcpInflightSubscriber } from './mcp-inflight.subscriber'
+import { createMcpSessionSubscriber } from './mcp-session.subscriber'
 import { createTeamChannelSubscriber } from './team-channel.subscriber'
 
+/**
+ * Every subscriber here is created once when the orchestrator boots and lives until the
+ * app is disposed. Nothing in the component tree owns one, so a component unmounting -
+ * a layout swap, say - cannot take a subscription down with it.
+ *
+ * `autoConnect` says whether a subscriber connects as soon as there is a team.
+ * `false` marks one the user opts into: it is created with the rest but stays
+ * disconnected until something asks for it, so a team load never quietly brings it up.
+ * See ensureTeamChannelConnected() in stores/account.js, which acts on this.
+ */
 export default [
-    { key: 'teamChannel' as const, create: createTeamChannelSubscriber, requiredLifecycle: ['destroy'] as const },
-    { key: 'liveStatus' as const, create: createLiveStatusSubscriber, requiredLifecycle: ['destroy'] as const },
-    { key: 'applications' as const, create: createApplicationsSubscriber, requiredLifecycle: ['destroy'] as const },
-    { key: 'hostedInstances' as const, create: createHostedInstancesSubscriber, requiredLifecycle: ['destroy'] as const }
+    { key: 'teamChannel' as const, create: createTeamChannelSubscriber, requiredLifecycle: ['destroy'] as const, autoConnect: true },
+    { key: 'liveStatus' as const, create: createLiveStatusSubscriber, requiredLifecycle: ['destroy'] as const, autoConnect: true },
+    { key: 'applications' as const, create: createApplicationsSubscriber, requiredLifecycle: ['destroy'] as const, autoConnect: true },
+    { key: 'hostedInstances' as const, create: createHostedInstancesSubscriber, requiredLifecycle: ['destroy'] as const, autoConnect: true },
+    // Exposing this tab to MCP clients is the user's call, never a side effect of loading a team
+    { key: 'mcpInflight' as const, create: createMcpInflightSubscriber, requiredLifecycle: ['destroy'] as const, autoConnect: false },
+    { key: 'mcpSession' as const, create: createMcpSessionSubscriber, requiredLifecycle: ['destroy'] as const, autoConnect: false }
 ]

--- a/frontend/src/types/publishers/publisher.types.ts
+++ b/frontend/src/types/publishers/publisher.types.ts
@@ -16,9 +16,16 @@ export interface TeamPublisherI extends Publisher {
     isConnected(): boolean
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface TabPresencePublisherI extends TeamPublisherI {
+    /**
+     * Publish a heartbeat now rather than waiting out the interval. Callers use it
+     * whenever something has just changed what the platform should know about this tab.
+     */
+    announcePresence(): void
+}
+
 export type PublisherInstances = {
-    // concrete publishers added here as needed
+    tabPresence: TabPresencePublisherI | null
 }
 
 export interface CreatePublisherOptions<TTransport extends Transport = Transport> {

--- a/frontend/src/types/subscribers/subscriber.types.ts
+++ b/frontend/src/types/subscribers/subscriber.types.ts
@@ -24,6 +24,8 @@ export type SubscriberInstances = {
     liveStatus: TeamSubscriberI | null
     applications: TeamSubscriberI | null
     hostedInstances: TeamSubscriberI | null
+    mcpInflight: TeamSubscriberI | null
+    mcpSession: TeamSubscriberI | null
 }
 
 export interface CreateSubscriberOptions<TTransport extends Transport = Transport> {

--- a/test/unit/frontend/services/app.orchestrator.spec.js
+++ b/test/unit/frontend/services/app.orchestrator.spec.js
@@ -172,7 +172,15 @@ describe('AppOrchestrator', () => {
             mqtt: null,
             automations: null
         })
-        expect(orchestrator.$subscribers).toEqual({ teamChannel: null, liveStatus: null, applications: null, hostedInstances: null })
+        expect(orchestrator.$subscribers).toEqual({
+            teamChannel: null,
+            liveStatus: null,
+            applications: null,
+            hostedInstances: null,
+            mcpInflight: null,
+            mcpSession: null
+        })
+        expect(orchestrator.$publishers).toEqual({ tabPresence: null })
         expect(orchestrator.$app).toBeNull()
         expect(orchestrator.$router).toBeNull()
         expect(orchestrator.$cleanupRegistered).toBe(false)

--- a/test/unit/frontend/stores/product-mcp.spec.js
+++ b/test/unit/frontend/stores/product-mcp.spec.js
@@ -1,29 +1,31 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const startTabPresence = vi.fn()
-const stopTabPresence = vi.fn()
-const startMcpInflight = vi.fn()
-const stopMcpInflight = vi.fn()
-const startMcpSession = vi.fn()
-const stopMcpSession = vi.fn()
 const emit = vi.fn()
 
-vi.mock('@/publishers/tab-presence.publisher', () => ({
-    startTabPresence: (...args) => startTabPresence(...args),
-    stopTabPresence: (...args) => stopTabPresence(...args),
-    announceTabPresence: vi.fn()
-}))
+// The comms are created by the orchestrator and outlive every component, so the store
+// only ever connects and disconnects them. These stand in for the live instances.
+const presence = {
+    connect: vi.fn(() => Promise.resolve()),
+    disconnect: vi.fn(() => Promise.resolve()),
+    announcePresence: vi.fn()
+}
+const inflight = {
+    connect: vi.fn(() => Promise.resolve()),
+    disconnect: vi.fn(() => Promise.resolve())
+}
+const session = {
+    connect: vi.fn(() => Promise.resolve()),
+    disconnect: vi.fn(() => Promise.resolve())
+}
 
-vi.mock('@/subscribers/mcp-inflight.subscriber', () => ({
-    startMcpInflight: (...args) => startMcpInflight(...args),
-    stopMcpInflight: (...args) => stopMcpInflight(...args)
-}))
-
-vi.mock('@/subscribers/mcp-session.subscriber', () => ({
-    startMcpSession: (...args) => startMcpSession(...args),
-    stopMcpSession: (...args) => stopMcpSession(...args)
-}))
+vi.mock('@/services/app.orchestrator', () => {
+    const orchestrator = () => ({
+        $publishers: { tabPresence: presence },
+        $subscribers: { mcpInflight: inflight, mcpSession: session }
+    })
+    return { default: orchestrator, getAppOrchestrator: orchestrator }
+})
 
 vi.mock('@/services/alerts.js', () => ({
     default: { emit: (...args) => emit(...args) }
@@ -81,14 +83,19 @@ describe('product-mcp store', () => {
     describe('enable', () => {
         it('brings up all three comms', () => {
             store.enable(TEAM)
-            expect(startTabPresence).toHaveBeenCalledWith(TEAM)
-            expect(startMcpInflight).toHaveBeenCalledWith(TEAM)
-            expect(startMcpSession).toHaveBeenCalledWith(TEAM)
+            expect(presence.connect).toHaveBeenCalledWith(TEAM)
+            expect(inflight.connect).toHaveBeenCalledWith(TEAM)
+            expect(session.connect).toHaveBeenCalledWith(TEAM)
+        })
+
+        it('announces presence rather than waiting out the interval', async () => {
+            store.enable(TEAM)
+            await vi.waitFor(() => expect(presence.announcePresence).toHaveBeenCalled())
         })
 
         it('does nothing without a team', () => {
             store.enable(null)
-            expect(startTabPresence).not.toHaveBeenCalled()
+            expect(presence.connect).not.toHaveBeenCalled()
             expect(store.active).toBe(false)
         })
 
@@ -112,9 +119,18 @@ describe('product-mcp store', () => {
 
             expect(closed).toBe(true)
             expect(store.active).toBe(false)
-            expect(stopMcpSession).toHaveBeenCalled()
-            expect(stopMcpInflight).toHaveBeenCalled()
-            expect(stopTabPresence).toHaveBeenCalledWith({ announceClose: true })
+            expect(session.disconnect).toHaveBeenCalled()
+            expect(inflight.disconnect).toHaveBeenCalled()
+            expect(presence.disconnect).toHaveBeenCalled()
+        })
+
+        it('leaves the comms in place to be reconnected, rather than destroying them', async () => {
+            store.enable(TEAM)
+            await store.disable()
+
+            store.enable(TEAM)
+
+            expect(presence.connect).toHaveBeenCalledTimes(2)
         })
 
         it('reports false on the second call, so one opt-out is announced once', async () => {
@@ -124,57 +140,34 @@ describe('product-mcp store', () => {
         })
     })
 
-    describe('teardown', () => {
-        it('drops the comms silently, leaving the tab exposed for a remount', async () => {
-            store.enable(TEAM)
-            await store.teardown()
-
-            expect(store.active).toBe(true)
-            expect(stopTabPresence).toHaveBeenCalledWith({ announceClose: false })
-        })
-    })
-
-    describe('mount refcount', () => {
-        it('starts the comms only on the first toggle', () => {
+    describe('resume', () => {
+        it('reconnects a tab whose exposure survived a reload', () => {
             store.active = true
-            store.retain(TEAM)
-            store.retain(TEAM)
+            store.resume(TEAM)
 
-            expect(startTabPresence).toHaveBeenCalledTimes(1)
-            expect(store.mounts).toBe(2)
+            expect(presence.connect).toHaveBeenCalledWith(TEAM)
+            expect(inflight.connect).toHaveBeenCalledWith(TEAM)
+            expect(session.connect).toHaveBeenCalledWith(TEAM)
         })
 
-        it('keeps the comms up while a second toggle is still mounted', async () => {
+        it('does nothing for a tab that was never exposed', () => {
+            store.resume(TEAM)
+            expect(presence.connect).not.toHaveBeenCalled()
+        })
+
+        it('does nothing before the team is known', () => {
             store.active = true
-            store.retain(TEAM)
-            store.retain(TEAM)
-            vi.clearAllMocks()
-
-            await store.release()
-
-            expect(store.mounts).toBe(1)
-            expect(stopTabPresence).not.toHaveBeenCalled()
+            store.resume(null)
+            expect(presence.connect).not.toHaveBeenCalled()
         })
 
-        it('tears down once the last toggle leaves', async () => {
+        it('leaves the reported clients alone, so a second toggle mounting does not blank the count', () => {
             store.active = true
-            store.retain(TEAM)
-            store.retain(TEAM)
-            await store.release()
-            await store.release()
+            store.setClients(['a'])
 
-            expect(store.mounts).toBe(0)
-            expect(stopTabPresence).toHaveBeenCalledWith({ announceClose: false })
-        })
+            store.resume(TEAM)
 
-        it('does not start the comms for a tab that was never exposed', () => {
-            store.retain(TEAM)
-            expect(startTabPresence).not.toHaveBeenCalled()
-        })
-
-        it('never counts below zero', async () => {
-            await store.release()
-            expect(store.mounts).toBe(0)
+            expect(store.clients).toEqual(['a'])
         })
     })
 

--- a/test/unit/frontend/subscribers/mcp-inflight.subscriber.spec.js
+++ b/test/unit/frontend/subscribers/mcp-inflight.subscriber.spec.js
@@ -18,7 +18,6 @@ vi.mock('@/stores/product-expert.js', () => ({ useProductExpertStore }))
 vi.mock('@/stores/context.js', () => ({ useContextStore }))
 // the topic helper reaches for the stores through the barrel
 vi.mock('@/stores', () => ({ useAccountAuthStore, useProductExpertStore, useContextStore }))
-vi.mock('@/services/app.orchestrator', () => ({ default: () => ({ $app: {}, $router: {}, $services: { mqtt: {} } }) }))
 
 function makeTransport () {
     return {

--- a/test/unit/frontend/subscribers/mcp-session.subscriber.spec.js
+++ b/test/unit/frontend/subscribers/mcp-session.subscriber.spec.js
@@ -2,10 +2,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 const getTeamCommsCreds = vi.fn()
 const setClients = vi.fn()
-const announceTabPresence = vi.fn()
+const announcePresence = vi.fn()
 
 const authStore = { user: { id: 'user-hashid-1' }, getSessionId: () => 'browser-session-1' }
-const mcpStore = { setClients }
+const mcpStore = { setClients, announcePresence }
 
 const useAccountAuthStore = vi.fn(() => authStore)
 const useProductMcpStore = vi.fn(() => mcpStore)
@@ -15,10 +15,6 @@ vi.mock('@/api/team.js', () => ({
 }))
 vi.mock('@/stores/account-auth.js', () => ({ useAccountAuthStore }))
 vi.mock('@/stores/product-mcp.js', () => ({ useProductMcpStore }))
-vi.mock('@/publishers/tab-presence.publisher', () => ({
-    announceTabPresence: (...args) => announceTabPresence(...args)
-}))
-vi.mock('@/services/app.orchestrator', () => ({ default: () => ({ $app: {}, $router: {}, $services: { mqtt: {} } }) }))
 
 function makeTransport () {
     return {
@@ -51,7 +47,7 @@ describe('McpSessionSubscriber', async () => {
     beforeEach(async () => {
         getTeamCommsCreds.mockReset()
         setClients.mockReset()
-        announceTabPresence.mockReset()
+        announcePresence.mockReset()
         await destroyMcpSessionSubscriber()
     })
 
@@ -75,7 +71,7 @@ describe('McpSessionSubscriber', async () => {
 
         test('asks for a fresh heartbeat once subscribed, so no answer is missed', async () => {
             await connected()
-            expect(announceTabPresence).toHaveBeenCalled()
+            expect(announcePresence).toHaveBeenCalled()
         })
 
         test('detaches on destroy', async () => {


### PR DESCRIPTION
## Description

The MCP comms (tab presence publisher, in-flight subscriber, session subscriber) were started and stopped by the Expert button mounting and unmounting. Moving between a platform page and the immersive editor swaps the layout, so the header is a different component instance. Vue runs the old `beforeUnmount` before the new `mounted`, so the teardown was still awaiting its stops when the remount had already recreated everything, and the stops then landed on the fresh objects.

The result was a tab that still looked exposed (toggle on, still listed, still heartbeating) but answered nothing. Every `ui_*` and `flow_building_*` call just timed out. Refreshing the page fixed it, which is what confirmed it was lifecycle rather than
capability.

The mount counter was an earlier attempt at this. It could not work, because it was arbitrating a lifecycle that should never have been component scoped in the first place.

  ### What changed

The comms now live in the subscriber and publisher registries, so the orchestrator creates them once at boot and disposes them with the app. Nothing in the component tree owns them anymore.

* The store only connects and disconnects. It never creates or destroys.
* The Expert button is purely a control now. It subscribes, unsubscribes, and kicks off  the heartbeat, with no unmount hook at all.
* Registry entries carry an `autoConnect` flag. MCP is `false`, so a team load never  quietly exposes a tab.
* Everything from the previous attempt is gone: `mounts`, `retain`, `release`, `teardown`,
 `activePublisher`, `silenceCloseNotice` and the `announceClose` param.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/8284

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

