### PR TITLE
docs: add networking requirements page for self-hosted installs

### DIFF
--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -105,6 +105,8 @@ When deploying the FlowFuse platform behind a firewall or proxy, ensure that the
 * Port `80` (HTTP)
 * Port `443` (HTTPS)
 
+The platform also needs outbound access to a set of hostnames. See [Networking requirements](../networking-requirements.md).
+
 #### AWS Elastic Container Service
 
 At this time we do not support deploying FlowFuse to AWS's Elastic Container Service.

--- a/docs/install/introduction.md
+++ b/docs/install/introduction.md
@@ -31,6 +31,12 @@ We also provide one-click installs of the Docker version:
  - [Digital Ocean Docker Install Guide](/docs/install/docker/digital-ocean.md)
  - [AWS Docker Install Guide](/docs/install/docker/aws-marketplace.md)
 
+## Networking requirements
+
+If the platform runs behind a firewall or proxy, see
+[Networking requirements](/docs/install/networking-requirements.md) for the outbound
+hostnames and ports FlowFuse needs.
+
 ## Upgrading FlowFuse
 
 If you are upgrading FlowFuse, please refer to the [Upgrade Guide](/docs/upgrade/README.md)

--- a/docs/install/introduction.md
+++ b/docs/install/introduction.md
@@ -31,11 +31,9 @@ We also provide one-click installs of the Docker version:
  - [Digital Ocean Docker Install Guide](/docs/install/docker/digital-ocean.md)
  - [AWS Docker Install Guide](/docs/install/docker/aws-marketplace.md)
 
