### PR TITLE
Run only forge unit and system tests in the postgres CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,7 @@ jobs:
           FF_TEST_DB_POSTGRES_PASSWORD: secret
           FF_TEST_DB_POSTGRES_DATABASE: flowforge
           NODE_OPTIONS: "--max-old-space-size=6144"
-        run: npm run test
+        run: npm run test:unit:forge && npm run test:system
 
   ui-unit-tests:
     if: ${{ needs.check-changes.outputs.run_ui_tests == 'true' }}


### PR DESCRIPTION
Closes #8434

The `postgres-tests` job was running `npm run test`, which includes lint and the frontend vitest suite. Neither touches the database and both already run in the `ui-unit-tests` job, so the postgres run was just repeating them.

The job now runs `npm run test:unit:forge && npm run test:system`, matching what `backend-tests` runs against SQLite. Coverage instrumentation is skipped too, Codecov already gets its report from the SQLite run.
