### PR TITLE
Allow SSO Debug logging to be enabled per provider

### DIFF
--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -381,7 +381,11 @@ module.exports.init = async function (app) {
      * @param {object} providerOpts The SSO Provider configuration object
      */
     async function applyApplicationOverrides (user, desiredTeamApplicationroles, providerOpts) {
-        app.log.debug(`Desired Application Roles for ${user.username} ${JSON.stringify(desiredTeamApplicationroles)}`)
+        if (providerOpts.debugEnabled) {
+            app.log.info(`Desired Application Roles for ${user.username} ${JSON.stringify(desiredTeamApplicationroles)}`)
+        } else {
+            app.log.debug(`Desired Application Roles for ${user.username} ${JSON.stringify(desiredTeamApplicationroles)}`)
+        }
         // Work out which teams currently have SSO-managed overrides so we can clear
         // any that are no longer desired. Only teams in scope of this provider are
         // considered.
@@ -400,7 +404,11 @@ module.exports.init = async function (app) {
                 })
                 .map(teamMembership => teamMembership.Team.hashid)
         )
-        app.log.debug(`Existing Application Roles for ${user.username} ${JSON.stringify([...existingOverrideTeamIds])}`)
+        if (providerOpts.debugEnabled) {
+            app.log.info(`Existing Application Roles for ${user.username} ${JSON.stringify([...existingOverrideTeamIds])}`)
+        } else {
+            app.log.debug(`Existing Application Roles for ${user.username} ${JSON.stringify([...existingOverrideTeamIds])}`)
+        }
 
         // First pass - apply the desired overrides. Done sequentially so that the
         // apply and clear passes cannot race on the same membership.
@@ -412,7 +420,11 @@ module.exports.init = async function (app) {
                 // This team has been dealt with - don't clear it in the second pass
                 existingOverrideTeamIds.delete(teamId)
             } else {
-                app.log.debug(`User ${user.name} not a member of Team ${teamId} so not overriding Application access`)
+                if (providerOpts.debugEnabled) {
+                    app.log.info(`User ${user.name} not a member of Team ${teamId} so not overriding Application access`)
+                } else {
+                    app.log.debug(`User ${user.name} not a member of Team ${teamId} so not overriding Application access`)
+                }
             }
         }
 
@@ -448,7 +460,11 @@ module.exports.init = async function (app) {
             let adminGroup = false
             const desiredTeamMemberships = {}
             const desiredTeamApplicationroles = {}
-            app.log.debug(`SAML Group Assertions for ${user.username} ${JSON.stringify(groupAssertions)}`)
+            if (providerOpts.debugEnabled) {
+                app.log.info(`SAML Group Assertions for ${user.username} ${JSON.stringify(groupAssertions)}`)
+            } else {
+                app.log.debug(`SAML Group Assertions for ${user.username} ${JSON.stringify(groupAssertions)}`)
+            }
             for (const ga of groupAssertions) {
                 // Trim prefix/postfix from group name
                 let shortGA = ga
@@ -456,7 +472,11 @@ module.exports.init = async function (app) {
                     const start = providerOpts.groupPrefixLength || 0
                     const end = providerOpts.groupSuffixLength || 0
                     shortGA = ga.slice(start, ga.length - end)
-                    app.log.debug(`Converting Group name ${ga} to ${shortGA}`)
+                    if (providerOpts.debugEnabled) {
+                        app.log.info(`Converting Group name ${ga} to ${shortGA}`)
+                    } else {
+                        app.log.debug(`Converting Group name ${ga} to ${shortGA}`)
+                    }
                 }
                 // Parse the group name - format: 'ff-SLUG-ROLE'
                 // Generate a slug->role object (desiredTeamMemberships)
@@ -501,7 +521,11 @@ module.exports.init = async function (app) {
                     await user.save()
                 }
             }
-            app.log.debug(`Desired Teams for ${user.username} ${JSON.stringify(desiredTeamMemberships)}`)
+            if (providerOpts.debugEnabled) {
+                app.log.info(`Desired Teams for ${user.username} ${JSON.stringify(desiredTeamMemberships)}`)
+            } else {
+                app.log.debug(`Desired Teams for ${user.username} ${JSON.stringify(desiredTeamMemberships)}`)
+            }
 
             // Get the existing memberships and generate a slug->membership object (existingMemberships)
             const existingMemberships = {}
@@ -519,7 +543,11 @@ module.exports.init = async function (app) {
                     existingMemberships[membership.Team.slug] = membership
                 }
             })
-            app.log.debug(`Existing Teams for ${user.username} ${JSON.stringify(existingMemberships)}`)
+            if (providerOpts.debugEnabled) {
+                app.log.info(`Existing Teams for ${user.username} ${JSON.stringify(existingMemberships)}`)
+            } else {
+                app.log.debug(`Existing Teams for ${user.username} ${JSON.stringify(existingMemberships)}`)
+            }
 
             // We now have the list of desiredTeamMemberships and existingMemberships
             // that are in scope of being modified
