### PR TITLE
Allow admin to provide list of groupid->name mappings in saml config

### DIFF
--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -465,7 +465,15 @@ module.exports.init = async function (app) {
             } else {
                 app.log.debug(`SAML Group Assertions for ${user.username} ${JSON.stringify(groupAssertions)}`)
             }
-            for (const ga of groupAssertions) {
+            for (let ga of groupAssertions) {
+                if (providerOpts.groupIdMap && providerOpts.groupIdMap[ga]) {
+                    if (providerOpts.debugEnabled) {
+                        app.log.info(`Mapping Group ID ${ga} to Group Name ${providerOpts.groupIdMap[ga]}`)
+                    } else {
+                        app.log.debug(`Mapping Group ID ${ga} to Group Name ${providerOpts.groupIdMap[ga]}`)
+                    }
+                    ga = providerOpts.groupIdMap[ga]
+                }
                 // Trim prefix/postfix from group name
                 let shortGA = ga
                 if (providerOpts.groupPrefixLength || providerOpts.groupSuffixLength) {

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -30,7 +30,7 @@
                             Identity Provider Issuer ID / URL
                             <template #description>Supplied by your Identity Provider</template>
                         </FormRow>
-                        <FormRow v-model="input.options.cert">
+                        <FormRow v-model="input.options.cert" class="max-w-xl">
                             X.509 Certificate Public Key
                             <template #description>Supplied by your Identity Provider</template>
                             <template #input><textarea v-model="input.options.cert" class="font-mono w-full" placeholder="---BEGIN CERTIFICATE---&#10;loremipsumdolorsitamet&#10;consecteturadipiscinge&#10;---END CERTIFICATE---&#10;" rows="6" /></template>
@@ -115,6 +115,12 @@
                             Group Name Suffix Length
                             <template #description>The length of any suffix added to the FlowFuse Group Name format</template>
                         </FormRow>
+                        <FormRow v-model="input.options.groupIdMap" class="max-w-xl">
+                            Group ID/name mappings
+                            <template #description>If the SAML provider only returns Group IDs (certain Entra configurations for example), provide a list of GroupId to GroupName mappings - one per line</template>
+                            <template #input><textarea v-model="input.options.groupIdMap" class="font-mono w-full" rows="6" placeholder="123-abc-456 ff-example-owners" /></template>
+                        </FormRow>
+
                         <FormRow v-model="input.options.groupAllTeams" :options="[{ value:true, label: 'Apply to all teams' }, { value:false, label: 'Apply to selected teams' }]">
                             Team Scope
                             <template #description>Should this apply to all teams on the platform, or just a restricted list of teams</template>
@@ -191,6 +197,7 @@ export default {
                     groupAdminName: '',
                     groupPrefixLength: 0,
                     groupSuffixLength: 0,
+                    groupIdMap: '',
                     sendIdpHint: false,
                     debugEnabled: false
                 }
@@ -306,6 +313,7 @@ export default {
                     delete opts.options.groupTeams
                     delete opts.options.groupAdmin
                     delete opts.options.groupAdminName
+                    delete opts.options.groupIdMap
                 } else {
                     if (opts.options.groupAllTeams) {
                         delete opts.options.groupTeams
@@ -313,6 +321,20 @@ export default {
                     } else {
                         // groupTeams is stored as an array of team ids.
                         opts.options.groupTeams = opts.options.groupTeams.split(/(?:\r|\n|\r\n)/).filter(n => n.trim().length > 0)
+                    }
+                    // groupIdMap is stored as an object of groupId:groupName pairs. Convert from multi-line string to object.
+                    if (opts.options.groupIdMap) {
+                        const groupIdMap = {}
+                        opts.options.groupIdMap.split(/(?:\r|\n|\r\n)/).forEach(line => {
+                            // Split on only the first whitespace, to allow for group names with spaces
+                            const [groupId, groupName] = line.trim().split(/\s+(.*)/, 2)
+                            if (groupId && groupName) {
+                                groupIdMap[groupId] = groupName
+                            }
+                        })
+                        opts.options.groupIdMap = groupIdMap
+                    } else {
+                        delete opts.options.groupIdMap
                     }
                     if (!opts.options.groupAdmin) {
                         delete opts.options.groupAdminName
@@ -393,6 +415,11 @@ export default {
                 this.input.options.groupAssertionName = this.input.options.groupAssertionName || 'ff-roles'
                 // groupTeams is stored as an array - convert to multi-line string for the edit form
                 this.input.options.groupTeams = (this.input.options.groupTeams || []).join('\n')
+                // groupIdMap is stored as an object - convert to multi-line string for the edit form
+                if (this.input.options.groupIdMap && typeof this.input.options.groupIdMap === 'object') {
+                    this.input.options.groupIdMap = Object.entries(this.input.options.groupIdMap).map(([groupId, groupName]) => `${groupId} ${groupName}`).join('\n')
+                }
+                this.input.options.groupPrefixLength = this.input.options.groupPrefixLength ?? 0
                 this.input.options.sendIdpHint = this.input.options.sendIdpHint ?? false
                 this.input.options.debugEnabled = this.input.options.debugEnabled ?? false
             } else {


### PR DESCRIPTION
Closes #8474 
This pull request introduces support for mapping SAML Group IDs to human-readable Group Names, which is particularly useful for SSO providers that return only group IDs (such as certain Microsoft Entra configurations). The changes span both backend logic and the SSO provider admin UI to allow administrators to define and manage these mappings.

**SAML Group ID Mapping Support**

* Added logic in `forge/ee/lib/sso/index.js` to map SAML Group IDs to Group Names using a provided mapping (`groupIdMap`), with improved debug logging to trace the mapping process.

**Admin UI Enhancements for SSO Provider Configuration**

* Added a new form field in `createEditProvider.vue` for entering Group ID to Group Name mappings as a multi-line string, with clear instructions for administrators. [[1]](diffhunk://#diff-a59c29732c16a33431fa4c21ddbf9d609939f156df8a422426daf3999e2a7d40R118-R123) [[2]](diffhunk://#diff-a59c29732c16a33431fa4c21ddbf9d609939f156df8a422426daf3999e2a7d40R200)
* Implemented conversion logic in `createEditProvider.vue` to transform the multi-line string input into an object for backend consumption, and vice versa for editing existing providers. [[1]](diffhunk://#diff-a59c29732c16a33431fa4c21ddbf9d609939f156df8a422426daf3999e2a7d40R325-R338) [[2]](diffhunk://#diff-a59c29732c16a33431fa4c21ddbf9d609939f156df8a422426daf3999e2a7d40R418-R422)
* Ensured proper cleanup of `groupIdMap` when it is not needed, avoiding unnecessary data in the provider configuration.
* Improved UI layout for the certificate input by adding a maximum width for better readability.