### PR TITLE
[201] Mobile sign up + popup: Remove background image

### DIFF
--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable vue/no-v-html -->
 
 <template>
-    <ff-layout-box class="ff-signup ff--center-box">
+    <ff-layout-box class="ff-signup ff--center-box" :class="{ 'ff-signup--popup': isPopup }">
         <template v-if="splash && !isPopup" #splash-content>
             <div data-el="splash" v-html="splash" />
         </template>

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -109,6 +109,8 @@ $nav_height: 60px;
 
 @media screen and (max-width: ($ff-screen-md - 1px)) {
     .ff-signup {
+        background-image: none;
+
         .ff-layout--box--wrapper {
             flex-direction: column;
             gap: 0;
@@ -125,6 +127,10 @@ $nav_height: 60px;
             padding-top: 16px;
         }
     }
+}
+
+.ff-signup--popup {
+    background-image: none;
 }
 
 .ff-layout--box--right .ff-layout--box--content {


### PR DESCRIPTION
## Description

Removes the background image on mobile signup and in the popup. It can't be done from admin settings, the curved shape isn't in the banner HTML, it's a CSS background on the page layout.

## Related Issue(s)

Resolves https://github.com/FlowFuse/engineering/issues/201

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

