### PR TITLE
Add hidden aiOnboarding platform flag

### DIFF
--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -52,6 +52,11 @@ async function commonFeatures (app, opts) {
     // explicitly disabled in the config.
     const isMcpThirdPartyEnabled = isAiEnabled && (app.config?.expert?.enabled ?? false)
     app.config.features.register('mcpThirdParty', isMcpThirdPartyEnabled, true)
+
+    // Set the AI-led onboarding flag. Hidden and config-only: off unless
+    // expert.onboarding.enabled is explicitly set in the config.
+    const isAiOnboardingEnabled = isAiEnabled && (app.config?.expert?.enabled ?? false) && app.config?.expert?.onboarding?.enabled === true
+    app.config.features.register('aiOnboarding', isAiOnboardingEnabled, true)
 }
 
 module.exports = fp(async function (app, opts) {

--- a/frontend/src/composables/FeatureChecks.ts
+++ b/frontend/src/composables/FeatureChecks.ts
@@ -131,8 +131,6 @@ export const FEATURE_CONFIGS: FeatureConfig[] = [
         output: 'isAiOnboardingFeatureEnabled',
         platformKey: 'aiOnboarding',
         dependsOn: 'isExpertAssistantFeatureEnabled',
-        // The onboarding conversation runs over MQTT, so it also needs the
-        // same broker chain the product-expert store's `shouldUseMqtt` checks
         dependsOnPlatform: 'externalBroker',
         dependsOnTeam: 'teamBroker'
     },

--- a/frontend/src/composables/FeatureChecks.ts
+++ b/frontend/src/composables/FeatureChecks.ts
@@ -128,6 +128,15 @@ export const FEATURE_CONFIGS: FeatureConfig[] = [
     { output: 'isExpertAssistantFeatureEnabled', platformKey: 'expertAssistant', teamKey: 'expertAssistant', optOut: true, dependsOnPlatform: 'ai', dependsOnTeam: 'ai', dependsOnTeamOptOut: true },
     { output: 'isExpertInsightsFeatureEnabled', platformKey: 'expertInsights', teamKey: 'expertInsights', optOut: true, dependsOnPlatform: 'ai', dependsOnTeam: 'ai', dependsOnTeamOptOut: true },
     {
+        output: 'isAiOnboardingFeatureEnabled',
+        platformKey: 'aiOnboarding',
+        dependsOn: 'isExpertAssistantFeatureEnabled',
+        // The onboarding conversation runs over MQTT, so it also needs the
+        // same broker chain the product-expert store's `shouldUseMqtt` checks
+        dependsOnPlatform: 'externalBroker',
+        dependsOnTeam: 'teamBroker'
+    },
+    {
         output: 'isGeneratedSnapshotDescriptionFeatureEnabled',
         platformKey: 'generatedSnapshotDescription',
         teamKey: 'generatedSnapshotDescription',

--- a/test/unit/frontend/composables/FeatureChecks.spec.js
+++ b/test/unit/frontend/composables/FeatureChecks.spec.js
@@ -188,6 +188,47 @@ describe('buildFeatureChecks', () => {
         })
     })
 
+    describe('ai onboarding', () => {
+        // isAiOnboardingFeatureEnabled -> platformKey 'aiOnboarding',
+        // dependsOn 'isExpertAssistantFeatureEnabled', dependsOnPlatform 'externalBroker', dependsOnTeam 'teamBroker'
+        const enabledPlatform = platformState({ features: { aiOnboarding: true, expertAssistant: true, ai: true, externalBroker: true } })
+        const enabledTeam = team({ features: { teamBroker: true } })
+
+        test('enabled when the flag and all dependencies are enabled', () => {
+            const checks = buildFeatureChecks(enabledPlatform, enabledTeam)
+            expect(checks.isAiOnboardingFeatureEnabled).toBe(true)
+        })
+
+        test('disabled when the platform flag is missing', () => {
+            const checks = buildFeatureChecks(
+                platformState({ features: { expertAssistant: true, ai: true, externalBroker: true } }),
+                enabledTeam
+            )
+            expect(checks.isAiOnboardingFeatureEnabled).toBe(false)
+        })
+
+        test('forced false when the expert assistant dependency is disabled', () => {
+            const checks = buildFeatureChecks(
+                platformState({ features: { aiOnboarding: true, expertAssistant: true, ai: false, externalBroker: true } }),
+                enabledTeam
+            )
+            expect(checks.isAiOnboardingFeatureEnabled).toBe(false)
+        })
+
+        test('forced false when the platform external broker dependency is missing', () => {
+            const checks = buildFeatureChecks(
+                platformState({ features: { aiOnboarding: true, expertAssistant: true, ai: true } }),
+                enabledTeam
+            )
+            expect(checks.isAiOnboardingFeatureEnabled).toBe(false)
+        })
+
+        test('forced false when the team broker dependency is missing', () => {
+            const checks = buildFeatureChecks(enabledPlatform, team())
+            expect(checks.isAiOnboardingFeatureEnabled).toBe(false)
+        })
+    })
+
     describe('posthogKey', () => {
         // isMcpThirdPartyFeatureEnabled -> platform+team+ai deps, posthogKey 'MCP_THIRD_PARTY'
         const fullyEnabledState = platformState({ features: { mcpThirdParty: true, ai: true } })


### PR DESCRIPTION
Closes #8366

Part of #8365. This adds the config-only platform flag that AI-led onboarding will sit behind. Nothing uses it yet, the signup changes and the on-demand provisioning endpoint come in follow-up PRs.

The backend registers an `aiOnboarding` flag from `expert.onboarding.enabled` in the config, ANDed with the existing ai and expert gates, same pattern as `expertInsights`. Off unless a deployment explicitly sets it, and there is no admin UI for it.

On the frontend it comes out as `isAiOnboardingFeatureEnabled` on `featuresCheck`. The entry depends on `isExpertAssistantFeatureEnabled` plus the `externalBroker`/`teamBroker` chain, since the onboarding conversation runs over MQTT and this saves call sites from restating what `shouldUseMqtt` checks. `isSupportAgent` stays a runtime store check as it is session state rather than a feature.

Tests cover the new feature check and each dependency gate in `FeatureChecks.spec.js`. The one-line backend registration is not unit tested directly, matching how the sibling flags are handled; the signup work in #8367 will boot with the flag set and cover that wiring.