### PR TITLE
feat(expert): structured plan card with active-plan pointer

### DIFF
--- a/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
+++ b/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
@@ -83,6 +83,11 @@
             :plan="answer.content"
             :message-uuid="messageUuid"
             :answer-uuid="answer._uuid"
+            :name="answer.name || ''"
+            :description="answer.description || ''"
+            :status="answer.status || 'proposed'"
+            :active="isActivePlan"
+            :awaiting-approval="isAwaitingPlanApproval"
             :disabled="interactionDisabled"
             :should-stream="shouldStream"
             class="mb-3"
@@ -171,7 +176,7 @@ export default {
     },
     computed: {
         ...mapState(useProductAssistantStore, ['supportedActions', 'toolApprovalStatuses']),
-        ...mapState(useProductExpertStore, ['agentMode', 'isWaitingForResponse', 'messages']),
+        ...mapState(useProductExpertStore, ['agentMode', 'isWaitingForResponse', 'messages', 'activePlanId']),
         isLatestMessage () {
             const msgs = this.messages || []
             return msgs.length > 0 && msgs[msgs.length - 1]?._uuid === this.messageUuid
@@ -234,6 +239,12 @@ export default {
         },
         isPlanAnswer () {
             return this.answer.kind === 'plan'
+        },
+        isAwaitingPlanApproval () {
+            return (this.answer.status || 'proposed') === 'proposed' && !this.interactionDisabled
+        },
+        isActivePlan () {
+            return !!this.answer.planId && this.answer.planId === this.activePlanId
         },
         isEditorContext () {
             // In editor context, the route name includes 'editor'

--- a/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
+++ b/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
@@ -85,7 +85,6 @@
             :answer-uuid="answer._uuid"
             :name="answer.name || ''"
             :description="answer.description || ''"
-            :status="answer.status || 'proposed'"
             :active="isActivePlan"
             :awaiting-approval="isAwaitingPlanApproval"
             :disabled="interactionDisabled"
@@ -241,7 +240,7 @@ export default {
             return this.answer.kind === 'plan'
         },
         isAwaitingPlanApproval () {
-            return (this.answer.status || 'proposed') === 'proposed' && !this.interactionDisabled
+            return !this.isActivePlan && !this.interactionDisabled
         },
         isActivePlan () {
             return !!this.answer.planId && this.answer.planId === this.activePlanId

--- a/frontend/src/components/expert/components/messages/components/CollapsibleSection.vue
+++ b/frontend/src/components/expert/components/messages/components/CollapsibleSection.vue
@@ -59,11 +59,10 @@ export default {
             el.style.overflow = 'hidden'
             el.style.height = '0'
             el.style.opacity = '0'
-            requestAnimationFrame(() => {
-                el.style.transition = `height ${DURATION}ms ease, opacity ${DURATION}ms ease`
-                el.style.height = `${target}px`
-                el.style.opacity = '1'
-            })
+            this.forceReflow(el)
+            el.style.transition = `height ${DURATION}ms ease, opacity ${DURATION}ms ease`
+            el.style.height = `${target}px`
+            el.style.opacity = '1'
             this.onEnd(el, 'height', done)
         },
         onAfterEnter (el) {
@@ -89,12 +88,20 @@ export default {
             return el.offsetHeight
         },
         onEnd (el, prop, done) {
-            const handler = (event) => {
-                if (event.target !== el || event.propertyName !== prop) return
+            let settled = false
+            const finish = () => {
+                if (settled) return
+                settled = true
                 el.removeEventListener('transitionend', handler)
+                clearTimeout(timer)
                 done()
             }
+            const handler = (event) => {
+                if (event.target !== el || event.propertyName !== prop) return
+                finish()
+            }
             el.addEventListener('transitionend', handler)
+            const timer = setTimeout(finish, DURATION + 50)
         }
     }
 }

--- a/frontend/src/components/expert/components/messages/components/TaskList.vue
+++ b/frontend/src/components/expert/components/messages/components/TaskList.vue
@@ -2,7 +2,7 @@
     <collapsible-section
         v-if="items.length"
         class="ff-expert-tasklist"
-        :auto-open="active"
+        auto-open
     >
         <template #header>
             <ListBulletIcon class="ff-expert-tasklist--glyph" />
@@ -44,9 +44,6 @@ export default {
     computed: {
         doneCount () {
             return this.items.filter(item => item.status === 'done').length
-        },
-        active () {
-            return this.items.some(item => item.status === 'in_progress' || item.status === 'pending')
         }
     },
     methods: {

--- a/frontend/src/components/expert/components/messages/components/resources/PlanCard.vue
+++ b/frontend/src/components/expert/components/messages/components/resources/PlanCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="expert-plan">
+    <div v-if="!hasStructure" class="expert-plan">
         <rich-content
             :content="plan"
             :message-uuid="messageUuid"
@@ -8,50 +8,78 @@
             class="plan-body"
         />
         <div class="plan-actions">
-            <ff-button
-                kind="primary"
-                size="small"
-                :disabled="disabled"
-                @click="$emit('approve')"
-            >
+            <ff-button kind="primary" size="small" :disabled="disabled" @click="$emit('approve')">
                 Approve
             </ff-button>
-            <ff-button
-                kind="secondary"
-                size="small"
-                :disabled="disabled"
-                title="Load the plan into the message box to edit it yourself"
-                @click="$emit('edit-manual')"
-            >
+            <ff-button kind="secondary" size="small" :disabled="disabled" title="Load the plan into the message box to edit it yourself" @click="$emit('edit-manual')">
                 Edit
             </ff-button>
-            <ff-button
-                kind="secondary"
-                size="small"
-                :disabled="disabled"
-                title="Tell the Expert what to change and get an updated plan"
-                @click="$emit('request-changes')"
-            >
+            <ff-button kind="secondary" size="small" :disabled="disabled" title="Tell the Expert what to change and get an updated plan" @click="$emit('request-changes')">
                 Request changes
             </ff-button>
-            <ff-button
-                kind="tertiary"
-                size="small"
-                :disabled="disabled"
-                @click="$emit('reject')"
-            >
+            <ff-button kind="tertiary" size="small" :disabled="disabled" @click="$emit('reject')">
                 Reject
             </ff-button>
         </div>
     </div>
+
+    <div v-else class="expert-plan expert-plan--structured">
+        <template v-if="awaitingApproval">
+            <div class="plan-head">
+                <span class="plan-name">Plan: {{ name }}</span>
+                <span class="plan-status" :class="`is-${status}`">{{ statusLabel }}</span>
+            </div>
+            <p v-if="description" class="plan-desc">{{ description }}</p>
+            <rich-content
+                :content="plan"
+                :message-uuid="messageUuid"
+                :answer-uuid="answerUuid"
+                :should-stream="false"
+                class="plan-body"
+            />
+            <div class="plan-actions">
+                <ff-button kind="primary" size="small" :disabled="disabled" @click="$emit('approve')">
+                    Approve
+                </ff-button>
+                <ff-button kind="secondary" size="small" :disabled="disabled" title="Load the plan into the message box to edit it yourself" @click="$emit('edit-manual')">
+                    Edit
+                </ff-button>
+                <ff-button kind="secondary" size="small" :disabled="disabled" title="Tell the Expert what to change and get an updated plan" @click="$emit('request-changes')">
+                    Request changes
+                </ff-button>
+                <ff-button kind="tertiary" size="small" :disabled="disabled" @click="$emit('reject')">
+                    Reject
+                </ff-button>
+            </div>
+        </template>
+        <collapsible-section v-else class="plan-collapsed">
+            <template #header>
+                <span class="plan-name">Plan: {{ name }}</span>
+                <span v-if="active" class="plan-badge">Active</span>
+                <span class="plan-status" :class="`is-${status}`">{{ statusLabel }}</span>
+            </template>
+            <p v-if="description" class="plan-desc">{{ description }}</p>
+            <rich-content
+                :content="plan"
+                :message-uuid="messageUuid"
+                :answer-uuid="answerUuid"
+                :should-stream="false"
+                class="plan-body"
+            />
+        </collapsible-section>
+    </div>
 </template>
 
 <script>
+import CollapsibleSection from '../CollapsibleSection.vue'
+
 import RichContent from './RichContent.vue'
+
+const STATUS_LABELS = { proposed: 'Proposed', approved: 'Approved', rejected: 'Rejected' }
 
 export default {
     name: 'PlanCard',
-    components: { RichContent },
+    components: { RichContent, CollapsibleSection },
     props: {
         plan: {
             type: String,
@@ -65,6 +93,26 @@ export default {
             type: String,
             required: true
         },
+        name: {
+            type: String,
+            default: ''
+        },
+        description: {
+            type: String,
+            default: ''
+        },
+        status: {
+            type: String,
+            default: 'proposed'
+        },
+        active: {
+            type: Boolean,
+            default: false
+        },
+        awaitingApproval: {
+            type: Boolean,
+            default: true
+        },
         disabled: {
             type: Boolean,
             default: false
@@ -75,6 +123,14 @@ export default {
         }
     },
     emits: ['approve', 'edit-manual', 'request-changes', 'reject', 'streaming-complete'],
+    computed: {
+        hasStructure () {
+            return this.name.length > 0
+        },
+        statusLabel () {
+            return STATUS_LABELS[this.status] || STATUS_LABELS.proposed
+        }
+    },
     mounted () {
         // plan cards are interactive, not streamed text; signal completion
         // so the AnswerWrapper streaming order can advance.
@@ -94,10 +150,61 @@ export default {
     gap: 0.75rem;
 }
 
+.plan-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.plan-name {
+    font-weight: 600;
+}
+
+.plan-status {
+    font-size: 0.75rem;
+    padding: 0.0625rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--ff-color-border);
+    color: var(--ff-color-text-subtle);
+
+    &.is-approved {
+        color: var(--ff-color-success);
+        border-color: var(--ff-color-success);
+    }
+
+    &.is-rejected {
+        color: var(--ff-color-danger);
+        border-color: var(--ff-color-danger);
+    }
+}
+
+.plan-badge {
+    font-size: 0.75rem;
+    padding: 0.0625rem 0.5rem;
+    border-radius: 999px;
+    background: var(--ff-color-accent-surface);
+    color: var(--ff-color-accent-text);
+}
+
+.plan-desc {
+    margin: 0;
+    color: var(--ff-color-text-subtle);
+}
+
 .plan-actions {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 8px;
+}
+
+.plan-collapsed {
+    :deep(.ff-collapsible--header) {
+        gap: 0.5rem;
+    }
+
+    .plan-status {
+        margin-left: auto;
+    }
 }
 </style>

--- a/frontend/src/components/expert/components/messages/components/resources/PlanCard.vue
+++ b/frontend/src/components/expert/components/messages/components/resources/PlanCard.vue
@@ -8,16 +8,38 @@
             class="plan-body"
         />
         <div class="plan-actions">
-            <ff-button kind="primary" size="small" :disabled="disabled" @click="$emit('approve')">
+            <ff-button
+                kind="primary"
+                size="small"
+                :disabled="disabled"
+                @click="$emit('approve')"
+            >
                 Approve
             </ff-button>
-            <ff-button kind="secondary" size="small" :disabled="disabled" title="Load the plan into the message box to edit it yourself" @click="$emit('edit-manual')">
+            <ff-button
+                kind="secondary"
+                size="small"
+                :disabled="disabled"
+                title="Load the plan into the message box to edit it yourself"
+                @click="$emit('edit-manual')"
+            >
                 Edit
             </ff-button>
-            <ff-button kind="secondary" size="small" :disabled="disabled" title="Tell the Expert what to change and get an updated plan" @click="$emit('request-changes')">
+            <ff-button
+                kind="secondary"
+                size="small"
+                :disabled="disabled"
+                title="Tell the Expert what to change and get an updated plan"
+                @click="$emit('request-changes')"
+            >
                 Request changes
             </ff-button>
-            <ff-button kind="tertiary" size="small" :disabled="disabled" @click="$emit('reject')">
+            <ff-button
+                kind="tertiary"
+                size="small"
+                :disabled="disabled"
+                @click="$emit('reject')"
+            >
                 Reject
             </ff-button>
         </div>
@@ -27,7 +49,6 @@
         <template v-if="awaitingApproval">
             <div class="plan-head">
                 <span class="plan-name">Plan: {{ name }}</span>
-                <span class="plan-status" :class="`is-${status}`">{{ statusLabel }}</span>
             </div>
             <p v-if="description" class="plan-desc">{{ description }}</p>
             <rich-content
@@ -38,16 +59,38 @@
                 class="plan-body"
             />
             <div class="plan-actions">
-                <ff-button kind="primary" size="small" :disabled="disabled" @click="$emit('approve')">
+                <ff-button
+                    kind="primary"
+                    size="small"
+                    :disabled="disabled"
+                    @click="$emit('approve')"
+                >
                     Approve
                 </ff-button>
-                <ff-button kind="secondary" size="small" :disabled="disabled" title="Load the plan into the message box to edit it yourself" @click="$emit('edit-manual')">
+                <ff-button
+                    kind="secondary"
+                    size="small"
+                    :disabled="disabled"
+                    title="Load the plan into the message box to edit it yourself"
+                    @click="$emit('edit-manual')"
+                >
                     Edit
                 </ff-button>
-                <ff-button kind="secondary" size="small" :disabled="disabled" title="Tell the Expert what to change and get an updated plan" @click="$emit('request-changes')">
+                <ff-button
+                    kind="secondary"
+                    size="small"
+                    :disabled="disabled"
+                    title="Tell the Expert what to change and get an updated plan"
+                    @click="$emit('request-changes')"
+                >
                     Request changes
                 </ff-button>
-                <ff-button kind="tertiary" size="small" :disabled="disabled" @click="$emit('reject')">
+                <ff-button
+                    kind="tertiary"
+                    size="small"
+                    :disabled="disabled"
+                    @click="$emit('reject')"
+                >
                     Reject
                 </ff-button>
             </div>
@@ -56,7 +99,6 @@
             <template #header>
                 <span class="plan-name">Plan: {{ name }}</span>
                 <span v-if="active" class="plan-badge">Active</span>
-                <span class="plan-status" :class="`is-${status}`">{{ statusLabel }}</span>
             </template>
             <p v-if="description" class="plan-desc">{{ description }}</p>
             <rich-content
@@ -74,8 +116,6 @@
 import CollapsibleSection from '../CollapsibleSection.vue'
 
 import RichContent from './RichContent.vue'
-
-const STATUS_LABELS = { proposed: 'Proposed', approved: 'Approved', rejected: 'Rejected' }
 
 export default {
     name: 'PlanCard',
@@ -101,10 +141,6 @@ export default {
             type: String,
             default: ''
         },
-        status: {
-            type: String,
-            default: 'proposed'
-        },
         active: {
             type: Boolean,
             default: false
@@ -126,9 +162,6 @@ export default {
     computed: {
         hasStructure () {
             return this.name.length > 0
-        },
-        statusLabel () {
-            return STATUS_LABELS[this.status] || STATUS_LABELS.proposed
         }
     },
     mounted () {
@@ -140,10 +173,6 @@ export default {
 </script>
 
 <style scoped lang="scss">
-// Render like a normal answer: no card border/background, just the plan content
-// followed by the action buttons. The gap spaces the buttons from the content.
-// The plan content inherits the message bubble's font-size, line-height and
-// colour, so the Markdown renders exactly like any other chat answer.
 .expert-plan {
     display: flex;
     flex-direction: column;
@@ -158,24 +187,6 @@ export default {
 
 .plan-name {
     font-weight: 600;
-}
-
-.plan-status {
-    font-size: 0.75rem;
-    padding: 0.0625rem 0.5rem;
-    border-radius: 999px;
-    border: 1px solid var(--ff-color-border);
-    color: var(--ff-color-text-subtle);
-
-    &.is-approved {
-        color: var(--ff-color-success);
-        border-color: var(--ff-color-success);
-    }
-
-    &.is-rejected {
-        color: var(--ff-color-danger);
-        border-color: var(--ff-color-danger);
-    }
 }
 
 .plan-badge {
@@ -201,10 +212,6 @@ export default {
 .plan-collapsed {
     :deep(.ff-collapsible--header) {
         gap: 0.5rem;
-    }
-
-    .plan-status {
-        margin-left: auto;
     }
 }
 </style>

--- a/frontend/src/components/expert/components/messages/components/resources/PlanCard.vue
+++ b/frontend/src/components/expert/components/messages/components/resources/PlanCard.vue
@@ -186,15 +186,17 @@ export default {
 }
 
 .plan-name {
+    font-size: 1.125rem;
     font-weight: 600;
+    color: var(--ff-color-text);
 }
 
 .plan-badge {
     font-size: 0.75rem;
     padding: 0.0625rem 0.5rem;
     border-radius: 999px;
-    background: var(--ff-color-accent-surface);
-    color: var(--ff-color-accent-text);
+    background: var(--ff-color-accent);
+    color: var(--ff-color-text-on-brand);
 }
 
 .plan-desc {
@@ -212,6 +214,10 @@ export default {
 .plan-collapsed {
     :deep(.ff-collapsible--header) {
         gap: 0.5rem;
+    }
+
+    .plan-desc {
+        margin-bottom: 0.75rem;
     }
 }
 </style>

--- a/frontend/src/stores/product-expert-insights-agent.js
+++ b/frontend/src/stores/product-expert-insights-agent.js
@@ -12,6 +12,7 @@ export const useProductExpertInsightsAgentStore = defineStore('product-expert-in
     state: () => ({
         sessionId: null,
         messages: [],
+        activeTaskList: null,
         abortController: null,
         sessionStartTime: null,
         sessionWarningShown: false,

--- a/frontend/src/stores/product-expert-support-agent.js
+++ b/frontend/src/stores/product-expert-support-agent.js
@@ -8,6 +8,7 @@ export const useProductExpertSupportAgentStore = defineStore('product-expert-sup
         context: null,
         sessionId: null,
         messages: [],
+        activeTaskList: null,
 
         // Session timing
         abortController: null,
@@ -28,7 +29,7 @@ export const useProductExpertSupportAgentStore = defineStore('product-expert-sup
         }
     },
     persist: {
-        pick: ['context', 'messages', 'sessionId', 'sessionStartTime', 'sessionWarningShown', 'sessionExpiredShown'],
+        pick: ['context', 'messages', 'activeTaskList', 'sessionId', 'sessionStartTime', 'sessionWarningShown', 'sessionExpiredShown'],
         storage: sessionStorage,
         afterHydrate ({ store }) {
             store.messages.forEach(msg => {

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -69,7 +69,7 @@ export const useProductExpertStore = defineStore('product-expert', {
         isWaitingForResponse () { return !!this._agentStore.abortController || this._inFlightRequests.size > 0 },
         isSupportAgent: (state) => state.agentMode === SUPPORT_AGENT,
         isInsightsAgent: (state) => state.agentMode === INSIGHTS_AGENT,
-        activePlanId: (state) => state.activeTaskList?.planId ?? null,
+        activePlanId () { return this.activeTaskList?.planId ?? null },
         hasSelectedCapabilities () {
             return useProductExpertInsightsAgentStore().selectedCapabilities?.length > 0
         },

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -419,9 +419,7 @@ export const useProductExpertStore = defineStore('product-expert', {
                 }
             }
 
-            if (parsedTopic.inflightType !== 'expert:tasks') {
-                this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
-            }
+            this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
 
             const responseTopic = topicHelper.buildTopic({
                 entityType: parsedTopic.entityType,

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -69,6 +69,7 @@ export const useProductExpertStore = defineStore('product-expert', {
         isWaitingForResponse () { return !!this._agentStore.abortController || this._inFlightRequests.size > 0 },
         isSupportAgent: (state) => state.agentMode === SUPPORT_AGENT,
         isInsightsAgent: (state) => state.agentMode === INSIGHTS_AGENT,
+        activePlanId: (state) => state.activeTaskList?.planId ?? null,
         hasSelectedCapabilities () {
             return useProductExpertInsightsAgentStore().selectedCapabilities?.length > 0
         },

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -34,7 +34,6 @@ export const useProductExpertStore = defineStore('product-expert', {
         questionCadence: 'all', // 'all' = ask every clarifying question at once, 'one' = one at a time
         planMode: false,
         inFlightUpdates: [],
-        activeTaskList: null,
         pendingInput: '',
         // One-shot chat composer command, consumed and cleared like pendingInput.
         // 'request-plan-change' focuses an empty composer for the plan card's "Request
@@ -64,6 +63,7 @@ export const useProductExpertStore = defineStore('product-expert', {
         },
         abortController () { return this._agentStore.abortController },
         messages () { return this._agentStore.messages },
+        activeTaskList () { return this._agentStore.activeTaskList },
         hasMessages () { return this._agentStore.messages.length > 0 },
         isSessionExpired () { return this._agentStore.sessionExpiredShown },
         isWaitingForResponse () { return !!this._agentStore.abortController || this._inFlightRequests.size > 0 },
@@ -453,22 +453,26 @@ export const useProductExpertStore = defineStore('product-expert', {
                 break
             case parsedTopic.inflightType === 'expert:tasks': {
                 const items = Array.isArray(payload.items) ? payload.items : []
-                this.activeTaskList = items.length
+                this._agentStore.activeTaskList = items.length
                     ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items }
                     : null
-                await mqttService.publishMessage(connectionKey, {
-                    qos: 2,
-                    topic: responseTopic,
-                    payload: JSON.stringify({
-                        ack: true
-                    }),
-                    correlationData: transactionId,
-                    userProperties: {
-                        sessionId,
-                        transactionId: chatTransactionId,
-                        origin: window.origin || window.location.origin
-                    }
-                })
+                try {
+                    await mqttService.publishMessage(connectionKey, {
+                        qos: 2,
+                        topic: responseTopic,
+                        payload: JSON.stringify({
+                            ack: true
+                        }),
+                        correlationData: transactionId,
+                        userProperties: {
+                            sessionId,
+                            transactionId: chatTransactionId,
+                            origin: window.origin || window.location.origin
+                        }
+                    })
+                } catch (e) {
+                    console.warn('expert:tasks ack failed:', e)
+                }
                 break
             }
             case parsedTopic.inflightType === 'automation-ui:mcp-get-features': {
@@ -655,7 +659,7 @@ export const useProductExpertStore = defineStore('product-expert', {
 
             agentStore.sessionId = uuidv4()
             agentStore.messages = []
-            this.activeTaskList = null
+            agentStore.activeTaskList = null
 
             // A new chat drops the per-session tool grants ("Always allow/deny for this chat")
             // and the resolved-approval outcomes tied to the messages we just cleared.
@@ -1359,10 +1363,11 @@ export const useProductExpertStore = defineStore('product-expert', {
                 }
             }
             this._inFlightRequests.clear()
+            this._agentStore.activeTaskList = null
         }
     },
     persist: {
-        pick: ['shouldWakeUpAssistant', 'questionCadence', 'agentMode', 'activeTaskList'],
+        pick: ['shouldWakeUpAssistant', 'questionCadence', 'agentMode'],
         storage: sessionStorage
     }
 })

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -448,10 +448,14 @@ export const useProductExpertStore = defineStore('product-expert', {
                 })
                 break
             case parsedTopic.inflightType === 'expert:tasks': {
-                const items = Array.isArray(payload.items) ? payload.items : []
-                this.activeTaskList = items.length
-                    ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items }
-                    : null
+                // Only replace the list when the message carries one; status-only
+                // pings omit `items` and update the loading line above without
+                // touching the panel.
+                if (Array.isArray(payload.items)) {
+                    this.activeTaskList = payload.items.length
+                        ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items: payload.items }
+                        : null
+                }
                 await mqttService.publishMessage(connectionKey, {
                     qos: 2,
                     topic: responseTopic,

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -419,7 +419,11 @@ export const useProductExpertStore = defineStore('product-expert', {
                 }
             }
 
-            this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
+            // expert:tasks has its own panel; its status rides expert:status-message.
+            // Every other inflight type feeds the loading line.
+            if (parsedTopic.inflightType !== 'expert:tasks') {
+                this._addInFlightUpdate(payload.status || payload.toolname || 'Processing request...')
+            }
 
             const responseTopic = topicHelper.buildTopic({
                 entityType: parsedTopic.entityType,
@@ -448,14 +452,10 @@ export const useProductExpertStore = defineStore('product-expert', {
                 })
                 break
             case parsedTopic.inflightType === 'expert:tasks': {
-                // Only replace the list when the message carries one; status-only
-                // pings omit `items` and update the loading line above without
-                // touching the panel.
-                if (Array.isArray(payload.items)) {
-                    this.activeTaskList = payload.items.length
-                        ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items: payload.items }
-                        : null
-                }
+                const items = Array.isArray(payload.items) ? payload.items : []
+                this.activeTaskList = items.length
+                    ? { planId: payload.planId ?? null, title: payload.title || 'Tasks', items }
+                    : null
                 await mqttService.publishMessage(connectionKey, {
                     qos: 2,
                     topic: responseTopic,


### PR DESCRIPTION
> Stacked on top of the task list PR #8468. Review and merge that one first.

Closes FlowFuse/engineering#345

## Summary

Turns the plan reply into a structured card with a name, a description, and a collapsible body, and introduces an active-plan pointer so the chat always shows which plan is currently in effect.

When a plan is waiting for approval the card is expanded with its action buttons. Once approved it collapses to a single line, and the plan that owns the currently pinned task list is marked with an `Active` pill. Approving another plan, or reactivating an earlier one, moves the pill and swaps the pinned task list to match.

## Changes

- `PlanCard.vue`: structured layout with a `Plan: <name>` heading, a description line, and the plan body inside a collapsible section; an `Active` pill in the collapsed header; awaiting-approval vs approved states; heading sized like a top-level heading and the pill given a solid accent fill for legibility.
- `AnswerWrapper.vue`: passes `name`, `description`, `active`, and `awaiting-approval` into the card, deriving `isActivePlan` from the plan id and the active-plan pointer.
- `product-expert.js`: adds the `activePlanId` getter, derived from the pinned task list's `planId`, so the active plan and its task list stay in sync.

## Anatomy of the card

While a plan awaits approval the card is fully expanded. The heading is the plan name, followed by the plan description, then the plan content, with the action buttons at the bottom. The card also falls back gracefully: a plan without structured fields renders as before, so this is backward compatible.

![Plan card awaiting approval, annotated with plan name, description, and content](https://github.com/user-attachments/assets/f9fc1b8a-7c41-4c1e-a528-0b8ffd0c5318)

## Collapsed states

Once approved the card collapses to a single line. The active plan carries the `Active` pill; other plans do not.

**Active:**

![Collapsed plan card with the Active pill](https://github.com/user-attachments/assets/b8d387cb-edd9-4430-ad00-cea91e25e783)

**Not active:**

![Collapsed plan card without the Active pill](https://github.com/user-attachments/assets/8a4cfd09-9814-4651-8fe1-89a72509d8a9)

## Active-plan pointer

Only one plan is active at a time. Approving a new plan makes the previous one no longer active, so the `Active` pill moves to the newest approved plan.

![Two plans in the chat, the Active pill on the newest approved plan](https://github.com/user-attachments/assets/266d4ff1-cacc-47be-9c61-cabb701322e9)

## Reactivating an earlier plan

You can ask the Expert to reactivate a previous plan. Doing so moves the `Active` pill back to that plan and swaps the pinned task list to that plan's tasks.

**Reactivating the first plan:** the pinned task list at the bottom now shows the first plan's tasks.

![Reactivating the first plan, pinned task list shows the first plan's tasks](https://github.com/user-attachments/assets/cd42c0bc-ce45-4d68-ae89-ce0969dd7cf1)

**Reactivating the second plan again:** the pinned task list swaps to the second plan's tasks, matching the currently active plan.

![Reactivating the second plan, pinned task list shows the second plan's tasks](https://github.com/user-attachments/assets/a42e93fa-0010-4916-9435-0a3822c98b67)

## Backward compatibility

The whole plan and task experience is gated behind the `supportsPlansAndTasks` capability flag, which is introduced in the stacked task list PR #8468. When the flag is absent the agent runs in its previous mode and does not emit the plan/task surface.

A plan reply without the structured name/description fields also renders exactly as it did before, so older agent responses are unaffected.

## Testing

- Approved a plan and confirmed the card collapses and gains the `Active` pill.
- Approved a second plan and confirmed the pill moves off the first.
- Reactivated the first plan and confirmed the pill and the pinned task list both switch back to it.
- Reactivated the second plan and confirmed both switch to it.
- Confirmed an unstructured plan reply still renders correctly.
- Verified light rendering; card uses shared theme tokens for both themes.

