### PR TITLE
[8424] Show MCP tokens as auto-renewing in the tokens list

### DIFF
--- a/forge/db/controllers/AccessToken.js
+++ b/forge/db/controllers/AccessToken.js
@@ -1,10 +1,6 @@
 const { Op } = require('sequelize')
 
-const { generateToken, generateNumericToken, sha256, randomPhrase } = require('../utils')
-
-const DEFAULT_TOKEN_SESSION_EXPIRY = 1000 * 60 * 30 // 30 mins session - with refresh token support
-
-const DEFAULT_REFRESH_TOKEN_EXPIRY = 1000 * 60 * 60 * 24 * 30 // 30 days - sliding refresh token lifetime
+const { generateToken, generateNumericToken, sha256, randomPhrase, DEFAULT_TOKEN_SESSION_EXPIRY, DEFAULT_REFRESH_TOKEN_EXPIRY } = require('../utils')
 
 // Concurrent refreshes of the same refresh token reuse the cached access token
 // rather than each minting a new one and overwriting the row. Re-mint once the

--- a/forge/db/models/AccessToken.js
+++ b/forge/db/models/AccessToken.js
@@ -118,7 +118,7 @@ module.exports = {
                             name: { [Op.ne]: null }
                         },
                         order: [['id', 'ASC']],
