### PR TITLE
Keep refreshable tokens out of the nightly expireTokens sweep

### DIFF
--- a/forge/housekeeper/tasks/expireTokens.js
+++ b/forge/housekeeper/tasks/expireTokens.js
@@ -10,7 +10,18 @@ module.exports = {
     schedule: `${randomInt(0, 59)} ${randomInt(0, 23)} * * *`,
     run: async function (app) {
         await app.db.models.Session.destroy({ where: { expiresAt: { [Op.lt]: Date.now() } } })
-        await app.db.models.AccessToken.destroy({ where: { expiresAt: { [Op.lt]: Date.now() } } })
+        // A token row can outlive its access token expiry: MCP OAuth grants keep a
+        // longer-lived refresh token on the same row (see getOrExpire, RFC 6749 §1.5).
+        // Only remove rows once the refresh token is also expired or absent.
+        await app.db.models.AccessToken.destroy({
+            where: {
+                expiresAt: { [Op.lt]: Date.now() },
+                [Op.or]: [
+                    { refreshTokenExpiresAt: null },
+                    { refreshTokenExpiresAt: { [Op.lt]: Date.now() } }
+                ]
+            }
+        })
         // Remove any OAuthSession objects that were created more than 5 minutes ago
         await app.db.models.OAuthSession.destroy({ where: { createdAt: { [Op.lt]: Date.now() - 1000 * 60 * 5 } } })
         // Remove any AsyncLoginSession objects that were created more than 30 minutes ago

--- a/test/unit/forge/housekeeper/tasks/expireTokens_spec.js
+++ b/test/unit/forge/housekeeper/tasks/expireTokens_spec.js
@@ -1,0 +1,83 @@
+const should = require('should')
+
+const expireTokensTask = require('../../../../../forge/housekeeper/tasks/expireTokens')
+
+const setup = require('../setup')
+
+describe('Expire Tokens Task', function () {
+    /** @type {import('../setup').TestApplication} */
+    let app
+
+    before(async function () {
+        app = await setup()
+    })
+
+    after(async function () {
+        await app.close()
+    })
+
+    afterEach(async function () {
+        await app.db.models.AccessToken.destroy({ where: {} })
+    })
+
+    async function createToken ({ expiresAt, refreshToken, refreshTokenExpiresAt }) {
+        return app.db.models.AccessToken.create({
+            name: 'test token',
+            token: 'ffpat_' + Math.random().toString(36).slice(2),
+            refreshToken,
+            scope: '',
+            expiresAt,
+            refreshTokenExpiresAt,
+            ownerId: '' + app.user.id,
+            ownerType: 'user'
+        })
+    }
+
+    it('keeps a token whose access token expired but whose refresh token is still valid', async function () {
+        const token = await createToken({
+            expiresAt: Date.now() - 1000 * 60 * 60, // expired an hour ago
+            refreshToken: 'ffpat_refresh-valid',
+            refreshTokenExpiresAt: Date.now() + 1000 * 60 * 60 * 24 // valid for another day
+        })
+
+        await expireTokensTask.run(app)
+
+        const found = await app.db.models.AccessToken.findOne({ where: { id: token.id } })
+        should.exist(found, 'token with a valid refresh token should survive the sweep')
+    })
+
+    it('removes a token whose access and refresh tokens have both expired', async function () {
+        const token = await createToken({
+            expiresAt: Date.now() - 1000 * 60 * 60,
+            refreshToken: 'ffpat_refresh-expired',
+            refreshTokenExpiresAt: Date.now() - 1000 * 60
+        })
+
+        await expireTokensTask.run(app)
+
+        const found = await app.db.models.AccessToken.findOne({ where: { id: token.id } })
+        should.not.exist(found)
+    })
+
+    it('removes an expired token that has no refresh token', async function () {
+        const token = await createToken({
+            expiresAt: Date.now() - 1000 * 60 * 60
+        })
+
+        await expireTokensTask.run(app)
+
+        const found = await app.db.models.AccessToken.findOne({ where: { id: token.id } })
+        should.not.exist(found)
+    })
+
+    it('keeps a token whose access token has not expired', async function () {
+        const token = await createToken({
+            expiresAt: Date.now() + 1000 * 60 * 60
+        })
+
+        await expireTokensTask.run(app)
+
+        const found = await app.db.models.AccessToken.findOne({ where: { id: token.id } })
+        should.exist(found)
+    })
+})


### PR DESCRIPTION
Closes #8421 (sub-issue of #8416, the lockout we witnessed in real use).

The daily `expireTokens` housekeeper task deleted every AccessToken whose `expiresAt` had passed, without looking at `refreshTokenExpiresAt`. MCP OAuth grants keep a 30 minute access token and a 30 day refresh token on the same row, so unless the agent had refreshed within the last half hour before the task fired, the sweep deleted the whole grant. The agent's next refresh failed with "Invalid refresh_token" and the token vanished from the user's token list.

The request path already handles this correctly (`getOrExpire` keeps the row while the refresh token is valid, per RFC 6749 §1.5). This applies the same guard to the sweep: only delete rows where the refresh token is also expired or absent.

Tokens without a `refreshTokenExpiresAt` (plain PATs, editor sessions, device tokens) are swept exactly as before. Added unit tests for the task covering all four combinations.