### PR TITLE
[8425] Enforce a grant expiry on MCP OAuth tokens

### DIFF
--- a/forge/db/controllers/AccessToken.js
+++ b/forge/db/controllers/AccessToken.js
@@ -14,6 +14,11 @@ const MCP_ACCESS_TOKEN_REMAINING_LIMIT = 1000 * 60 * 5 // 5 minutes
 
 const DEFAULT_DEVICE_OTC_EXPIRY = 1000 * 60 * 60 * 24 // 24 hours
 
+// Cap a proposed expiry (ms) so an MCP grant never outlives its consent-chosen end date
+function capToGrant (timestamp, grantExpiresAtMs) {
+    return grantExpiresAtMs ? Math.min(timestamp, grantExpiresAtMs) : timestamp
+}
+
 /*
  * fft - project
  * ffpr - password reset
@@ -273,11 +278,11 @@ module.exports = {
         await app.settings.set('platform:stats:token', false)
     },
 
-    createMCPOAuthToken: async function (app, userId, { readOnly = false, teamIds = [] } = {}) {
+    createMCPOAuthToken: async function (app, userId, { readOnly = false, teamIds = [], grantExpiresAt = null } = {}) {
         const token = generateToken(32, 'ffpat')
         const refreshToken = generateToken(32, 'ffpat')
-        const expiresAt = Date.now() + DEFAULT_TOKEN_SESSION_EXPIRY
-        const refreshTokenExpiresAt = Date.now() + DEFAULT_REFRESH_TOKEN_EXPIRY
+        const expiresAt = capToGrant(Date.now() + DEFAULT_TOKEN_SESSION_EXPIRY, grantExpiresAt)
+        const refreshTokenExpiresAt = capToGrant(Date.now() + DEFAULT_REFRESH_TOKEN_EXPIRY, grantExpiresAt)
 
         await app.db.sequelize.transaction(async (t) => {
             const tok = await app.db.models.AccessToken.create({
@@ -287,6 +292,7 @@ module.exports = {
                 scope: '',
                 expiresAt,
                 refreshTokenExpiresAt,
+                grantExpiresAt,
                 readOnly,
                 adminOptIn: false,
                 ownerId: '' + userId,
@@ -474,10 +480,11 @@ module.exports = {
             return { token: cached.token, expiresAt: cached.expiresAt, refreshToken }
         }
 
+        const grantExpiresAtMs = existingToken.grantExpiresAt ? existingToken.grantExpiresAt.getTime() : null
         const token = generateToken(32, prefix)
-        const expiresAt = Date.now() + DEFAULT_TOKEN_SESSION_EXPIRY
+        const expiresAt = capToGrant(Date.now() + DEFAULT_TOKEN_SESSION_EXPIRY, grantExpiresAtMs)
         await app.db.models.AccessToken.update(
-            { token, expiresAt, refreshTokenExpiresAt: Date.now() + DEFAULT_REFRESH_TOKEN_EXPIRY },
+            { token, expiresAt, refreshTokenExpiresAt: capToGrant(Date.now() + DEFAULT_REFRESH_TOKEN_EXPIRY, grantExpiresAtMs) },
             { where: { refreshToken: existingToken.refreshToken } }
         )
         await cache?.set(cacheKey, { token, expiresAt })

--- a/forge/db/migrations/20260904-01-add-grantExpiresAt-to-AccessTokens.js
+++ b/forge/db/migrations/20260904-01-add-grantExpiresAt-to-AccessTokens.js
@@ -1,0 +1,24 @@
+/**
+ * Record the user-chosen end date of an MCP OAuth grant.
+ *
+ * The consent screen lets the user pick when the grant expires (at most one
+ * year out). The refresh window (refreshTokenExpiresAt) slides forward on
+ * every refresh, so it cannot hold that choice: grantExpiresAt stores it
+ * permanently and refreshing is capped so the grant never outlives it.
+ *
+ *   grantExpiresAt - the consent-chosen end of the grant. Null for tokens
+ *                    that do not carry one, which keep the previous behaviour.
+ */
+
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.addColumn('AccessTokens', 'grantExpiresAt', {
+            type: DataTypes.DATE,
+            allowNull: true,
+            defaultValue: null
+        })
+    },
+    down: async (context) => {}
+}

