### PR TITLE
Return 400 for a refresh_token grant with no refresh_token

### DIFF
--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -598,6 +598,9 @@ module.exports = async function (app) {
                 reply.send(response)
             }
         } else if (grant_type === 'refresh_token') {
+            if (!refresh_token) {
+                return badRequest(reply, 'invalid_request', 'Invalid refresh_token')
+            }
             const existingToken = await app.db.models.AccessToken.byRefreshToken(refresh_token)
             if (!existingToken) {
                 badRequest(reply, 'invalid_request', 'Invalid refresh_token')

--- a/test/unit/forge/routes/auth/oauth_spec.js
+++ b/test/unit/forge/routes/auth/oauth_spec.js
@@ -463,6 +463,17 @@ describe('OAuth', async function () {
             refreshed.should.have.property('refresh_token')
         })
 
+        it('rejects a refresh_token grant that is missing the refresh_token', async function () {
+            const reg = (await register()).json()
+            const response = await mcpApp.inject({
+                method: 'POST',
+                url: '/account/token',
+                payload: { grant_type: 'refresh_token', client_id: reg.client_id }
+            })
+            response.should.have.property('statusCode', 400)
+            response.json().should.have.property('error', 'invalid_request')
+        })
+
         it('rejects an authorize redirect_uri that was not registered', async function () {
             const reg = (await register(['http://localhost:9876/oauth/callback'])).json()
             const { challenge } = pkce()


### PR DESCRIPTION
Closes #8422

A `POST /account/token` request with `grant_type=refresh_token` but no `refresh_token` in the body went straight into the token lookup, where `sha256(undefined)` threw and the endpoint returned a 500. Now the refresh branch validates the field first and returns `400 invalid_request`, matching how the `authorization_code` branch validates its inputs.

Added a test covering the missing-field case.