### PR TITLE
Add an Expert sync step to the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-feature.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature.yml
@@ -18,6 +18,21 @@ body:
       - Enterprise Tier Only (EE)
       - Other (See comments)
 - type: dropdown
+  id: expert-sync
+  attributes:
+    label: Does this need to be reflected in the FlowFuse Expert?
+    description: New or changed platform capabilities usually need matching Expert work, either MCP tooling so the Expert can drive the feature, or a skill so it knows how to use it. Select everything that applies.
+    multiple: true
+    options:
+      - No Expert impact
+      - Needs new MCP tooling
+      - Needs existing MCP tooling updated
+      - Needs a new skill
+      - Needs an existing skill updated
+      - Not sure, needs input
+  validations:
+      required: true
+- type: dropdown
   id: estimation
   attributes:
     label: Have you provided an initial effort estimate for this issue?

--- a/.github/ISSUE_TEMPLATE/05-epic.yml
+++ b/.github/ISSUE_TEMPLATE/05-epic.yml
@@ -23,6 +23,21 @@ body:
       - Team + Enterprise Tiers (EE)
       - Enterprise Tier Only (EE)
       - Other (See comments)
+- type: dropdown
+  id: expert-sync
+  attributes:
+    label: Does this need to be reflected in the FlowFuse Expert?
+    description: New or changed platform capabilities usually need matching Expert work, either MCP tooling so the Expert can drive the feature, or a skill so it knows how to use it. Select everything that applies.
+    multiple: true
+    options:
+      - No Expert impact
+      - Needs new MCP tooling
+      - Needs existing MCP tooling updated
+      - Needs a new skill
+      - Needs an existing skill updated
+      - Not sure, needs input
+  validations:
+      required: true
 - type: markdown
   attributes:
     value: |

--- a/.github/ISSUE_TEMPLATE/06-story.yml
+++ b/.github/ISSUE_TEMPLATE/06-story.yml
@@ -48,6 +48,21 @@ body:
       - ...
 
 - type: dropdown
+  id: expert-sync
+  attributes:
+    label: Does this need to be reflected in the FlowFuse Expert?
+    description: New or changed platform capabilities usually need matching Expert work, either MCP tooling so the Expert can drive the feature, or a skill so it knows how to use it. Select everything that applies.
+    multiple: true
+    options:
+      - No Expert impact
+      - Needs new MCP tooling
+      - Needs existing MCP tooling updated
+      - Needs a new skill
+      - Needs an existing skill updated
+      - Not sure, needs input
+  validations:
+      required: true
+- type: dropdown
   id: estimation
   attributes:
     label: Have you provided an initial effort estimate for this issue?

--- a/.github/ISSUE_TEMPLATE/07-task.yml
+++ b/.github/ISSUE_TEMPLATE/07-task.yml
@@ -17,6 +17,21 @@ body:
     description: Is this task part of an existing epic or story?
     placeholder: '#123'
 - type: dropdown
+  id: expert-sync
+  attributes:
+    label: Does this need to be reflected in the FlowFuse Expert?
+    description: New or changed platform capabilities usually need matching Expert work, either MCP tooling so the Expert can drive the feature, or a skill so it knows how to use it. Select everything that applies.
+    multiple: true
+    options:
+      - No Expert impact
+      - Needs new MCP tooling
+      - Needs existing MCP tooling updated
+      - Needs a new skill
+      - Needs an existing skill updated
+      - Not sure, needs input
+  validations:
+      required: true
+- type: dropdown
   id: estimation
   attributes:
     label: Have you provided an initial effort estimate for this issue?


### PR DESCRIPTION
Closes #8326

Adds a required `expert-sync` dropdown to the feature, epic, story and task templates, so filing new work makes you say whether the Expert needs to keep up with it: new MCP tooling, updates to existing tooling, or a new/changed skill.

Multi-select, because these combine. A feature often needs both a tool and a skill. Required, for the same reason the effort estimate dropdown is, otherwise it just gets skipped.

Where it sits in each template:

* feature: after pricing, before estimation
* epic: after pricing, before the estimate hint
* story: after acceptance criteria, before estimation
* task: after the epic/story ref, before estimation

Left out of bug, docs and art request, since those don't introduce new capability.

One thing worth a second opinion: "Not sure, needs input" is an escape hatch and some people will default to it. Kept it because the alternative is someone guessing "No Expert impact" and it silently never getting picked up, but happy to drop it if you'd rather force a real answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PrTwn67jrvovn2GeBtrsME