--- a/forge/db/models/AccessToken.js
+++ b/forge/db/models/AccessToken.js
@@ -46,6 +46,8 @@ module.exports = {
             }
         },
         refreshTokenExpiresAt: { type: DataTypes.DATE },
+        // Consent-chosen end of an MCP OAuth grant; refresh cannot extend past it
+        grantExpiresAt: { type: DataTypes.DATE },
         name: { type: DataTypes.STRING },
         readOnly: { type: DataTypes.BOOLEAN, defaultValue: false, allowNull: false },
         adminOptIn: { type: DataTypes.BOOLEAN, defaultValue: false, allowNull: false }

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -383,13 +383,14 @@ module.exports = async function (app) {
                 type: 'object',
                 properties: {
                     readOnly: { type: 'boolean' },
-                    teamIds: { type: 'array', items: { type: 'string' } }
+                    teamIds: { type: 'array', items: { type: 'string' } },
+                    expiresAt: { type: 'number' }
                 }
             }
         }
     }, async function (request, reply) {
         const requestId = request.params.id
-        const { readOnly = false, teamIds = [] } = request.body
+        const { readOnly = false, teamIds = [], expiresAt } = request.body
 
         const session = await app.db.models.OAuthSession.findOne({ where: { id: requestId } })
         if (!session) {
@@ -403,8 +404,13 @@ module.exports = async function (app) {
         if (!requestObject.mcp) {
             return badRequest(reply, 'invalid_request', 'Invalid request')
         }
+        // A grant expiry must be in the future, at most one year out
+        const ONE_YEAR = 1000 * 60 * 60 * 24 * 365
+        if (expiresAt !== undefined && (expiresAt <= Date.now() || expiresAt > Date.now() + ONE_YEAR)) {
+            return badRequest(reply, 'invalid_request', 'Invalid expiresAt')
+        }
 
-        session.value = { ...requestObject, readOnly, teamIds }
+        session.value = { ...requestObject, readOnly, teamIds, expiresAt }
         await session.save()
 
         reply.send({ status: 'ok' })
@@ -523,7 +529,8 @@ module.exports = async function (app) {
                     requestObject.userId,
                     {
                         readOnly: requestObject.readOnly || false,
-                        teamIds: requestObject.teamIds || []
+                        teamIds: requestObject.teamIds || [],
+                        grantExpiresAt: requestObject.expiresAt || null
                     }
                 )
                 const response = {

--- a/test/unit/forge/db/controllers/AccessToken_spec.js
+++ b/test/unit/forge/db/controllers/AccessToken_spec.js
@@ -421,6 +421,49 @@ describe('AccessToken controller', function () {
             should.not.exist(await app.db.controllers.AccessToken.refreshToken(original.refreshToken))
             ;(await app.db.models.AccessToken.count()).should.equal(0)
         })
+
+        describe('with a grant expiry', function () {
+            const DAY = 24 * 60 * 60 * 1000
+
+            it('stores the grant expiry and caps the refresh window at it', async function () {
+                const grantExpiresAt = Date.now() + 10 * DAY
+                const result = await createToken({ grantExpiresAt })
+
+                const row = await app.db.models.AccessToken.byRefreshToken(result.refreshToken)
+                row.grantExpiresAt.getTime().should.equal(grantExpiresAt)
+                // 10 days is inside the 30 day window, so the cap applies
+                row.refreshTokenExpiresAt.getTime().should.equal(grantExpiresAt)
+            })
+
+            it('keeps the default refresh window when the grant expiry is further out', async function () {
+                const grantExpiresAt = Date.now() + 365 * DAY
+                const result = await createToken({ grantExpiresAt })
+
+                const row = await app.db.models.AccessToken.byRefreshToken(result.refreshToken)
+                row.refreshTokenExpiresAt.getTime().should.be.approximately(Date.now() + 30 * DAY, 5000)
+            })
+
+            it('cannot slide the refresh window past the grant expiry', async function () {
+                const grantExpiresAt = Date.now() + 1 * DAY
+                const original = await createToken({ grantExpiresAt })
+                await setRowExpiry(original.refreshToken, { accessMs: -5000 })
+
+                const refreshed = await app.db.controllers.AccessToken.refreshToken(original.refreshToken)
+                should.exist(refreshed)
+                const after = await app.db.models.AccessToken.byRefreshToken(original.refreshToken)
+                after.refreshTokenExpiresAt.getTime().should.be.belowOrEqual(grantExpiresAt)
+            })
+
+            it('cannot mint an access token that outlives the grant expiry', async function () {
+                const grantExpiresAt = Date.now() + 10 * 60 * 1000
+                const original = await createToken({ grantExpiresAt })
+                await setRowExpiry(original.refreshToken, { accessMs: -5000 })
+
+                const refreshed = await app.db.controllers.AccessToken.refreshToken(original.refreshToken)
+                should.exist(refreshed)
+                refreshed.expiresAt.should.be.belowOrEqual(grantExpiresAt)
+            })
+        })
     })
 
     describe('getOrExpire', function () {

--- a/test/unit/forge/routes/auth/oauth_spec.js
+++ b/test/unit/forge/routes/auth/oauth_spec.js
@@ -410,11 +410,12 @@ describe('OAuth', async function () {
             should.exist(m, 'expected redirect to MCP consent page: ' + authResponse.headers.location)
             const requestId = m[1]
 
-            // consent - user chooses read-only, scoped to their team
+            // consent - user chooses read-only, scoped to their team, expiring in 90 days
+            const grantExpiresAt = Date.now() + 90 * 24 * 60 * 60 * 1000
             const consentResponse = await mcpApp.inject({
                 method: 'PUT',
                 url: `/account/authorize/${requestId}/consent`,
-                payload: { readOnly: true, teamIds: [mcpApp.team.hashid] },
+                payload: { readOnly: true, teamIds: [mcpApp.team.hashid], expiresAt: grantExpiresAt },
                 cookies: { sid }
             })
             consentResponse.should.have.property('statusCode', 200)
@@ -449,6 +450,7 @@ describe('OAuth', async function () {
             // the issued token reflects the consent choices
             const issued = await mcpApp.db.models.AccessToken.byRefreshToken(token.refresh_token)
             issued.should.have.property('readOnly', true)
+            issued.grantExpiresAt.getTime().should.equal(grantExpiresAt)
 
             // refresh - a public MCP client refreshes without a client secret
             const refreshResponse = await mcpApp.inject({
@@ -472,6 +474,46 @@ describe('OAuth', async function () {
             })
             response.should.have.property('statusCode', 400)
             response.json().should.have.property('error', 'invalid_request')
+        })
+
+        describe('consent expiry validation', function () {
+            // Start an authorize flow and return the consent request id
+            async function startConsent () {
+                const reg = (await register()).json()
+                const { challenge } = pkce()
+                const authResponse = await mcpApp.inject({ method: 'GET', url: authorizeURL(reg.client_id, redirectURI, challenge), cookies: { sid } })
+                authResponse.should.have.property('statusCode', 302)
+                return /\/account\/request\/([^/]+)\/mcp$/.exec(authResponse.headers.location)[1]
+            }
+
+            async function consent (requestId, payload) {
+                return mcpApp.inject({
+                    method: 'PUT',
+                    url: `/account/authorize/${requestId}/consent`,
+                    payload,
+                    cookies: { sid }
+                })
+            }
+
+            it('accepts consent without an expiry date', async function () {
+                const requestId = await startConsent()
+                const response = await consent(requestId, { readOnly: true, teamIds: [] })
+                response.should.have.property('statusCode', 200)
+            })
+
+            it('rejects consent with an expiry in the past', async function () {
+                const requestId = await startConsent()
+                const response = await consent(requestId, { readOnly: true, teamIds: [], expiresAt: Date.now() - 1000 })
+                response.should.have.property('statusCode', 400)
+                response.json().should.have.property('error', 'invalid_request')
+            })
+
+            it('rejects consent with an expiry more than a year away', async function () {
+                const requestId = await startConsent()
+                const response = await consent(requestId, { readOnly: true, teamIds: [], expiresAt: Date.now() + 370 * 24 * 60 * 60 * 1000 })
+                response.should.have.property('statusCode', 400)
+                response.json().should.have.property('error', 'invalid_request')
+            })
         })
 
         it('rejects an authorize redirect_uri that was not registered', async function () {


### PR DESCRIPTION
Store a consent-chosen `grantExpiresAt` on the token row and cap both the access token expiry and the sliding refresh window at it, at creation and on every refresh, so refreshing can never extend a grant past its end date. The consent endpoint validates the date when provided: in the future, at most one year out. It becomes mandatory once the consent screen sends it (next PR in the stack).

Closes #8425
