### PR TITLE
Consolidate default workspace provisioning and skip it for AI onboarding

### DIFF
--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -1,4 +1,12 @@
+const crypto = require('crypto')
+
 const { Roles, RoleNames } = require('../../lib/roles')
+
+function provisioningError (message, code) {
+    const err = new Error(message)
+    err.code = code
+    return err
+}
 
 module.exports = {
 
@@ -21,6 +29,65 @@ module.exports = {
         })
 
         return team
+    },
+
+    /**
+     * Create the default application for a team, named after the user.
+     */
+    createDefaultApplication: async function (app, team, user) {
+        const applicationName = `${user.name}'s Application`
+        const application = await app.db.models.Application.create({
+            name: applicationName.charAt(0).toUpperCase() + applicationName.slice(1),
+            TeamId: team.id
+        })
+        await app.auditLog.Team.application.created(user, null, team, application)
+        await app.auditLog.Application.application.created(user, null, application)
+        return application
+    },
+
+    /**
+     * Provision the default workspace in a team: the application and hosted
+     * instance a classic signup would create. The instance type comes from the
+     * `user:team:auto-create:instanceType` platform setting.
+     *
+     * Throws errors with a `code` property (`team_not_empty`,
+     * `invalid_instance_type`, `invalid_stack`, `invalid_template`) so callers
+     * can decide how to surface them.
+     */
+    provisionDefaultWorkspace: async function (app, team, user) {
+        const existingInstances = await app.db.models.Project.byTeam(team.hashid)
+        if (existingInstances.length > 0) {
+            throw provisioningError('Team already has instances', 'team_not_empty')
+        }
+
+        const instanceTypeId = app.settings.get('user:team:auto-create:instanceType')
+        const instanceType = instanceTypeId && await app.db.models.ProjectType.byId(instanceTypeId)
+        if (!instanceType) {
+            throw provisioningError(`Instance type with id ${instanceTypeId} from 'user:team:auto-create:instanceType' not found`, 'invalid_instance_type')
+        }
+        const instanceStack = await instanceType.getDefaultStack() || (await instanceType.getProjectStacks())?.[0]
+        if (!instanceStack) {
+            throw provisioningError(`Unable to find a stack for use with instance type ${instanceTypeId}`, 'invalid_stack')
+        }
+        const instanceTemplate = await app.db.models.ProjectTemplate.findOne({ where: { active: true } })
+        if (!instanceTemplate) {
+            throw provisioningError('Unable to find the default instance template', 'invalid_template')
+        }
+
+        const applications = await app.db.models.Application.byTeam(team.id)
+        let application = applications[0]
+        const applicationCreated = !application
+        if (applicationCreated) {
+            application = await app.db.controllers.Team.createDefaultApplication(team, user)
+        }
+
+        const safeTeamName = team.name.toLowerCase().replace(/[\W_]/g, '-')
+        const safeUserName = user.username.toLowerCase().replace(/[\W_]/g, '-')
+        const instance = await app.db.controllers.Project.create(team, application, user, instanceType, instanceStack, instanceTemplate, {
+            name: `${safeTeamName}-${safeUserName}-${crypto.randomBytes(4).toString('hex')}`
+        })
+
+        return { application, instance, applicationCreated }
     },
 
     changeUserRole: async function (app, teamHashId, userHashId, role) {

--- a/forge/lib/userTeam.js
+++ b/forge/lib/userTeam.js
@@ -59,51 +59,20 @@ async function completeUserSignup (app, user, { createTeamOverride = false } = {
         }
     }
 
+    // With AI-led onboarding enabled, stop here: the team stays empty and the
+    // default workspace gets provisioned later, on demand.
+    if (app.config.features.enabled('aiOnboarding')) {
+        return
+    }
+
     // only create a starting instance if the flag is set and this user and their teams have no instances
     if (app.settings.get('user:team:auto-create:instanceType') &&
             personalTeam &&
             !((await app.db.models.Project.byUser(user)).length)) {
-        const instanceTypeId = app.settings.get('user:team:auto-create:instanceType')
-
-        const instanceType = await app.db.models.ProjectType.byId(instanceTypeId)
-        const instanceStack = await instanceType?.getDefaultStack() || (await instanceType.getProjectStacks())?.[0]
-        const instanceTemplate = await app.db.models.ProjectTemplate.findOne({ where: { active: true } })
-
-        const userTeamMemberships = await app.db.models.Team.forUser(user)
-        if (userTeamMemberships.length <= 0) {
-            console.warn("Flag to auto-create instance is set ('user:team:auto-create:instanceType'), but user has no team, consider setting 'user:team:auto-create'")
-            return // reply.send({ status: 'okay' })
-        } else if (!instanceType) {
-            throw new Error(`Instance type with id ${instanceTypeId} from 'user:team:auto-create:instanceType' not found`)
-        } else if (!instanceStack) {
-            throw new Error(`Unable to find a stack for use with instance type ${instanceTypeId} to auto-create user instance`)
-        } else if (!instanceTemplate) {
-            throw new Error('Unable to find the default instance template from which to auto-create user instance')
-        }
-
-        const applications = await app.db.models.Application.byTeam(personalTeam.id)
-        let application
-        if (applications.length > 0) {
-            application = applications[0]
-        } else {
-            const applicationName = `${user.name}'s Application`
-
-            application = await app.db.models.Application.create({
-                name: applicationName.charAt(0).toUpperCase() + applicationName.slice(1),
-                TeamId: personalTeam.id
-            })
-
+        const { application, instance, applicationCreated } = await app.db.controllers.Team.provisionDefaultWorkspace(personalTeam, user)
+        if (applicationCreated) {
             await app.auditLog.User.account.verify.autoCreateApplication(user, null, application)
         }
-
-        const safeTeamName = personalTeam.name.toLowerCase().replace(/[\W_]/g, '-')
-        const safeUserName = user.username.toLowerCase().replace(/[\W_]/g, '-')
-
-        const instanceProperties = {
-            name: `${safeTeamName}-${safeUserName}-${crypto.randomBytes(4).toString('hex')}`
-        }
-        const instance = await app.db.controllers.Project.create(personalTeam, application, user, instanceType, instanceStack, instanceTemplate, instanceProperties)
-
         await app.auditLog.User.account.verify.autoCreateInstance(user, null, instance)
     }
 }

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -1,5 +1,3 @@
-const crypto = require('crypto')
-
 const { Op } = require('sequelize')
 
 const { Roles } = require('../../lib/roles')
@@ -515,17 +513,6 @@ module.exports = async function (app) {
         }
     })
 
