### PR TITLE
Let users type their own answer on Expert question cards

### DIFF
--- a/frontend/src/components/expert/components/messages/AiMessage.vue
+++ b/frontend/src/components/expert/components/messages/AiMessage.vue
@@ -6,6 +6,7 @@
             :key="slugify(`${fAnswer.kind}-${fAnswer.title}-${fAnswer.summary}-${fAnswer._uuid}`)"
             :message-uuid="_uuid"
             :answer="fAnswer"
+            :instant="instant"
             @streaming-complete="setSubItemStreamedState(key)"
         />
     </div>
@@ -56,6 +57,10 @@ export default {
         _streamed: {
             required: true,
             type: Boolean
+        },
+        instant: {
+            type: Boolean,
+            default: false
         }
     },
     setup () {
@@ -102,7 +107,7 @@ export default {
         }
     },
     async mounted () {
-        await this.initStreamer(this.filteredAnswers, { shouldStream: !this._streamed })
+        await this.initStreamer(this.filteredAnswers, { shouldStream: !this.instant && !this._streamed })
     },
     methods: { slugify }
 }

--- a/frontend/src/components/expert/components/messages/CollapsedQuestionTurn.vue
+++ b/frontend/src/components/expert/components/messages/CollapsedQuestionTurn.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="collapsed-question-turn" :class="{ expanded }">
-        <template v-if="!expanded">
+        <div v-if="!expanded" class="folded-turn">
             <div
                 v-for="(entry, index) in turn.entries"
                 :key="index"
@@ -16,40 +16,56 @@
                 >
                     {{ entry.question }}
                 </button>
-                <div class="folded-answers">
+                <div v-if="chipsFor(entry).length || showSkipped(entry)" class="folded-answers">
                     <button
                         v-for="(chip, chipIndex) in chipsFor(entry)"
                         :key="chipIndex"
                         type="button"
                         class="answer-chip"
                         data-action="edit-answer"
-                        title="Load this answer into the composer to correct it"
+                        title="Edit this answer"
                         @click="editAnswer(entry)"
                     >
                         <span class="chip-label">{{ chip }}</span>
-                        <span class="chip-remove" aria-hidden="true">&times;</span>
+                        <PencilIcon class="chip-edit" aria-hidden="true" />
                     </button>
-                    <span v-if="chipsFor(entry).length === 0" class="skipped-marker">Skipped</span>
+                    <span v-if="showSkipped(entry)" class="skipped-marker">Skipped</span>
                 </div>
             </div>
-        </template>
-        <div v-else class="expanded-messages">
             <button
+                v-if="unmatchedReply"
                 type="button"
-                class="question-text"
-                data-action="toggle-turn"
-                title="Collapse this step"
-                @click="expanded = false"
+                class="answer-chip folded-reply"
+                data-action="edit-answer"
+                title="Edit this answer"
+                @click="editReply"
             >
-                Collapse this step
+                <span class="chip-label">{{ unmatchedReply }}</span>
+                <PencilIcon class="chip-edit" aria-hidden="true" />
             </button>
-            <AiMessage v-bind="{ ...turn.questionsMessage }" />
-            <HumanMessage v-if="turn.replyMessage" v-bind="{ ...turn.replyMessage }" />
         </div>
+        <transition name="expand">
+            <div v-if="expanded" class="expand-wrap">
+                <div class="expanded-messages">
+                    <button
+                        type="button"
+                        class="question-text"
+                        data-action="toggle-turn"
+                        title="Collapse this step"
+                        @click="expanded = false"
+                    >
+                        Collapse this step
+                    </button>
+                    <AiMessage v-bind="{ ...turn.questionsMessage }" :instant="true" />
+                    <HumanMessage v-if="turn.replyMessage" v-bind="{ ...turn.replyMessage }" />
+                </div>
+            </div>
+        </transition>
     </div>
 </template>
 
 <script>
+import { PencilIcon } from '@heroicons/vue/20/solid'
 import { mapActions } from 'pinia'
 
 import AiMessage from './AiMessage.vue'
