### PR TITLE
ci: Ignore patch bumps and group development dependecies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     cooldown:
       default-days: 1
     open-pull-requests-limit: 50
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     cooldown:
       default-days: 1
     open-pull-requests-limit: 50
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
## Description

This pull request adjust the Dependabot configuration and:
* groups development dependencies into single pull request
* ignores patch versions bumps

## Related Issue(s)

https://github.com/FlowFuse/engineering/issues/309
https://github.com/FlowFuse/engineering/issues/308

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