-    async function createTeamApplication (user, team) {
-        const applicationName = `${user.name}'s Application`
-        const application = await app.db.models.Application.create({
-            name: applicationName.charAt(0).toUpperCase() + applicationName.slice(1),
-            TeamId: team.id
-        })
-        await app.auditLog.Team.application.created(user, null, team, application)
-        await app.auditLog.Application.application.created(user, null, application)
-        return application
-    }
-
     /**
      * Create a new team
      * /api/v1/teams
@@ -625,25 +612,11 @@ module.exports = async function (app) {
                     await app.billing.setupTrialTeamSubscription(team, request.session.User)
                     // In trial mode, we may also auto-create their first application and instance
                     if (app.settings.get('user:team:auto-create:instanceType')) {
-                        const instanceTypeId = app.settings.get('user:team:auto-create:instanceType')
-                        const instanceType = await app.db.models.ProjectType.byId(instanceTypeId)
-                        const instanceStack = await instanceType?.getDefaultStack() || (await instanceType.getProjectStacks())?.[0]
-                        const instanceTemplate = await app.db.models.ProjectTemplate.findOne({ where: { active: true } })
-                        if (!instanceType) {
-                            app.log.warn(`Unable to create Trial Instance in team ${team.hashid}: Instance type with id ${instanceTypeId} from 'user:team:auto-create:instanceType' not found`)
-                        } else if (!instanceStack) {
-                            app.log.warn(`Unable to create Trial Instance in team ${team.hashid}: Unable to find a stack for use with instance type ${instanceTypeId}`)
-                        } else if (!instanceTemplate) {
-                            app.log.warn(`Unable to create Trial Instance in team ${team.hashid}: Unable to find the default instance template`)
-                        } else {
-                            const safeTeamName = team.name.toLowerCase().replace(/[\W_]/g, '-')
-                            const safeUserName = request.session.User.username.toLowerCase().replace(/[\W_]/g, '-')
-                            const application = await createTeamApplication(request.session.User, team)
+                        try {
+                            await app.db.controllers.Team.provisionDefaultWorkspace(team, request.session.User)
                             defaultTeamCreated = true
-                            const instanceProperties = {
-                                name: `${safeTeamName}-${safeUserName}-${crypto.randomBytes(4).toString('hex')}`
-                            }
-                            await app.db.controllers.Project.create(team, application, request.session.User, instanceType, instanceStack, instanceTemplate, instanceProperties)
+                        } catch (err) {
+                            app.log.warn(`Unable to create Trial Instance in team ${team.hashid}: ${err.message}`)
                         }
                     }
                 } else {
@@ -657,7 +630,7 @@ module.exports = async function (app) {
             }
             // Haven't created an application yet, but settings say we should
             if (!defaultTeamCreated && app.settings.get('user:team:auto-create:application')) {
-                await createTeamApplication(request.session.User, team)
+                await app.db.controllers.Team.createDefaultApplication(team, request.session.User)
             }
             await appendBillingDetails(teamView, team, request)
             reply.send(teamView)

--- a/test/unit/forge/db/controllers/Team_spec.js
+++ b/test/unit/forge/db/controllers/Team_spec.js
@@ -190,4 +190,100 @@ describe('Team controller', function () {
             throw new Error('Allowed last owner to be removed')
         })
     })
+
+    describe('createDefaultApplication', function () {
+        it('creates an application named after the user and audits it', async function () {
+            const user = await app.db.models.User.byUsername('alice')
+            const team = await app.factory.createTeam({ name: 'default-app-team' })
+
+            const application = await app.db.controllers.Team.createDefaultApplication(team, user)
+
+            application.should.have.property('name', "Alice Skywalker's Application")
+            application.should.have.property('TeamId', team.id)
+
+            const auditEntries = await app.db.models.AuditLog.findAll({ where: { event: 'application.created' } })
+            auditEntries.should.have.length(2)
+        })
+    })
+
+    describe('provisionDefaultWorkspace', function () {
+        let projectType
+        let originalTeamLimit
+        before(async function () {
+            originalTeamLimit = app.license.defaults.teams
+            app.license.defaults.teams = 50
+            await app.factory.createProjectTemplate({ name: 'provision-template', settings: {}, policy: {} }, app.TestObjects.userAlice)
+            projectType = await app.factory.createProjectType({ name: 'provision-type', description: '', properties: {} })
+            await app.factory.createStack({ name: 'provision-stack' }, projectType)
+
+            const teamTypeProperties = app.TestObjects.defaultTeamType.properties
+            teamTypeProperties.instances = { [projectType.hashid]: { active: true } }
+            app.TestObjects.defaultTeamType.properties = teamTypeProperties
+            await app.TestObjects.defaultTeamType.save()
+        })
+
+        after(function () {
+            app.license.defaults.teams = originalTeamLimit
+        })
+
+        beforeEach(async function () {
+            await app.settings.set('user:team:auto-create:instanceType', projectType.hashid)
+        })
+
+        it('creates a default application and instance in an empty team', async function () {
+            const user = await app.db.models.User.byUsername('alice')
+            const team = await app.factory.createTeam({ name: 'provision team one' })
+
+            const result = await app.db.controllers.Team.provisionDefaultWorkspace(team, user)
+
+            result.should.have.property('applicationCreated', true)
+            result.application.should.have.property('name', "Alice Skywalker's Application")
+            result.instance.name.should.match(/^provision-team-one-alice-[0-9a-f]{8}$/)
+
+            const instances = await app.db.models.Project.byTeam(team.hashid)
+            instances.should.have.length(1)
+        })
+
+        it('reuses an existing application', async function () {
+            const user = await app.db.models.User.byUsername('alice')
+            const team = await app.factory.createTeam({ name: 'provision team two' })
+            const existingApplication = await app.factory.createApplication({ name: 'existing-app' }, team)
+
+            const result = await app.db.controllers.Team.provisionDefaultWorkspace(team, user)
+
+            result.should.have.property('applicationCreated', false)
+            result.application.should.have.property('id', existingApplication.id)
+
+            const applications = await app.db.models.Application.byTeam(team.id)
+            applications.should.have.length(1)
+        })
+
+        it('refuses to provision a team that already has instances', async function () {
+            const user = await app.db.models.User.byUsername('alice')
+            const team = await app.factory.createTeam({ name: 'provision team three' })
+            await app.db.controllers.Team.provisionDefaultWorkspace(team, user)
+
+            try {
+                await app.db.controllers.Team.provisionDefaultWorkspace(team, user)
+            } catch (err) {
+                err.should.have.property('code', 'team_not_empty')
+                return
+            }
+            throw new Error('Provisioned a non-empty team')
+        })
+
+        it('throws when the instance type setting is not set', async function () {
+            await app.settings.set('user:team:auto-create:instanceType', null)
+            const user = await app.db.models.User.byUsername('alice')
+            const team = await app.factory.createTeam({ name: 'provision team four' })
+
+            try {
+                await app.db.controllers.Team.provisionDefaultWorkspace(team, user)
+            } catch (err) {
+                err.should.have.property('code', 'invalid_instance_type')
+                return
+            }
+            throw new Error('Provisioned without an instance type')
+        })
+    })
 })

--- a/test/unit/forge/ee/routes/api/team_spec.js
+++ b/test/unit/forge/ee/routes/api/team_spec.js
@@ -63,6 +63,58 @@ describe('Team API - with billing enabled', function () {
         sandbox.restore()
     })
 
+    describe('Create Team - trial mode', function () {
+        beforeEach(async function () {
+            const teamTypeProperties = app.defaultTeamType.properties
+            teamTypeProperties.trial = { active: true, duration: 5, sendEmail: false }
+            app.defaultTeamType.properties = teamTypeProperties
+            await app.defaultTeamType.save()
+            await app.settings.set('team:create', true)
+
+            await app.factory.createUser({
+                admin: false,
+                username: 'dave',
+                name: 'Dave Vader',
+                email: 'dave@example.com',
+                password: 'ddPassword'
+            })
+            await login('dave', 'ddPassword')
+        })
+
+        async function createTrialTeam () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/teams',
+                cookies: { sid: TestObjects.tokens.dave },
+                payload: { name: 'daves team', slug: 'daves-team', type: app.defaultTeamType.hashid, trial: true }
+            })
+            response.statusCode.should.equal(200)
+            return app.db.models.Team.bySlug('daves-team')
+        }
+
+        it('auto-creates a default application and instance when the instanceType setting is on', async function () {
+            await app.settings.set('user:team:auto-create:instanceType', app.projectType.hashid)
+            const team = await createTrialTeam()
+
+            const applications = await app.db.models.Application.byTeam(team.id)
+            applications.should.have.length(1)
+            applications[0].should.have.property('name', "Dave Vader's Application")
+
+            const instances = await app.db.models.Project.byTeam(team.hashid)
+            instances.should.have.length(1)
+            instances[0].name.should.match(/^daves-team-dave-[0-9a-f]{8}$/)
+        })
+
+        it('does not auto-create anything when the instanceType setting is off', async function () {
+            const team = await createTrialTeam()
+
+            const applications = await app.db.models.Application.byTeam(team.id)
+            applications.should.have.length(0)
+            const instances = await app.db.models.Project.byTeam(team.hashid)
+            instances.should.have.length(0)
+        })
+    })
+
     describe('Delete Team', function () {
         it('Delete team with expired trial and projects', async function () {
             const subscription = await app.team.getSubscription()

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -1323,6 +1323,33 @@ describe('Team API', function () {
     describe('Create team', async function () {
         // POST /api/v1/teams
         // - Admin/Owner/Member
+        it('creates a default application when the auto-create application setting is on', async function () {
+            await app.settings.set('user:team:auto-create:application', true)
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/teams',
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: { name: 'create-team-1', slug: 'create-team-1', type: app.defaultTeamType.hashid }
+            })
+            response.statusCode.should.equal(200)
+            const team = await app.db.models.Team.bySlug('create-team-1')
+            const applications = await app.db.models.Application.byTeam(team.id)
+            applications.should.have.length(1)
+            applications[0].should.have.property('name', `${TestObjects.alice.name}'s Application`)
+        })
+
+        it('does not create a default application by default', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/teams',
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: { name: 'create-team-2', slug: 'create-team-2', type: app.defaultTeamType.hashid }
+            })
+            response.statusCode.should.equal(200)
+            const team = await app.db.models.Team.bySlug('create-team-2')
+            const applications = await app.db.models.Application.byTeam(team.id)
+            applications.should.have.length(0)
+        })
     })
 
     describe('Delete team', async function () {

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -338,6 +338,48 @@ describe('Accounts API', async function () {
                 instance.safeName.should.match(/team-user-user3-(\w)+/)
             })
 
+            it('skips application and instance creation when AI onboarding is enabled', async function () {
+                app.config.features.register('aiOnboarding', true, true)
+                try {
+                    app.settings.set('user:signup', true)
+                    app.settings.set('user:team:auto-create', true)
+                    app.settings.set('user:team:auto-create:instanceType', app.projectType.hashid)
+
+                    const response = await registerUser({
+                        username: 'flaguser',
+                        password: '12345678',
+                        name: 'Flag User',
+                        email: 'flaguser@example.com'
+                    })
+                    response.statusCode.should.equal(200)
+
+                    const user = await app.db.models.User.findOne({ where: { username: 'flaguser' } })
+                    const verificationToken = await app.db.controllers.User.generateEmailVerificationToken(user)
+                    const verifyResponse = await app.inject({
+                        method: 'POST',
+                        url: '/account/verify/token',
+                        payload: {
+                            token: verificationToken.token
+                        },
+                        cookies: { sid: TestObjects.tokens.flaguser }
+                    })
+                    verifyResponse.statusCode.should.equal(200)
+
+                    // The team is still created
+                    const teamMemberships = await app.db.models.Team.forUser(user)
+                    teamMemberships.length.should.equal(1)
+
+                    // ...but with nothing in it
+                    const applications = await app.db.models.Application.byTeam(teamMemberships[0].Team.id)
+                    applications.length.should.equal(0)
+                    const instances = await app.db.models.Project.byUser(user)
+                    instances.length.should.equal(0)
+                } finally {
+                    app.config.features.register('aiOnboarding', false, true)
+                    app.settings.set('user:team:auto-create:instanceType', null)
+                }
+            })
+
             it('auto-creates an application & instance if instanceType option is set and there is no application yet', async function () {
                 app.settings.set('user:signup', true)
                 app.settings.set('user:team:auto-create', true)


### PR DESCRIPTION
Closes #8367

Part of #8365, stacked on #8431.

`completeUserSignup` used to create the default application and instance inline at email verification, and `forge/routes/api/team.js` had two more partial copies of the same logic (the trial block and the `user:team:auto-create:application` path). This folds all of it into two Team controller methods: `createDefaultApplication` and `provisionDefaultWorkspace`. The latter is what the on demand endpoint in #8368 will sit on top of. It guards with typed errors (`team_not_empty`, `invalid_instance_type`, `invalid_stack`, `invalid_template`) and returns the created application and instance so callers can do their own auditing and navigation.

When the `aiOnboarding` flag from #8431 is on, signup now stops after invite handling and team creation, so the user lands in an empty team and the Expert can set things up from the conversation. This covers all four signup callers (email verify, admin create, both SSO paths).

Two deliberate behavior changes: the application auto created at signup now also shows up in the team and application audit logs (it previously only emitted the user scoped `verify.autoCreateApplication` event), and the trial path gained the team empty guard and application reuse, both of which are no ops for a brand new team.

The trial block and the auto create application path had no test coverage at all, so this adds pin tests for them before the refactor, plus tests for the new controller methods and the flagged signup. The existing signup suite passes unchanged, which was the bar here.