### PR TITLE
docs: show the agent picker before the written-out steps

### DIFF
--- a/docs/user/expert/third-party-agents.md
+++ b/docs/user/expert/third-party-agents.md
@@ -14,6 +14,13 @@ Because the agent is yours, so is the model it runs on.
 
 Any MCP client that supports the HTTP transport can connect. That is the only requirement.
 
+Pick your agent for the address to copy and the steps that apply to it:
+
+::agent-setup-tabs{:exclude-expert="true" :signup="false" surface="docs"}
+::
+
+The same three steps, written out:
+
 1. **Add the FlowFuse MCP address in your agent's connector settings.** See [where to add it, per agent](#where-to-add-it-per-agent) if you are not sure where yours lives.
 
    On FlowFuse Cloud:
@@ -63,11 +70,6 @@ When you ask for flow work, your agent will guide you to connect an editor sessi
 ## Where to add it, per agent
 
 The agents below are the common ones and where their settings live. Every other AI Agent that supports MCP over HTTP connects the same way.
-
-Pick yours for the address and the steps that apply to it:
-
-::agent-setup-tabs{:exclude-expert="true" :signup="false" surface="docs"}
-::
 
 ### Microsoft Copilot
 


### PR DESCRIPTION
On [Connect Your Own Agent](https://flowfuse.com/docs/user/expert/third-party-agents/) the picker sat under **Where to add it, per agent**, so a reader met the raw MCP address in step 1 and only reached the per-agent tabs much further down.

The single `::agent-setup-tabs` embed now sits at the top of **Connect your agent**, directly after the "any MCP client" line. Nothing is dropped: the three numbered steps, the Cloud and self-hosted addresses, and every per-agent section stay in text below it. The embed is not duplicated, since two instances on one page would emit duplicate tab and panel ids.