### PR TITLE
Add on-demand default workspace provisioning endpoint

### DIFF
--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -17,6 +17,7 @@ const Permissions = {
     'team:read': { description: 'View a Team', role: Roles.Dashboard, access: 'read' },
     'team:edit': { description: 'Edit Team', role: Roles.Owner, access: 'write' },
     'team:delete': { description: 'Delete Team', role: Roles.Owner, access: 'write' },
+    'team:default-workspace:create': { description: 'Provision the default workspace in a Team', role: Roles.Member, access: 'write' },
     'team:audit-log': { description: 'Access Team Audit Log', role: Roles.Owner, access: 'read' },
     'team:device:bulk-delete': { description: 'Delete Devices', role: Roles.Owner, access: 'write' },
     'team:device:bulk-edit': { description: 'Edit Devices', role: Roles.Owner, access: 'write' },

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -655,6 +655,53 @@ module.exports = async function (app) {
     })
 
     /**
+     * Provision the default workspace (application + instance) in an empty team.
+     * Gives a team the same starting point a classic signup would have created.
+     * Only available when AI-led onboarding is enabled, as classic signups
+     * already provision at email verification.
+     * /api/v1/teams/:teamId/default-workspace
+     */
+    app.post('/:teamId/default-workspace', {
+        preHandler: app.needsPermission('team:default-workspace:create'),
+        schema: {
+            summary: 'Provision the default application and instance in an empty team',
+            tags: ['Teams'],
+            params: {
+                type: 'object',
+                properties: {
+                    teamId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        application: { $ref: 'ApplicationSummary' },
+                        instance: { $ref: 'Instance' }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
+        if (!app.config.features.enabled('aiOnboarding')) {
+            return reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+        }
+        try {
+            const { application, instance } = await app.db.controllers.Team.provisionDefaultWorkspace(request.team, request.session.User)
+            reply.send({
+                application: app.db.views.Application.applicationSummary(application),
+                instance: await app.db.views.Project.project(instance, { includeSettings: false })
+            })
+        } catch (err) {
+            const statusCode = err.code === 'team_not_empty' ? 409 : 400
+            reply.code(statusCode).send({ code: err.code || 'unexpected_error', error: err.message })
+        }
+    })
+
+    /**
      * Delete a team
      * /api/v1/teams/:teamId
      */

--- a/frontend/src/types/generated.ts
+++ b/frontend/src/types/generated.ts
@@ -2030,6 +2030,56 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/teams/{teamId}/default-workspace": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Provision the default application and instance in an empty team */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    teamId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            application?: components["schemas"]["ApplicationSummary"];
+                            instance?: components["schemas"]["Instance"];
+                        };
+                    };
+                };
+                /** @description Default Response */
+                "4XX": {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["APIError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/teams/{teamId}/comms-credentials": {
         parameters: {
             query?: never;

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -1352,6 +1352,104 @@ describe('Team API', function () {
         })
     })
 
+    describe('Provision default workspace', async function () {
+        // POST /api/v1/teams/:teamId/default-workspace
+        beforeEach(async function () {
+            app.config.features.register('aiOnboarding', true, true)
+            await app.settings.set('user:team:auto-create:instanceType', app.projectType.hashid)
+        })
+
+        async function createEmptyTeam (user, role) {
+            const team = await app.db.models.Team.create({ name: generateName('provision-team'), TeamTypeId: app.defaultTeamType.id })
+            await team.addUser(user, { through: { role } })
+            return team
+        }
+
+        it('member can provision an empty team', async function () {
+            const team = await createEmptyTeam(TestObjects.bob, Roles.Member)
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${team.hashid}/default-workspace`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('application')
+            result.application.should.have.property('id')
+            result.application.should.have.property('name', `${TestObjects.bob.name}'s Application`)
+            result.should.have.property('instance')
+            result.instance.should.have.property('id')
+            result.instance.should.have.property('name')
+
+            const applications = await app.db.models.Application.byTeam(team.id)
+            applications.length.should.equal(1)
+            const instances = await app.db.models.Project.byTeam(team.hashid)
+            instances.length.should.equal(1)
+        })
+
+        it('refuses to provision a team that already has instances', async function () {
+            const team = await createEmptyTeam(TestObjects.bob, Roles.Owner)
+            const firstResponse = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${team.hashid}/default-workspace`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            firstResponse.statusCode.should.equal(200)
+
+            const secondResponse = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${team.hashid}/default-workspace`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            secondResponse.statusCode.should.equal(409)
+            secondResponse.json().should.have.property('code', 'team_not_empty')
+        })
+
+        it('dashboard role cannot provision', async function () {
+            const team = await createEmptyTeam(TestObjects.dave, Roles.Dashboard)
+            await login('dave', 'ddPassword')
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${team.hashid}/default-workspace`,
+                cookies: { sid: TestObjects.tokens.dave }
+            })
+            response.statusCode.should.equal(403)
+        })
+
+        it('non-member cannot provision', async function () {
+            const team = await createEmptyTeam(TestObjects.bob, Roles.Owner)
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${team.hashid}/default-workspace`,
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            response.statusCode.should.equal(404)
+        })
+
+        it('is not available when the aiOnboarding flag is off', async function () {
+            app.config.features.register('aiOnboarding', false, true)
+            const team = await createEmptyTeam(TestObjects.bob, Roles.Member)
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${team.hashid}/default-workspace`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(404)
+        })
+
+        it('fails cleanly when the platform has no default instance type configured', async function () {
+            await app.settings.set('user:team:auto-create:instanceType', null)
+            const team = await createEmptyTeam(TestObjects.bob, Roles.Member)
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${team.hashid}/default-workspace`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(400)
+            response.json().should.have.property('code', 'invalid_instance_type')
+        })
+    })
+
     describe('Delete team', async function () {
         // DELETE /api/v1/teams/:teamId
         // - Admin/Owner/Member


### PR DESCRIPTION
Closes #8368

Part of #8365, stacked on #8432. Last piece of the story.

Once AI-led onboarding stops provisioning at signup, something has to produce the classic starting point later: the escape hatch for people who would rather set things up themselves, and the A/B control cohort on arrival. Both go through this one endpoint, which keeps the cohort assignment in the browser since the server has no PostHog flag evaluation.

`POST /api/v1/teams/:teamId/default-workspace` sits on the `provisionDefaultWorkspace` controller from #8432. It returns the created application and instance so the UI can navigate straight to the instance. A team that already has instances gets a 409 with `team_not_empty` rather than a second set, so a double call surfaces as a bug instead of hiding. A platform without a default instance type configured gets a 400 with the specific code. The endpoint 404s when the `aiOnboarding` flag is off, since classic signups already provision and there is no legitimate caller.

Permissions: new `team:default-workspace:create` at member level, so any team member can call it and nobody outside the team can.

Also regenerates the OpenAPI types, which is a purely additive diff for the new path.