### PR TITLE
fix: let the MCP consent page scroll when the team list is long

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -23,7 +23,7 @@
                 </ff-layout-platform>
             </template>
             <template v-else-if="pageLayout === 'modal'">
-                <ff-layout-box>
+                <ff-layout-box :class="{ 'ff--center-box': $route.meta?.centerBox }">
                     <router-view />
                 </ff-layout-box>
             </template>

--- a/frontend/src/pages/account/routes.js
+++ b/frontend/src/pages/account/routes.js
@@ -36,7 +36,9 @@ export default [
         path: '/account/request/:id/mcp',
         component: AccessRequestMCP,
         meta: {
-            layout: 'modal'
+            layout: 'modal',
+            // The team list can grow past the viewport, so allow this page to scroll
+            centerBox: true
         }
     },
     {

--- a/frontend/src/pages/account/routes.js
+++ b/frontend/src/pages/account/routes.js
@@ -37,7 +37,6 @@ export default [
         component: AccessRequestMCP,
         meta: {
             layout: 'modal',
-            // The team list can grow past the viewport, so allow this page to scroll
             centerBox: true
         }
     },


### PR DESCRIPTION
On `/account/request/:id/mcp` the Specific teams list could grow past the viewport, pushing the Deny and Allow buttons off screen so consent could not be completed. This opts just that route into the existing `ff--center-box` modifier via `meta.centerBox` so the page scrolls, leaving the other modal pages unchanged.

![MCP consent page scrolled to the Deny and Allow buttons with many teams](https://github.com/user-attachments/assets/e3eb245a-f9f7-4ac0-a68a-59c1dc618512)

![MCP consent page scrolled through the full team list](https://github.com/user-attachments/assets/b980db8a-325b-46d0-9c5f-ff421a323d9f)

Closes #8453
