### PR TITLE
Cap the Expert bridge heartbeat resync so it fails closed

### DIFF
--- a/forge/ee/lib/expert/tasks/heartbeat.js
+++ b/forge/ee/lib/expert/tasks/heartbeat.js
@@ -4,7 +4,7 @@ const { randomInt } = require('../../../../housekeeper/utils')
 const { syncBridge } = require('../emxq-bridge/setup.js')
 const sleep = async (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
-module.exports = ({ schedule, startDelay, maxResponseTime, maxSuccessiveFailureCount } = {}) => {
+module.exports = ({ schedule, startDelay, maxResponseTime, maxSuccessiveFailureCount, maxResyncAttempts } = {}) => {
     const now = Date.now()
     if (startDelay === undefined || startDelay === null) {
         startDelay = 2 * 60 * 1000 // default to 2 minutes if not provided (0 is a valid value, meaning no delay)
@@ -20,6 +20,7 @@ module.exports = ({ schedule, startDelay, maxResponseTime, maxSuccessiveFailureC
     startDelay = +startDelay
     maxResponseTime = +maxResponseTime
     maxSuccessiveFailureCount = +(maxSuccessiveFailureCount ?? 3)
+    maxResyncAttempts = +(maxResyncAttempts ?? 5) // stop re-synchronizing after this many attempts, leaving the bridge down
 
     // Check everything is in order and throw if not
     if (!Number.isFinite(startDelay) || startDelay < 0) {
@@ -30,6 +31,9 @@ module.exports = ({ schedule, startDelay, maxResponseTime, maxSuccessiveFailureC
     }
     if (!Number.isFinite(maxSuccessiveFailureCount) || maxSuccessiveFailureCount < 0) {
         throw new RangeError(`maxSuccessiveFailureCount must be a non-negative number, got ${maxSuccessiveFailureCount}`)
+    }
+    if (!Number.isFinite(maxResyncAttempts) || maxResyncAttempts < 1) {
+        throw new RangeError(`maxResyncAttempts must be a positive number, got ${maxResyncAttempts}`)
     }
 
     // Validate schedule (basic/non-exhaustive):
@@ -67,13 +71,23 @@ module.exports = ({ schedule, startDelay, maxResponseTime, maxSuccessiveFailureC
 
             // Request a heartbeat from the Expert Agent via the bridge
             expertCommsHandler.requestBridgeHeartbeat(maxResponseTime, async (err, result) => {
-                if (err && result.errorCount > 0 && result.errorCount % maxSuccessiveFailureCount === 0) {
-                    app.log.error(`Expert Agent bridge heartbeat failed ${result.errorCount} times in a row, re-synchronizing the bridge`)
-                    try {
-                        await syncBridge(app, { force: true }) // force tears down and re-creates the bridge.
-                    } catch (syncErr) {
-                        app.log.error(`Error synchronizing bridge after heartbeat failure: ${syncErr.message}`)
-                    }
+                if (!err || result.errorCount <= 0 || result.errorCount % maxSuccessiveFailureCount !== 0) {
+                    return
+                }
+                // Fail closed: once we have re-synchronized maxResyncAttempts times without
+                // recovery, leave the bridge down until a heartbeat succeeds and resets errorCount.
+                const resyncCap = maxSuccessiveFailureCount * maxResyncAttempts
+                if (result.errorCount > resyncCap) {
+                    return
+                }
+                app.log.error(`Expert Agent bridge heartbeat failed ${result.errorCount} times in a row, re-synchronizing the bridge`)
+                try {
+                    await syncBridge(app, { force: true }) // force tears down and re-creates the bridge.
+                } catch (syncErr) {
+                    app.log.error(`Error synchronizing bridge after heartbeat failure: ${syncErr.message}`)
+                }
+                if (result.errorCount === resyncCap) {
+                    app.log.error(`Expert Agent bridge re-synchronized ${maxResyncAttempts} times without recovery, leaving it down until a heartbeat succeeds`)
                 }
             })
         }

--- a/forge/ee/lib/expert/tasks/heartbeat.js
+++ b/forge/ee/lib/expert/tasks/heartbeat.js
@@ -20,7 +20,7 @@ module.exports = ({ schedule, startDelay, maxResponseTime, maxSuccessiveFailureC
     startDelay = +startDelay
     maxResponseTime = +maxResponseTime
     maxSuccessiveFailureCount = +(maxSuccessiveFailureCount ?? 3)
-    maxResyncAttempts = +(maxResyncAttempts ?? 5) // stop re-synchronizing after this many attempts, leaving the bridge down
+    maxResyncAttempts = +(maxResyncAttempts ?? 3) // stop re-synchronizing after this many attempts, leaving the bridge down
 
     // Check everything is in order and throw if not
     if (!Number.isFinite(startDelay) || startDelay < 0) {

--- a/test/unit/forge/ee/lib/expert/tasks/heartbeat_spec.js
+++ b/test/unit/forge/ee/lib/expert/tasks/heartbeat_spec.js
@@ -94,6 +94,10 @@ describe('Expert Agent bridge heartbeat task', function () {
             should(() => heartbeatTaskFactory({ maxSuccessiveFailureCount: -1 })).throw(RangeError)
         })
 
+        it('throws a RangeError for a maxResyncAttempts below 1', function () {
+            should(() => heartbeatTaskFactory({ maxResyncAttempts: 0 })).throw(RangeError)
+        })
+
         it('throws for an invalid cron expression', function () {
             should(() => heartbeatTaskFactory({ schedule: 'not-a-cron-expression' })).throw()
         })
@@ -169,6 +173,46 @@ describe('Expert Agent bridge heartbeat task', function () {
             const [, callback] = app.comms.expert.requestBridgeHeartbeat.firstCall.args
             await callback(new Error('heartbeat missed'), { errorCount: 3 })
             await callback(new Error('heartbeat missed'), { errorCount: 6 })
+
+            syncBridgeStub.calledTwice.should.be.true()
+        })
+
+        it('stops re-syncing once maxResyncAttempts is reached, leaving the bridge down', async function () {
+            const task = heartbeatTaskFactory({ startDelay: 0, maxSuccessiveFailureCount: 3, maxResyncAttempts: 2, schedule: '0 0 * * * *' })
+            const app = makeApp()
+            await runTask(task, app)
+
+            const [, callback] = app.comms.expert.requestBridgeHeartbeat.firstCall.args
+            await callback(new Error('heartbeat missed'), { errorCount: 3 }) // first attempt
+            await callback(new Error('heartbeat missed'), { errorCount: 6 }) // second attempt (cap)
+            await callback(new Error('heartbeat missed'), { errorCount: 9 }) // past the cap, parked
+
+            syncBridgeStub.calledTwice.should.be.true()
+        })
+
+        it('logs the parked state once when the resync cap is reached', async function () {
+            const task = heartbeatTaskFactory({ startDelay: 0, maxSuccessiveFailureCount: 3, maxResyncAttempts: 2, schedule: '0 0 * * * *' })
+            const app = makeApp()
+            await runTask(task, app)
+
+            const [, callback] = app.comms.expert.requestBridgeHeartbeat.firstCall.args
+            await callback(new Error('heartbeat missed'), { errorCount: 3 })
+            await callback(new Error('heartbeat missed'), { errorCount: 6 })
+            await callback(new Error('heartbeat missed'), { errorCount: 9 })
+
+            app.log.error.withArgs(sinon.match(/leaving it down until a heartbeat succeeds/)).callCount.should.equal(1)
+        })
+
+        it('resumes re-syncing after a successful heartbeat resets the failure count', async function () {
+            const task = heartbeatTaskFactory({ startDelay: 0, maxSuccessiveFailureCount: 3, maxResyncAttempts: 2, schedule: '0 0 * * * *' })
+            const app = makeApp()
+            await runTask(task, app)
+
+            const [, callback] = app.comms.expert.requestBridgeHeartbeat.firstCall.args
+            await callback(new Error('heartbeat missed'), { errorCount: 6 }) // at the cap, re-syncs
+            await callback(new Error('heartbeat missed'), { errorCount: 9 }) // parked, no re-sync
+            await callback(null, { errorCount: 0 })                          // recovery resets the counter
+            await callback(new Error('heartbeat missed'), { errorCount: 3 }) // re-syncs again
 
             syncBridgeStub.calledTwice.should.be.true()
         })


### PR DESCRIPTION
Bounds the Expert bridge heartbeat resync loop so it stops disrupting EMQX when the central broker is unreachable.

The heartbeat used to force-rebuild the bridge every few failures with no ceiling, looping forever when the broker could not be reached. A rebuild only helps a bridge that has drifted locally, not one that cannot reach the broker or has a bad token, so the loop was futile and disruptive.

- A bridge that has never completed a heartbeat is no longer rebuilt: that is a config, token or network problem, logged once and left for EMQX to reconnect.
- A bridge that connected before and later fails is re-synchronized with exponential backoff (up to `maxResyncInterval`) instead of on a fixed cadence, re-arming on the next success.

Fixes #8482
