### PR TITLE
Only show top-banner if no left-banner set

### DIFF
--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -7,7 +7,7 @@
         </template>
         <form v-if="!ssoCreated" id="ff-sign-up" class="max-w-md m-auto" @submit.prevent="registerUser()">
             <p
-                v-if="settings['branding:account:signUpTopBanner']"
+                v-if="showTopBanner"
                 data-el="banner-text"
                 class="text-center -mt-6 pb-4 text-gray-400"
                 v-html="settings['branding:account:signUpTopBanner']"
@@ -131,6 +131,15 @@ export default {
         ...mapState(useAccountSettingsStore, ['settings']),
         splash () {
             return this.settings['branding:account:signUpLeftBanner']
+        },
+        showTopBanner () {
+            // Only show the top banner if:
+            // - content has been configured for it and,
+            //   - either, in a popup
+            //   - or, no left banner configured
+            return !!this.settings['branding:account:signUpTopBanner'] && (
+                this.isPopup || !this.splash
+            )
         },
         isPopup () {
             return isPopupContext(this.$route.query)

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -166,7 +166,51 @@ describe('FlowFuse platform admin users', () => {
             cy.get('[data-el="splash"]').should('not.exist')
         })
 
-        it('can customise the content of the "Sign Up" screen', () => {
+        it('can customise the content of the "Sign Up" screen - splash only', () => {
+            cy.intercept('GET', '/api/*/settings').as('getSettings')
+
+            cy.visit('/admin/settings/general')
+            cy.wait('@getSettings')
+
+            cy.get('[data-el="splash"]').type('<h1>Welcome to FlowFuse</h1>')
+            cy.get('[data-el="banner"]').clear()
+
+            cy.get('[data-action="save-settings"]').click()
+
+            cy.logout()
+
+            cy.visit('/')
+
+            cy.get('[data-action="sign-up"]').click()
+
+            cy.url().should('include', '/account/create')
+
+            cy.get('[data-el="banner-text"]').should('not.exist')
+            cy.get('[data-el="splash"]').contains('Welcome to FlowFuse')
+        })
+        it('can customise the content of the "Sign Up" screen - banner only', () => {
+            cy.intercept('GET', '/api/*/settings').as('getSettings')
+
+            cy.visit('/admin/settings/general')
+            cy.wait('@getSettings')
+
+            cy.get('[data-el="splash"]').clear()
+            cy.get('[data-el="banner"]').type('this is banner')
+
+            cy.get('[data-action="save-settings"]').click()
+
+            cy.logout()
+
+            cy.visit('/')
+
+            cy.get('[data-action="sign-up"]').click()
+
+            cy.url().should('include', '/account/create')
+
+            cy.get('[data-el="banner-text"]').contains('this is banner')
+            cy.get('[data-el="splash"]').should('not.exist')
+        })
+        it('can customise the content of the "Sign Up" screen - splash and banner', () => {
             cy.intercept('GET', '/api/*/settings').as('getSettings')
 
             cy.visit('/admin/settings/general')
@@ -185,8 +229,14 @@ describe('FlowFuse platform admin users', () => {
 
             cy.url().should('include', '/account/create')
 
-            cy.get('[data-el="banner-text"]').contains('this is banner')
+            // For the regular page, with both configured, only the splash should be shown
+            cy.get('[data-el="banner-text"]').should('not.exist')
             cy.get('[data-el="splash"]').contains('Welcome to FlowFuse')
+
+            // For the popup, with both configured, only the banner should be shown
+            cy.visit('/account/create?context=popup')
+            cy.get('[data-el="banner-text"]').contains('this is banner')
+            cy.get('[data-el="splash"]').should('not.exist')
         })
     })
 })


### PR DESCRIPTION
Part of #8196 

This updates the account create page to only show the top-banner if:
 - in the popup window context
 - otherwise, hide if left-banner has been configured