### PR TITLE
Hold tab presence until the loaded entity matches the route

### DIFF
--- a/frontend/src/publishers/tab-presence.publisher.ts
+++ b/frontend/src/publishers/tab-presence.publisher.ts
@@ -1,3 +1,5 @@
+import { watch } from 'vue'
+
 import { definePublisherSingleton } from './publisher.factory'
 import { TeamPublisher } from './team-publisher.contract'
 
@@ -11,7 +13,7 @@ const HEARTBEAT_INTERVAL = 45_000
 
 class TabPresencePublisher extends TeamPublisher {
     private $heartbeatTimer: ReturnType<typeof setInterval> | null = null
-    private $removeRouterGuard: (() => void) | null = null
+    private $stopContextWatch: (() => void) | null = null
     private $onVisibilityChange: (() => void) | null = null
     private $userId: string | null = null
     private $sessionId: string | null = null
@@ -56,12 +58,21 @@ class TabPresencePublisher extends TeamPublisher {
 
         this.$heartbeatTimer = setInterval(() => this._publishPresence(), HEARTBEAT_INTERVAL)
 
-        if (this.$router) {
-            // TODO this should reside in it's dedicated route guard
-            this.$removeRouterGuard = this.$router.afterEach(() => {
-                this._publishPresence()
-            })
-        }
+        // A route change flips the context to not-ready, then its loader lands and settles it.
+        // Republish whenever the ready snapshot changes; while not ready _publishPresence holds
+        // off, so a navigation defers until its entity is loaded rather than sending a stale one.
+        this.$stopContextWatch = watch(
+            () => {
+                const store = useContextStore()
+                if (!store.isExpertContextReady) {
+                    return 'pending'
+                }
+                const context = store.expert
+                const { entityType, entityId } = context.topicParts ?? {}
+                return `${context.pageName ?? ''}:${entityType ?? ''}:${entityId ?? ''}:${this._capabilities(context).join(',')}`
+            },
+            () => this._publishPresence()
+        )
 
         this.$onVisibilityChange = () => this._publishPresence()
         document.addEventListener('visibilitychange', this.$onVisibilityChange)
@@ -73,9 +84,9 @@ class TabPresencePublisher extends TeamPublisher {
             this.$heartbeatTimer = null
         }
 
-        if (this.$removeRouterGuard) {
-            this.$removeRouterGuard()
-            this.$removeRouterGuard = null
+        if (this.$stopContextWatch) {
+            this.$stopContextWatch()
+            this.$stopContextWatch = null
         }
 
         if (this.$onVisibilityChange) {
@@ -118,6 +129,10 @@ class TabPresencePublisher extends TeamPublisher {
         const topic = this._sessionTopic('heartbeat')
         if (!topic) return
         const contextStore = useContextStore()
+        // Hold off mid-navigation so we never publish a stale entity's context.
+        if (!contextStore.isExpertContextReady) {
+            return
+        }
         const context = contextStore.expert
         this._publish(topic, {
             visibility: document.visibilityState,

--- a/frontend/src/stores/context.js
+++ b/frontend/src/stores/context.js
@@ -50,9 +50,7 @@ export const useContextStore = defineStore('context', {
         isImmersiveEditor () {
             return this.editorEntityType !== null
         },
-        // Whether the loaded entity matches the route, so presence publishes the right topicParts
-        // instead of a stale one from the page just left. Editors advertise flow_building, so a
-        // team fallback there is the MCP routing failure - they must resolve their exact entity.
+        // Whether the loaded entity matches the route, so presence never publishes a stale one.
         isExpertContextReady (state) {
             const route = state.route
             if (!route) {
@@ -68,8 +66,7 @@ export const useContextStore = defineStore('context', {
             }
 
             const { entityType, entityId } = useMqttExpertTopicHelper().getEntityTopicPaths()
-            // Resolving to the team is the steady state for team and global pages; any deeper
-            // entity must belong to this route rather than the one whose loader has not landed.
+            // The team is the steady state for team and global pages; any deeper entity must belong to this route.
             if (entityType === 't') {
                 return !!this.team?.id
             }

--- a/frontend/src/stores/context.js
+++ b/frontend/src/stores/context.js
@@ -50,6 +50,31 @@ export const useContextStore = defineStore('context', {
         isImmersiveEditor () {
             return this.editorEntityType !== null
         },
+        // Whether the loaded entity matches the route, so presence publishes the right topicParts
+        // instead of a stale one from the page just left. Editors advertise flow_building, so a
+        // team fallback there is the MCP routing failure - they must resolve their exact entity.
+        isExpertContextReady (state) {
+            const route = state.route
+            if (!route) {
+                return false
+            }
+
+            const editorType = this.editorEntityType
+            if (editorType === 'instance') {
+                return state.instance?.id === route.params.id
+            }
+            if (editorType === 'device') {
+                return state.device?.id === route.params.id
+            }
+
+            const { entityType, entityId } = useMqttExpertTopicHelper().getEntityTopicPaths()
+            // Resolving to the team is the steady state for team and global pages; any deeper
+            // entity must belong to this route rather than the one whose loader has not landed.
+            if (entityType === 't') {
+                return !!this.team?.id
+            }
+            return Object.values(route.params).flat().includes(entityId)
+        },
         expert (state) {
             const authStore = useAccountAuthStore()
             const assistantStore = useProductAssistantStore()

--- a/test/unit/frontend/stores/context.spec.js
+++ b/test/unit/frontend/stores/context.spec.js
@@ -355,6 +355,73 @@ describe('context store', () => {
             })
         })
 
+        describe('isExpertContextReady', () => {
+            it('returns false when there is no route', () => {
+                const store = useContextStore()
+                expect(store.isExpertContextReady).toBe(false)
+            })
+
+            describe('immersive editors', () => {
+                it('is not ready while the instance the route addresses has not loaded', () => {
+                    const store = useContextStore()
+                    store.updateRoute({ name: 'instance-editor-overview', params: { id: 'inst-1' } })
+                    expect(store.isExpertContextReady).toBe(false)
+                })
+
+                it('is not ready while a stale instance from the previous page is still loaded', () => {
+                    const store = useContextStore()
+                    store.setInstance({ id: 'inst-0' })
+                    store.updateRoute({ name: 'instance-editor-overview', params: { id: 'inst-1' } })
+                    expect(store.isExpertContextReady).toBe(false)
+                })
+
+                it('is ready once the loaded instance matches the route', () => {
+                    const store = useContextStore()
+                    store.updateRoute({ name: 'instance-editor-overview', params: { id: 'inst-1' } })
+                    store.setInstance({ id: 'inst-1' })
+                    expect(store.isExpertContextReady).toBe(true)
+                })
+
+                it('is ready once the loaded device matches a device editor route', () => {
+                    const store = useContextStore()
+                    store.updateRoute({ name: 'device-editor-overview', params: { id: 'dev-1' } })
+                    store.setDevice({ id: 'dev-1' })
+                    expect(store.isExpertContextReady).toBe(true)
+                })
+            })
+
+            describe('non-editor routes', () => {
+                it('is not ready on a team page before the team loads', () => {
+                    const store = useContextStore()
+                    store.updateRoute({ name: 'team-brokers', params: { team_slug: 'alpha' } })
+                    expect(store.isExpertContextReady).toBe(false)
+                })
+
+                it('is ready on a team page once the team is present', () => {
+                    const store = useContextStore()
+                    store.setTeam({ id: 'team-1' })
+                    store.updateRoute({ name: 'team-brokers', params: { team_slug: 'alpha' } })
+                    expect(store.isExpertContextReady).toBe(true)
+                })
+
+                it('is not ready while a stale entity from the previous page is still loaded', () => {
+                    const store = useContextStore()
+                    store.setTeam({ id: 'team-1' })
+                    store.setInstance({ id: 'inst-0' })
+                    store.updateRoute({ name: 'instance-overview', params: { id: 'inst-1' } })
+                    expect(store.isExpertContextReady).toBe(false)
+                })
+
+                it('is ready once the loaded entity belongs to the route', () => {
+                    const store = useContextStore()
+                    store.setTeam({ id: 'team-1' })
+                    store.updateRoute({ name: 'instance-overview', params: { id: 'inst-1' } })
+                    store.setInstance({ id: 'inst-1' })
+                    expect(store.isExpertContextReady).toBe(true)
+                })
+            })
+        })
+
         describe('expert getter', () => {
             it('returns safe defaults if route is null', () => {
                 const store = useContextStore()


### PR DESCRIPTION
## Summary

A browser tab publishes a presence snapshot over MQTT so an MCP client can pin it and route calls to the page it is on. That snapshot carries the tab's topicParts (team / application / instance / device). This PR stops the tab from publishing that snapshot while it is mid-navigation, so it never advertises an entity left over from the page it just left.

## Problem

Presence was republished on every route change (`router.afterEach`). But a route change updates the route synchronously, while the new page's entity loads asynchronously afterwards. A heartbeat fired in that gap published the previous page's topicParts stamped with the new page's name.

The worst case is opening the Node-RED editor: the editor route advertises the `flow_building` capability, but until its instance or device has loaded, topicParts falls back to the team topic. A client pinning the tab then receives a team topic where it needs an instance or device, and `flow_building_list_tabs` fails with the tab not having reported which team, application or instance it is on.

## Solution

A new `isExpertContextReady` getter on the context store reports whether the entity currently loaded matches the current route:

- Editor routes must resolve their exact instance or device (the loaded id equals the route id), because they are the only routes that advertise `flow_building` and a fallback there is the routing failure above.
- Team and global pages are ready once a team is present.
- Other entity-scoped pages are ready once the resolved entity's id appears in the current route's params.

Two changes hang off it:

1. `_publishPresence` returns early while the context is not ready, so a stale snapshot is never sent.
2. The `router.afterEach` republish is replaced with a `watch` on the ready snapshot (page name, entity type, entity id, capabilities). Presence republishes when that settled snapshot changes rather than on every raw navigation; while not ready the watch holds a sentinel so it fires exactly once, when the entity resolves.

## Behaviour

- Navigating between pages: presence publishes once per page, after its entity has loaded, never during the load.
- Switching sub-tabs of the same entity (for example instance overview to devices): the entity is already loaded, so readiness stays true and presence republishes with the new page name.
- The 45s heartbeat is unchanged and continues to refresh whatever page the tab is currently on.

## Testing

Added unit tests for `isExpertContextReady` covering editor routes (exact-id match), team fallback, and other entity-scoped routes.

## Related

Closes #8460. Pairs with #8458 (MQTT will delay), which keeps an existing pin alive across a reload; this PR keeps the advertised topicParts correct.