### PR TITLE
Require explicit access level and team scope on the MCP consent screen

### DIFF
--- a/frontend/src/pages/account/AccessRequestMCP.vue
+++ b/frontend/src/pages/account/AccessRequestMCP.vue
@@ -80,8 +80,9 @@ export default {
     },
     data () {
         return {
-            accessLevel: 'full',
-            teamScope: 'all',
+            // No defaults: the user must make an explicit choice before Allow enables
+            accessLevel: null,
+            teamScope: null,
             selectedTeamIds: [],
             teams: [],
             submitting: false,
@@ -103,6 +104,7 @@ export default {
         },
         disableAllow () {
             if (this.submitting) return true
+            if (!this.accessLevel || !this.teamScope) return true
             if (this.teamScope === 'specific' && this.selectedTeamIds.length === 0) return true
             return false
         }

--- a/test/unit/frontend/pages/account/AccessRequestMCP.spec.js
+++ b/test/unit/frontend/pages/account/AccessRequestMCP.spec.js
@@ -1,0 +1,78 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { expect, vi } from 'vitest'
+
+vi.mock('@/stores/account-auth.js', () => ({
+    useAccountAuthStore: () => ({ user: null })
+}))
+vi.mock('@/api/team.ts', () => ({
+    default: {
+        getTeams: vi.fn().mockResolvedValue({
+            teams: [
+                { id: 'team-1', name: 'Team One' },
+                { id: 'team-2', name: 'Team Two' }
+            ]
+        })
+    }
+}))
+vi.mock('@/api/client.ts', () => ({
+    default: { put: vi.fn().mockResolvedValue({}) }
+}))
+
+// imported after mocks so vi.mock hoisting resolves correctly
+import AccessRequestMCP from '../../../../../frontend/src/pages/account/AccessRequestMCP.vue'
+import FFUIComponents from '../../../../../frontend/src/ui-components/index.js'
+
+async function mountPage () {
+    const wrapper = mount(AccessRequestMCP, {
+        global: {
+            plugins: [FFUIComponents],
+            mocks: {
+                $router: { currentRoute: { value: { params: { id: 'request-id' } } } }
+            }
+        }
+    })
+    await flushPromises()
+    return wrapper
+}
+
+function findRadio (wrapper, label) {
+    return wrapper.findAll('.ff-radio-btn').find(r => r.text().includes(label))
+}
+
+function allowButton (wrapper) {
+    return wrapper.find('[data-action="allow-access"]')
+}
+
+describe('AccessRequestMCP', () => {
+    test('does not preselect an access level or team scope', async () => {
+        const wrapper = await mountPage()
+
+        const checked = wrapper.findAll('.ff-radio-btn .checkbox')
+            .filter(c => c.attributes('checked') === 'true')
+        expect(checked.length).toBe(0)
+    })
+
+    test('disables Allow until both access level and team scope are chosen', async () => {
+        const wrapper = await mountPage()
+
+        expect(allowButton(wrapper).attributes('disabled')).toBeDefined()
+
+        await findRadio(wrapper, 'Full access').trigger('click')
+        expect(allowButton(wrapper).attributes('disabled')).toBeDefined()
+
+        await findRadio(wrapper, 'All teams').trigger('click')
+        expect(allowButton(wrapper).attributes('disabled')).toBeUndefined()
+    })
+
+    test('keeps Allow disabled for specific teams until a team is selected', async () => {
+        const wrapper = await mountPage()
+
+        await findRadio(wrapper, 'Read-only').trigger('click')
+        await findRadio(wrapper, 'Specific teams').trigger('click')
+        expect(allowButton(wrapper).attributes('disabled')).toBeDefined()
+
+        const teamCheckbox = wrapper.findAll('.ff-checkbox').find(c => c.text().includes('Team One'))
+        await teamCheckbox.find('label').trigger('click')
+        expect(allowButton(wrapper).attributes('disabled')).toBeUndefined()
+    })
+})


### PR DESCRIPTION
Closes #8417

The MCP OAuth consent page preselected "Full access" and "All teams", so the quickest path through was to blindly click Allow and hand the agent read/write access to everything.

Now both radio groups start with nothing selected, and the Allow button stays disabled until the user has picked an access level and a team scope (the existing "specific teams needs at least one team" guard still applies on top).

Added unit tests for the page covering the no-preselection state and the button gating.


<img width="635" height="897" alt="Screenshot" src="https://github.com/user-attachments/assets/aec132f4-c8d5-4c6c-a304-f9c3db5b8e31" />