@@ -591,7 +619,11 @@ module.exports.init = async function (app) {
             filter,
             attributes: ['cn']
         })
-        app.log.debug(`LDAP Groups for ${user.username} ${JSON.stringify(searchEntries)}`)
+        if (providerOpts.debugEnabled) {
+            app.log.info(`LDAP Groups for ${user.username} ${JSON.stringify(searchEntries)}`)
+        } else {
+            app.log.debug(`LDAP Groups for ${user.username} ${JSON.stringify(searchEntries)}`)
+        }
         const promises = []
         let adminGroup = false
         const desiredTeamMemberships = {}
@@ -609,7 +641,11 @@ module.exports.init = async function (app) {
             if (match) {
                 // check for Application override groups of the form `ff-<team>[<application>]-<role>`
                 if (!await recordApplicationOverride(desiredTeamApplicationroles, match, providerOpts)) {
-                    app.log.debug(`Found group ${searchEntries[i].cn} for user ${user.username}`)
+                    if (providerOpts.debugEnabled) {
+                        app.log.info(`Found group ${searchEntries[i].cn} for user ${user.username}`)
+                    } else {
+                        app.log.debug(`Found group ${searchEntries[i].cn} for user ${user.username}`)
+                    }
                     const teamSlug = match[1]
                     const teamRoleName = match[2]
                     const teamRole = Roles[teamRoleName]
@@ -630,7 +666,11 @@ module.exports.init = async function (app) {
                 adminGroup = true
             }
         }
-        app.log.debug(`Desired Teams for ${user.username} ${JSON.stringify(desiredTeamMemberships)}`)
+        if (providerOpts.debugEnabled) {
+            app.log.info(`Desired Teams for ${user.username} ${JSON.stringify(desiredTeamMemberships)}`)
+        } else {
+            app.log.debug(`Desired Teams for ${user.username} ${JSON.stringify(desiredTeamMemberships)}`)
+        }
         if (providerOpts.groupAdmin) {
             if (user.admin && !adminGroup) {
                 app.auditLog.User.user.updatedUser(0, null, [{ key: 'admin', old: true, new: false }], user)
@@ -664,7 +704,11 @@ module.exports.init = async function (app) {
                 existingMemberships[membership.Team.slug] = membership
             }
         })
-        app.log.debug(`Existing Teams for ${user.username} ${JSON.stringify(existingMemberships)}`)
+        if (providerOpts.debugEnabled) {
+            app.log.info(`Existing Teams for ${user.username} ${JSON.stringify(existingMemberships)}`)
+        } else {
+            app.log.debug(`Existing Teams for ${user.username} ${JSON.stringify(existingMemberships)}`)
+        }
         // We now have the list of desiredTeamMemberships and existingMemberships
         // that are in scope of being modified
 

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -18,6 +18,7 @@
                 </ff-button>
                 <template v-else>
                     <FormRow v-model="input.active" type="checkbox">Active</FormRow>
+                    <FormRow v-model="input.options.debugEnabled" type="checkbox">Enable Debug Logging</FormRow>
                     <template v-if="input.type === 'saml'">
                         <FormRow v-model="provider.acsURL" type="uneditable">ACS URL</FormRow>
                         <FormRow v-model="provider.entityID" type="uneditable">Entity ID / Issuer</FormRow>
@@ -190,7 +191,8 @@ export default {
                     groupAdminName: '',
                     groupPrefixLength: 0,
                     groupSuffixLength: 0,
-                    sendIdpHint: false
+                    sendIdpHint: false,
+                    debugEnabled: false
                 }
             },
             errors: {},
@@ -358,7 +360,8 @@ export default {
                     groupAssertionName: 'ff-roles',
                     groupPrefixLength: 0,
                     groupSuffixLength: 0,
-                    sendIdpHint: false
+                    sendIdpHint: false,
+                    debugEnabled: false
                 }
             } else {
                 this.loading = true
@@ -391,6 +394,7 @@ export default {
                 // groupTeams is stored as an array - convert to multi-line string for the edit form
                 this.input.options.groupTeams = (this.input.options.groupTeams || []).join('\n')
                 this.input.options.sendIdpHint = this.input.options.sendIdpHint ?? false
+                this.input.options.debugEnabled = this.input.options.debugEnabled ?? false
             } else {
                 // eslint-disable-next-line no-template-curly-in-string
                 this.input.options.userFilter = this.input.options.userFilter || '(uid=${username})'


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
To aid with debugging SSO configurations this allows a platform admin to enable debug level logging for a specific SSO provider in the configuration UI.

Defaults to off and works for both SAML and LDAP

<img width="784" height="779" alt="image" src="https://github.com/user-attachments/assets/053e1955-2715-4c00-9c59-e629ac931474" />


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

