### PR TITLE
feat(expert): pinned task list in the Expert chat

### DIFF
--- a/frontend/src/components/expert/Expert.vue
+++ b/frontend/src/components/expert/Expert.vue
@@ -18,6 +18,8 @@
         <!-- Updates Available Banner -->
         <update-banner v-if="isEditorContext && isInstanceRunning" />
 
+        <task-list v-if="activeTaskList" :items="activeTaskList.items" :title="activeTaskList.title" />
+
         <expert-chat-input ref="chatInput" @stop="handleStopGeneration" />
     </div>
 </template>
@@ -30,6 +32,7 @@ import ExpertMessages from './components/ExpertMessages.vue'
 import ExpertModeSwitcher from './components/ExpertModeSwitcher.vue'
 import InfoBanner from './components/InfoBanner.vue'
 import UpdateBanner from './components/UpdateBanner.vue'
+import TaskList from './components/messages/components/TaskList.vue'
 
 import { useAccountSettingsStore } from '@/stores/account-settings.js'
 import { useProductAssistantStore } from '@/stores/product-assistant.js'
@@ -44,7 +47,8 @@ export default {
         InfoBanner,
         ExpertMessages,
         ExpertChatInput,
-        UpdateBanner
+        UpdateBanner,
+        TaskList
     },
     inject: {
         togglePinWithWidth: {
@@ -75,7 +79,8 @@ export default {
             'abortController',
             'agentMode',
             'messages',
-            'isInsightsAgent'
+            'isInsightsAgent',
+            'activeTaskList'
         ]),
         ...mapState(useUxDrawersStore, {
             isPinned: state => state.rightDrawer.fixed

--- a/frontend/src/components/expert/components/messages/components/CollapsibleSection.vue
+++ b/frontend/src/components/expert/components/messages/components/CollapsibleSection.vue
@@ -1,0 +1,137 @@
+<template>
+    <div class="ff-collapsible" :class="{ 'is-up': openUp }">
+        <div class="ff-collapsible--header" @click="toggle">
+            <ChevronRightIcon class="ff-collapsible--chevron" :class="{ rotated: expanded }" />
+            <slot name="header" />
+        </div>
+        <transition :css="false" @enter="onEnter" @after-enter="onAfterEnter" @leave="onLeave">
+            <div v-if="expanded" ref="content" class="ff-collapsible--content">
+                <slot />
+            </div>
+        </transition>
+    </div>
+</template>
+
+<script>
+import { ChevronRightIcon } from '@heroicons/vue/20/solid'
+
+const DURATION = 220
+
+export default {
+    name: 'CollapsibleSection',
+    components: { ChevronRightIcon },
+    props: {
+        autoOpen: {
+            type: Boolean,
+            default: false
+        },
+        forceOpen: {
+            type: Boolean,
+            default: false
+        },
+        openUp: {
+            type: Boolean,
+            default: false
+        }
+    },
+    data () {
+        return {
+            manualExpanded: null
+        }
+    },
+    computed: {
+        expanded () {
+            if (this.forceOpen) return true
+            return this.manualExpanded !== null ? this.manualExpanded : this.autoOpen
+        }
+    },
+    methods: {
+        toggle () {
+            if (this.forceOpen) return
+            this.manualExpanded = !this.expanded
+        },
+        reducedMotion () {
+            return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+        },
+        onEnter (el, done) {
+            if (this.reducedMotion()) return done()
+            const target = el.scrollHeight
+            el.style.overflow = 'hidden'
+            el.style.height = '0'
+            el.style.opacity = '0'
+            requestAnimationFrame(() => {
+                el.style.transition = `height ${DURATION}ms ease, opacity ${DURATION}ms ease`
+                el.style.height = `${target}px`
+                el.style.opacity = '1'
+            })
+            this.onEnd(el, 'height', done)
+        },
+        onAfterEnter (el) {
+            el.style.height = ''
+            el.style.opacity = ''
+            el.style.overflow = ''
+            el.style.transition = ''
+        },
+        onLeave (el, done) {
+            if (this.reducedMotion()) return done()
+            el.style.overflow = 'hidden'
+            el.style.height = `${el.scrollHeight}px`
+            el.style.opacity = '1'
+            // Force a reflow so the browser registers the start height before collapsing.
+            this.forceReflow(el)
+            el.style.transition = `height ${DURATION}ms ease, opacity ${DURATION}ms ease`
+            el.style.height = '0'
+            el.style.opacity = '0'
+            this.onEnd(el, 'height', done)
+        },
+        forceReflow (el) {
+            // Reading a layout property flushes pending style writes so the next one animates.
+            return el.offsetHeight
+        },
+        onEnd (el, prop, done) {
+            const handler = (event) => {
+                if (event.target !== el || event.propertyName !== prop) return
+                el.removeEventListener('transitionend', handler)
+                done()
+            }
+            el.addEventListener('transitionend', handler)
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.ff-collapsible {
+    display: flex;
+    flex-direction: column;
+
+    &.is-up {
+        flex-direction: column-reverse;
+    }
+}
+
+.ff-collapsible--header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: var(--ff-color-text-subtle);
+
+    &:hover {
+        color: var(--ff-color-text);
+    }
+}
+
+.ff-collapsible--chevron {
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+    transition: transform 0.2s ease;
+
+    &.rotated {
+        transform: rotate(90deg);
+    }
+}
+</style>

--- a/frontend/src/components/expert/components/messages/components/CollapsibleSection.vue
+++ b/frontend/src/components/expert/components/messages/components/CollapsibleSection.vue
@@ -59,11 +59,10 @@ export default {
             el.style.overflow = 'hidden'
             el.style.height = '0'
             el.style.opacity = '0'
-            requestAnimationFrame(() => {
-                el.style.transition = `height ${DURATION}ms ease, opacity ${DURATION}ms ease`
-                el.style.height = `${target}px`
-                el.style.opacity = '1'
-            })
+            this.forceReflow(el)
+            el.style.transition = `height ${DURATION}ms ease, opacity ${DURATION}ms ease`
+            el.style.height = `${target}px`
+            el.style.opacity = '1'
             this.onEnd(el, 'height', done)
         },
         onAfterEnter (el) {
@@ -89,12 +88,20 @@ export default {
             return el.offsetHeight
         },
         onEnd (el, prop, done) {
-            const handler = (event) => {
-                if (event.target !== el || event.propertyName !== prop) return
+            let settled = false
+            const finish = () => {
+                if (settled) return
+                settled = true
                 el.removeEventListener('transitionend', handler)
+                clearTimeout(timer)
                 done()
             }
+            const handler = (event) => {
+                if (event.target !== el || event.propertyName !== prop) return
+                finish()
+            }
             el.addEventListener('transitionend', handler)
+            const timer = setTimeout(finish, DURATION + 50)
         }
     }
 }

--- a/frontend/src/components/expert/components/messages/components/TaskList.vue
+++ b/frontend/src/components/expert/components/messages/components/TaskList.vue
@@ -10,34 +10,27 @@
             <span class="ff-expert-tasklist--title">{{ title }}</span>
             <span class="ff-expert-tasklist--count">{{ doneCount }}/{{ items.length }}</span>
         </template>
-        <div class="ff-expert-tasklist--body">
-            <div
+        <ul class="ff-expert-tasklist--body">
+            <li
                 v-for="(item, index) in items"
                 :key="item.id || index"
                 class="ff-expert-tasklist--row"
                 :class="`is-${item.status}`"
             >
-                <span class="ff-expert-tasklist--status" aria-hidden="true">
-                    <CheckCircleIcon v-if="item.status === 'done'" class="ff-expert-tasklist--done-icon" />
-                    <span v-else class="ff-expert-tasklist--dot" />
-                </span>
-                <span class="ff-expert-tasklist--text">
-                    {{ item.text }}
-                    <span v-if="item.status === 'in_progress'" class="ff-expert-tasklist--running">(in progress)</span>
-                </span>
-            </div>
-        </div>
+                {{ item.text }}
+            </li>
+        </ul>
     </collapsible-section>
 </template>
 
 <script>
-import { CheckCircleIcon, ListBulletIcon } from '@heroicons/vue/20/solid'
+import { ListBulletIcon } from '@heroicons/vue/20/solid'
 
 import CollapsibleSection from './CollapsibleSection.vue'
 
 export default {
     name: 'TaskList',
-    components: { CollapsibleSection, ListBulletIcon, CheckCircleIcon },
+    components: { CollapsibleSection, ListBulletIcon },
     props: {
         items: {
             type: Array,
@@ -86,78 +79,29 @@ export default {
 }
 
 .ff-expert-tasklist--body {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem 0.25rem;
+    list-style: disc;
+    padding: 0.75rem 1rem 0.25rem 2rem;
     max-height: 40vh;
     overflow-y: auto;
     cursor: default;
 }
 
 .ff-expert-tasklist--row {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
     font-size: 0.875rem;
+    line-height: 1.4;
     color: var(--ff-color-text);
 
-    .ff-expert-tasklist--status {
-        flex-shrink: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 1rem;
-        height: 1rem;
-        margin-top: 0.125rem;
+    & + & {
+        margin-top: 0.5rem;
     }
 
-    .ff-expert-tasklist--done-icon {
-        width: 1rem;
-        height: 1rem;
-        color: var(--ff-color-success);
-    }
-
-    .ff-expert-tasklist--dot {
-        width: 0.6rem;
-        height: 0.6rem;
-        border-radius: 50%;
-        box-sizing: border-box;
-    }
-
-    &.is-pending .ff-expert-tasklist--dot {
-        border: 1.5px solid var(--ff-color-border-strong);
-    }
-
-    &.is-in_progress .ff-expert-tasklist--dot {
-        background: var(--ff-color-accent);
-        animation: ff-expert-tasklist-shimmer 1.4s ease-in-out infinite;
-    }
-
-    .ff-expert-tasklist--text {
-        flex: 1;
-        min-width: 0;
-        line-height: 1.4;
-    }
-
-    &.is-done .ff-expert-tasklist--text {
+    &.is-done {
         color: var(--ff-color-text-subtle);
         text-decoration: line-through;
     }
 
-    &.is-in_progress .ff-expert-tasklist--text {
-        font-weight: 500;
+    &.is-in_progress {
+        font-style: italic;
     }
-}
-
-.ff-expert-tasklist--running {
-    color: var(--ff-color-text-subtle);
-    font-weight: 400;
-    animation: ff-expert-tasklist-shimmer 1.4s ease-in-out infinite;
-}
-
-@keyframes ff-expert-tasklist-shimmer {
-    0%, 100% { opacity: 0.45; }
-    50% { opacity: 1; }
 }
 </style>

--- a/frontend/src/components/expert/components/messages/components/TaskList.vue
+++ b/frontend/src/components/expert/components/messages/components/TaskList.vue
@@ -1,0 +1,163 @@
+<template>
+    <collapsible-section
+        v-if="items.length"
+        class="ff-expert-tasklist"
+        :auto-open="active"
+        open-up
+    >
+        <template #header>
+            <ListBulletIcon class="ff-expert-tasklist--glyph" />
+            <span class="ff-expert-tasklist--title">{{ title }}</span>
+            <span class="ff-expert-tasklist--count">{{ doneCount }}/{{ items.length }}</span>
+        </template>
+        <div class="ff-expert-tasklist--body">
+            <div
+                v-for="(item, index) in items"
+                :key="item.id || index"
+                class="ff-expert-tasklist--row"
+                :class="`is-${item.status}`"
+            >
+                <span class="ff-expert-tasklist--status" aria-hidden="true">
+                    <CheckCircleIcon v-if="item.status === 'done'" class="ff-expert-tasklist--done-icon" />
+                    <span v-else class="ff-expert-tasklist--dot" />
+                </span>
+                <span class="ff-expert-tasklist--text">
+                    {{ item.text }}
+                    <span v-if="item.status === 'in_progress'" class="ff-expert-tasklist--running">(in progress)</span>
+                </span>
+            </div>
+        </div>
+    </collapsible-section>
+</template>
+
+<script>
+import { CheckCircleIcon, ListBulletIcon } from '@heroicons/vue/20/solid'
+
+import CollapsibleSection from './CollapsibleSection.vue'
+
+export default {
+    name: 'TaskList',
+    components: { CollapsibleSection, ListBulletIcon, CheckCircleIcon },
+    props: {
+        items: {
+            type: Array,
+            required: true
+        },
+        title: {
+            type: String,
+            required: false,
+            default: 'Planning'
+        }
+    },
+    computed: {
+        doneCount () {
+            return this.items.filter(item => item.status === 'done').length
+        },
+        active () {
+            return this.items.some(item => item.status === 'in_progress' || item.status === 'pending')
+        }
+    }
+}
+</script>
+
+<style scoped lang="scss">
+.ff-expert-tasklist {
+    border-top: 1px solid var(--ff-color-border);
+    background: var(--ff-color-bg-app);
+
+    :deep(.ff-collapsible--header) {
+        padding: 0.5rem 1rem;
+    }
+}
+
+.ff-expert-tasklist--glyph {
+    width: 0.875rem;
+    height: 0.875rem;
+    flex-shrink: 0;
+}
+
+.ff-expert-tasklist--title {
+    font-weight: 500;
+}
+
+.ff-expert-tasklist--count {
+    font-variant-numeric: tabular-nums;
+    margin-left: auto;
+}
+
+.ff-expert-tasklist--body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem 0.25rem;
+    max-height: 40vh;
+    overflow-y: auto;
+    cursor: default;
+}
+
+.ff-expert-tasklist--row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: var(--ff-color-text);
+
+    .ff-expert-tasklist--status {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 1rem;
+        height: 1rem;
+        margin-top: 0.125rem;
+    }
+
+    .ff-expert-tasklist--done-icon {
+        width: 1rem;
+        height: 1rem;
+        color: var(--ff-color-success);
+    }
+
+    .ff-expert-tasklist--dot {
+        width: 0.6rem;
+        height: 0.6rem;
+        border-radius: 50%;
+        box-sizing: border-box;
+    }
+
+    &.is-pending .ff-expert-tasklist--dot {
+        border: 1.5px solid var(--ff-color-border-strong);
+    }
+
+    &.is-in_progress .ff-expert-tasklist--dot {
+        background: var(--ff-color-accent);
+        animation: ff-expert-tasklist-shimmer 1.4s ease-in-out infinite;
+    }
+
+    .ff-expert-tasklist--text {
+        flex: 1;
+        min-width: 0;
+        line-height: 1.4;
+    }
+
+    &.is-done .ff-expert-tasklist--text {
+        color: var(--ff-color-text-subtle);
+        text-decoration: line-through;
+    }
+
+    &.is-in_progress .ff-expert-tasklist--text {
+        font-weight: 500;
+    }
+}
+
+.ff-expert-tasklist--running {
+    color: var(--ff-color-text-subtle);
+    font-weight: 400;
+    animation: ff-expert-tasklist-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes ff-expert-tasklist-shimmer {
+    0%, 100% { opacity: 0.45; }
+    50% { opacity: 1; }
+}
+</style>

--- a/frontend/src/components/expert/components/messages/components/TaskList.vue
+++ b/frontend/src/components/expert/components/messages/components/TaskList.vue
@@ -3,7 +3,6 @@
         v-if="items.length"
         class="ff-expert-tasklist"
         :auto-open="active"
-        open-up
     >
         <template #header>
             <ListBulletIcon class="ff-expert-tasklist--glyph" />
@@ -17,7 +16,7 @@
                 class="ff-expert-tasklist--row"
                 :class="`is-${item.status}`"
             >
-                {{ item.text }}
+                {{ item.text }}<span class="ff-expert-tasklist--status">{{ statusLabel(item.status) }}</span>
             </li>
         </ul>
     </collapsible-section>
@@ -39,7 +38,7 @@ export default {
         title: {
             type: String,
             required: false,
-            default: 'Planning'
+            default: 'Tasks'
         }
     },
     computed: {
@@ -48,6 +47,18 @@ export default {
         },
         active () {
             return this.items.some(item => item.status === 'in_progress' || item.status === 'pending')
+        }
+    },
+    methods: {
+        statusLabel (status) {
+            switch (status) {
+            case 'in_progress':
+                return '(In Progress)'
+            case 'done':
+                return '(Done)'
+            default:
+                return '(To Do)'
+            }
         }
     }
 }
@@ -70,6 +81,7 @@ export default {
 }
 
 .ff-expert-tasklist--title {
+    font-size: 1rem;
     font-weight: 500;
 }
 
@@ -80,14 +92,14 @@ export default {
 
 .ff-expert-tasklist--body {
     list-style: disc;
-    padding: 0.75rem 1rem 0.25rem 2rem;
+    padding: 0.75rem 1rem 1.25rem 2rem;
     max-height: 40vh;
     overflow-y: auto;
     cursor: default;
 }
 
 .ff-expert-tasklist--row {
-    font-size: 0.875rem;
+    font-size: 1rem;
     line-height: 1.4;
     color: var(--ff-color-text);
 
@@ -102,6 +114,20 @@ export default {
 
     &.is-in_progress {
         font-style: italic;
+    }
+}
+
+.ff-expert-tasklist--status {
+    margin-left: 0.375rem;
+    font-size: 0.875rem;
+    display: inline-block;
+    text-decoration: none;
+    font-style: normal;
+    white-space: nowrap;
+    color: var(--ff-color-text-subtle);
+
+    .is-in_progress & {
+        color: var(--ff-color-accent);
     }
 }
 </style>

--- a/frontend/src/components/expert/components/messages/components/TaskList.vue
+++ b/frontend/src/components/expert/components/messages/components/TaskList.vue
@@ -2,7 +2,7 @@
     <collapsible-section
         v-if="items.length"
         class="ff-expert-tasklist"
-        :auto-open="active"
+        auto-open
     >
         <template #header>
             <ListBulletIcon class="ff-expert-tasklist--glyph" />
@@ -44,9 +44,6 @@ export default {
     computed: {
         doneCount () {
             return this.items.filter(item => item.status === 'done').length
-        },
-        active () {
-            return this.items.some(item => item.status === 'in_progress' || item.status === 'pending')
         }
     },
     methods: {

--- a/frontend/src/stores/context.js
+++ b/frontend/src/stores/context.js
@@ -145,15 +145,10 @@ export const useContextStore = defineStore('context', {
                 supportsPlatformUIAutomation: useAccountSettingsStore().featuresCheck?.isExpertPlatformAutomationFeatureEnabled ?? false,
                 questionCadence: useProductExpertStore().questionCadence,
                 planMode: useProductExpertStore().planMode,
-                // Capability flags: signal that this version can render the question,
-                // plan, and approval cards. Older instances omit them and the agent drops
-                // the matching tool / runs in backward-compatible mode.
                 supportsQuestions: true,
                 supportsPlanMode: true,
                 supportsHITL: true,
-                // Human-in-the-loop tool permissions (#421). The agent gates each
-                // flow-building tool call against this map; canUseWriteTools drives
-                // role inheritance (fail-closed) for write/delete tools.
+                supportsPlansAndTasks: true,
                 toolPermissions: assistantStore.resolvedToolPermissions,
                 canUseWriteTools: hasAMinimumTeamRoleOf(Roles.Member, this.teamMembership)
             }

--- a/frontend/src/stores/product-expert-insights-agent.js
+++ b/frontend/src/stores/product-expert-insights-agent.js
@@ -12,6 +12,7 @@ export const useProductExpertInsightsAgentStore = defineStore('product-expert-in
     state: () => ({
         sessionId: null,
         messages: [],
+        activeTaskList: null,
         abortController: null,
         sessionStartTime: null,
         sessionWarningShown: false,

--- a/frontend/src/stores/product-expert-support-agent.js
+++ b/frontend/src/stores/product-expert-support-agent.js
@@ -8,6 +8,7 @@ export const useProductExpertSupportAgentStore = defineStore('product-expert-sup
         context: null,
         sessionId: null,
         messages: [],
+        activeTaskList: null,
 
         // Session timing
         abortController: null,
@@ -28,7 +29,7 @@ export const useProductExpertSupportAgentStore = defineStore('product-expert-sup
         }
     },
     persist: {
-        pick: ['context', 'messages', 'sessionId', 'sessionStartTime', 'sessionWarningShown', 'sessionExpiredShown'],
+        pick: ['context', 'messages', 'activeTaskList', 'sessionId', 'sessionStartTime', 'sessionWarningShown', 'sessionExpiredShown'],
         storage: sessionStorage,
         afterHydrate ({ store }) {
             store.messages.forEach(msg => {

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -34,6 +34,7 @@ export const useProductExpertStore = defineStore('product-expert', {
         questionCadence: 'all', // 'all' = ask every clarifying question at once, 'one' = one at a time
         planMode: false,
         inFlightUpdates: [],
+        activeTaskList: null,
         pendingInput: '',
         // One-shot chat composer command, consumed and cleared like pendingInput.
         // 'request-plan-change' focuses an empty composer for the plan card's "Request
@@ -417,7 +418,9 @@ export const useProductExpertStore = defineStore('product-expert', {
                 }
             }
 
-            this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
+            if (parsedTopic.inflightType !== 'expert:tasks') {
+                this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
+            }
 
             const responseTopic = topicHelper.buildTopic({
                 entityType: parsedTopic.entityType,
@@ -445,6 +448,26 @@ export const useProductExpertStore = defineStore('product-expert', {
                     }
                 })
                 break
+            case parsedTopic.inflightType === 'expert:tasks': {
+                const items = Array.isArray(payload.items) ? payload.items : []
+                this.activeTaskList = items.length
+                    ? { planId: payload.planId ?? null, title: payload.title || 'Planning', items }
+                    : null
+                await mqttService.publishMessage(connectionKey, {
+                    qos: 2,
+                    topic: responseTopic,
+                    payload: JSON.stringify({
+                        ack: true
+                    }),
+                    correlationData: transactionId,
+                    userProperties: {
+                        sessionId,
+                        transactionId: chatTransactionId,
+                        origin: window.origin || window.location.origin
+                    }
+                })
+                break
+            }
             case parsedTopic.inflightType === 'automation-ui:mcp-get-features': {
                 // handle UI MCP features request
                 try {
@@ -629,6 +652,7 @@ export const useProductExpertStore = defineStore('product-expert', {
 
             agentStore.sessionId = uuidv4()
             agentStore.messages = []
+            this.activeTaskList = null
 
             // A new chat drops the per-session tool grants ("Always allow/deny for this chat")
             // and the resolved-approval outcomes tied to the messages we just cleared.

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -34,7 +34,6 @@ export const useProductExpertStore = defineStore('product-expert', {
         questionCadence: 'all', // 'all' = ask every clarifying question at once, 'one' = one at a time
         planMode: false,
         inFlightUpdates: [],
-        activeTaskList: null,
         pendingInput: '',
         // One-shot chat composer command, consumed and cleared like pendingInput.
         // 'request-plan-change' focuses an empty composer for the plan card's "Request
@@ -64,6 +63,7 @@ export const useProductExpertStore = defineStore('product-expert', {
         },
         abortController () { return this._agentStore.abortController },
         messages () { return this._agentStore.messages },
+        activeTaskList () { return this._agentStore.activeTaskList },
         hasMessages () { return this._agentStore.messages.length > 0 },
         isSessionExpired () { return this._agentStore.sessionExpiredShown },
         isWaitingForResponse () { return !!this._agentStore.abortController || this._inFlightRequests.size > 0 },
@@ -452,22 +452,26 @@ export const useProductExpertStore = defineStore('product-expert', {
                 break
             case parsedTopic.inflightType === 'expert:tasks': {
                 const items = Array.isArray(payload.items) ? payload.items : []
-                this.activeTaskList = items.length
+                this._agentStore.activeTaskList = items.length
                     ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items }
                     : null
-                await mqttService.publishMessage(connectionKey, {
-                    qos: 2,
-                    topic: responseTopic,
-                    payload: JSON.stringify({
-                        ack: true
-                    }),
-                    correlationData: transactionId,
-                    userProperties: {
-                        sessionId,
-                        transactionId: chatTransactionId,
-                        origin: window.origin || window.location.origin
-                    }
-                })
+                try {
+                    await mqttService.publishMessage(connectionKey, {
+                        qos: 2,
+                        topic: responseTopic,
+                        payload: JSON.stringify({
+                            ack: true
+                        }),
+                        correlationData: transactionId,
+                        userProperties: {
+                            sessionId,
+                            transactionId: chatTransactionId,
+                            origin: window.origin || window.location.origin
+                        }
+                    })
+                } catch (e) {
+                    console.warn('expert:tasks ack failed:', e)
+                }
                 break
             }
             case parsedTopic.inflightType === 'automation-ui:mcp-get-features': {
@@ -654,7 +658,7 @@ export const useProductExpertStore = defineStore('product-expert', {
 
             agentStore.sessionId = uuidv4()
             agentStore.messages = []
-            this.activeTaskList = null
+            agentStore.activeTaskList = null
 
             // A new chat drops the per-session tool grants ("Always allow/deny for this chat")
             // and the resolved-approval outcomes tied to the messages we just cleared.
@@ -1358,10 +1362,11 @@ export const useProductExpertStore = defineStore('product-expert', {
                 }
             }
             this._inFlightRequests.clear()
+            this._agentStore.activeTaskList = null
         }
     },
     persist: {
-        pick: ['shouldWakeUpAssistant', 'questionCadence', 'agentMode', 'activeTaskList'],
+        pick: ['shouldWakeUpAssistant', 'questionCadence', 'agentMode'],
         storage: sessionStorage
     }
 })

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -451,7 +451,7 @@ export const useProductExpertStore = defineStore('product-expert', {
             case parsedTopic.inflightType === 'expert:tasks': {
                 const items = Array.isArray(payload.items) ? payload.items : []
                 this.activeTaskList = items.length
-                    ? { planId: payload.planId ?? null, title: payload.title || 'Planning', items }
+                    ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items }
                     : null
                 await mqttService.publishMessage(connectionKey, {
                     qos: 2,
@@ -1359,7 +1359,7 @@ export const useProductExpertStore = defineStore('product-expert', {
         }
     },
     persist: {
-        pick: ['shouldWakeUpAssistant', 'questionCadence', 'agentMode'],
+        pick: ['shouldWakeUpAssistant', 'questionCadence', 'agentMode', 'activeTaskList'],
         storage: sessionStorage
     }
 })

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -418,7 +418,11 @@ export const useProductExpertStore = defineStore('product-expert', {
                 }
             }
 
-            this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
+            // expert:tasks has its own panel; its status rides expert:status-message.
+            // Every other inflight type feeds the loading line.
+            if (parsedTopic.inflightType !== 'expert:tasks') {
+                this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
+            }
 
             const responseTopic = topicHelper.buildTopic({
                 entityType: parsedTopic.entityType,
@@ -447,14 +451,10 @@ export const useProductExpertStore = defineStore('product-expert', {
                 })
                 break
             case parsedTopic.inflightType === 'expert:tasks': {
-                // Only replace the list when the message carries one; status-only
-                // pings omit `items` and update the loading line above without
-                // touching the panel.
-                if (Array.isArray(payload.items)) {
-                    this.activeTaskList = payload.items.length
-                        ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items: payload.items }
-                        : null
-                }
+                const items = Array.isArray(payload.items) ? payload.items : []
+                this.activeTaskList = items.length
+                    ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items }
+                    : null
                 await mqttService.publishMessage(connectionKey, {
                     qos: 2,
                     topic: responseTopic,

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -447,10 +447,14 @@ export const useProductExpertStore = defineStore('product-expert', {
                 })
                 break
             case parsedTopic.inflightType === 'expert:tasks': {
-                const items = Array.isArray(payload.items) ? payload.items : []
-                this.activeTaskList = items.length
-                    ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items }
-                    : null
+                // Only replace the list when the message carries one; status-only
+                // pings omit `items` and update the loading line above without
+                // touching the panel.
+                if (Array.isArray(payload.items)) {
+                    this.activeTaskList = payload.items.length
+                        ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items: payload.items }
+                        : null
+                }
                 await mqttService.publishMessage(connectionKey, {
                     qos: 2,
                     topic: responseTopic,

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -418,9 +418,7 @@ export const useProductExpertStore = defineStore('product-expert', {
                 }
             }
 
-            if (parsedTopic.inflightType !== 'expert:tasks') {
-                this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
-            }
+            this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
 
             const responseTopic = topicHelper.buildTopic({
                 entityType: parsedTopic.entityType,


### PR DESCRIPTION
Closes FlowFuse/engineering#344

## Summary

Adds a pinned task list to the Expert chat that shows the current set of tasks. Tasks are not always bound to a plan: when they belong to a plan the header shows the plan name, otherwise it simply reads `Tasks`. The list sits just above the composer so progress stays visible while you scroll the conversation, and it survives a chat refresh.

The agent side sends a task surface over MQTT whenever the tasks or their states change. The panel renders each task with its state, a done/total counter, and a collapsible header. The whole feature is gated behind a `supportsPlansAndTasks` capability flag so an older instance simply never receives the surface.

## Changes

- New `TaskList.vue`: renders the current tasks with native disc bullets, a per-task state label, and a done/total count in the header.
- New `CollapsibleSection.vue`: a small reusable collapsible used by the task list header (and reused by the plan card in the stacked PR).
- `product-expert.js`: new `activeTaskList` state, an `expert:tasks` inflight handler that stores the surface and acks it, clears the list on a new chat, and persists `activeTaskList` in `sessionStorage` so it comes back after a refresh.
- `context.js`: advertises the new `supportsPlansAndTasks` capability flag alongside the existing ones.
- `Expert.vue`: mounts the task list between the messages and the composer.

## Task states

Every task carries a state and is labelled in place, so the list reads clearly without a legend:

- To Do: plain text, `(To Do)`
- In Progress: italic with an accent-coloured `(In Progress)`
- Done: struck through and subtle, `(Done)`

The header shows the done/total count and auto-opens while any task is still pending or in progress.

**All three states together (light):**

![Task list with To Do, In Progress, and Done states in light mode](https://github.com/user-attachments/assets/12fd1974-d359-4edd-b2fc-69313dcedb02)

**Same, in dark mode:**

![Task list with all three states in dark mode](https://github.com/user-attachments/assets/bd86279c-0acf-457d-817f-cd13bfbcde7a)

**Every task done:** the counter reads 5/5 and each row is struck through.

![Task list with every task done, counter 5/5](https://github.com/user-attachments/assets/9bcd22c4-cb7c-492f-8b7d-d39b2e244212)

**Collapsed:** the header collapses to a single line and keeps the counter (here 4/4).

![Collapsed task list header showing 4/4](https://github.com/user-attachments/assets/4b0be786-97cd-4f05-9ade-9028fd2e84df)

## Persistence

The active task list is persisted to `sessionStorage`, so refreshing the chat brings the list back in the same way the messages already return. Starting a new chat clears it.

## Backward compatibility

The agent keeps planning and tracking task state internally either way. The only thing the `supportsPlansAndTasks` flag gates is the emission: the task surface is published over MQTT only when the client advertises the flag. On an older frontend the surface is never sent, so the agent behaves exactly as before and there is simply no panel to receive it.

## Testing

- Started a plan-driven conversation and confirmed the task list appears above the composer with the correct states and counter.
- Toggled the collapsible header open and closed.
- Refreshed the chat and confirmed the list is restored.
- Started a new chat and confirmed the list is cleared.
- Verified light and dark rendering.

