### PR TITLE
Refine the folded question turns on the onboarding surface

### DIFF
--- a/frontend/src/components/expert/components/messages/AiMessage.vue
+++ b/frontend/src/components/expert/components/messages/AiMessage.vue
@@ -6,6 +6,7 @@
             :key="slugify(`${fAnswer.kind}-${fAnswer.title}-${fAnswer.summary}-${fAnswer._uuid}`)"
             :message-uuid="_uuid"
             :answer="fAnswer"
+            :instant="instant"
             @streaming-complete="setSubItemStreamedState(key)"
         />
     </div>
@@ -56,6 +57,10 @@ export default {
         _streamed: {
             required: true,
             type: Boolean
+        },
+        instant: {
+            type: Boolean,
+            default: false
         }
     },
     setup () {
@@ -102,7 +107,7 @@ export default {
         }
     },
     async mounted () {
-        await this.initStreamer(this.filteredAnswers, { shouldStream: !this._streamed })
+        await this.initStreamer(this.filteredAnswers, { shouldStream: !this.instant && !this._streamed })
     },
     methods: { slugify }
 }

--- a/frontend/src/components/expert/components/messages/CollapsedQuestionTurn.vue
+++ b/frontend/src/components/expert/components/messages/CollapsedQuestionTurn.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="collapsed-question-turn" :class="{ expanded }">
-        <template v-if="!expanded">
+        <div v-if="!expanded" class="folded-turn">
             <div
                 v-for="(entry, index) in turn.entries"
                 :key="index"
@@ -16,40 +16,56 @@
                 >
                     {{ entry.question }}
                 </button>
-                <div class="folded-answers">
+                <div v-if="chipsFor(entry).length || showSkipped(entry)" class="folded-answers">
                     <button
                         v-for="(chip, chipIndex) in chipsFor(entry)"
                         :key="chipIndex"
                         type="button"
                         class="answer-chip"
                         data-action="edit-answer"
-                        title="Load this answer into the composer to correct it"
+                        title="Edit this answer"
                         @click="editAnswer(entry)"
                     >
                         <span class="chip-label">{{ chip }}</span>
-                        <span class="chip-remove" aria-hidden="true">&times;</span>
+                        <PencilIcon class="chip-edit" aria-hidden="true" />
                     </button>
-                    <span v-if="chipsFor(entry).length === 0" class="skipped-marker">Skipped</span>
+                    <span v-if="showSkipped(entry)" class="skipped-marker">Skipped</span>
                 </div>
             </div>
-        </template>
-        <div v-else class="expanded-messages">
             <button
+                v-if="unmatchedReply"
                 type="button"
-                class="question-text"
-                data-action="toggle-turn"
-                title="Collapse this step"
-                @click="expanded = false"
+                class="answer-chip folded-reply"
+                data-action="edit-answer"
+                title="Edit this answer"
+                @click="editReply"
             >
-                Collapse this step
+                <span class="chip-label">{{ unmatchedReply }}</span>
+                <PencilIcon class="chip-edit" aria-hidden="true" />
             </button>
-            <AiMessage v-bind="{ ...turn.questionsMessage }" />
-            <HumanMessage v-if="turn.replyMessage" v-bind="{ ...turn.replyMessage }" />
         </div>
+        <transition name="expand">
+            <div v-if="expanded" class="expand-wrap">
+                <div class="expanded-messages">
+                    <button
+                        type="button"
+                        class="question-text"
+                        data-action="toggle-turn"
+                        title="Collapse this step"
+                        @click="expanded = false"
+                    >
+                        Collapse this step
+                    </button>
+                    <AiMessage v-bind="{ ...turn.questionsMessage }" :instant="true" />
+                    <HumanMessage v-if="turn.replyMessage" v-bind="{ ...turn.replyMessage }" />
+                </div>
+            </div>
+        </transition>
     </div>
 </template>
 
 <script>
+import { PencilIcon } from '@heroicons/vue/20/solid'
 import { mapActions } from 'pinia'
 
 import AiMessage from './AiMessage.vue'
