### PR TITLE
Fix error for `lock file's globals@17.11.0 does not satisfy globals@17.12.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
                 "eslint-plugin-no-only-tests": "^3.4.0",
                 "eslint-plugin-vue": "^10.9.2",
                 "file-loader": "^6.2.0",
-                "globals": "^17.7.0",
+                "globals": "17.12.0",
                 "html-link-extractor": "^1.0.5",
                 "html-webpack-plugin": "^5.5.3",
                 "jsdom": "^30.0.1",
@@ -15133,9 +15133,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "17.11.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
-            "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+            "version": "17.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+            "integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -37198,9 +37198,9 @@
             }
         },
         "globals": {
-            "version": "17.11.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
-            "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+            "version": "17.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+            "integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
             "dev": true
         },
         "globalthis": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
         "eslint-plugin-no-only-tests": "^3.4.0",
         "eslint-plugin-vue": "^10.9.2",
         "file-loader": "^6.2.0",
-        "globals": "^17.7.0",
+        "globals": "17.12.0",
         "html-link-extractor": "^1.0.5",
         "html-webpack-plugin": "^5.5.3",
         "jsdom": "^30.0.1",


### PR DESCRIPTION
## Description

`npm ci` has been failing on main since `globals@17.12.0` was published this morning. The `^17.7.0` range let npm ignore the version pinned in the lockfile and pull the newest release from the registry instead then it died because the two didn't match. An exact pin removes the re-resolution, so the next `globals` release can't break the build.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

