### PR TITLE
docs: correct the ChatGPT developer mode path

### DIFF
--- a/docs/user/expert/third-party-agents.md
+++ b/docs/user/expert/third-party-agents.md
@@ -79,7 +79,7 @@ Access through Copilot Studio runs over Power Platform connectors, so any Power 
 
 ### ChatGPT
 
-Custom connectors live behind developer mode. A workspace administrator enables it under **Workspace Settings**, then **Permissions & Roles**, before anyone can add one. The connector itself is then added from the prompt dashboard, with the MCP address, and you sign in there.
+Custom connectors live behind developer mode. Turn it on under **Settings**, then **Apps & Connectors**, then **Advanced settings**, then add FlowFuse by URL and sign in. Developer mode needs a paid plan, so it is not available on the free tier.
 
 ### Claude
 


### PR DESCRIPTION
## Description

**Outcome: the ChatGPT step points at where developer mode actually is.**

Was: **Workspace Settings**, then **Permissions & Roles**, with the connector added from a prompt dashboard.

Now: **Settings**, then **Apps & Connectors**, then **Advanced settings**, turn on developer mode, then add FlowFuse by URL. It also needs a paid plan, so it is not on the free tier.

Source is https://www.mcpbundles.com/blog/state-of-mcp-clients#chatgpt--b-the-discovery-problem, found while checking the earlier wording. Worth confirming on a paid account: the person who found it has a free tier and could not test it. It is more accurate than what is there now either way.

The same correction for the website's agent picker is in https://github.com/FlowFuse/website/pull/5699.

## Related Issue(s)

https://github.com/FlowFuse/flowfuse/issues/8192
