### PR TITLE
Fix hydrateMessages silently dropping user messages

### DIFF
--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -849,8 +849,11 @@ export const useProductExpertStore = defineStore('product-expert', {
         },
         hydrateMessages (messages) {
             if (!messages) return
-            const isAiMessage = (message) => message.answer && Array.isArray(message.answer)
-            const isUserMessage = (message) => Object.prototype.hasOwnProperty.call(message, 'query') && message.query
+            // both predicates must return real booleans: the switch(true)
+            // below matches with strict equality, so a truthy string (e.g.
+            // the query text) would silently never match
+            const isAiMessage = (message) => Boolean(message.answer && Array.isArray(message.answer))
+            const isUserMessage = (message) => Boolean(Object.prototype.hasOwnProperty.call(message, 'query') && message.query)
 
             messages.forEach((message) => {
                 switch (true) {

--- a/test/unit/frontend/stores/product-expert-hydrate.spec.js
+++ b/test/unit/frontend/stores/product-expert-hydrate.spec.js
@@ -1,0 +1,30 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('@/composables/services/MqttExpertTopicHelper.ts', () => ({ default: {}, getEntityTopicPaths: () => ({}) }))
+
+// imported after mocks so vi.mock hoisting resolves correctly
+import { useProductExpertStore } from '../../../../frontend/src/stores/product-expert.js'
+
+// The shape hydrateMessages consumes: `{ answer: [...] }` for AI turns,
+// `{ query: '...' }` for the user's.
+const MIXED_TRANSCRIPT = [
+    { answer: [{ kind: 'questions', questions: [{ question: 'Where is the data coming from?', options: [] }] }] },
+    { query: 'Where is the data coming from? Sensors' },
+    { answer: [{ content: 'Great, noted.' }] },
+    { query: 'What else do you need to know?' },
+    { answer: [{ content: 'Nothing, we are done.' }] }
+]
+
+describe('product-expert hydrateMessages', () => {
+    // Regression: the switch(true) dispatch matches with strict equality, so
+    // a predicate returning a truthy string instead of a boolean silently
+    // dropped every user message from rehydrated transcripts.
+    test('hydrates ai and human messages in order', () => {
+        setActivePinia(createPinia())
+        const store = useProductExpertStore()
+        store.hydrateMessages(MIXED_TRANSCRIPT)
+        expect(store.messages.map(m => m._type)).toEqual(['ai', 'human', 'ai', 'human', 'ai'])
+        expect(store.messages[1].content).toBe('Where is the data coming from? Sensors')
+    })
+})


### PR DESCRIPTION
Found while building the onboarding surface, but this is shipped behaviour: `hydrateMessages` in the product-expert store rehydrates a saved transcript with a `switch (true)`, which matches cases by strict equality. The `isUserMessage` predicate returned `hasOwnProperty && message.query`, which evaluates to the query string rather than a boolean, so it never strictly equals `true` and every user message is silently skipped. The AI branch only works because `Array.isArray` happens to return a real boolean.

In practice this means the editor to platform conversation handoff (`wakeUpAssistant` with `shouldHydrateMessages`) rebuilds the transcript with the assistant's answers but none of the user's messages.

Both predicates now return actual booleans, with a comment explaining why that matters, plus a regression spec that hydrates a mixed transcript and asserts the message sequence.