### PR TITLE
Build the onboarding surface shell

### DIFF
--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -573,6 +573,15 @@ const deleteGitToken = async (teamId: string, tokenId: string) => {
     return client.delete(`/api/v1/teams/${teamId}/git/tokens/${tokenId}`)
 }
 
+/**
+ * Provision the default workspace (application + instance) in an empty team.
+ * Used by AI-led onboarding's "set it up myself" escape hatch. 409s with
+ * code 'team_not_empty' if the team already has instances.
+ */
+const provisionDefaultWorkspace = async (teamId: string) => {
+    return client.post(`/api/v1/teams/${teamId}/default-workspace`).then(res => res.data)
+}
+
 const getTeamInstanceCounts = async (teamId: string, states: string[], type: string, applicationId: string | null = null) => {
     const params = new URLSearchParams()
     states.forEach(state => params.append('state', state))
@@ -627,5 +636,6 @@ export default {
     getTeamDeviceGroups,
     getGitTokens,
     createGitToken,
-    deleteGitToken
+    deleteGitToken,
+    provisionDefaultWorkspace
 }

--- a/frontend/src/components/ResizeBar.vue
+++ b/frontend/src/components/ResizeBar.vue
@@ -58,6 +58,10 @@ export default {
     &.horizontal {
         width: 100%;
         height: 6px;
+        // the base border-right is the drawer-edge divider for the vertical
+        // variant; in horizontal mode it painted a stray 1px tick at the
+        // right end of the bar
+        border-right: none;
 
         &::before {
             writing-mode: horizontal-tb;

--- a/frontend/src/components/expert/Expert.vue
+++ b/frontend/src/components/expert/Expert.vue
@@ -8,7 +8,7 @@
             :class="{ 'has-mode-switcher': isInsightsModeEnabled && isEditorContext }"
             @scroll="handleScroll"
         >
-            <info-banner />
+            <info-banner v-if="!isOnboardingSurface" />
 
             <expert-messages @resizing="scrollToBottom" />
 
@@ -50,6 +50,10 @@ export default {
         togglePinWithWidth: {
             from: 'togglePinWithWidth',
             default: () => () => {} // No-op function when not provided
+        },
+        expertSurface: {
+            from: 'expert-surface',
+            default: 'drawer'
         }
     },
     props: {
@@ -85,6 +89,11 @@ export default {
             // In editor context, the route name includes 'editor'
             return this.$route?.name?.includes('editor') || false
         },
+        isOnboardingSurface () {
+            // In onboarding, the Expert opens the conversation itself, so the
+            // canned welcome message and the support banner stay out of it.
+            return this.expertSurface === 'onboarding'
+        },
         isInsightsModeEnabled () {
             return !!this.featuresCheck?.isExpertInsightsFeatureEnabled
         },
@@ -109,7 +118,9 @@ export default {
                 if (this.isInsightsAgent) {
                     await this.getCapabilities()
                 }
-                this.addWelcomeMessageIfNeeded()
+                if (!this.isOnboardingSurface) {
+                    this.addWelcomeMessageIfNeeded()
+                }
             }
         },
         'instance.meta.state': {

--- a/frontend/src/components/expert/components/ExpertChatInput.vue
+++ b/frontend/src/components/expert/components/ExpertChatInput.vue
@@ -5,8 +5,10 @@
             direction="horizontal"
             @mousedown="onStartResize"
         />
-        <!-- Action buttons row -->
-        <div class="action-buttons">
+        <!-- Action buttons row. Hidden during onboarding: the conversation is
+             the whole flow there, so Start over, Plan mode and settings only
+             offer ways to derail it. -->
+        <div v-if="expertSurface !== 'onboarding'" class="action-buttons">
             <button
                 type="button"
                 class="btn-start-over"
@@ -146,6 +148,10 @@ export default {
         togglePinWithWidth: {
             from: 'togglePinWithWidth',
             default: () => () => {} // No-op function when not provided
+        },
+        expertSurface: {
+            from: 'expert-surface',
+            default: 'drawer'
         }
     },
     emits: ['send', 'stop'],
@@ -227,6 +233,9 @@ export default {
             }
             if (this.requestingPlanChange) {
                 return 'Describe a change to the plan, or paste an edited version'
+            }
+            if (this.expertSurface === 'onboarding') {
+                return 'Or just tell me in your own words'
             }
             return this.isInsightsAgent
                 ? 'Tell us what you want to know about'

--- a/frontend/src/components/expert/components/ExpertMessages.vue
+++ b/frontend/src/components/expert/components/ExpertMessages.vue
@@ -1,8 +1,9 @@
 <template>
     <div ref="messagesWrapper" class="messages-wrapper">
         <ul class="flex flex-col gap-3">
-            <li v-for="message in messages" :key="message._uuid" class="flex flex-col gap-3">
-                <component :is="messageTypes[message._type]" v-if="messageTypes[message._type]" v-bind="{...message}" />
+            <li v-for="entry in renderList" :key="entryKey(entry)" class="flex flex-col gap-3">
+                <collapsed-question-turn v-if="entry.kind === 'folded-turn'" :turn="entry" />
+                <component :is="messageTypes[entry.message._type]" v-else-if="messageTypes[entry.message._type]" v-bind="{...entry.message}" />
             </li>
             <li v-if="isWaitingForResponse">
                 <expert-loading-indicator />
@@ -16,9 +17,12 @@
 import { mapState } from 'pinia'
 import { markRaw } from 'vue'
 
+import { buildCollapsedTranscript } from '../composables/collapseTranscript.js'
+
 import ExpertLoadingIndicator from './ExpertLoadingIndicator.vue'
 
 import AiMessage from './messages/AiMessage.vue'
+import CollapsedQuestionTurn from './messages/CollapsedQuestionTurn.vue'
 import HumanMessage from './messages/HumanMessage.vue'
 import SystemMessage from './messages/SystemMessage.vue'
 
@@ -27,7 +31,13 @@ import { useProductExpertStore } from '@/stores/product-expert.js'
 
 export default {
     name: 'ExpertMessages',
-    components: { ExpertLoadingIndicator },
+    components: { CollapsedQuestionTurn, ExpertLoadingIndicator },
+    inject: {
+        expertSurface: {
+            from: 'expert-surface',
+            default: 'drawer'
+        }
+    },
     emits: ['resizing'],
     data () {
         return {
@@ -43,6 +53,15 @@ export default {
                 human: markRaw(HumanMessage),
                 system: markRaw(SystemMessage)
             }
+        },
+        renderList () {
+            // The onboarding surface folds answered question turns into quiet
+            // lines (the collapsing-transcript treatment); the drawer renders
+            // the transcript as-is.
+            if (this.expertSurface === 'onboarding') {
+                return buildCollapsedTranscript(this.messages)
+            }
+            return this.messages.map(message => ({ kind: 'message', message }))
         }
     },
     mounted () {
@@ -54,6 +73,9 @@ export default {
         window.removeEventListener('keydown', this.onKeyDown)
     },
     methods: {
+        entryKey (entry) {
+            return entry.kind === 'folded-turn' ? entry.questionsMessage._uuid : entry.message._uuid
+        },
         onKeyDown (e) {
             if (e.altKey && e.shiftKey && e.key.toLowerCase() === 'd') {
                 e.preventDefault()

--- a/frontend/src/components/expert/components/messages/CollapsedQuestionTurn.vue
+++ b/frontend/src/components/expert/components/messages/CollapsedQuestionTurn.vue
@@ -1,0 +1,188 @@
+<template>
+    <div class="collapsed-question-turn" :class="{ expanded }">
+        <template v-if="!expanded">
+            <div
+                v-for="(entry, index) in turn.entries"
+                :key="index"
+                class="folded-question"
+                data-el="folded-question"
+            >
+                <button
+                    type="button"
+                    class="question-text"
+                    data-action="toggle-turn"
+                    title="Show the full question card"
+                    @click="expanded = true"
+                >
+                    {{ entry.question }}
+                </button>
+                <div class="folded-answers">
+                    <button
+                        v-for="(chip, chipIndex) in chipsFor(entry)"
+                        :key="chipIndex"
+                        type="button"
+                        class="answer-chip"
+                        data-action="edit-answer"
+                        title="Load this answer into the composer to correct it"
+                        @click="editAnswer(entry)"
+                    >
+                        <span class="chip-label">{{ chip }}</span>
+                        <span class="chip-remove" aria-hidden="true">&times;</span>
+                    </button>
+                    <span v-if="chipsFor(entry).length === 0" class="skipped-marker">Skipped</span>
+                </div>
+            </div>
+        </template>
+        <div v-else class="expanded-messages">
+            <button
+                type="button"
+                class="question-text"
+                data-action="toggle-turn"
+                title="Collapse this step"
+                @click="expanded = false"
+            >
+                Collapse this step
+            </button>
+            <AiMessage v-bind="{ ...turn.questionsMessage }" />
+            <HumanMessage v-if="turn.replyMessage" v-bind="{ ...turn.replyMessage }" />
+        </div>
+    </div>
+</template>
+
+<script>
+import { mapActions } from 'pinia'
+
+import AiMessage from './AiMessage.vue'
+import HumanMessage from './HumanMessage.vue'
+
+import { useProductExpertStore } from '@/stores/product-expert.js'
+
+export default {
+    name: 'CollapsedQuestionTurn',
+    components: {
+        AiMessage,
+        HumanMessage
+    },
+    props: {
+        turn: {
+            type: Object,
+            required: true
+        }
+    },
+    data () {
+        return {
+            expanded: false
+        }
+    },
+    computed: {
+        // A hand-typed or edited reply doesn't match the question lines, so
+        // every entry resolves to null; fall back to the raw reply text once.
+        hasMatchedAnswers () {
+            return this.turn.entries.some(entry => entry.answer !== null)
+        }
+    },
+    methods: {
+        ...mapActions(useProductExpertStore, ['setPendingInput']),
+        // One chip per pick: QuestionsList composes multi-select answers as a
+        // comma-separated list, so split for display only. Editing any chip
+        // loads the whole answer line, since a resend replaces the full turn.
+        chipsFor (entry) {
+            if (entry.answer) {
+                return entry.answer.split(', ')
+            }
+            if (!this.hasMatchedAnswers && this.turn.replyMessage?.content) {
+                return [this.turn.replyMessage.content]
+            }
+            return []
+        },
+        editAnswer (entry) {
+            if (entry.answer) {
+                this.setPendingInput(`${entry.question} ${entry.answer}`)
+            } else if (this.turn.replyMessage?.content) {
+                this.setPendingInput(this.turn.replyMessage.content)
+            }
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.collapsed-question-turn {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.folded-question {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.125rem 0 0.125rem 0.875rem;
+    border-left: 2px solid var(--ff-color-border);
+}
+
+.question-text {
+    font-size: 0.8125rem;
+    color: var(--ff-color-text-subtle);
+    text-align: left;
+    cursor: pointer;
+
+    &:hover {
+        color: var(--ff-color-text-strong);
+    }
+}
+
+.folded-answers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.answer-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--ff-color-text-strong);
+    background: var(--ff-color-bg-surface);
+    border: 1px solid var(--ff-color-border);
+    border-radius: 9999px;
+    padding: 0.25rem 0.75rem;
+    cursor: pointer;
+    max-width: 100%;
+
+    &:hover {
+        border-color: var(--ff-color-accent);
+    }
+}
+
+.chip-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 22rem;
+}
+
+.chip-remove {
+    font-weight: 400;
+    color: var(--ff-color-text-subtle);
+    line-height: 1;
+}
+
+.skipped-marker {
+    font-size: 0.875rem;
+    font-style: italic;
+    color: var(--ff-color-text-subtle);
+}
+
+.expanded-messages {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding-left: 0.875rem;
+    border-left: 2px solid var(--ff-color-accent);
+}
+</style>

--- a/frontend/src/components/expert/composables/collapseTranscript.js
+++ b/frontend/src/components/expert/composables/collapseTranscript.js
@@ -1,0 +1,71 @@
+/**
+ * Transcript folding for the onboarding surface's collapsing-transcript
+ * treatment. Pure functions over the store's message list: no state.
+ *
+ * A "questions turn" is an AI message carrying a questions answer, followed
+ * (usually) by the human reply QuestionsList composed for it. Once the turn
+ * has passed, the pair folds into one entry so the transcript stays quiet.
+ */
+
+function getQuestions (message) {
+    if (message._type !== 'ai' || !Array.isArray(message.answer)) {
+        return []
+    }
+    return message.answer
+        .filter(answer => Array.isArray(answer.questions) && answer.questions.length > 0)
+        .flatMap(answer => answer.questions)
+}
+
+/**
+ * Match each question to its line in the composed reply. QuestionsList sends
+ * one "<question> <answers>" line per question; anything that doesn't match
+ * (a hand-typed reply, an edited answer) resolves to null and the caller
+ * falls back to showing the raw reply.
+ */
+function extractAnswers (questions, replyContent) {
+    const lines = (replyContent || '').split('\n')
+    return questions.map(q => {
+        const line = lines.find(l => l.startsWith(q.question))
+        if (!line) {
+            return { question: q.question, answer: null }
+        }
+        const answer = line.slice(q.question.length).trim()
+        return { question: q.question, answer: answer.length > 0 ? answer : null }
+    })
+}
+
+/**
+ * Build the render list for a collapsing transcript.
+ *
+ * Returns entries of two kinds:
+ *  - { kind: 'message', message }: render as-is
+ *  - { kind: 'folded-turn', questionsMessage, replyMessage, entries }:
+ *    a past questions turn folded to one line per question. replyMessage is
+ *    the absorbed human reply, or null if the user never answered.
+ */
+function buildCollapsedTranscript (messages) {
+    const result = []
+    for (let i = 0; i < messages.length; i++) {
+        const message = messages[i]
+        const questions = getQuestions(message)
+        const isLast = i === messages.length - 1
+        if (questions.length === 0 || isLast) {
+            result.push({ kind: 'message', message })
+            continue
+        }
+        const next = messages[i + 1]
+        const replyMessage = next && next._type === 'human' ? next : null
+        if (replyMessage) {
+            i++
+        }
+        result.push({
+            kind: 'folded-turn',
+            questionsMessage: message,
+            replyMessage,
+            entries: extractAnswers(questions, replyMessage?.content)
+        })
+    }
+    return result
+}
+
+export { buildCollapsedTranscript }

--- a/frontend/src/components/expert/composables/onboardingFixture.js
+++ b/frontend/src/components/expert/composables/onboardingFixture.js
@@ -1,0 +1,57 @@
+/**
+ * TEMPORARY: a hardcoded onboarding conversation so the surface has something
+ * to render while the Expert-side work lands. Once flowfuse#8369 teaches the
+ * Expert to open the onboarding session itself, delete this file and the
+ * seeding call in pages/team/Onboarding.vue.
+ *
+ * Shapes match what `hydrateMessages` in stores/product-expert.js expects:
+ * `{ answer: [...] }` for AI turns, `{ query: '...' }` for the user's.
+ */
+const ONBOARDING_FIXTURE_MESSAGES = [
+    {
+        answer: [{
+            kind: 'questions',
+            questions: [{
+                question: 'What do you want working?',
+                multiSelect: false,
+                options: [
+                    { label: 'Readings into a dashboard' },
+                    { label: 'Alerts when something breaks' },
+                    { label: 'Data into a database' }
+                ]
+            }]
+        }]
+    },
+    { query: 'What do you want working? Readings into a dashboard' },
+    {
+        answer: [{
+            kind: 'questions',
+            questions: [{
+                question: 'Where do the readings come from?',
+                multiSelect: true,
+                options: [
+                    { label: 'Allen-Bradley PLC' },
+                    { label: 'Siemens PLC' },
+                    { label: 'over Ethernet' }
+                ]
+            }]
+        }]
+    },
+    { query: 'Where do the readings come from? Allen-Bradley PLC, over Ethernet' },
+    {
+        answer: [{
+            kind: 'questions',
+            questions: [{
+                question: "How should it let you know when something's wrong?",
+                multiSelect: true,
+                options: [
+                    { label: 'Show it on the same screen' },
+                    { label: 'Email me' },
+                    { label: 'Post to a chat channel', description: 'Slack, Teams and similar' }
+                ]
+            }]
+        }]
+    }
+]
+
+export { ONBOARDING_FIXTURE_MESSAGES }

--- a/frontend/src/layouts/Plain.vue
+++ b/frontend/src/layouts/Plain.vue
@@ -7,6 +7,9 @@
                 <!-- Desktop: Full wordmark logo -->
                 <img class="ff-logo hidden lg:block" :src="wordmarkLogo" alt="FlowFuse">
             </router-link>
+            <!-- Teleport target for page-level header actions (e.g. the
+                 onboarding escape hatch) -->
+            <div id="plain-layout-actions" class="ff-plain-layout-actions" />
         </div>
         <div class="ff-layout--plain--wrapper">
             <!-- <LeftDrawer /> -->
@@ -41,3 +44,12 @@ export default {
     }
 }
 </script>
+
+<style scoped lang="scss">
+.ff-plain-layout-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0 1.5rem;
+}
+</style>

--- a/frontend/src/pages/team/Onboarding.vue
+++ b/frontend/src/pages/team/Onboarding.vue
@@ -1,0 +1,245 @@
+<template>
+    <div class="ff-team-onboarding" data-page="team-onboarding">
+        <PageNotFound v-if="notAvailable" />
+        <template v-else-if="team">
+            <!-- The layout's header (the teleport target) finishes mounting
+                 after this page does, so the teleport waits a tick -->
+            <Teleport v-if="teleportReady" to="#plain-layout-actions">
+                <a
+                    href="#"
+                    class="skip-onboarding"
+                    data-action="skip-onboarding"
+                    @click.prevent="skipOnboarding"
+                >Set it up myself</a>
+            </Teleport>
+            <div class="onboarding-column">
+                <ExpertPanel />
+            </div>
+        </template>
+    </div>
+</template>
+
+<script>
+import { mapState } from 'pinia'
+
+import teamApi from '@/api/team.ts'
+import ExpertPanel from '@/components/expert/Expert.vue'
+import { ONBOARDING_FIXTURE_MESSAGES } from '@/components/expert/composables/onboardingFixture.js'
+import PageNotFound from '@/pages/PageNotFound.vue'
+import Alerts from '@/services/alerts.js'
+import { useAccountSettingsStore } from '@/stores/account-settings.js'
+import { useAccountStore } from '@/stores/account.js'
+import { useContextStore } from '@/stores/context.js'
+import { useProductExpertSupportAgentStore } from '@/stores/product-expert-support-agent.js'
+import { useProductExpertStore } from '@/stores/product-expert.js'
+
+export default {
+    name: 'TeamOnboarding',
+    components: {
+        ExpertPanel,
+        PageNotFound
+    },
+    provide () {
+        return {
+            // Switches the shared expert components into the onboarding
+            // treatment (collapsing transcript, no info banner, no canned
+            // welcome message). The drawer keeps the 'drawer' default.
+            'expert-surface': 'onboarding'
+        }
+    },
+    data () {
+        return {
+            provisioning: false,
+            teleportReady: false
+        }
+    },
+    computed: {
+        ...mapState(useContextStore, ['team']),
+        ...mapState(useAccountSettingsStore, ['featuresCheck']),
+        notAvailable () {
+            // Mirrors the backend's guards: the on-demand provisioning
+            // endpoint 404s without the flag and 409s once instances exist,
+            // so this page is only reachable in the same window.
+            if (!this.team) {
+                return false
+            }
+            return !this.featuresCheck.isAiOnboardingFeatureEnabled || this.team.instanceCount > 0
+        }
+    },
+    watch: {
+        '$route.params.team_slug': {
+            immediate: true,
+            handler (slug) {
+                if (slug) {
+                    useAccountStore().setTeam(slug)
+                }
+            }
+        },
+        team: {
+            immediate: true,
+            handler () {
+                this.seedFixtureTranscript()
+            }
+        }
+    },
+    mounted () {
+        this.$nextTick(() => {
+            this.teleportReady = true
+        })
+    },
+    methods: {
+        // TEMPORARY until flowfuse#8369: the Expert can't open a conversation
+        // on its own yet, so seed a placeholder transcript to work against.
+        // A transcript holding only canned messages (`generated`, e.g. the
+        // drawer's welcome text) counts as empty and gets replaced.
+        seedFixtureTranscript () {
+            if (!this.team || this.notAvailable) {
+                return
+            }
+            const expertStore = useProductExpertStore()
+            if (!expertStore.messages.every(message => message.generated)) {
+                return
+            }
+            if (expertStore.messages.length > 0) {
+                useProductExpertSupportAgentStore().reset()
+            }
+            expertStore.hydrateMessages(ONBOARDING_FIXTURE_MESSAGES)
+        },
+        async skipOnboarding () {
+            if (this.provisioning) {
+                return
+            }
+            this.provisioning = true
+            try {
+                await teamApi.provisionDefaultWorkspace(this.team.id)
+            } catch (err) {
+                // A team that already has instances is exactly where the
+                // escape hatch wants to land anyway
+                if (err.response?.data?.code !== 'team_not_empty') {
+                    this.provisioning = false
+                    Alerts.emit('Unable to set up your workspace. Please try again.', 'warning')
+                    return
+                }
+            }
+            this.$router.push({ name: 'team-home', params: { team_slug: this.team.slug } })
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.ff-team-onboarding {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    overflow: hidden;
+    background: var(--ff-color-bg-app);
+}
+
+.skip-onboarding {
+    font-size: 0.875rem;
+    color: var(--ff-color-text-subtle);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    white-space: nowrap;
+
+    &:hover {
+        color: var(--ff-color-text-strong);
+    }
+}
+
+.onboarding-column {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    max-width: 46rem;
+    padding: 1.5rem;
+    min-height: 0;
+}
+
+/*
+ * The onboarding treatment for the embedded expert panel. Everything below
+ * restyles the shared chat components for this surface only; the drawer's
+ * own styling is untouched.
+ */
+
+.onboarding-column :deep(.ff-expert) {
+    background: transparent;
+}
+
+/* Flatten the chat bubbles: the transcript reads as a document, not a chat */
+.onboarding-column :deep(.message-bubble.ai-message) {
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+}
+
+.onboarding-column :deep(.message-bubble.human-message) {
+    background: transparent;
+    color: var(--ff-color-text-subtle);
+    padding: 0;
+    align-self: stretch;
+}
+
+/* The active question set renders as a card, per the mockup */
+.onboarding-column :deep(.expert-questions) {
+    background: var(--ff-color-bg-surface);
+    border: 1px solid var(--ff-color-border);
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    gap: 1.25rem;
+}
+
+.onboarding-column :deep(.expert-questions .question-title) {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+/* Options render as full-width bordered tiles */
+.onboarding-column :deep(.expert-questions .ff-radio-btn),
+.onboarding-column :deep(.expert-questions .ff-checkbox) {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    border: 1px solid var(--ff-color-border);
+    border-radius: 0.375rem;
+    padding: 0.875rem 1rem 0.875rem 2.75rem;
+    background: var(--ff-color-bg-surface);
+    cursor: pointer;
+
+    /* the control is absolutely positioned top-left by default;
+       center it against the tile */
+    .checkbox {
+        top: 50%;
+        left: 1rem;
+        transform: translateY(-50%);
+    }
+
+    &:hover {
+        border-color: var(--ff-color-text-subtle);
+    }
+
+    &:has(.checkbox[checked='true']) {
+        border-color: var(--ff-color-accent);
+        background: var(--ff-color-accent-surface);
+    }
+}
+
+/* The composer sits quietly at the bottom: no divider, no panel chrome */
+.onboarding-column :deep(.ff-expert-input) {
+    border-top: none;
+    background: transparent;
+    min-height: 0;
+    padding: 1rem 0;
+}
+
+.onboarding-column :deep(.expert-questions .ff-radio-group-options) {
+    gap: 0.625rem;
+}
+
+.onboarding-column :deep(.expert-questions .questions-actions) {
+    margin-top: 0.25rem;
+}
+</style>

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -18,6 +18,7 @@ import LibraryRoutes from './Library/routes.js'
 import TeamMembersMembers from './Members/General.vue'
 import TeamMembersInvitations from './Members/Invitations.vue'
 import TeamMembers from './Members/index.vue'
+import TeamOnboarding from './Onboarding.vue'
 import TeamPerformance from './Performance/index.vue'
 import TeamPipelines from './Pipelines/index.vue'
 import TeamSettingsDanger from './Settings/Danger.vue'
@@ -252,6 +253,17 @@ export default [
         name: 'register-device',
         meta: {
             title: 'Register Remote Instance',
+            layout: 'plain'
+        }
+    },
+    {
+        // AI-led onboarding. Deliberately outside the `team` route tree: the
+        // plain layout has no RightDrawer. The page itself 404s when onboarding doesn't apply.
+        path: '/team/:team_slug/onboarding',
+        component: TeamOnboarding,
+        name: 'team-onboarding',
+        meta: {
+            title: 'Team - Getting Started',
             layout: 'plain'
         }
     },

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -849,8 +849,11 @@ export const useProductExpertStore = defineStore('product-expert', {
         },
         hydrateMessages (messages) {
             if (!messages) return
-            const isAiMessage = (message) => message.answer && Array.isArray(message.answer)
-            const isUserMessage = (message) => Object.prototype.hasOwnProperty.call(message, 'query') && message.query
+            // both predicates must return real booleans: the switch(true)
+            // below matches with strict equality, so a truthy string (e.g.
+            // the query text) would silently never match
+            const isAiMessage = (message) => Boolean(message.answer && Array.isArray(message.answer))
+            const isUserMessage = (message) => Boolean(Object.prototype.hasOwnProperty.call(message, 'query') && message.query)
 
             messages.forEach((message) => {
                 switch (true) {

--- a/test/unit/frontend/components/expert/CollapsedQuestionTurn.spec.js
+++ b/test/unit/frontend/components/expert/CollapsedQuestionTurn.spec.js
@@ -1,0 +1,106 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+    return {
+        expertStore: { setPendingInput: vi.fn() }
+    }
+})
+
+vi.mock('@/stores/product-expert.js', () => ({
+    useProductExpertStore: () => mocks.expertStore
+}))
+// The real message components pull in the full expert tree; the fold only
+// needs placeholders it can expand into.
+vi.mock('@/components/expert/components/messages/AiMessage.vue', () => ({
+    default: { name: 'AiMessage', template: '<div data-stub="ai-message" />' }
+}))
+vi.mock('@/components/expert/components/messages/HumanMessage.vue', () => ({
+    default: { name: 'HumanMessage', template: '<div data-stub="human-message" />' }
+}))
+
+// imported after mocks so vi.mock hoisting resolves correctly
+import CollapsedQuestionTurn from '../../../../../frontend/src/components/expert/components/messages/CollapsedQuestionTurn.vue'
+
+function answeredTurn () {
+    return {
+        kind: 'folded-turn',
+        questionsMessage: { _uuid: 'a1', _type: 'ai', answer: [] },
+        replyMessage: { _uuid: 'h1', _type: 'human', content: 'Q1? Sensors' },
+        entries: [
+            { question: 'Q1?', answer: 'Sensors' },
+            { question: 'Q2?', answer: 'A dashboard' }
+        ]
+    }
+}
+
+function mountTurn (turn = answeredTurn()) {
+    return mount(CollapsedQuestionTurn, {
+        props: { turn }
+    })
+}
+
+describe('CollapsedQuestionTurn', () => {
+    beforeEach(() => {
+        mocks.expertStore.setPendingInput.mockClear()
+    })
+
+    test('renders one quiet line per question with the pick as a chip', () => {
+        const wrapper = mountTurn()
+        const rows = wrapper.findAll('[data-el="folded-question"]')
+        expect(rows.length).toBe(2)
+        expect(rows[0].text()).toContain('Q1?')
+        expect(rows[0].find('[data-action="edit-answer"]').text()).toContain('Sensors')
+        expect(rows[1].find('[data-action="edit-answer"]').text()).toContain('A dashboard')
+    })
+
+    test('clicking a chip loads the answer into the composer for correction', async () => {
+        const wrapper = mountTurn()
+        await wrapper.findAll('[data-action="edit-answer"]')[0].trigger('click')
+        expect(mocks.expertStore.setPendingInput).toHaveBeenCalledWith('Q1? Sensors')
+    })
+
+    test('an unanswered turn shows a skipped marker and no chips', () => {
+        const turn = answeredTurn()
+        turn.replyMessage = null
+        turn.entries = [{ question: 'Q1?', answer: null }]
+        const wrapper = mountTurn(turn)
+        expect(wrapper.findAll('[data-action="edit-answer"]').length).toBe(0)
+        expect(wrapper.find('[data-el="folded-question"]').text()).toContain('Skipped')
+    })
+
+    test('a multi-select answer renders one chip per pick', async () => {
+        const turn = answeredTurn()
+        turn.entries = [{ question: 'Q1?', answer: 'Allen-Bradley PLC, over Ethernet' }]
+        const wrapper = mountTurn(turn)
+        const chips = wrapper.findAll('[data-action="edit-answer"]')
+        expect(chips.length).toBe(2)
+        expect(chips[0].text()).toContain('Allen-Bradley PLC')
+        expect(chips[1].text()).toContain('over Ethernet')
+
+        // editing any pick loads the whole answer line for correction
+        await chips[1].trigger('click')
+        expect(mocks.expertStore.setPendingInput).toHaveBeenCalledWith('Q1? Allen-Bradley PLC, over Ethernet')
+    })
+
+    test('a free-form reply keeps the raw text as the chip', () => {
+        const turn = answeredTurn()
+        turn.replyMessage = { _uuid: 'h1', _type: 'human', content: 'typed by hand' }
+        turn.entries = [{ question: 'Q1?', answer: null }]
+        const wrapper = mountTurn(turn)
+        const chip = wrapper.find('[data-action="edit-answer"]')
+        expect(chip.text()).toContain('typed by hand')
+    })
+
+    test('expands to the original messages and folds back', async () => {
+        const wrapper = mountTurn()
+        expect(wrapper.find('[data-stub="ai-message"]').exists()).toBe(false)
+
+        await wrapper.find('[data-action="toggle-turn"]').trigger('click')
+        expect(wrapper.find('[data-stub="ai-message"]').exists()).toBe(true)
+        expect(wrapper.find('[data-stub="human-message"]').exists()).toBe(true)
+
+        await wrapper.find('[data-action="toggle-turn"]').trigger('click')
+        expect(wrapper.find('[data-stub="ai-message"]').exists()).toBe(false)
+    })
+})

--- a/test/unit/frontend/components/expert/collapseTranscript.spec.js
+++ b/test/unit/frontend/components/expert/collapseTranscript.spec.js
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest'
+
+import { buildCollapsedTranscript } from '../../../../../frontend/src/components/expert/composables/collapseTranscript.js'
+
+function aiMessage (uuid, answer) {
+    return { _uuid: uuid, _type: 'ai', answer }
+}
+
+function humanMessage (uuid, content) {
+    return { _uuid: uuid, _type: 'human', content }
+}
+
+function questionsAnswer (questions) {
+    return { kind: 'questions', questions }
+}
+
+describe('buildCollapsedTranscript', () => {
+    test('passes plain messages through untouched', () => {
+        const messages = [
+            humanMessage('h1', 'hello'),
+            aiMessage('a1', [{ kind: 'chat', content: 'hi there' }])
+        ]
+        const result = buildCollapsedTranscript(messages)
+        expect(result).toEqual([
+            { kind: 'message', message: messages[0] },
+            { kind: 'message', message: messages[1] }
+        ])
+    })
+
+    test('folds an answered questions turn and absorbs the reply', () => {
+        const questions = [
+            { question: 'Where is your data coming from?', options: [] },
+            { question: 'What do you want to see at the end?', options: [] }
+        ]
+        const messages = [
+            aiMessage('a1', [questionsAnswer(questions)]),
+            humanMessage('h1', 'Where is your data coming from? Sensors\nWhat do you want to see at the end? A dashboard'),
+            aiMessage('a2', [{ kind: 'chat', content: 'great' }])
+        ]
+        const result = buildCollapsedTranscript(messages)
+        expect(result.length).toBe(2)
+        expect(result[0].kind).toBe('folded-turn')
+        expect(result[0].questionsMessage).toBe(messages[0])
+        expect(result[0].replyMessage).toBe(messages[1])
+        expect(result[0].entries).toEqual([
+            { question: 'Where is your data coming from?', answer: 'Sensors' },
+            { question: 'What do you want to see at the end?', answer: 'A dashboard' }
+        ])
+        expect(result[1]).toEqual({ kind: 'message', message: messages[2] })
+    })
+
+    test('does not fold the latest questions message', () => {
+        const messages = [
+            humanMessage('h1', 'hello'),
+            aiMessage('a1', [questionsAnswer([{ question: 'Q?', options: [] }])])
+        ]
+        const result = buildCollapsedTranscript(messages)
+        expect(result).toEqual([
+            { kind: 'message', message: messages[0] },
+            { kind: 'message', message: messages[1] }
+        ])
+    })
+
+    test('folds an unanswered stale questions message without absorbing anything', () => {
+        const messages = [
+            aiMessage('a1', [questionsAnswer([{ question: 'Q?', options: [] }])]),
+            aiMessage('a2', [{ kind: 'chat', content: 'moving on' }])
+        ]
+        const result = buildCollapsedTranscript(messages)
+        expect(result.length).toBe(2)
+        expect(result[0].kind).toBe('folded-turn')
+        expect(result[0].replyMessage).toBe(null)
+        expect(result[0].entries).toEqual([{ question: 'Q?', answer: null }])
+        expect(result[1]).toEqual({ kind: 'message', message: messages[1] })
+    })
+
+    test('keeps the raw reply when answers cannot be matched to questions', () => {
+        const messages = [
+            aiMessage('a1', [questionsAnswer([{ question: 'Q?', options: [] }])]),
+            humanMessage('h1', 'a free-form answer typed by hand'),
+            aiMessage('a2', [{ kind: 'chat', content: 'ok' }])
+        ]
+        const result = buildCollapsedTranscript(messages)
+        expect(result[0].kind).toBe('folded-turn')
+        expect(result[0].entries).toEqual([{ question: 'Q?', answer: null }])
+        expect(result[0].replyMessage).toBe(messages[1])
+    })
+
+    test('never folds non-questions ai messages', () => {
+        const messages = [
+            aiMessage('a1', [{ kind: 'chat', content: 'welcome' }]),
+            humanMessage('h1', 'hello'),
+            aiMessage('a2', [{ kind: 'chat', content: 'hi' }])
+        ]
+        const result = buildCollapsedTranscript(messages)
+        expect(result.every(entry => entry.kind === 'message')).toBe(true)
+    })
+})

--- a/test/unit/frontend/pages/team/Onboarding.spec.js
+++ b/test/unit/frontend/pages/team/Onboarding.spec.js
@@ -1,0 +1,186 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+    return {
+        contextStore: { team: null },
+        settingsStore: { featuresCheck: {} },
+        accountStore: { setTeam: vi.fn().mockResolvedValue() },
+        expertStore: { messages: [], hydrateMessages: vi.fn() },
+        supportAgentStore: { reset: vi.fn() }
+    }
+})
+
+vi.mock('@/stores/context.js', () => ({
+    useContextStore: () => mocks.contextStore
+}))
+vi.mock('@/stores/account-settings.js', () => ({
+    useAccountSettingsStore: () => mocks.settingsStore
+}))
+vi.mock('@/stores/account.js', () => ({
+    useAccountStore: () => mocks.accountStore
+}))
+vi.mock('@/stores/product-expert.js', () => ({
+    useProductExpertStore: () => mocks.expertStore
+}))
+vi.mock('@/stores/product-expert-support-agent.js', () => ({
+    useProductExpertSupportAgentStore: () => mocks.supportAgentStore
+}))
+// The real panel drags in the whole expert component tree (including
+// @flowfuse/flow-renderer, which does not load under vitest); the page only
+// needs to decide whether to mount it.
+vi.mock('@/components/expert/Expert.vue', () => ({
+    default: { name: 'ExpertPanel', template: '<div data-stub="expert-panel" />' }
+}))
+vi.mock('@/pages/PageNotFound.vue', () => ({
+    default: { name: 'PageNotFound', template: '<div data-stub="page-not-found" />' }
+}))
+vi.mock('@/api/team.ts', () => ({
+    default: {
+        provisionDefaultWorkspace: vi.fn().mockResolvedValue({ application: {}, instance: {} })
+    }
+}))
+
+// imported after mocks so vi.mock hoisting resolves correctly
+import teamApi from '../../../../../frontend/src/api/team.ts'
+
+// imported after mocks so vi.mock hoisting resolves correctly
+import Onboarding from '../../../../../frontend/src/pages/team/Onboarding.vue'
+
+const routerPush = vi.fn()
+
+async function mountPage () {
+    const wrapper = mount(Onboarding, {
+        global: {
+            stubs: {
+                // render teleported content in place so it is findable
+                teleport: true
+            },
+            mocks: {
+                $route: { params: { team_slug: 'ateam' } },
+                $router: { push: routerPush }
+            }
+        }
+    })
+    await flushPromises()
+    return wrapper
+}
+
+describe('Onboarding page', () => {
+    beforeEach(() => {
+        mocks.contextStore.team = { id: 't1', slug: 'ateam', instanceCount: 0 }
+        mocks.settingsStore.featuresCheck = { isAiOnboardingFeatureEnabled: true }
+        mocks.accountStore.setTeam.mockClear()
+    })
+
+    test('resolves the team from the route slug', async () => {
+        await mountPage()
+        expect(mocks.accountStore.setTeam).toHaveBeenCalledWith('ateam')
+    })
+
+    test('renders the onboarding surface for an empty team with the flag on', async () => {
+        const wrapper = await mountPage()
+        expect(wrapper.find('[data-stub="expert-panel"]').exists()).toBe(true)
+        expect(wrapper.find('[data-stub="page-not-found"]').exists()).toBe(false)
+    })
+
+    test('renders the 404 page when the aiOnboarding feature is off', async () => {
+        mocks.settingsStore.featuresCheck = { isAiOnboardingFeatureEnabled: false }
+        const wrapper = await mountPage()
+        expect(wrapper.find('[data-stub="page-not-found"]').exists()).toBe(true)
+        expect(wrapper.find('[data-stub="expert-panel"]').exists()).toBe(false)
+    })
+
+    test('renders the 404 page when the team already has instances', async () => {
+        mocks.contextStore.team = { id: 't1', slug: 'ateam', instanceCount: 2 }
+        const wrapper = await mountPage()
+        expect(wrapper.find('[data-stub="page-not-found"]').exists()).toBe(true)
+        expect(wrapper.find('[data-stub="expert-panel"]').exists()).toBe(false)
+    })
+
+    test('renders neither surface nor 404 while the team is still loading', async () => {
+        mocks.contextStore.team = null
+        const wrapper = await mountPage()
+        expect(wrapper.find('[data-stub="page-not-found"]').exists()).toBe(false)
+        expect(wrapper.find('[data-stub="expert-panel"]').exists()).toBe(false)
+    })
+
+    test('provides the onboarding surface variant to the expert components', async () => {
+        const wrapper = await mountPage()
+        expect(wrapper.vm.$options.provide.call(wrapper.vm)['expert-surface']).toBe('onboarding')
+    })
+
+    describe('fixture transcript', () => {
+        beforeEach(() => {
+            mocks.expertStore.hydrateMessages.mockClear()
+            mocks.supportAgentStore.reset.mockClear()
+            mocks.expertStore.messages = []
+        })
+
+        test('seeds the placeholder conversation when the transcript is empty', async () => {
+            await mountPage()
+            expect(mocks.expertStore.hydrateMessages).toHaveBeenCalledTimes(1)
+            const seeded = mocks.expertStore.hydrateMessages.mock.calls[0][0]
+            expect(Array.isArray(seeded)).toBe(true)
+            expect(seeded.length).toBeGreaterThan(0)
+            expect(mocks.supportAgentStore.reset).not.toHaveBeenCalled()
+        })
+
+        test('replaces a transcript that only holds canned messages', async () => {
+            mocks.expertStore.messages = [{ _type: 'ai', generated: true }]
+            await mountPage()
+            expect(mocks.supportAgentStore.reset).toHaveBeenCalledTimes(1)
+            expect(mocks.expertStore.hydrateMessages).toHaveBeenCalledTimes(1)
+        })
+
+        test('does not reseed a real conversation', async () => {
+            mocks.expertStore.messages = [{ _type: 'human', content: 'hello' }]
+            await mountPage()
+            expect(mocks.expertStore.hydrateMessages).not.toHaveBeenCalled()
+            expect(mocks.supportAgentStore.reset).not.toHaveBeenCalled()
+        })
+
+        test('does not seed on the 404 rendering', async () => {
+            mocks.settingsStore.featuresCheck = { isAiOnboardingFeatureEnabled: false }
+            await mountPage()
+            expect(mocks.expertStore.hydrateMessages).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('escape hatch', () => {
+        beforeEach(() => {
+            teamApi.provisionDefaultWorkspace.mockClear()
+            teamApi.provisionDefaultWorkspace.mockResolvedValue({ application: {}, instance: {} })
+            routerPush.mockClear()
+        })
+
+        test('offers a way out of onboarding', async () => {
+            const wrapper = await mountPage()
+            expect(wrapper.find('[data-action="skip-onboarding"]').exists()).toBe(true)
+        })
+
+        test('provisions the default workspace and lands on the team home', async () => {
+            const wrapper = await mountPage()
+            await wrapper.find('[data-action="skip-onboarding"]').trigger('click')
+            await flushPromises()
+            expect(teamApi.provisionDefaultWorkspace).toHaveBeenCalledWith('t1')
+            expect(routerPush).toHaveBeenCalledWith({ name: 'team-home', params: { team_slug: 'ateam' } })
+        })
+
+        test('an already-provisioned team still lands on the team home', async () => {
+            teamApi.provisionDefaultWorkspace.mockRejectedValue({
+                response: { status: 409, data: { code: 'team_not_empty' } }
+            })
+            const wrapper = await mountPage()
+            await wrapper.find('[data-action="skip-onboarding"]').trigger('click')
+            await flushPromises()
+            expect(routerPush).toHaveBeenCalledWith({ name: 'team-home', params: { team_slug: 'ateam' } })
+        })
+
+        test('does not offer the way out on the 404 rendering', async () => {
+            mocks.settingsStore.featuresCheck = { isAiOnboardingFeatureEnabled: false }
+            const wrapper = await mountPage()
+            expect(wrapper.find('[data-action="skip-onboarding"]').exists()).toBe(false)
+        })
+    })
+})

--- a/test/unit/frontend/stores/product-expert-hydrate.spec.js
+++ b/test/unit/frontend/stores/product-expert-hydrate.spec.js
@@ -1,0 +1,16 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('@/composables/services/MqttExpertTopicHelper.ts', () => ({ default: {}, getEntityTopicPaths: () => ({}) }))
+
+import { ONBOARDING_FIXTURE_MESSAGES } from '../../../../frontend/src/components/expert/composables/onboardingFixture.js'
+import { useProductExpertStore } from '../../../../frontend/src/stores/product-expert.js'
+
+describe('hydrate fixture', () => {
+    test('hydrates ai and human messages', () => {
+        setActivePinia(createPinia())
+        const store = useProductExpertStore()
+        store.hydrateMessages(ONBOARDING_FIXTURE_MESSAGES)
+        expect(store.messages.map(m => m._type)).toEqual(['ai', 'human', 'ai', 'human', 'ai'])
+    })
+})


### PR DESCRIPTION
Closes #8381

Part of #8380, stacked on #8436. The surface the onboarding conversation renders in, using the collapsing transcript treatment we settled on.

The page lives at `/team/:team_slug/onboarding` on the plain layout, deliberately outside the `team` route tree so there is no RightDrawer (the conversation can never render twice), no platform chrome and no billing bounce. It renders a 404 in place whenever onboarding does not apply: flag off, or the team already has instances, mirroring the backend guards on the provisioning endpoint.

The conversation is the existing `Expert.vue` panel mounted whole, reading the same store as the drawer. No message state lives in the surface, which is what keeps the future drawer handoff (#8384) free. An injected `expert-surface` variant (defaulting to `drawer`, so the drawer is untouched) switches the treatment: answered question turns fold into quiet lines with the picks as editable pill chips (a new pure `buildCollapsedTranscript` helper plus a `CollapsedQuestionTurn` component), the info banner, canned welcome message, Start over, Plan mode and settings controls are hidden, and the composer reads "Or just tell me in your own words". The rest of the treatment (flattened bubbles, the active question card with full width option tiles) is scoped deep CSS in the page, so deleting the page deletes the look.

The header gets a teleport target in the plain layout, and the page teleports a "Set it up myself" escape hatch into it, wired to the on-demand provisioning endpoint from #8436: provision, then land on the classic team home, with a 409 `team_not_empty` treated as already provisioned. The receding-after-engagement behaviour stays with #8382.

Since the Expert cannot open a conversation on its own yet (#8369), the page seeds a hardcoded placeholder transcript when the conversation is empty, clearly marked temporary with a pointer to that issue.

Two unrelated fixes are split into their own commits: `hydrateMessages` silently dropped every user message (its switch(true) matched a truthy string against `true`), which also affects the editor to platform handoff, and the horizontal resize bar painted a stray 1px tick inherited from the vertical variant's edge divider.

Verified against the mockup in a live browser in light and dark themes. 31 new unit tests across the fold helper, the folded turn component, the page and the hydrate regression.