### PR TITLE
Allow admin to force team type change

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -801,6 +801,9 @@ module.exports = async function (app) {
             if (request.body.type) {
                 auditLogFunc = app.auditLog.Team.team.type.changed
                 let billingIntervalUpgrade = false
+                // If the request is from an admin, and the team has unmanaged billing, we allow the admin
+                // to override the limit checks and change the team type.
+                let isAdminOverridingLimits = false
                 const bodyOptions = { ...request.body }
                 const targetTypeId = bodyOptions.type
                 delete bodyOptions.type
@@ -821,6 +824,12 @@ module.exports = async function (app) {
                     const sameTeamType = targetTypeId === request.team.TeamType.hashid
 
                     billingIntervalUpgrade = sameTeamType && upgradingToYearlySubscription && currentlyOnMonthlySubscription
+
+                    // An admin user is changing the type of a team without a managed subscription.
+                    // Disable the limit checks for this operation
+                    if (request.session.User?.admin && subscription.isUnmanaged()) {
+                        isAdminOverridingLimits = true
+                    }
                 }
 
                 if (targetTypeId !== request.team.TeamType.hashid || billingIntervalUpgrade) {
@@ -835,7 +844,9 @@ module.exports = async function (app) {
                     }
                     // Two stage process to update team type
                     // - first we check its allowed.
-                    await request.team.checkTeamTypeUpdateAllowed(targetTeamType)
+                    if (!isAdminOverridingLimits) {
+                        await request.team.checkTeamTypeUpdateAllowed(targetTeamType)
+                    }
                     // - then we apply it
                     await request.team.updateTeamType(targetTeamType, { interval: billingInterval })
                 } else {

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -602,7 +602,7 @@ export default {
         },
         teamDeviceLimitReached () {
             const teamTypeDeviceLimit = getTeamProperty(this.team, 'devices.limit')
-            if (teamTypeDeviceLimit > 0 && this.teamDeviceCount >= teamTypeDeviceLimit) {
+            if (teamTypeDeviceLimit > -1 && this.teamDeviceCount >= teamTypeDeviceLimit) {
                 // Device specific limit has been reached
                 return true
             }

--- a/frontend/src/components/multi-step-forms/device/steps/DeviceStep.vue
+++ b/frontend/src/components/multi-step-forms/device/steps/DeviceStep.vue
@@ -117,7 +117,7 @@ export default {
         },
         teamDeviceLimitReached () {
             const teamTypeDeviceLimit = getTeamProperty(this.team, 'devices.limit')
-            if (teamTypeDeviceLimit > 0 && this.team.deviceCount >= teamTypeDeviceLimit) {
+            if (teamTypeDeviceLimit > -1 && this.team.deviceCount >= teamTypeDeviceLimit) {
                 // Device specific limit has been reached
                 return true
             }

--- a/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
@@ -97,7 +97,7 @@ export default {
         },
         teamDeviceLimitReached () {
             const teamTypeDeviceLimit = getTeamProperty(this.team, 'devices.limit')
-            if (teamTypeDeviceLimit > -1 && this.totalDevices >= teamTypeDeviceLimit) {
+            if (teamTypeDeviceLimit > -1 && this.team.deviceCount >= teamTypeDeviceLimit) {
                 // Device specific limit has been reached
                 return true
             }

--- a/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
+++ b/frontend/src/pages/team/Home/components/RecentlyModifiedDevices.vue
@@ -23,8 +23,10 @@
         <div v-else class="no-devices flex flex-col flex-1 justify-center text-gray-500 italic">
             <p class="text-center self-center">
                 No remote Node-RED Instances found.
-                <span class="text-indigo-500 cursor-pointer" @click.stop.prevent="openCreateDialog">Add a Remote Instance</span>
-                to get started.
+                <template v-if="!teamDeviceLimitReached">
+                    <span class="text-indigo-500 cursor-pointer" @click.stop.prevent="openCreateDialog">Add a Remote Instance</span>
+                    to get started.
+                </template>
             </p>
         </div>
 
@@ -56,6 +58,7 @@ import { mapState } from 'pinia'
 import teamAPI from '../../../../api/team.js'
 
 import TeamLink from '../../../../components/router-links/TeamLink.vue'
+import { getTeamProperty } from '../../../../composables/TeamProperties.js'
 
 import DeviceActions from '../../../../mixins/DeviceActions.js'
 import DeviceTile from '../../Applications/components/compact/DeviceTile.vue'
@@ -91,6 +94,14 @@ export default {
         ...mapState(useContextStore, ['team']),
         instancesLeft () {
             return this.totalDevices - this.devices.length
+        },
+        teamDeviceLimitReached () {
+            const teamTypeDeviceLimit = getTeamProperty(this.team, 'devices.limit')
+            if (teamTypeDeviceLimit > -1 && this.totalDevices >= teamTypeDeviceLimit) {
+                // Device specific limit has been reached
+                return true
+            }
+            return false
         }
     },
     mounted () {

--- a/frontend/src/pages/team/Home/index.vue
+++ b/frontend/src/pages/team/Home/index.vue
@@ -227,7 +227,7 @@ export default {
         },
         teamDeviceLimitReached () {
             const teamTypeDeviceLimit = getTeamProperty(this.team, 'devices.limit')
-            if (teamTypeDeviceLimit > -1 && this.totalDevices >= teamTypeDeviceLimit) {
+            if (teamTypeDeviceLimit > -1 && this.team.deviceCount >= teamTypeDeviceLimit) {
                 // Device specific limit has been reached
                 return true
             }

--- a/frontend/src/pages/team/Home/index.vue
+++ b/frontend/src/pages/team/Home/index.vue
@@ -87,7 +87,7 @@
                                     v-ff-tooltip:left="!hasPermission('device:create') && 'Your role does not allow creating new remote instances. Contact a team admin to change your role.'"
                                     data-action="create-project"
                                     kind="secondary"
-                                    :disabled="!hasPermission('device:create')"
+                                    :disabled="!hasPermission('device:create') || teamDeviceLimitReached"
                                     @click="showCreateDeviceDialog"
                                 >
                                     <template #icon-left>
@@ -147,6 +147,7 @@ import ProjectsIcon from '../../../components/icons/Projects.js'
 import InstanceStat from '../../../components/tiles/InstanceCounter.vue'
 import { useInstanceStates } from '../../../composables/InstanceStates.js'
 import usePermissions from '../../../composables/Permissions.js'
+import { getTeamProperty } from '../../../composables/TeamProperties.js'
 import Alerts from '../../../services/alerts.js'
 import ConfirmInstanceDeleteDialog from '../../instance/Settings/dialogs/ConfirmInstanceDeleteDialog.vue'
 import DeviceCredentialsDialog from '../Devices/dialogs/DeviceCredentialsDialog.vue'
@@ -223,6 +224,14 @@ export default {
             return this.deviceStateCounts
                 ? Object.values(this.deviceStateCounts).reduce((total, count) => total + count, 0)
                 : 0
+        },
+        teamDeviceLimitReached () {
+            const teamTypeDeviceLimit = getTeamProperty(this.team, 'devices.limit')
+            if (teamTypeDeviceLimit > -1 && this.totalDevices >= teamTypeDeviceLimit) {
+                // Device specific limit has been reached
+                return true
+            }
+            return false
         }
     },
     async mounted () {

--- a/frontend/src/pages/team/Settings/TeamAdminTools.vue
+++ b/frontend/src/pages/team/Settings/TeamAdminTools.vue
@@ -134,11 +134,11 @@
                         <th>Remote Instance:</th>
                         <td v-if="!editingLimits">
                             <span v-if="!getTeamProperty('devices_free')">
-                                <div>{{ getTeamProperty('instances_' + getTeamProperty('devices_combinedFreeType') + '_free') || 0 }} - {{ getTeamProperty(`devices_limit`) || 'unlimited' }}</div>
+                                <div>{{ getTeamProperty('instances_' + getTeamProperty('devices_combinedFreeType') + '_free') || 0 }} - {{ getTeamProperty(`devices_limit`) > -1 ? getTeamProperty(`devices_limit`) : 'unlimited' }}</div>
                                 <div class="text-xs">Shared with {{ getInstanceTypeName(getTeamProperty('devices_combinedFreeType')) }} </div>
                             </span>
                             <span v-else>
-                                {{ getTeamProperty(`devices_free`) || 0 }} - {{ getTeamProperty(`devices_limit`) || 'unlimited' }}
+                                {{ getTeamProperty(`devices_free`) || 0 }} - {{ getTeamProperty(`devices_limit`) > -1 ? getTeamProperty(`devices_limit`) : 'unlimited' }}
                             </span>
                         </td>
                         <td v-else>

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -49,6 +49,9 @@
                                 </li>
                             </ul>
                         </div>
+                        <div v-if="isUnmanaged && user.admin" class="mb-8 text-sm space-y-2 border border-red-500 rounded-md p-4 bg-red-50">
+                            <b>Admin:</b> You can override these limits <i>after</i> you change the team type. Go to the Team Settings page and apply the required limit overrides.
+                        </div>
                     </template>
                     <template v-else-if="billingEnabled && !isUnmanaged">
                         <div class="mb-8 text-sm text-gray-500 space-y-2 text-center">
@@ -156,7 +159,8 @@ export default {
                     this.input.teamTypeId &&
                     this.isSelectionAvailable &&
                     (this.billingMissing || isChangingTeamType || this.isUpgradingFromMonthlyToYearly) &&
-                    this.upgradeErrors.length === 0
+                    // An admin can override errors if the team is unmanaged, otherwise there must be no errors
+                    (this.upgradeErrors.length === 0 || (this.isUnmanaged && this.user.admin))
         },
         isUpgradingFromMonthlyToYearly () {
             const inputTeamHasAnnual = Object.prototype.hasOwnProperty.call(this.input, 'teamType') &&


### PR DESCRIPTION
Follow up to #8456 

This allows an admin to change team type of an manual billing team even if the team usage exceeds the new team type usage limits. A warning is shown to the admin making the change in this scenario - telling them to apply the necessary limit overrides after making the team type change.

The second commit fixes the handling of a `0` device limit in the frontend. That was interpreted to mean 'unlimited' - whereas the backend uses `-1` to mean unlimited. With the new Hub plan, a limit of `0` is valid but wasn't being honoured in the UI.

With this fix it now shows the team limit banner on the Remote instance page, and disables the 'add instance' button on the team home page if the limit has been reached.

