### PR TITLE
docs: correct the ChatGPT and Claude connector steps

### DIFF
--- a/docs/user/expert/third-party-agents.md
+++ b/docs/user/expert/third-party-agents.md
@@ -74,11 +74,11 @@ Access through Copilot Studio runs over Power Platform connectors, so any Power 
 
 ### ChatGPT
 
-Custom connectors live behind developer mode. A workspace administrator enables it under **Workspace Settings**, then **Permissions & Roles**, before anyone can add one. Then add FlowFuse as a connector with the MCP address and sign in.
+Custom connectors live behind developer mode. A workspace administrator enables it under **Workspace Settings**, then **Permissions & Roles**, before anyone can add one. The connector itself is then added from the prompt dashboard, with the MCP address, and you sign in there.
 
 ### Claude
 
-Open **Settings**, then **Customize**, then **Connectors**, add a custom connector, and enter the FlowFuse MCP address.
+Where custom connectors are available on your plan, add one and enter the FlowFuse MCP address.
 
 On Team and Enterprise plans an owner adds the connector for the organisation first, and then each person connects and signs in individually.
 


### PR DESCRIPTION
## Description

**Outcome: two steps stop telling people to do something they cannot do.**

- **ChatGPT.** The connector is added from the prompt dashboard once developer mode is on. There is no connector screen to go to. Developer mode and the administrator gate were already right.
- **Claude.** There is no Connectors screen to point at yet, so the step no longer names **Settings**, **Customize**, **Connectors**. It now says to add a custom connector where the plan has them. Worth putting the path back once FlowFuse is listed.

Gemini needs no change here. On this page it only appears as Gemini CLI, which does support MCP. Removing it from the website's agent picker is https://github.com/FlowFuse/website/pull/5701.

Not done here: checking which agents work with OAuth and a custom URL while custom connectors are unavailable. That needs testing.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/8192
