### PR TITLE
Remove stray border tick on horizontal resize bars

### DIFF
--- a/frontend/src/components/ResizeBar.vue
+++ b/frontend/src/components/ResizeBar.vue
@@ -58,6 +58,10 @@ export default {
     &.horizontal {
         width: 100%;
         height: 6px;
+        // the base border-right is the drawer-edge divider for the vertical
+        // variant; in horizontal mode it painted a stray 1px tick at the
+        // right end of the bar
+        border-right: none;
 
         &::before {
             writing-mode: horizontal-tb;


### PR DESCRIPTION
The `.resize-bar` base style carries a `border-right` that acts as the visible drawer-edge divider for the original vertical variant. When horizontal support was added (d03b8ebaa) the base border was never neutralised, so horizontal bars (e.g. the one above the Expert chat composer) paint a stray 1px vertical tick at their right end. The horizontal variant now clears it; the vertical variant keeps its edge line.