@@ -61,7 +77,8 @@ export default {
     name: 'CollapsedQuestionTurn',
     components: {
         AiMessage,
-        HumanMessage
+        HumanMessage,
+        PencilIcon
     },
     props: {
         turn: {
@@ -77,25 +94,27 @@ export default {
     computed: {
         hasMatchedAnswers () {
             return this.turn.entries.some(entry => entry.answer !== null)
+        },
+        unmatchedReply () {
+            if (this.hasMatchedAnswers) {
+                return null
+            }
+            return this.turn.replyMessage?.content || null
         }
     },
     methods: {
         ...mapActions(useProductExpertStore, ['setPendingInput']),
         chipsFor (entry) {
-            if (entry.answer) {
-                return entry.answer.split(', ')
-            }
-            if (!this.hasMatchedAnswers && this.turn.replyMessage?.content) {
-                return [this.turn.replyMessage.content]
-            }
-            return []
+            return entry.answer ? entry.answer.split(', ') : []
+        },
+        showSkipped (entry) {
+            return !entry.answer && !this.unmatchedReply
         },
         editAnswer (entry) {
-            if (entry.answer) {
-                this.setPendingInput(`${entry.question} ${entry.answer}`)
-            } else if (this.turn.replyMessage?.content) {
-                this.setPendingInput(this.turn.replyMessage.content)
-            }
+            this.setPendingInput(`${entry.question} ${entry.answer}`)
+        },
+        editReply () {
+            this.setPendingInput(this.turn.replyMessage.content)
         }
     }
 }
@@ -108,13 +127,20 @@ export default {
     gap: 1rem;
 }
 
+.folded-turn {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.125rem 0 0.125rem 0.875rem;
+    border-left: 2px solid var(--ff-color-border);
+}
+
 .folded-question {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
-    padding: 0.125rem 0 0.125rem 0.875rem;
-    border-left: 2px solid var(--ff-color-border);
 }
 
 .question-text {
@@ -160,10 +186,11 @@ export default {
     max-width: 22rem;
 }
 
-.chip-remove {
-    font-weight: 400;
+.chip-edit {
+    width: 0.875rem;
+    height: 0.875rem;
     color: var(--ff-color-text-subtle);
-    line-height: 1;
+    flex-shrink: 0;
 }
 
 .skipped-marker {
@@ -172,11 +199,24 @@ export default {
     color: var(--ff-color-text-subtle);
 }
 
+.expand-wrap {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition: grid-template-rows 0.22s ease;
+}
+
+.expand-enter-from,
+.expand-leave-to {
+    grid-template-rows: 0fr;
+}
+
 .expanded-messages {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 0.75rem;
+    min-height: 0;
+    overflow: hidden;
     padding-left: 0.875rem;
     border-left: 2px solid var(--ff-color-accent);
 }

--- a/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
+++ b/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
@@ -72,9 +72,9 @@
             :questions="answer.questions"
             :disabled="interactionDisabled"
             :should-stream="shouldStream"
+            :initial-answer="questionAnswers[answer._uuid] || null"
             class="mb-3"
             @select="onQuestionsSubmit"
-            @edit="onQuestionsEdit"
             @streaming-complete="onComponentComplete('questions-list')"
         />
 
@@ -171,7 +171,7 @@ export default {
     },
     computed: {
         ...mapState(useProductAssistantStore, ['supportedActions', 'toolApprovalStatuses']),
-        ...mapState(useProductExpertStore, ['agentMode', 'isWaitingForResponse', 'messages']),
+        ...mapState(useProductExpertStore, ['agentMode', 'isWaitingForResponse', 'messages', 'questionAnswers']),
         isLatestMessage () {
             const msgs = this.messages || []
             return msgs.length > 0 && msgs[msgs.length - 1]?._uuid === this.messageUuid
@@ -351,7 +351,7 @@ export default {
         }
     },
     methods: {
-        ...mapActions(useProductExpertStore, ['updateAnswerStreamedState', 'handleQuery', 'setPendingInput', 'setComposerCommand', 'setPlanMode', 'resolveToolApproval']),
+        ...mapActions(useProductExpertStore, ['updateAnswerStreamedState', 'handleQuery', 'setPendingInput', 'setComposerCommand', 'setPlanMode', 'resolveToolApproval', 'saveQuestionAnswer']),
         buildStreamingOrder () {
             // order matters
             // this is where the decision of the streaming order of components is decided
@@ -373,11 +373,10 @@ export default {
 
             this.streamedComponents.push(key)
         },
-        onQuestionsSubmit (text) {
-            this.handleQuery({ query: text })
-        },
-        onQuestionsEdit (text) {
-            this.setPendingInput(text)
+        onQuestionsSubmit ({ query, answer }) {
+            // Persist the picks and typed answer so the sent card keeps them after a refresh.
+            this.saveQuestionAnswer(this.answer._uuid, answer)
+            this.handleQuery({ query })
         },
         onPlanApprove () {
             // Approving exits read-only plan mode so the build runs as a normal acting turn,

--- a/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
+++ b/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
@@ -374,7 +374,6 @@ export default {
             this.streamedComponents.push(key)
         },
         onQuestionsSubmit ({ query, answer }) {
-            // Persist the picks and typed answer so the sent card keeps them after a refresh.
             this.saveQuestionAnswer(this.answer._uuid, answer)
             this.handleQuery({ query })
         },

--- a/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
+++ b/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
@@ -156,6 +156,10 @@ export default {
         messageUuid: {
             type: String,
             required: true
+        },
+        instant: {
+            type: Boolean,
+            default: false
         }
     },
     emits: ['streaming-complete'],
@@ -317,7 +321,7 @@ export default {
             return this.streamedComponents.length >= this.componentStreamingOrder.indexOf(key)
         },
         shouldStream () {
-            return !this.answer._streamed
+            return !this.instant && !this.answer._streamed
         }
     },
     watch: {
@@ -369,7 +373,7 @@ export default {
             if (this.hasToolApproval) this.componentStreamingOrder.push('tool-approval-card')
         },
         async onComponentComplete (key) {
-            if (!this.shouldStream) await this.waitFor(200)
+            if (!this.shouldStream && !this.instant) await this.waitFor(200)
 
             this.streamedComponents.push(key)
         },

--- a/frontend/src/components/expert/components/messages/components/resources/QuestionsList.vue
+++ b/frontend/src/components/expert/components/messages/components/resources/QuestionsList.vue
@@ -80,8 +80,7 @@ export default {
             type: Boolean,
             default: false
         },
-        // A previously sent answer to restore (picks and typed text), so a card keeps
-        // its state after a page refresh. Null on a fresh, unanswered card.
+        // a previously sent answer (picks and typed text) to restore after a page refresh
         initialAnswer: {
             type: Object,
             default: null
@@ -95,10 +94,8 @@ export default {
             selections: initial?.selections
                 ? initial.selections.map(picks => [...picks])
                 : this.questions.map(() => []),
-            // one free-text answer per question; empty until the user types their own
             freeTexts: initial?.freeTexts ? [...initial.freeTexts] : this.questions.map(() => ''),
-            // whether the typed answer is the chosen one (its radio/checkbox is on). Kept
-            // separate from freeTexts so a typed-but-unpicked answer stays in the field.
+            // separate from freeTexts so a typed-but-unpicked answer stays in the field
             freeTextSelected: initial?.freeTextSelected ? [...initial.freeTextSelected] : this.questions.map(() => false),
             // ff-radio-group expects an options array; the option label doubles as its value.
             // disabled is mirrored from the prop in the watcher below so a stale card greys out.
@@ -135,8 +132,7 @@ export default {
         },
         setSingle (qIndex, label) {
             this.selections.splice(qIndex, 1, label === null || label === undefined ? [] : [label])
-            // Single-select: picking an option deselects the typed answer. The text stays
-            // in the field so the user can go back to it, it just is not the chosen answer.
+            // picking an option deselects the typed answer, but leaves the text in the field
             if (label !== null && label !== undefined) {
                 this.freeTextSelected.splice(qIndex, 1, false)
             }
@@ -149,8 +145,8 @@ export default {
             this.selections.splice(qIndex, 1, next)
         },
         selectFreeText (qIndex) {
+            // single-select: the typed answer and the options are mutually exclusive
             this.freeTextSelected.splice(qIndex, 1, true)
-            // Single-select: the typed answer and the options are mutually exclusive.
             this.selections.splice(qIndex, 1, [])
         },
         toggleFreeText (qIndex, checked) {
@@ -161,17 +157,14 @@ export default {
             if (value.trim().length === 0) {
                 return
             }
-            // Typing chooses the typed answer; on single-select that clears any picked option,
-            // on multi-select it is added alongside whatever options are already checked.
+            // typing chooses the typed answer; on single-select that clears any picked option
             this.freeTextSelected.splice(qIndex, 1, true)
             if (!this.questions[qIndex].multiSelect) {
                 this.selections.splice(qIndex, 1, [])
             }
         },
         compose () {
-            // always send one "question: answer(s)" line per question, even for a single
-            // question, so the agent always sees both the question and the chosen answer.
-            // A chosen typed answer joins the picks so the line keeps the same shape as before.
+            // one "question answer(s)" line per question, unchanged in shape from before
             return this.questions
                 .map((q, i) => {
                     const answers = [...(this.selections[i] || [])]
@@ -184,8 +177,7 @@ export default {
                 .join('\n')
         },
         submit () {
-            // Send the agent the composed text (unchanged shape) plus the raw answer state,
-            // which the parent persists so the card keeps its picks after a refresh.
+            // emit the composed text plus the raw answer state the parent persists for refresh
             this.$emit('select', {
                 query: this.compose(),
                 answer: {
@@ -242,8 +234,7 @@ export default {
     align-items: center;
     gap: 0;
 
-    // The control keeps its 25px label gutter (empty label) so the field's left edge
-    // lines up under the option labels above; centre the control against the field.
+    // keep the control's label gutter so the field lines up under the option labels, and centre the control
     :deep(.ff-radio-btn),
     :deep(.ff-checkbox) {
         min-height: 32px;
@@ -261,7 +252,7 @@ export default {
     min-width: 0;
 }
 
-// Match the greyed-out treatment the options get on a past (disabled) card.
+// match the greyed-out treatment the options get on a disabled card
 .question-free-text--disabled {
     cursor: not-allowed;
 

--- a/frontend/src/components/expert/components/messages/components/resources/QuestionsList.vue
+++ b/frontend/src/components/expert/components/messages/components/resources/QuestionsList.vue
@@ -26,24 +26,39 @@
                     <span v-if="opt.description" class="option-description">{{ opt.description }}</span>
                 </ff-checkbox>
             </div>
+
+            <div class="question-free-text" :class="{ 'question-free-text--disabled': disabled }">
+                <ff-radio-button
+                    v-if="!q.multiSelect"
+                    label=""
+                    value="__free-text__"
+                    :checked="freeTextSelected[qIndex]"
+                    :disabled="disabled"
+                    @select="() => selectFreeText(qIndex)"
+                />
+                <ff-checkbox
+                    v-else
+                    :model-value="freeTextSelected[qIndex]"
+                    :disabled="disabled"
+                    @update:model-value="checked => toggleFreeText(qIndex, checked)"
+                />
+                <ff-text-input
+                    class="question-free-text__input"
+                    :model-value="freeTexts[qIndex]"
+                    :disabled="disabled"
+                    placeholder="Type your own answer..."
+                    @update:model-value="value => setFreeText(qIndex, value)"
+                />
+            </div>
         </div>
         <div class="questions-actions">
             <ff-button
                 kind="primary"
                 size="small"
                 :disabled="disabled || !allAnswered"
-                @click="$emit('select', compose())"
+                @click="submit"
             >
                 Send
-            </ff-button>
-            <ff-button
-                kind="secondary"
-                size="small"
-                :disabled="disabled || !allAnswered"
-                title="Edit before sending"
-                @click="$emit('edit', compose())"
-            >
-                Edit
             </ff-button>
         </div>
     </div>
@@ -64,13 +79,27 @@ export default {
         shouldStream: {
             type: Boolean,
             default: false
+        },
+        // A previously sent answer to restore (picks and typed text), so a card keeps
+        // its state after a page refresh. Null on a fresh, unanswered card.
+        initialAnswer: {
+            type: Object,
+            default: null
         }
     },
-    emits: ['select', 'edit', 'streaming-complete'],
+    emits: ['select', 'streaming-complete'],
     data () {
+        const initial = this.initialAnswer
         return {
             // one array of selected option labels per question
-            selections: this.questions.map(() => []),
+            selections: initial?.selections
+                ? initial.selections.map(picks => [...picks])
+                : this.questions.map(() => []),
+            // one free-text answer per question; empty until the user types their own
+            freeTexts: initial?.freeTexts ? [...initial.freeTexts] : this.questions.map(() => ''),
+            // whether the typed answer is the chosen one (its radio/checkbox is on). Kept
+            // separate from freeTexts so a typed-but-unpicked answer stays in the field.
+            freeTextSelected: initial?.freeTextSelected ? [...initial.freeTextSelected] : this.questions.map(() => false),
             // ff-radio-group expects an options array; the option label doubles as its value.
             // disabled is mirrored from the prop in the watcher below so a stale card greys out.
             optionSets: this.questions.map(q => (q.options || []).map(opt => ({
@@ -83,7 +112,11 @@ export default {
     },
     computed: {
         allAnswered () {
-            return this.questions.every((q, i) => (this.selections[i] || []).length > 0)
+            return this.questions.every((q, i) => {
+                const hasSelection = (this.selections[i] || []).length > 0
+                const hasFreeText = this.freeTextSelected[i] && (this.freeTexts[i] || '').trim().length > 0
+                return hasSelection || hasFreeText
+            })
         }
     },
     watch: {
@@ -102,6 +135,11 @@ export default {
         },
         setSingle (qIndex, label) {
             this.selections.splice(qIndex, 1, label === null || label === undefined ? [] : [label])
+            // Single-select: picking an option deselects the typed answer. The text stays
+            // in the field so the user can go back to it, it just is not the chosen answer.
+            if (label !== null && label !== undefined) {
+                this.freeTextSelected.splice(qIndex, 1, false)
+            }
         },
         setMulti (qIndex, label, checked) {
             const current = this.selections[qIndex] || []
@@ -110,12 +148,52 @@ export default {
                 : current.filter(l => l !== label)
             this.selections.splice(qIndex, 1, next)
         },
+        selectFreeText (qIndex) {
+            this.freeTextSelected.splice(qIndex, 1, true)
+            // Single-select: the typed answer and the options are mutually exclusive.
+            this.selections.splice(qIndex, 1, [])
+        },
+        toggleFreeText (qIndex, checked) {
+            this.freeTextSelected.splice(qIndex, 1, checked)
+        },
+        setFreeText (qIndex, value) {
+            this.freeTexts.splice(qIndex, 1, value)
+            if (value.trim().length === 0) {
+                return
+            }
+            // Typing chooses the typed answer; on single-select that clears any picked option,
+            // on multi-select it is added alongside whatever options are already checked.
+            this.freeTextSelected.splice(qIndex, 1, true)
+            if (!this.questions[qIndex].multiSelect) {
+                this.selections.splice(qIndex, 1, [])
+            }
+        },
         compose () {
             // always send one "question: answer(s)" line per question, even for a single
-            // question, so the agent always sees both the question and the chosen answer
+            // question, so the agent always sees both the question and the chosen answer.
+            // A chosen typed answer joins the picks so the line keeps the same shape as before.
             return this.questions
-                .map((q, i) => `${q.question} ${(this.selections[i] || []).join(', ')}`)
+                .map((q, i) => {
+                    const answers = [...(this.selections[i] || [])]
+                    const freeText = (this.freeTexts[i] || '').trim()
+                    if (this.freeTextSelected[i] && freeText) {
+                        answers.push(freeText)
+                    }
+                    return `${q.question} ${answers.join(', ')}`
+                })
                 .join('\n')
+        },
+        submit () {
+            // Send the agent the composed text (unchanged shape) plus the raw answer state,
+            // which the parent persists so the card keeps its picks after a refresh.
+            this.$emit('select', {
+                query: this.compose(),
+                answer: {
+                    selections: this.selections.map(picks => [...picks]),
+                    freeTexts: [...this.freeTexts],
+                    freeTextSelected: [...this.freeTextSelected]
+                }
+            })
         }
     }
 }
@@ -157,6 +235,48 @@ export default {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+}
+
+.question-free-text {
+    display: flex;
+    align-items: center;
+    gap: 0;
+
+    // The control keeps its 25px label gutter (empty label) so the field's left edge
+    // lines up under the option labels above; centre the control against the field.
+    :deep(.ff-radio-btn),
+    :deep(.ff-checkbox) {
+        min-height: 32px;
+        align-items: center;
+    }
+
+    :deep(.checkbox) {
+        top: 50%;
+        transform: translateY(-50%);
+    }
+}
+
+.question-free-text__input {
+    flex: 1;
+    min-width: 0;
+}
+
+// Match the greyed-out treatment the options get on a past (disabled) card.
+.question-free-text--disabled {
+    cursor: not-allowed;
+
+    :deep(.ff-text-input) {
+        background-color: transparent;
+        border-color: var(--ff-color-border);
+    }
+
+    :deep(input) {
+        color: var(--ff-color-text-subtle);
+    }
+
+    :deep(input::placeholder) {
+        color: var(--ff-color-text-subtle);
+    }
 }
 
 // The checkbox slot renders both the label and (optionally) its description; stack them.

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -39,8 +39,7 @@ export const useProductExpertStore = defineStore('product-expert', {
         // 'request-plan-change' focuses an empty composer for the plan card's "Request
         // changes"; 'reset' clears a plan loaded via "Edit manually" but not sent.
         composerCommand: null,
-        // Answers chosen on question cards, keyed by the card's answer uuid, so a sent card
-        // keeps its picks and typed answer after a page refresh. { [answerUuid]: { selections, freeTexts, freeTextSelected } }
+        // question-card answers keyed by answer uuid, so a sent card survives a refresh
         questionAnswers: {},
         _seenTransactionIds: new Map(),
         // Open human-in-the-loop approval batch (#421). When a turn defers a tool batch

--- a/frontend/src/stores/product-expert.js
+++ b/frontend/src/stores/product-expert.js
@@ -39,6 +39,9 @@ export const useProductExpertStore = defineStore('product-expert', {
         // 'request-plan-change' focuses an empty composer for the plan card's "Request
         // changes"; 'reset' clears a plan loaded via "Edit manually" but not sent.
         composerCommand: null,
+        // Answers chosen on question cards, keyed by the card's answer uuid, so a sent card
+        // keeps its picks and typed answer after a page refresh. { [answerUuid]: { selections, freeTexts, freeTextSelected } }
+        questionAnswers: {},
         _seenTransactionIds: new Map(),
         // Open human-in-the-loop approval batch (#421). When a turn defers a tool batch
         // for approval the agent ends the turn and returns the card(s); we hold the
@@ -207,6 +210,12 @@ export const useProductExpertStore = defineStore('product-expert', {
         },
         setPendingInput (text) {
             this.pendingInput = text
+        },
+        saveQuestionAnswer (answerUuid, answer) {
+            if (!answerUuid) {
+                return
+            }
+            this.questionAnswers = { ...this.questionAnswers, [answerUuid]: answer }
         },
         setComposerCommand (command) {
             this.composerCommand = command
@@ -629,6 +638,7 @@ export const useProductExpertStore = defineStore('product-expert', {
 
             agentStore.sessionId = uuidv4()
             agentStore.messages = []
+            this.questionAnswers = {}
 
             // A new chat drops the per-session tool grants ("Always allow/deny for this chat")
             // and the resolved-approval outcomes tied to the messages we just cleared.
@@ -1335,7 +1345,7 @@ export const useProductExpertStore = defineStore('product-expert', {
         }
     },
     persist: {
-        pick: ['shouldWakeUpAssistant', 'questionCadence', 'agentMode'],
+        pick: ['shouldWakeUpAssistant', 'questionCadence', 'agentMode', 'questionAnswers'],
         storage: sessionStorage
     }
 })

--- a/test/unit/frontend/components/expert/CollapsedQuestionTurn.spec.js
+++ b/test/unit/frontend/components/expert/CollapsedQuestionTurn.spec.js
@@ -83,13 +83,17 @@ describe('CollapsedQuestionTurn', () => {
         expect(mocks.expertStore.setPendingInput).toHaveBeenCalledWith('Q1? Allen-Bradley PLC, over Ethernet')
     })
 
-    test('a free-form reply keeps the raw text as the chip', () => {
+    test('a free-form reply shows once for the turn, not repeated per question', async () => {
         const turn = answeredTurn()
         turn.replyMessage = { _uuid: 'h1', _type: 'human', content: 'typed by hand' }
-        turn.entries = [{ question: 'Q1?', answer: null }]
+        turn.entries = [{ question: 'Q1?', answer: null }, { question: 'Q2?', answer: null }]
         const wrapper = mountTurn(turn)
-        const chip = wrapper.find('[data-action="edit-answer"]')
-        expect(chip.text()).toContain('typed by hand')
+        const chips = wrapper.findAll('[data-action="edit-answer"]')
+        expect(chips.length).toBe(1)
+        expect(chips[0].text()).toContain('typed by hand')
+
+        await chips[0].trigger('click')
+        expect(mocks.expertStore.setPendingInput).toHaveBeenCalledWith('typed by hand')
     })
 
     test('expands to the original messages and folds back', async () => {

--- a/test/unit/frontend/components/expert/QuestionsList.spec.js
+++ b/test/unit/frontend/components/expert/QuestionsList.spec.js
@@ -3,8 +3,6 @@ import { describe, expect, test } from 'vitest'
 
 import QuestionsList from '../../../../../frontend/src/components/expert/components/messages/components/resources/QuestionsList.vue'
 
-// The ff-* form controls are globally registered in the app but not in the test
-// env; stub them so the component mounts and we can drive its answer state.
 const stubs = {
     'ff-radio-group': true,
     'ff-radio-button': true,
@@ -21,10 +19,6 @@ function mountList (questions, props = {}) {
 }
 
 const singleQuestion = [{ question: 'Which feature do you use most?', options: [{ label: 'MQTT' }, { label: 'Dashboard' }] }]
-const twoQuestions = [
-    { question: 'Q1?', options: [{ label: 'A' }, { label: 'B' }] },
-    { question: 'Q2?', options: [{ label: 'C' }, { label: 'D' }] }
-]
 const multiQuestion = [{ question: 'Which protocols?', multiSelect: true, options: [{ label: 'MQTT' }, { label: 'HTTP' }] }]
 
 describe('QuestionsList', () => {
@@ -34,64 +28,26 @@ describe('QuestionsList', () => {
         expect(wrapper.vm.compose()).toBe('Which feature do you use most? MQTT')
     })
 
-    test('composes from a typed answer when no option is picked', () => {
-        const wrapper = mountList(singleQuestion)
-        wrapper.vm.setFreeText(0, 'Something custom')
-        expect(wrapper.vm.compose()).toBe('Which feature do you use most? Something custom')
-    })
-
-    test('single-select: typing an answer clears the picked option', () => {
+    test('single-select: a picked option and a typed answer are mutually exclusive', () => {
         const wrapper = mountList(singleQuestion)
         wrapper.vm.setSingle(0, 'MQTT')
         wrapper.vm.setFreeText(0, 'My own answer')
         expect(wrapper.vm.selections[0]).toEqual([])
         expect(wrapper.vm.compose()).toBe('Which feature do you use most? My own answer')
-    })
 
-    test('single-select: picking an option deselects the typed answer but keeps the text', () => {
-        const wrapper = mountList(singleQuestion)
-        wrapper.vm.setFreeText(0, 'My own answer')
         wrapper.vm.setSingle(0, 'Dashboard')
         expect(wrapper.vm.freeTextSelected[0]).toBe(false)
-        expect(wrapper.vm.freeTexts[0]).toBe('My own answer')
         expect(wrapper.vm.compose()).toBe('Which feature do you use most? Dashboard')
     })
 
-    test('multi-select: a chosen typed answer joins the checked options', () => {
+    test('multi-select: a typed answer joins the checked options, and can be dropped alone', () => {
         const wrapper = mountList(multiQuestion)
         wrapper.vm.setMulti(0, 'MQTT', true)
         wrapper.vm.setFreeText(0, 'Modbus')
         expect(wrapper.vm.compose()).toBe('Which protocols? MQTT, Modbus')
-    })
 
-    test('multi-select: deselecting the typed answer keeps the options and drops the text', () => {
-        const wrapper = mountList(multiQuestion)
-        wrapper.vm.setMulti(0, 'MQTT', true)
-        wrapper.vm.setFreeText(0, 'Modbus')
         wrapper.vm.toggleFreeText(0, false)
-        expect(wrapper.vm.freeTexts[0]).toBe('Modbus')
         expect(wrapper.vm.compose()).toBe('Which protocols? MQTT')
-    })
-
-    test('allAnswered is satisfied by a typed answer alone', () => {
-        const wrapper = mountList(twoQuestions)
-        expect(wrapper.vm.allAnswered).toBe(false)
-        wrapper.vm.setSingle(0, 'A')
-        expect(wrapper.vm.allAnswered).toBe(false)
-        wrapper.vm.setFreeText(1, 'typed for the second')
-        expect(wrapper.vm.allAnswered).toBe(true)
-    })
-
-    test('choosing the free-text option without typing is not answered', () => {
-        const wrapper = mountList(singleQuestion)
-        wrapper.vm.selectFreeText(0)
-        expect(wrapper.vm.allAnswered).toBe(false)
-    })
-
-    test('whitespace-only typed answers do not count as answered', () => {
-        const wrapper = mountList(singleQuestion)
-        wrapper.vm.setFreeText(0, '   ')
-        expect(wrapper.vm.allAnswered).toBe(false)
     })
 
     test('submit emits the composed query and the raw answer state to persist', () => {
@@ -99,40 +55,17 @@ describe('QuestionsList', () => {
         wrapper.vm.setMulti(0, 'MQTT', true)
         wrapper.vm.setFreeText(0, 'Modbus')
         wrapper.vm.submit()
-        const payload = wrapper.emitted('select')[0][0]
-        expect(payload.query).toBe('Which protocols? MQTT, Modbus')
-        expect(payload.answer).toEqual({
-            selections: [['MQTT']],
-            freeTexts: ['Modbus'],
-            freeTextSelected: [true]
+        expect(wrapper.emitted('select')[0][0]).toEqual({
+            query: 'Which protocols? MQTT, Modbus',
+            answer: { selections: [['MQTT']], freeTexts: ['Modbus'], freeTextSelected: [true] }
         })
     })
 
     test('restores picks and typed text from a previously sent answer', () => {
         const wrapper = mountList(multiQuestion, {
-            initialAnswer: {
-                selections: [['MQTT']],
-                freeTexts: ['Modbus'],
-                freeTextSelected: [true]
-            }
+            initialAnswer: { selections: [['MQTT']], freeTexts: ['Modbus'], freeTextSelected: [true] }
         })
         expect(wrapper.vm.compose()).toBe('Which protocols? MQTT, Modbus')
         expect(wrapper.vm.allAnswered).toBe(true)
-    })
-
-    test('does not mutate the restored answer object', () => {
-        const initialAnswer = {
-            selections: [['MQTT']],
-            freeTexts: [''],
-            freeTextSelected: [false]
-        }
-        const wrapper = mountList(multiQuestion, { initialAnswer })
-        wrapper.vm.setMulti(0, 'HTTP', true)
-        expect(initialAnswer.selections).toEqual([['MQTT']])
-    })
-
-    test('no longer exposes an edit action', () => {
-        const wrapper = mountList(singleQuestion)
-        expect(wrapper.vm.$options.emits).not.toContain('edit')
     })
 })

--- a/test/unit/frontend/components/expert/QuestionsList.spec.js
+++ b/test/unit/frontend/components/expert/QuestionsList.spec.js
@@ -1,0 +1,138 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+
+import QuestionsList from '../../../../../frontend/src/components/expert/components/messages/components/resources/QuestionsList.vue'
+
+// The ff-* form controls are globally registered in the app but not in the test
+// env; stub them so the component mounts and we can drive its answer state.
+const stubs = {
+    'ff-radio-group': true,
+    'ff-radio-button': true,
+    'ff-checkbox': true,
+    'ff-text-input': true,
+    'ff-button': true
+}
+
+function mountList (questions, props = {}) {
+    return mount(QuestionsList, {
+        props: { questions, ...props },
+        global: { stubs }
+    })
+}
+
+const singleQuestion = [{ question: 'Which feature do you use most?', options: [{ label: 'MQTT' }, { label: 'Dashboard' }] }]
+const twoQuestions = [
+    { question: 'Q1?', options: [{ label: 'A' }, { label: 'B' }] },
+    { question: 'Q2?', options: [{ label: 'C' }, { label: 'D' }] }
+]
+const multiQuestion = [{ question: 'Which protocols?', multiSelect: true, options: [{ label: 'MQTT' }, { label: 'HTTP' }] }]
+
+describe('QuestionsList', () => {
+    test('composes the same "question answer" line from a picked option', () => {
+        const wrapper = mountList(singleQuestion)
+        wrapper.vm.setSingle(0, 'MQTT')
+        expect(wrapper.vm.compose()).toBe('Which feature do you use most? MQTT')
+    })
+
+    test('composes from a typed answer when no option is picked', () => {
+        const wrapper = mountList(singleQuestion)
+        wrapper.vm.setFreeText(0, 'Something custom')
+        expect(wrapper.vm.compose()).toBe('Which feature do you use most? Something custom')
+    })
+
+    test('single-select: typing an answer clears the picked option', () => {
+        const wrapper = mountList(singleQuestion)
+        wrapper.vm.setSingle(0, 'MQTT')
+        wrapper.vm.setFreeText(0, 'My own answer')
+        expect(wrapper.vm.selections[0]).toEqual([])
+        expect(wrapper.vm.compose()).toBe('Which feature do you use most? My own answer')
+    })
+
+    test('single-select: picking an option deselects the typed answer but keeps the text', () => {
+        const wrapper = mountList(singleQuestion)
+        wrapper.vm.setFreeText(0, 'My own answer')
+        wrapper.vm.setSingle(0, 'Dashboard')
+        expect(wrapper.vm.freeTextSelected[0]).toBe(false)
+        expect(wrapper.vm.freeTexts[0]).toBe('My own answer')
+        expect(wrapper.vm.compose()).toBe('Which feature do you use most? Dashboard')
+    })
+
+    test('multi-select: a chosen typed answer joins the checked options', () => {
+        const wrapper = mountList(multiQuestion)
+        wrapper.vm.setMulti(0, 'MQTT', true)
+        wrapper.vm.setFreeText(0, 'Modbus')
+        expect(wrapper.vm.compose()).toBe('Which protocols? MQTT, Modbus')
+    })
+
+    test('multi-select: deselecting the typed answer keeps the options and drops the text', () => {
+        const wrapper = mountList(multiQuestion)
+        wrapper.vm.setMulti(0, 'MQTT', true)
+        wrapper.vm.setFreeText(0, 'Modbus')
+        wrapper.vm.toggleFreeText(0, false)
+        expect(wrapper.vm.freeTexts[0]).toBe('Modbus')
+        expect(wrapper.vm.compose()).toBe('Which protocols? MQTT')
+    })
+
+    test('allAnswered is satisfied by a typed answer alone', () => {
+        const wrapper = mountList(twoQuestions)
+        expect(wrapper.vm.allAnswered).toBe(false)
+        wrapper.vm.setSingle(0, 'A')
+        expect(wrapper.vm.allAnswered).toBe(false)
+        wrapper.vm.setFreeText(1, 'typed for the second')
+        expect(wrapper.vm.allAnswered).toBe(true)
+    })
+
+    test('choosing the free-text option without typing is not answered', () => {
+        const wrapper = mountList(singleQuestion)
+        wrapper.vm.selectFreeText(0)
+        expect(wrapper.vm.allAnswered).toBe(false)
+    })
+
+    test('whitespace-only typed answers do not count as answered', () => {
+        const wrapper = mountList(singleQuestion)
+        wrapper.vm.setFreeText(0, '   ')
+        expect(wrapper.vm.allAnswered).toBe(false)
+    })
+
+    test('submit emits the composed query and the raw answer state to persist', () => {
+        const wrapper = mountList(multiQuestion)
+        wrapper.vm.setMulti(0, 'MQTT', true)
+        wrapper.vm.setFreeText(0, 'Modbus')
+        wrapper.vm.submit()
+        const payload = wrapper.emitted('select')[0][0]
+        expect(payload.query).toBe('Which protocols? MQTT, Modbus')
+        expect(payload.answer).toEqual({
+            selections: [['MQTT']],
+            freeTexts: ['Modbus'],
+            freeTextSelected: [true]
+        })
+    })
+
+    test('restores picks and typed text from a previously sent answer', () => {
+        const wrapper = mountList(multiQuestion, {
+            initialAnswer: {
+                selections: [['MQTT']],
+                freeTexts: ['Modbus'],
+                freeTextSelected: [true]
+            }
+        })
+        expect(wrapper.vm.compose()).toBe('Which protocols? MQTT, Modbus')
+        expect(wrapper.vm.allAnswered).toBe(true)
+    })
+
+    test('does not mutate the restored answer object', () => {
+        const initialAnswer = {
+            selections: [['MQTT']],
+            freeTexts: [''],
+            freeTextSelected: [false]
+        }
+        const wrapper = mountList(multiQuestion, { initialAnswer })
+        wrapper.vm.setMulti(0, 'HTTP', true)
+        expect(initialAnswer.selections).toEqual([['MQTT']])
+    })
+
+    test('no longer exposes an edit action', () => {
+        const wrapper = mountList(singleQuestion)
+        expect(wrapper.vm.$options.emits).not.toContain('edit')
+    })
+})


### PR DESCRIPTION
Part of #8380 / #8381, stacked on #8439.

Follows up the surface variant with a change to the question cards themselves: every question now takes a free-text answer, not just the tappable options.

* Each question renders a free-text field beside a matching selector (a radio on single-select, a checkbox on multi-select), aligned under the options above.
* Single-select is exclusive: typing selects the free-text answer and clears any picked option, and picking an option deselects the typed answer while leaving the text in the field so you can go back to it.
* Multi-select coexists: a typed answer is submitted alongside whatever options are checked, and its checkbox can be toggled off to drop it while keeping the picks.
* On a past (disabled) card the whole free-text row greys to match the disabled options.
* The `Edit` button is gone. Typing your own answer is now the way to answer in your own words, so a single `Send` remains. The submitted message keeps the same `question answer` lines per question as before, so nothing downstream changes.
* Picks and the typed answer are saved on `Send`, keyed by the card's answer id, so a sent card restores its state after a page refresh.

Covered by unit tests over the compose output, the single/multi selection rules, the submit payload, and restoring a saved answer.

## Screenshots

A single-select and a multi-select question, each with the free-text option beside the choices:

![Single-select and multi-select questions with a free-text option](https://github.com/user-attachments/assets/1aa78a3c-2616-433f-82c6-af735d1e2b8d)

Choosing the free-text option on a single-select question:

![Free-text option selected on a single-select question](https://github.com/user-attachments/assets/a5c70eab-4f24-416a-9afe-f148e085e48c)

Free-text answers chosen alongside options, ready to send:

![Free-text answers chosen alongside options](https://github.com/user-attachments/assets/3184c57c-f02e-4f0f-acd6-373e2e17603b)