@@ -61,7 +77,8 @@ export default {
     name: 'CollapsedQuestionTurn',
     components: {
         AiMessage,
-        HumanMessage
+        HumanMessage,
+        PencilIcon
     },
     props: {
         turn: {
@@ -77,25 +94,27 @@ export default {
     computed: {
         hasMatchedAnswers () {
             return this.turn.entries.some(entry => entry.answer !== null)
+        },
+        unmatchedReply () {
+            if (this.hasMatchedAnswers) {
+                return null
+            }
+            return this.turn.replyMessage?.content || null
         }
     },
     methods: {
         ...mapActions(useProductExpertStore, ['setPendingInput']),
         chipsFor (entry) {
-            if (entry.answer) {
-                return entry.answer.split(', ')
-            }
-            if (!this.hasMatchedAnswers && this.turn.replyMessage?.content) {
-                return [this.turn.replyMessage.content]
-            }
-            return []
+            return entry.answer ? entry.answer.split(', ') : []
+        },
+        showSkipped (entry) {
+            return !entry.answer && !this.unmatchedReply
         },
         editAnswer (entry) {
-            if (entry.answer) {
-                this.setPendingInput(`${entry.question} ${entry.answer}`)
-            } else if (this.turn.replyMessage?.content) {
-                this.setPendingInput(this.turn.replyMessage.content)
-            }
+            this.setPendingInput(`${entry.question} ${entry.answer}`)
+        },
+        editReply () {
+            this.setPendingInput(this.turn.replyMessage.content)
         }
     }
 }
@@ -108,13 +127,20 @@ export default {
     gap: 1rem;
 }
 
+.folded-turn {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.125rem 0 0.125rem 0.875rem;
+    border-left: 2px solid var(--ff-color-border);
+}
+
 .folded-question {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
-    padding: 0.125rem 0 0.125rem 0.875rem;
-    border-left: 2px solid var(--ff-color-border);
 }
 
 .question-text {
@@ -160,10 +186,11 @@ export default {
     max-width: 22rem;
 }
 
-.chip-remove {
-    font-weight: 400;
+.chip-edit {
+    width: 0.875rem;
+    height: 0.875rem;
     color: var(--ff-color-text-subtle);
-    line-height: 1;
+    flex-shrink: 0;
 }
 
 .skipped-marker {
@@ -172,11 +199,24 @@ export default {
     color: var(--ff-color-text-subtle);
 }
 
+.expand-wrap {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition: grid-template-rows 0.22s ease;
+}
+
+.expand-enter-from,
+.expand-leave-to {
+    grid-template-rows: 0fr;
+}
+
 .expanded-messages {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 0.75rem;
+    min-height: 0;
+    overflow: hidden;
     padding-left: 0.875rem;
     border-left: 2px solid var(--ff-color-accent);
 }

--- a/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
+++ b/frontend/src/components/expert/components/messages/components/AnswerWrapper.vue
@@ -156,6 +156,10 @@ export default {
         messageUuid: {
             type: String,
             required: true
+        },
+        instant: {
+            type: Boolean,
+            default: false
         }
     },
     emits: ['streaming-complete'],
@@ -317,7 +321,7 @@ export default {
             return this.streamedComponents.length >= this.componentStreamingOrder.indexOf(key)
         },
         shouldStream () {
-            return !this.answer._streamed
+            return !this.instant && !this.answer._streamed
         }
     },
     watch: {
@@ -369,7 +373,7 @@ export default {
             if (this.hasToolApproval) this.componentStreamingOrder.push('tool-approval-card')
         },
         async onComponentComplete (key) {
-            if (!this.shouldStream) await this.waitFor(200)
+            if (!this.shouldStream && !this.instant) await this.waitFor(200)
 
             this.streamedComponents.push(key)
         },

--- a/test/unit/frontend/components/expert/CollapsedQuestionTurn.spec.js
+++ b/test/unit/frontend/components/expert/CollapsedQuestionTurn.spec.js
@@ -83,13 +83,17 @@ describe('CollapsedQuestionTurn', () => {
         expect(mocks.expertStore.setPendingInput).toHaveBeenCalledWith('Q1? Allen-Bradley PLC, over Ethernet')
     })
 
-    test('a free-form reply keeps the raw text as the chip', () => {
+    test('a free-form reply shows once for the turn, not repeated per question', async () => {
         const turn = answeredTurn()
         turn.replyMessage = { _uuid: 'h1', _type: 'human', content: 'typed by hand' }
-        turn.entries = [{ question: 'Q1?', answer: null }]
+        turn.entries = [{ question: 'Q1?', answer: null }, { question: 'Q2?', answer: null }]
         const wrapper = mountTurn(turn)
-        const chip = wrapper.find('[data-action="edit-answer"]')
-        expect(chip.text()).toContain('typed by hand')
+        const chips = wrapper.findAll('[data-action="edit-answer"]')
+        expect(chips.length).toBe(1)
+        expect(chips[0].text()).toContain('typed by hand')
+
+        await chips[0].trigger('click')
+        expect(mocks.expertStore.setPendingInput).toHaveBeenCalledWith('typed by hand')
     })
 
     test('expands to the original messages and folds back', async () => {


### PR DESCRIPTION
Stacked on #8475, part of #8380 / #8381.

Follow-up fixes to the folded question turns introduced in #8439:

- A composer reply that matches no question was repeated as the answer under every folded question; it now shows once for the turn.
- The folded chip used a `×`, which reads as delete, though clicking it loads the answer back into the composer to edit; replaced with an edit icon.
- Each folded question had its own left bar, so one turn read as several separate items when collapsed while it is a single bubble when expanded; they now share one bar.
- Re-expanding a folded turn re-streamed the card, so the title appeared before its options and collapsing was instant; the expanded card now renders at once and the expand and collapse animate.
