### PR TITLE
[8426] Add a required expiry date to the MCP consent screen

### DIFF
--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -404,9 +404,9 @@ module.exports = async function (app) {
         if (!requestObject.mcp) {
             return badRequest(reply, 'invalid_request', 'Invalid request')
         }
-        // A grant expiry must be in the future, at most one year out
+        // The grant must expire: in the future, at most one year out
         const ONE_YEAR = 1000 * 60 * 60 * 24 * 365
-        if (expiresAt !== undefined && (expiresAt <= Date.now() || expiresAt > Date.now() + ONE_YEAR)) {
+        if (!expiresAt || expiresAt <= Date.now() || expiresAt > Date.now() + ONE_YEAR) {
             return badRequest(reply, 'invalid_request', 'Invalid expiresAt')
         }
 

--- a/frontend/src/pages/account/AccessRequestMCP.vue
+++ b/frontend/src/pages/account/AccessRequestMCP.vue
@@ -51,6 +51,18 @@
                     Select at least one team.
                 </div>
             </div>
+
+            <!-- Expiry -->
+            <div>
+                <label class="block text-sm font-medium mb-1">Expiry</label>
+                <p class="text-gray-500 text-sm mb-2">
+                    Choose when this access expires. It cannot last longer than a year.
+                </p>
+                <FormRow v-model="expiresAt" data-form="expiry-date" type="date" />
+                <div v-if="expiresAt && !expiryValid" class="mt-2 text-sm text-yellow-600">
+                    Pick a date in the future, at most one year away.
+                </div>
+            </div>
         </div>
 
         <div v-if="error" class="text-red-600 text-sm mb-4">{{ error }}</div>
@@ -66,9 +78,13 @@
 import { ArrowSmallLeftIcon, ArrowSmallRightIcon, CommandLineIcon, KeyIcon } from '@heroicons/vue/20/solid'
 import { mapState } from 'pinia'
 
+import FormRow from '../../components/FormRow.vue'
+
 import client from '@/api/client.ts'
 import teamApi from '@/api/team.ts'
 import { useAccountAuthStore } from '@/stores/account-auth.js'
+
+const ONE_YEAR = 1000 * 60 * 60 * 24 * 365
 
 export default {
     name: 'AccessRequestMCP',
@@ -76,13 +92,15 @@ export default {
         CommandLineIcon,
         KeyIcon,
         ArrowSmallRightIcon,
-        ArrowSmallLeftIcon
+        ArrowSmallLeftIcon,
+        FormRow
     },
     data () {
         return {
             // No defaults: the user must make an explicit choice before Allow enables
             accessLevel: null,
             teamScope: null,
+            expiresAt: null,
             selectedTeamIds: [],
             teams: [],
             submitting: false,
@@ -102,9 +120,15 @@ export default {
         requestId () {
             return this.$router.currentRoute.value.params.id
         },
+        expiryValid () {
+            if (!this.expiresAt) return false
+            const ts = Date.parse(this.expiresAt)
+            if (Number.isNaN(ts)) return false
+            return ts > Date.now() && ts <= Date.now() + ONE_YEAR
+        },
         disableAllow () {
             if (this.submitting) return true
-            if (!this.accessLevel || !this.teamScope) return true
+            if (!this.accessLevel || !this.teamScope || !this.expiryValid) return true
             if (this.teamScope === 'specific' && this.selectedTeamIds.length === 0) return true
             return false
         }
@@ -132,7 +156,8 @@ export default {
             try {
                 await client.put(`/account/authorize/${this.requestId}/consent`, {
                     readOnly: this.accessLevel === 'readonly',
-                    teamIds: this.teamScope === 'all' ? [] : this.selectedTeamIds
+                    teamIds: this.teamScope === 'all' ? [] : this.selectedTeamIds,
+                    expiresAt: Date.parse(this.expiresAt)
                 })
                 window.location.href = `/account/complete/${this.requestId}`
             } catch (err) {

--- a/test/unit/forge/routes/auth/oauth_spec.js
+++ b/test/unit/forge/routes/auth/oauth_spec.js
@@ -495,10 +495,11 @@ describe('OAuth', async function () {
                 })
             }
 
-            it('accepts consent without an expiry date', async function () {
+            it('rejects consent without an expiry date', async function () {
                 const requestId = await startConsent()
                 const response = await consent(requestId, { readOnly: true, teamIds: [] })
-                response.should.have.property('statusCode', 200)
+                response.should.have.property('statusCode', 400)
+                response.json().should.have.property('error', 'invalid_request')
             })
 
             it('rejects consent with an expiry in the past', async function () {

--- a/test/unit/frontend/pages/account/AccessRequestMCP.spec.js
+++ b/test/unit/frontend/pages/account/AccessRequestMCP.spec.js
@@ -52,7 +52,11 @@ describe('AccessRequestMCP', () => {
         expect(checked.length).toBe(0)
     })
 
-    test('disables Allow until both access level and team scope are chosen', async () => {
+    async function setExpiry (wrapper, value) {
+        await wrapper.find('[data-form="expiry-date"] input').setValue(value)
+    }
+
+    test('disables Allow until access level, team scope and expiry are all chosen', async () => {
         const wrapper = await mountPage()
 
         expect(allowButton(wrapper).attributes('disabled')).toBeDefined()
@@ -61,6 +65,24 @@ describe('AccessRequestMCP', () => {
         expect(allowButton(wrapper).attributes('disabled')).toBeDefined()
 
         await findRadio(wrapper, 'All teams').trigger('click')
+        expect(allowButton(wrapper).attributes('disabled')).toBeDefined()
+
+        await setExpiry(wrapper, futureDate(30))
+        expect(allowButton(wrapper).attributes('disabled')).toBeUndefined()
+    })
+
+    test('keeps Allow disabled for an expiry in the past or more than a year away', async () => {
+        const wrapper = await mountPage()
+        await findRadio(wrapper, 'Full access').trigger('click')
+        await findRadio(wrapper, 'All teams').trigger('click')
+
+        await setExpiry(wrapper, '2020-01-01')
+        expect(allowButton(wrapper).attributes('disabled')).toBeDefined()
+
+        await setExpiry(wrapper, futureDate(400))
+        expect(allowButton(wrapper).attributes('disabled')).toBeDefined()
+
+        await setExpiry(wrapper, futureDate(30))
         expect(allowButton(wrapper).attributes('disabled')).toBeUndefined()
     })
 
@@ -69,6 +91,7 @@ describe('AccessRequestMCP', () => {
 
         await findRadio(wrapper, 'Read-only').trigger('click')
         await findRadio(wrapper, 'Specific teams').trigger('click')
+        await setExpiry(wrapper, futureDate(30))
         expect(allowButton(wrapper).attributes('disabled')).toBeDefined()
 
         const teamCheckbox = wrapper.findAll('.ff-checkbox').find(c => c.text().includes('Team One'))
@@ -76,3 +99,7 @@ describe('AccessRequestMCP', () => {
         expect(allowButton(wrapper).attributes('disabled')).toBeUndefined()
     })
 })
+
+function futureDate (days) {
+    return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+}


### PR DESCRIPTION
The consent page gets an expiry date field alongside access level and team scope: the date must be in the future and at most one year out, Allow stays disabled until it is valid, and the chosen date is sent with the consent. With every client now providing it, the consent endpoint makes `expiresAt` mandatory.

Closes #8426

<img width="516" height="848" alt="Screenshot" src="https://github.com/user-attachments/assets/6785d583-5a79-457b-a862-46f995443bd5" />