-## Networking requirements
-
-If the platform runs behind a firewall or proxy, see
-[Networking requirements](/docs/install/networking-requirements.md) for the outbound
-hostnames and ports FlowFuse needs.
+Whichever installation you choose, the platform needs outbound network access to a set of
+hostnames. If it runs behind a firewall or proxy, see
+[Networking requirements](/docs/install/networking-requirements.md).
 
 ## Upgrading FlowFuse
 

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -95,6 +95,8 @@ Before you begin, ensure you have the following:
 6. **Cert-Manager:** EMQX requires the CRDs from cert-manager. See the [installation instructions](https://cert-manager.io/docs/installation/) for details.
 7. **EMQX Operator:** This installs the operator that deploys the platform's MQTT broker, which is required whenever the broker is enabled. You must install exactly version 2.2.29 — later versions are not supported. Follow the [installation instructions](https://docs.emqx.com/en/emqx-operator/latest/getting-started/getting-started.html#install-emqx-operator) and pin the version by adding `--version 2.2.29` to the install command.
 
+8. **Outbound network access:** The platform and the Node-RED instances it hosts need outbound access to a set of hostnames. See [Networking requirements](../networking-requirements.md).
+
 For a production-ready environment, we also recommend: 
 * **Database:** Prepare dedicated database on an external database server (see [FAQ](#how-to-use-external-database-server%3F) for more details)
 * **TLS Certificate:** Prepare a TLS certificate for your domain and configure FlowFuse platform to use it (see [Enable HTTPS](#i-would-like-to-secure-the-platform-with-https%2C-how-can-i-do-that%3F)) 

--- a/docs/install/networking-requirements.md
+++ b/docs/install/networking-requirements.md
@@ -1,0 +1,69 @@
+---
+navTitle: Networking requirements
+meta:
+   description: The outbound network access a self-hosted FlowFuse platform requires, listed by hostname, port and purpose, so a firewall change can be requested in one go.
+   tags:
+      - installation
+      - networking
+      - firewall
+      - proxy
+      - self-hosted
+      - flowfuse
+---
+
+# Networking requirements
+
+This page lists the outbound access a self-hosted FlowFuse platform needs. It applies to
+both the Docker and Kubernetes installations, and covers the FlowFuse application, the
+Node-RED instances it hosts, and the browsers that open the editor.
+
+Two related lists live elsewhere:
+
+- Inbound access to the platform is ports `80` and `443`. See
+  [Docker install](./docker/README.md#requirements) and [DNS setup](./dns-setup.md).
+- The Device Agent has its own list, which includes FlowFuse Cloud endpoints. See
+  [Device Agent networking requirements](../device-agent/install/overview.md#networking-requirements).
+
+All destinations below are outbound TCP.
+
+## Always required
+
+| Destination | Port | Purpose |
+| --- | --- | --- |
+| `registry.npmjs.org` | 443 | Installing Node-RED and node packages |
+| `catalogue.nodered.org` | 443 | Default node catalogue used by the editor palette |
+| `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com` | 443 | Pulling FlowFuse and Node-RED container images, at install and at every upgrade |
+| `ping.flowforge.com` | 443 | Anonymous usage telemetry |
+
+Telemetry can be turned off on open source installations, but
+[licensed installations cannot disable it](../admin/telemetry.md#configuring-telemetry).
+
+## Required for specific features
+
+Only open these if the feature is in use.
+
+| Destination | Port | Feature | Turn off with |
+| --- | --- | --- | --- |
+| `registry.flowfuse.com`, `ff-certified-nodes.flowfuse.cloud` | 443 | FlowFuse Certified Nodes, from the server, the editor browsers and the hosted instances | Leave the certified nodes token unset |
+| `app.flowfuse.com` | 443 | Daily import of the public blueprint library | `blueprintImport.enabled: false` |
+| `expert.flowfuse.com` | 443 | FlowFuse Expert and the in-editor assistant | `ai.enabled: false` |
+| `expert-broker.flowfuse.com` | 8883 | FlowFuse Expert MQTT broker, a Helm chart default | `ai.enabled: false` |
+| `api.github.com`, `github.com` | 443 | GitOps pipelines | Do not configure a GitOps integration |
+| `www.googleapis.com` | 443 | Google SSO | Do not configure Google SSO |
+| `acme-v02.api.letsencrypt.org` | 443 | Automatic TLS certificates | Use a certificate you supply yourself |
+| Your SMTP relay | 587 or 465 | Invitations, password resets and notifications | Leave `email` unconfigured |
+
+## Restricted networks
+
+A hostname allowlist covers the large majority of Node-RED nodes, but not all of them. Some
+packages download native builds at install time from arbitrary hosts, such as GitHub releases
+or S3 buckets. Those cannot be listed up front.
+
+If that is not acceptable, host the packages yourself and point FlowFuse at them:
+
+- An internal npm registry and your own node catalogue. See
+  [3rd party npm registries](../user/custom-npm-packages.md#npm-registries).
+- A mirror of the FlowFuse and Node-RED container images in your own registry.
+
+On Kubernetes, also see
+[Network Policies](./kubernetes/README.md#i-use-kubernetes-network-policies%2C-how-can-i-configure-them%3F).

--- a/docs/install/networking-requirements.md
+++ b/docs/install/networking-requirements.md
@@ -39,10 +39,6 @@ All destinations below are outbound TCP.
 | `registry.npmjs.org` | 443 | Instances | Installing Node-RED and node packages |
 | `catalogue.nodered.org` | 443 | Editor browsers | The node catalogue listed in the editor palette. The editor fetches it directly, the platform does not |
 | `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com` | 443 | Platform | Pulling the FlowFuse and Node-RED container images, at install and at every upgrade. Not needed if you pull the images from an internal registry or a pull-through proxy instead |
-| `ping.flowforge.com` | 443 | Platform | Anonymous usage telemetry |
-
-Telemetry can be turned off on open source installations, but
-[licensed installations cannot disable it](../admin/telemetry.md#configuring-telemetry).
 
 ## Required for specific features
 
@@ -52,10 +48,17 @@ Telemetry can be turned off on open source installations, but
 | `app.flowfuse.com` | 443 | Platform | The public blueprint library is imported daily, which is the default on a licensed install (`blueprintImport.enabled`) |
 | `expert.flowfuse.com` | 443 | Platform | FlowFuse Expert or the in-editor assistant is enabled (`ai.enabled`). Both are proxied by the platform, so instances and browsers do not need this |
 | `expert-broker.flowfuse.com` | 8883 | Platform | FlowFuse Expert is enabled on Kubernetes, where the Helm chart sets this broker as the default. On Docker there is no default, the broker has to be set explicitly |
-| `api.github.com`, `github.com` | 443 | Platform | A GitOps pipeline is configured |
+| `github.com`, `api.github.com` | 443 | Platform | A GitOps pipeline pushes to GitHub |
+| `dev.azure.com` | 443 | Platform | A GitOps pipeline pushes to Azure DevOps |
+| Your own Git server | 443 | Platform | A GitOps pipeline pushes to any other HTTPS Git server, for example GitLab, Bitbucket, Gitea or a self-hosted one |
 | `www.googleapis.com` | 443 | Platform | Google SSO is configured |
 | `acme-v02.api.letsencrypt.org` | 443 | Platform | Certificates are issued automatically, rather than supplied by you |
 | Your SMTP relay | 587 or 465 | Platform | Email is configured, for invitations, password resets and notifications |
+| `ping.flowfuse.com` | 443 | Platform | Anonymous usage telemetry is enabled, which is the default and [cannot be disabled on a licensed installation](../admin/telemetry.md#configuring-telemetry) |
+
+Blocking telemetry does not stop the platform. The post runs as a background task, once a
+day and once shortly after startup, and a failure is written to the platform log and left
+until the next run.
 
 ## Restricted networks
 

--- a/docs/install/networking-requirements.md
+++ b/docs/install/networking-requirements.md
@@ -13,9 +13,15 @@ meta:
 
 # Networking requirements
 
-This page lists the outbound access a self-hosted FlowFuse platform needs. It applies to
-both the Docker and Kubernetes installations, and covers the FlowFuse application, the
-Node-RED instances it hosts, and the browsers that open the editor.
+This page lists the outbound access a self-hosted FlowFuse installation needs. It applies to
+both the Docker and Kubernetes installations.
+
+The access is not all needed from the same place. Each table names who has to reach the
+destination:
+
+- **Platform** is the host, or cluster, running the FlowFuse application.
+- **Instances** are the hosted Node-RED instances and the remote instances running the Device Agent.
+- **Editor browsers** are the machines people open the Node-RED editor on.
 
 Two related lists live elsewhere:
 
@@ -28,42 +34,45 @@ All destinations below are outbound TCP.
 
 ## Always required
 
-| Destination | Port | Purpose |
-| --- | --- | --- |
-| `registry.npmjs.org` | 443 | Installing Node-RED and node packages |
-| `catalogue.nodered.org` | 443 | Default node catalogue used by the editor palette |
-| `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com` | 443 | Pulling FlowFuse and Node-RED container images, at install and at every upgrade |
-| `ping.flowforge.com` | 443 | Anonymous usage telemetry |
+| Destination | Port | Needed by | Purpose |
+| --- | --- | --- | --- |
+| `registry.npmjs.org` | 443 | Instances | Installing Node-RED and node packages |
+| `catalogue.nodered.org` | 443 | Editor browsers | The node catalogue listed in the editor palette. The editor fetches it directly, the platform does not |
+| `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com` | 443 | Platform | Pulling the FlowFuse and Node-RED container images, at install and at every upgrade. Not needed if you pull the images from an internal registry or a pull-through proxy instead |
+| `ping.flowforge.com` | 443 | Platform | Anonymous usage telemetry |
 
 Telemetry can be turned off on open source installations, but
 [licensed installations cannot disable it](../admin/telemetry.md#configuring-telemetry).
 
 ## Required for specific features
 
-Only open these if the feature is in use.
-
-| Destination | Port | Feature | Turn off with |
+| Destination | Port | Needed by | Required when |
 | --- | --- | --- | --- |
-| `registry.flowfuse.com`, `ff-certified-nodes.flowfuse.cloud` | 443 | FlowFuse Certified Nodes, from the server, the editor browsers and the hosted instances | Leave the certified nodes token unset |
-| `app.flowfuse.com` | 443 | Daily import of the public blueprint library | `blueprintImport.enabled: false` |
-| `expert.flowfuse.com` | 443 | FlowFuse Expert and the in-editor assistant | `ai.enabled: false` |
-| `expert-broker.flowfuse.com` | 8883 | FlowFuse Expert MQTT broker, a Helm chart default | `ai.enabled: false` |
-| `api.github.com`, `github.com` | 443 | GitOps pipelines | Do not configure a GitOps integration |
-| `www.googleapis.com` | 443 | Google SSO | Do not configure Google SSO |
-| `acme-v02.api.letsencrypt.org` | 443 | Automatic TLS certificates | Use a certificate you supply yourself |
-| Your SMTP relay | 587 or 465 | Invitations, password resets and notifications | Leave `email` unconfigured |
+| `registry.flowfuse.com`, `ff-certified-nodes.flowfuse.cloud` | 443 | Editor browsers and instances | FlowFuse Certified Nodes are in use, which needs a certified nodes token set on the platform |
+| `app.flowfuse.com` | 443 | Platform | The public blueprint library is imported daily, which is the default on a licensed install (`blueprintImport.enabled`) |
+| `expert.flowfuse.com` | 443 | Platform | FlowFuse Expert or the in-editor assistant is enabled (`ai.enabled`). Both are proxied by the platform, so instances and browsers do not need this |
+| `expert-broker.flowfuse.com` | 8883 | Platform | FlowFuse Expert is enabled on Kubernetes, where the Helm chart sets this broker as the default. On Docker there is no default, the broker has to be set explicitly |
+| `api.github.com`, `github.com` | 443 | Platform | A GitOps pipeline is configured |
+| `www.googleapis.com` | 443 | Platform | Google SSO is configured |
+| `acme-v02.api.letsencrypt.org` | 443 | Platform | Certificates are issued automatically, rather than supplied by you |
+| Your SMTP relay | 587 or 465 | Platform | Email is configured, for invitations, password resets and notifications |
 
 ## Restricted networks
 
-A hostname allowlist covers the large majority of Node-RED nodes, but not all of them. Some
-packages download native builds at install time from arbitrary hosts, such as GitHub releases
-or S3 buckets. Those cannot be listed up front.
+A hostname allowlist covers most Node-RED nodes, but not all of them. A minority of packages
+download native components while installing, from hosts such as GitHub releases or S3 buckets,
+which cannot be listed in advance. In practice you find out which packages do this when an
+install fails.
 
-If that is not acceptable, host the packages yourself and point FlowFuse at them:
+There is no small workaround for those packages. The options are an intercepting proxy, or
+building the packages and their components and hosting them yourself. Both are a significant
+piece of work. Plan for a small number of nodes being unavailable rather than for full coverage.
+
+If installs have to come from inside your own network, point FlowFuse at your own services:
 
 - An internal npm registry and your own node catalogue. See
   [3rd party npm registries](../user/custom-npm-packages.md#npm-registries).
-- A mirror of the FlowFuse and Node-RED container images in your own registry.
+- An internal container registry, or a pull-through proxy, for the FlowFuse and Node-RED images.
 
 On Kubernetes, also see
 [Network Policies](./kubernetes/README.md#i-use-kubernetes-network-policies%2C-how-can-i-configure-them%3F).


### PR DESCRIPTION
Adds an outbound egress list for self-hosted installs. Comes from a self-hosted enterprise renewal on a narrow-egress OT network that needs to file one change-controlled firewall request: https://github.com/FlowFuse/accounts/issues/128. Sales reports it is a common question.

Today there is no self-hosted egress list in the docs. The only list is on the Device Agent overview page, which covers agent to Cloud traffic, so a self-hoster behind a firewall reads Cloud-only endpoints as authoritative for their install.

## Where it lives

`docs/install/networking-requirements.md`, in the Installing FlowFuse nav group alongside DNS Setup and Configuring FlowFuse. It is reference material (what is required), not a how-to, so it is a flat table with conditions rather than a walkthrough. Linked from:

- install overview
- Docker install, Requirements
- Kubernetes install, Prerequisites

## Open questions for review

1. Wording of the restricted-networks caveat: an allowlist covers most nodes, but some packages fetch native builds from arbitrary hosts at install time and cannot be enumerated.
2. Should the Device Agent overview list be trimmed of Cloud-only rows and cross-linked here, or left as is? It also lists `registry.npmjs.com`, which should be `.org`.
3. Kubernetes side: any image-pull or operator hosts missing (EMQX operator, Traefik, cert-manager charts)?