-                        attributes: ['id', 'name', 'scope', 'expiresAt', 'readOnly', 'adminOptIn'],
+                        attributes: ['id', 'name', 'scope', 'expiresAt', 'readOnly', 'adminOptIn', 'refreshTokenExpiresAt', 'grantExpiresAt'],
                         include: [{
                             model: M.AccessTokenTeamScope,
                             include: [{

--- a/forge/db/utils.js
+++ b/forge/db/utils.js
@@ -330,6 +330,11 @@ function parseNrMqttId (id, kind = 'username') {
 
 module.exports = {
     init: _app => { app = _app },
+    // MCP OAuth token lifetimes. Defined here so both the AccessToken
+    // controller (which enforces them) and the AccessToken view (which
+    // reports the renewal cycle to the UI) share a single source.
+    DEFAULT_TOKEN_SESSION_EXPIRY: 1000 * 60 * 30, // 30 mins session - with refresh token support
+    DEFAULT_REFRESH_TOKEN_EXPIRY: 1000 * 60 * 60 * 24 * 30, // 30 days - sliding refresh token lifetime
     generateToken: (length, prefix) => (prefix ? prefix + '_' : '') + base64URLEncode(crypto.randomBytes(length || 32)),
     generateNumericToken: () => crypto.randomInt(0, 1000000).toString().padStart(6, '0'),
     hash: value => bcrypt.hashSync(value, 10),

--- a/forge/db/views/AccessToken.js
+++ b/forge/db/views/AccessToken.js
@@ -1,3 +1,5 @@
+const { DEFAULT_TOKEN_SESSION_EXPIRY } = require('../utils')
+
 module.exports = function (app) {
     app.addSchema({
         $id: 'ProvisioningTokenSummary',
@@ -66,6 +68,15 @@ module.exports = function (app) {
             expiresAt: { type: 'string', nullable: true },
             readOnly: { type: 'boolean' },
             adminOptIn: { type: 'boolean' },
+            autoRenews: {
+                type: 'object',
+                nullable: true,
+                properties: {
+                    every: { type: 'number' },
+                    until: { type: 'string', nullable: true },
+                    chosen: { type: 'boolean' }
+                }
+            },
             teams: {
                 type: 'array',
                 items: {
@@ -100,6 +111,17 @@ module.exports = function (app) {
                 id: app.db.models.Team.encodeHashid(s.TeamId),
                 name: s.Team?.name ?? null
             }))
+        }
+        // Tokens with a refresh token (MCP OAuth grants) renew their access
+        // token automatically: report the renewal cycle and the grant's end
+        // (the consent-chosen date, or the lapse-if-unused date for grants
+        // issued before the expiry field existed).
+        if (token.refreshTokenExpiresAt) {
+            tokenSummary.autoRenews = {
+                every: DEFAULT_TOKEN_SESSION_EXPIRY,
+                until: token.grantExpiresAt ?? token.refreshTokenExpiresAt,
+                chosen: !!token.grantExpiresAt
+            }
         }
         return tokenSummary
     }

--- a/frontend/src/pages/account/Security/Tokens.vue
+++ b/frontend/src/pages/account/Security/Tokens.vue
@@ -15,7 +15,9 @@
             </ff-button>
         </template>
         <template #context-menu="{row}">
-            <ff-kebab-item data-action="edit-token" label="Edit" @click="editToken(row)" />
+            <!-- Auto-renewing (MCP OAuth) tokens are managed by revoke and re-consent only:
+                 the edit dialog writes expiresAt but not the grant's real lifetime -->
+            <ff-kebab-item v-if="!row.autoRenews" data-action="edit-token" label="Edit" @click="editToken(row)" />
             <ff-kebab-item data-action="delete-token" label="Delete" @click="deleteToken(row)" />
         </template>
         <template v-if="tokens.length === 0" #table>

--- a/frontend/src/pages/account/components/ExpiryCell.vue
+++ b/frontend/src/pages/account/components/ExpiryCell.vue
@@ -1,14 +1,21 @@
 <template>
     <div class="flex items-center">
-        <div>{{ expires }}</div>
+        <div v-if="autoRenews" :title="autoRenewsTooltip" style="cursor:help">{{ autoRenewsLabel }}</div>
+        <div v-else>{{ expires }}</div>
     </div>
 </template>
 <script>
+import elapsedTime from '../../../utils/elapsedTime.ts'
+
 export default {
     name: 'ExpiryCell',
     props: {
         expiresAt: {
             type: String,
+            default: null
+        },
+        autoRenews: {
+            type: Object,
             default: null
         }
     },
@@ -20,6 +27,22 @@ export default {
             } else {
                 return 'Never'
             }
+        },
+        untilDate: function () {
+            return new Date(this.autoRenews.until).toLocaleDateString()
+        },
+        autoRenewsLabel: function () {
+            if (this.autoRenews.chosen) {
+                return `Auto-renews until ${this.untilDate}`
+            }
+            return 'Auto-renews'
+        },
+        autoRenewsTooltip: function () {
+            const cycle = elapsedTime(this.autoRenews.every, 0)
+            const ending = this.autoRenews.chosen
+                ? `Access ends on ${this.untilDate}.`
+                : `It lapses on ${this.untilDate} if unused.`
+            return `This is an agent connection. Its access token renews automatically every ${cycle} while in use. ${ending} Delete this entry to revoke access now.`
         }
     }
 }

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -10312,6 +10312,11 @@ export interface components {
             expiresAt: string | null;
             readOnly?: boolean;
             adminOptIn?: boolean;
+            autoRenews?: {
+                every?: number;
+                until?: string | null;
+                chosen?: boolean;
+            } | null;
             teams?: {
                 id?: string;
                 name?: string | null;

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -1018,6 +1018,32 @@ describe('User API', async function () {
             })
             deleteResponse.statusCode.should.equal(404)
         })
+        it('Lists an MCP OAuth token as auto-renewing', async function () {
+            const grantExpiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000
+            await app.db.controllers.AccessToken.createMCPOAuthToken(TestObjects.alice.id, { grantExpiresAt })
+            await app.db.controllers.AccessToken.createPersonalAccessToken(TestObjects.alice, '', null, 'Plain Token')
+
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/user/tokens',
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const json = response.json()
+
+            const mcpToken = json.tokens.find(t => t.name === 'MCP Agent')
+            should.exist(mcpToken)
+            mcpToken.should.have.property('autoRenews')
+            // the renewal cycle comes from the backend, matching the real rotation
+            mcpToken.autoRenews.should.have.property('every', 1000 * 60 * 30)
+            mcpToken.autoRenews.should.have.property('chosen', true)
+            new Date(mcpToken.autoRenews.until).getTime().should.equal(grantExpiresAt)
+
+            // plain PATs do not carry it
+            const plainToken = json.tokens.find(t => t.name === 'Plain Token')
+            should.exist(plainToken)
+            plainToken.should.not.have.property('autoRenews')
+        })
         it('Deleting a user removes any PATs from the db', async function () {
             const userToDelete = await app.db.models.User.create({ username: 'wayne', name: 'Wayne Vane', email: 'wayne@example.com', email_verified: true, password: 'wwPassword' })
             await login('wayne', 'wwPassword')

--- a/test/unit/frontend/pages/account/ExpiryCell.spec.js
+++ b/test/unit/frontend/pages/account/ExpiryCell.spec.js
@@ -1,0 +1,49 @@
+import { mount } from '@vue/test-utils'
+import { expect } from 'vitest'
+
+import ExpiryCell from '../../../../../frontend/src/pages/account/components/ExpiryCell.vue'
+
+const THIRTY_MINUTES = 1000 * 60 * 30
+const IN_90_DAYS = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString()
+
+describe('ExpiryCell', () => {
+    test('renders the expiry date for a plain token', () => {
+        const wrapper = mount(ExpiryCell, { props: { expiresAt: IN_90_DAYS } })
+        expect(wrapper.text()).toEqual(new Date(IN_90_DAYS).toLocaleDateString())
+    })
+
+    test('renders Never for a token without expiry', () => {
+        const wrapper = mount(ExpiryCell, { props: { expiresAt: null } })
+        expect(wrapper.text()).toEqual('Never')
+    })
+
+    test('renders the chosen grant end date for an auto-renewing token', () => {
+        const wrapper = mount(ExpiryCell, {
+            props: { expiresAt: null, autoRenews: { every: THIRTY_MINUTES, until: IN_90_DAYS, chosen: true } }
+        })
+        expect(wrapper.text()).toEqual(`Auto-renews until ${new Date(IN_90_DAYS).toLocaleDateString()}`)
+    })
+
+    test('renders a plain auto-renews label when no grant end date was chosen', () => {
+        const wrapper = mount(ExpiryCell, {
+            props: { expiresAt: null, autoRenews: { every: THIRTY_MINUTES, until: IN_90_DAYS, chosen: false } }
+        })
+        expect(wrapper.text()).toEqual('Auto-renews')
+    })
+
+    test('explains the renewal cycle in a tooltip, derived from the backend value', () => {
+        const wrapper = mount(ExpiryCell, {
+            props: { expiresAt: null, autoRenews: { every: THIRTY_MINUTES, until: IN_90_DAYS, chosen: true } }
+        })
+        const tooltip = wrapper.find('[title]').attributes('title')
+        expect(tooltip).toContain('30 minutes')
+        expect(tooltip).toContain(new Date(IN_90_DAYS).toLocaleDateString())
+    })
+
+    test('the tooltip cadence follows the backend value, nothing hardcoded', () => {
+        const wrapper = mount(ExpiryCell, {
+            props: { expiresAt: null, autoRenews: { every: 1000 * 60 * 15, until: IN_90_DAYS, chosen: true } }
+        })
+        expect(wrapper.find('[title]').attributes('title')).toContain('15 minutes')
+    })
+})

--- a/test/unit/frontend/pages/account/Tokens.spec.js
+++ b/test/unit/frontend/pages/account/Tokens.spec.js
@@ -1,0 +1,75 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { expect, vi } from 'vitest'
+
+vi.mock('@/api/user.js', () => ({
+    default: {
+        getPersonalAccessTokens: vi.fn().mockResolvedValue({
+            count: 2,
+            tokens: [
+                { id: 'plain', name: 'Plain Token', expiresAt: null, readOnly: false, adminOptIn: false, teams: [] },
+                {
+                    id: 'mcp',
+                    name: 'MCP Agent',
+                    expiresAt: null,
+                    readOnly: true,
+                    adminOptIn: false,
+                    teams: [],
+                    autoRenews: { every: 1000 * 60 * 30, until: '2027-01-01T00:00:00.000Z', chosen: true }
+                }
+            ]
+        })
+    }
+}))
+vi.mock('@/stores/account-auth.js', () => ({
+    useAccountAuthStore: () => ({ isAdminUser: false })
+}))
+vi.mock('@/pages/account/Security/dialogs/TokenDialog.vue', () => ({
+    default: { name: 'TokenDialog', template: '<div />' }
+}))
+vi.mock('@/pages/account/Security/dialogs/TokenCreated.vue', () => ({
+    default: { name: 'TokenCreated', template: '<div />' }
+}))
+
+// imported after mocks so vi.mock hoisting resolves correctly
+import Tokens from '../../../../../frontend/src/pages/account/Security/Tokens.vue'
+import FFUIComponents from '../../../../../frontend/src/ui-components/index.js'
+
+async function mountPage () {
+    const wrapper = mount(Tokens, {
+        attachTo: document.body,
+        global: {
+            plugins: [FFUIComponents],
+            stubs: { SectionTopMenu: true }
+        }
+    })
+    await flushPromises()
+    return wrapper
+}
+
+async function openKebabForRow (wrapper, name) {
+    const row = wrapper.findAll('tr').find(r => r.text().includes(name))
+    await row.find('.ff-kebab-menu__trigger').trigger('click')
+    await flushPromises()
+}
+
+describe('PersonalAccessTokens', () => {
+    afterEach(() => {
+        document.body.innerHTML = ''
+    })
+
+    test('offers edit and delete for a plain token', async () => {
+        const wrapper = await mountPage()
+        await openKebabForRow(wrapper, 'Plain Token')
+
+        expect(document.body.querySelector('[data-action="edit-token"]')).not.toBeNull()
+        expect(document.body.querySelector('[data-action="delete-token"]')).not.toBeNull()
+    })
+
+    test('offers delete but not edit for an auto-renewing token', async () => {
+        const wrapper = await mountPage()
+        await openKebabForRow(wrapper, 'MCP Agent')
+
+        expect(document.body.querySelector('[data-action="edit-token"]')).toBeNull()
+        expect(document.body.querySelector('[data-action="delete-token"]')).not.toBeNull()
+    })
+})


### PR DESCRIPTION
MCP grants showed the internal 30 minute access token expiry in the tokens list, reading as a token forever about to die. The token summary now carries an `autoRenews` object (renewal cycle from the shared backend constant, grant end date, whether the user chose it) and the expiry cell renders "Auto-renews until <date>" with a tooltip explaining the rotation cycle, the lapse rule and how to revoke. Grants issued before the expiry field existed render "Auto-renews" with the lapse date in the tooltip. Editing is hidden for these rows since the edit dialog writes `expiresAt` but not the grant's real lifetime; delete stays.

Closes #8424
